### PR TITLE
Add Gemini CLI agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 Local command-line orchestration for a coding PR review loop.
 
-Run a local Claude/Codex PR review loop using your existing CLI subscriptions,
+Run a local Claude/Codex/Gemini PR review loop using your existing CLI subscriptions,
 without paying separate model API costs.
 
 The main advantage is cost and account reuse: the tool shells out to your
-already-authenticated local CLIs (`claude`, `codex`, and `gh`) instead of
-calling model APIs directly. If your local agent CLIs are backed by existing AI
-subscriptions or authenticated developer accounts, the review loop can use
-those existing entitlements rather than requiring separate Claude/OpenAI API
+already-authenticated local CLIs (`claude`, `codex`, `gemini`, and `gh`) instead
+of calling model APIs directly. If your local agent CLIs are backed by existing
+AI subscriptions or authenticated developer accounts, the review loop can use
+those existing entitlements rather than requiring separate model API
 keys and per-token API billing.
 
 ## Who This Is For
 
-This is for developers who already use Claude Code, OpenAI Codex CLI, and
-GitHub, and want one local agent to implement or fix a PR while another local
-agent reviews it before merge.
+This is for developers who already use Claude Code, OpenAI Codex CLI, Gemini
+CLI, and GitHub, and want one local agent to implement or fix a PR while
+another local agent reviews it before merge.
 
 It is especially useful when you are already doing this manually by switching
 between agent CLIs and copying review feedback back and forth.
@@ -51,10 +51,7 @@ Currently supported local agent CLIs:
 
 - Claude Code via `claude`
 - OpenAI Codex CLI via `codex`
-
-Gemini CLI support is planned. The architecture is intended to support
-additional local agent CLIs over time while keeping the same local,
-subscription-friendly workflow.
+- Gemini CLI via `gemini`
 
 ## Install / Use
 
@@ -75,8 +72,8 @@ agent-loop --help
 ```
 
 This installs the `agent-loop` command from your checkout. The tool still
-requires local `gh`, `claude`, and/or `codex` authentication depending on which
-agents you use.
+requires local `gh`, `claude`, `codex`, and/or `gemini` authentication depending
+on which agents you use.
 
 ## Develop This Tool
 
@@ -117,6 +114,22 @@ By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
 ```bash
 agent-loop task "Fix the flaky test" --repo OWNER/REPO --coder codex --reviewer claude
+```
+
+Use Gemini as either side of the loop:
+
+```bash
+agent-loop task "Improve error handling" \
+  --repo OWNER/REPO \
+  --coder gemini \
+  --reviewer codex \
+  --gemini-dir /path/to/gemini/repo \
+  --codex-dir /path/to/codex/repo
+
+agent-loop pr 456 \
+  --repo OWNER/REPO \
+  --reviewer gemini \
+  --gemini-dir /path/to/gemini/repo
 ```
 
 Repeat `--reviewer` to require approvals from multiple reviewers. The PR is
@@ -160,4 +173,4 @@ See [docs/local_agent_loop.md](docs/local_agent_loop.md) for full usage and safe
 python -m pytest
 ```
 
-Tests use fake subprocess runners. They do not call real `claude`, `codex`, or `gh`.
+Tests use fake subprocess runners. They do not call real `claude`, `codex`, `gemini`, or `gh`.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1,6 +1,6 @@
 # Local Coding Review Agent Loop
 
-`coding-review-agent-loop` is a local CLI that orchestrates coding agents through a GitHub pull request review loop. Its main advantage is cost and account reuse: it shells out to locally authenticated `claude`, `codex`, and `gh` CLIs instead of calling model APIs directly. If your local agent CLIs are backed by existing AI subscriptions or authenticated developer accounts, the review loop can use those existing entitlements rather than requiring separate Claude/OpenAI API keys and per-token API billing.
+`coding-review-agent-loop` is a local CLI that orchestrates coding agents through a GitHub pull request review loop. Its main advantage is cost and account reuse: it shells out to locally authenticated `claude`, `codex`, `gemini`, and `gh` CLIs instead of calling model APIs directly. If your local agent CLIs are backed by existing AI subscriptions or authenticated developer accounts, the review loop can use those existing entitlements rather than requiring separate model API keys and per-token API billing.
 
 The default flow is:
 
@@ -9,7 +9,7 @@ The default flow is:
 3. If any reviewer finds blockers, the coder fixes the PR.
 4. The loop repeats until every reviewer approves in the same round or `--max-rounds` is reached.
 
-The default coder is Claude and the default reviewer is Codex. Reverse the direction with `--coder codex --reviewer claude`. Repeat `--reviewer` to require multiple reviewer approvals.
+The default coder is Claude and the default reviewer is Codex. Reverse the direction with `--coder codex --reviewer claude`, or use Gemini with `--coder gemini` / `--reviewer gemini`. Repeat `--reviewer` to require multiple reviewer approvals.
 
 ## Agent Backends
 
@@ -17,17 +17,15 @@ Currently supported local agent CLIs:
 
 - Claude Code via `claude`
 - OpenAI Codex CLI via `codex`
-
-Gemini CLI support is planned. The architecture is intended to support
-additional local agent CLIs over time while keeping the same local,
-subscription-friendly workflow.
+- Gemini CLI via `gemini`
 
 ## Prerequisites
 
 - `gh` is installed and authenticated for the target GitHub repository.
 - `claude` is installed and authenticated if either side uses Claude.
 - `codex` is installed and authenticated if either side uses Codex.
-- Use separate clones or worktrees for Claude and Codex to avoid local file conflicts. Missing `--claude-dir` / `--codex-dir` directories are created automatically; paths that already exist as files fail clearly.
+- `gemini` is installed and authenticated if either side uses Gemini.
+- Use separate clones or worktrees for each active agent to avoid local file conflicts. Missing `--claude-dir` / `--codex-dir` / `--gemini-dir` directories are created automatically; paths that already exist as files fail clearly.
 
 ## Usage
 
@@ -67,6 +65,28 @@ agent-loop task "Refactor the cache layer" \
   --reviewer claude \
   --claude-dir /path/to/claude/worktree \
   --codex-dir /path/to/codex/worktree
+```
+
+Use Gemini as the coder. Gemini is invoked in headless mode with `gemini --prompt`:
+
+```bash
+agent-loop task "Improve validation errors" \
+  --repo OWNER/REPO \
+  --coder gemini \
+  --reviewer codex \
+  --gemini-dir /path/to/gemini/worktree \
+  --codex-dir /path/to/codex/worktree
+```
+
+Use Gemini as one reviewer:
+
+```bash
+agent-loop pr 123 \
+  --repo OWNER/REPO \
+  --reviewer codex \
+  --reviewer gemini \
+  --codex-dir /path/to/codex/worktree \
+  --gemini-dir /path/to/gemini/worktree
 ```
 
 Require both reviewers to approve. The coder may also be listed as a reviewer
@@ -152,6 +172,7 @@ This applies:
 |-------|------|
 | `claude` | `--dangerously-skip-permissions` |
 | `codex exec` | `--dangerously-bypass-approvals-and-sandbox` |
+| `gemini` | `--yolo` |
 
 You can also provide exact per-agent replacements. Repeat once per token:
 
@@ -159,10 +180,11 @@ You can also provide exact per-agent replacements. Repeat once per token:
 agent-loop issue 56 \
   --repo OWNER/REPO \
   --claude-arg=--permission-mode --claude-arg=acceptEdits \
-  --codex-arg=--sandbox --codex-arg=workspace-write --codex-arg=--ask-for-approval --codex-arg=never
+  --codex-arg=--sandbox --codex-arg=workspace-write --codex-arg=--ask-for-approval --codex-arg=never \
+  --gemini-arg=--approval-mode --gemini-arg=auto_edit
 ```
 
-Providing any `--claude-arg` or `--codex-arg` replaces that agent's default entirely.
+Providing any `--claude-arg`, `--codex-arg`, or `--gemini-arg` replaces that agent's default entirely. Gemini's text output is used directly. If you pass `--gemini-arg=--output-format --gemini-arg=json`, the loop extracts the JSON `response` field before parsing markers.
 
 ## Protocol
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "hatchling.build"
 [project]
 name = "coding-review-agent-loop"
 version = "0.1.0"
-description = "Local Claude/Codex coding PR review loop orchestrator"
+description = "Local Claude/Codex/Gemini coding PR review loop orchestrator"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Wild Wind" }]
-keywords = ["agents", "codex", "claude", "github", "code-review"]
+keywords = ["agents", "codex", "claude", "gemini", "github", "code-review"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -11,7 +11,7 @@ from ..runner import Runner
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
-AgentName = Literal["claude", "codex"]
+AgentName = Literal["claude", "codex", "gemini"]
 
 
 @dataclass(frozen=True)

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -1,0 +1,61 @@
+"""Gemini CLI backend."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .base import AgentName, AgentResult
+from ..logging import agent_log_path, log
+from ..runner import Runner
+
+if TYPE_CHECKING:
+    from ..config import AgentLoopConfig
+
+
+def _parse_gemini_output(raw: str) -> str:
+    """Extract text from Gemini's optional --output-format json response."""
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            text = data.get("response", raw)
+            if isinstance(text, str):
+                return text
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return raw
+
+
+class GeminiBackend:
+    name: AgentName = "gemini"
+    display_name = "Gemini"
+    signature = "Google Gemini"
+
+    def workdir(self, config: AgentLoopConfig) -> Path:
+        return config.gemini_dir
+
+    def default_args(self, *, dangerous: bool) -> tuple[str, ...]:
+        return ("--yolo",) if dangerous else ()
+
+    def run(
+        self,
+        runner: Runner,
+        config: AgentLoopConfig,
+        prompt: str,
+        session_id: str | None = None,
+    ) -> AgentResult:
+        log_path = agent_log_path(config, "gemini")
+        log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}")
+        result = runner.run_with_log(
+            [config.gemini_cmd, "--prompt", prompt, *config.gemini_args],
+            cwd=config.gemini_dir,
+            log_path=log_path,
+            label="Gemini",
+            progress_interval_seconds=config.progress_interval_seconds,
+        )
+        log(config, f"Gemini finished; log: {log_path}")
+        return AgentResult(text=_parse_gemini_output(result.stdout), session_id=session_id)
+
+
+BACKEND = GeminiBackend()

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from .base import AgentBackend, AgentName
 from .claude import BACKEND as CLAUDE_BACKEND
 from .codex import BACKEND as CODEX_BACKEND
+from .gemini import BACKEND as GEMINI_BACKEND
 from ..errors import AgentLoopError
 from ..runner import Runner
 
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 BACKENDS: dict[AgentName, AgentBackend] = {
     "claude": CLAUDE_BACKEND,
     "codex": CODEX_BACKEND,
+    "gemini": GEMINI_BACKEND,
 }
 
 
@@ -63,3 +65,7 @@ def run_claude(
 
 def run_codex(runner: Runner, *, config: AgentLoopConfig, prompt: str) -> str:
     return CODEX_BACKEND.run(runner, config, prompt).text
+
+
+def run_gemini(runner: Runner, *, config: AgentLoopConfig, prompt: str) -> str:
+    return GEMINI_BACKEND.run(runner, config, prompt).text

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -14,6 +14,7 @@ from .agents.registry import (
     run_agent,
     run_claude,
     run_codex,
+    run_gemini,
 )
 from .config import (
     AgentLoopConfig,
@@ -64,15 +65,16 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--base", default="main", help="PR base branch for new issue work.")
         subparser.add_argument("--claude-dir", type=Path, default=Path.cwd())
         subparser.add_argument("--codex-dir", type=Path, default=Path.cwd())
+        subparser.add_argument("--gemini-dir", type=Path, default=Path.cwd())
         subparser.add_argument(
             "--coder",
-            choices=("claude", "codex"),
+            choices=("claude", "codex", "gemini"),
             default="claude",
             help="Agent that creates and fixes the PR (default: claude).",
         )
         subparser.add_argument(
             "--reviewer",
-            choices=("claude", "codex"),
+            choices=("claude", "codex", "gemini"),
             action="append",
             default=None,
             help=(
@@ -86,14 +88,16 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--dry-run", action="store_true")
         subparser.add_argument("--claude-cmd", default="claude")
         subparser.add_argument("--codex-cmd", default="codex")
+        subparser.add_argument("--gemini-cmd", default="gemini")
         subparser.add_argument("--gh-cmd", default="gh")
         subparser.add_argument(
             "--dangerous-agent-permissions",
             action="store_true",
             help=(
-                "Use permission-bypass defaults for both agents. Only use in trusted "
+                "Use permission-bypass defaults for configured agents. Only use in trusted "
                 "local repositories: Claude gets --dangerously-skip-permissions and "
-                "Codex gets --dangerously-bypass-approvals-and-sandbox."
+                "Codex gets --dangerously-bypass-approvals-and-sandbox, and Gemini "
+                "gets --yolo."
             ),
         )
         subparser.add_argument(
@@ -112,6 +116,15 @@ def build_parser() -> argparse.ArgumentParser:
             help=(
                 "Extra argument passed to codex exec (repeat for multiple). "
                 "Providing any --codex-arg replaces the default entirely."
+            ),
+        )
+        subparser.add_argument(
+            "--gemini-arg",
+            action="append",
+            default=None,
+            help=(
+                "Extra argument passed to gemini (repeat for multiple). "
+                "Providing any --gemini-arg replaces the default entirely."
             ),
         )
         subparser.add_argument(
@@ -144,7 +157,7 @@ def build_parser() -> argparse.ArgumentParser:
             "--log-dir",
             type=Path,
             default=Path(".agent-loop-logs"),
-            help="Directory for Claude/Codex subprocess logs (default: .agent-loop-logs).",
+            help="Directory for agent subprocess logs (default: .agent-loop-logs).",
         )
         subparser.add_argument(
             "--progress-interval-seconds",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -19,6 +19,7 @@ class AgentLoopConfig:
     repo: str
     claude_dir: Path
     codex_dir: Path
+    gemini_dir: Path
     coder: AgentName
     reviewer: AgentName | tuple[AgentName, ...]
     base: str
@@ -28,9 +29,11 @@ class AgentLoopConfig:
     allow_shared_dir: bool
     claude_cmd: str
     codex_cmd: str
+    gemini_cmd: str
     gh_cmd: str
     claude_args: tuple[str, ...]
     codex_args: tuple[str, ...]
+    gemini_args: tuple[str, ...]
     test_command: tuple[str, ...] | None
     ci_check_name: str
     ci_timeout_seconds: int
@@ -53,11 +56,20 @@ def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
 def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
     if config.allow_shared_dir:
         return
-    if config.claude_dir.resolve() == config.codex_dir.resolve():
-        raise AgentLoopError(
-            "--claude-dir and --codex-dir point to the same directory. "
-            "Use separate clones/worktrees, or pass --allow-shared-dir explicitly."
-        )
+    required: set[AgentName] = {config.coder, *reviewers(config)}
+    paths = {
+        "claude": (config.claude_dir, "--claude-dir"),
+        "codex": (config.codex_dir, "--codex-dir"),
+        "gemini": (config.gemini_dir, "--gemini-dir"),
+    }
+    active = [(agent, *paths[agent]) for agent in required]
+    for index, (_left_agent, left_path, left_option) in enumerate(active):
+        for _right_agent, right_path, right_option in active[index + 1 :]:
+            if left_path.resolve() == right_path.resolve():
+                raise AgentLoopError(
+                    f"{left_option} and {right_option} point to the same directory. "
+                    "Use separate clones/worktrees, or pass --allow-shared-dir explicitly."
+                )
 
 
 def ensure_workdir(path: Path, option_name: str) -> None:
@@ -77,6 +89,8 @@ def ensure_agent_workdirs(config: AgentLoopConfig) -> None:
         ensure_workdir(config.claude_dir, "--claude-dir")
     if "codex" in required:
         ensure_workdir(config.codex_dir, "--codex-dir")
+    if "gemini" in required:
+        ensure_workdir(config.gemini_dir, "--gemini-dir")
     ensure_distinct_workdirs(config)
 
 
@@ -103,6 +117,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         repo=repo,
         claude_dir=args.claude_dir.resolve(),
         codex_dir=codex_dir,
+        gemini_dir=args.gemini_dir.resolve(),
         coder=args.coder,
         reviewer=configured_reviewers,
         base=args.base,
@@ -112,6 +127,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         allow_shared_dir=args.allow_shared_dir,
         claude_cmd=args.claude_cmd,
         codex_cmd=args.codex_cmd,
+        gemini_cmd=args.gemini_cmd,
         gh_cmd=args.gh_cmd,
         claude_args=tuple(
             args.claude_arg
@@ -122,6 +138,11 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
             args.codex_arg
             if args.codex_arg is not None
             else default_agent_args("codex", dangerous=args.dangerous_agent_permissions)
+        ),
+        gemini_args=tuple(
+            args.gemini_arg
+            if args.gemini_arg is not None
+            else default_agent_args("gemini", dangerous=args.dangerous_agent_permissions)
         ),
         test_command=test_command,
         ci_check_name=args.ci_check_name,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from coding_review_agent_loop.agents.claude import _parse_claude_output
+from coding_review_agent_loop.agents.gemini import _parse_gemini_output
 from coding_review_agent_loop.cli import (
     AgentLoopConfig,
     AgentLoopError,
@@ -22,10 +23,19 @@ from coding_review_agent_loop.cli import (
 
 
 class FakeRunner(Runner):
-    def __init__(self, *, claude_outputs=None, codex_outputs=None, issue_payload=None, pr_payload=None):
+    def __init__(
+        self,
+        *,
+        claude_outputs=None,
+        codex_outputs=None,
+        gemini_outputs=None,
+        issue_payload=None,
+        pr_payload=None,
+    ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
         self.codex_outputs = list(codex_outputs or [])
+        self.gemini_outputs = list(gemini_outputs or [])
         self.issue_payload = issue_payload or {
             "number": 56,
             "state": "open",
@@ -68,6 +78,11 @@ class FakeRunner(Runner):
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
             return CommandResult(cmd, Path(cwd), "codex completed", "", 0)
 
+        if cmd[:1] == ["gemini"]:
+            output = self.gemini_outputs.pop(0)
+            log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
+            return CommandResult(cmd, Path(cwd), output, "", 0)
+
         return self.run(args, cwd=cwd, check=check)
 
     def run(self, args, *, cwd, input_text=None, check=True):
@@ -83,6 +98,9 @@ class FakeRunner(Runner):
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(output, encoding="utf-8")
             return CommandResult(cmd, Path(cwd), "", "", 0)
+
+        if cmd[:1] == ["gemini"]:
+            return CommandResult(cmd, Path(cwd), self.gemini_outputs.pop(0), "", 0)
 
         if cmd[:3] == ["gh", "pr", "comment"]:
             if "--body-file" in cmd:
@@ -120,6 +138,7 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         "repo": "OWNER/REPO",
         "claude_dir": tmp_path / "claude",
         "codex_dir": tmp_path / "codex",
+        "gemini_dir": tmp_path / "gemini",
         "coder": "claude",
         "reviewer": "codex",
         "base": "main",
@@ -129,9 +148,11 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         "allow_shared_dir": False,
         "claude_cmd": "claude",
         "codex_cmd": "codex",
+        "gemini_cmd": "gemini",
         "gh_cmd": "gh",
         "claude_args": (),
         "codex_args": (),
+        "gemini_args": (),
         "test_command": None,
         "ci_check_name": "test",
         "ci_timeout_seconds": 1200,
@@ -144,6 +165,7 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
     if create_dirs:
         config["claude_dir"].mkdir(parents=True, exist_ok=True)
         config["codex_dir"].mkdir(parents=True, exist_ok=True)
+        config["gemini_dir"].mkdir(parents=True, exist_ok=True)
     return AgentLoopConfig(**config)
 
 
@@ -166,6 +188,15 @@ def test_parse_claude_output_falls_back_on_non_string_result():
     text, sid = _parse_claude_output(raw)
     assert text == raw  # non-string result → fall back to raw
     assert sid == "abc"
+
+
+def test_parse_gemini_output_extracts_json_response():
+    raw = json.dumps({"response": "Reviewed.\n<!-- AGENT_STATE: approved -->"})
+    assert _parse_gemini_output(raw) == "Reviewed.\n<!-- AGENT_STATE: approved -->"
+
+
+def test_parse_gemini_output_falls_back_on_plain_text():
+    assert _parse_gemini_output("plain response") == "plain response"
 
 
 def test_parse_agent_state_accepts_html_marker():
@@ -344,6 +375,21 @@ def test_shared_workdir_requires_explicit_override(tmp_path):
         run_pr_loop(runner, pr_number=77, config=config)
 
 
+def test_gemini_shared_workdir_requires_explicit_override(tmp_path):
+    runner = FakeRunner()
+    shared = tmp_path / "repo"
+    shared.mkdir()
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        codex_dir=shared,
+        gemini_dir=shared,
+    )
+
+    with pytest.raises(AgentLoopError, match="same directory"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+
 def test_missing_agent_workdirs_are_created(tmp_path):
     runner = FakeRunner(
         claude_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"],
@@ -364,11 +410,42 @@ def test_missing_agent_workdirs_are_created(tmp_path):
     assert codex_dir.is_dir()
 
 
+def test_missing_gemini_workdir_is_created_when_configured(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"],
+    )
+    gemini_dir = tmp_path / "missing" / "gemini"
+    config = make_config(
+        tmp_path,
+        reviewer="gemini",
+        gemini_dir=gemini_dir,
+        create_dirs=False,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert gemini_dir.is_dir()
+
+
 def test_agent_workdir_existing_file_fails_clearly(tmp_path):
     runner = FakeRunner()
     claude_path = tmp_path / "claude-file"
     claude_path.write_text("not a dir", encoding="utf-8")
     config = make_config(tmp_path, claude_dir=claude_path, create_dirs=False)
+
+    with pytest.raises(AgentLoopError, match="not a directory"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+
+def test_gemini_workdir_existing_file_fails_clearly(tmp_path):
+    runner = FakeRunner()
+    gemini_path = tmp_path / "gemini-file"
+    gemini_path.write_text("not a dir", encoding="utf-8")
+    config = make_config(
+        tmp_path,
+        reviewer="gemini",
+        gemini_dir=gemini_path,
+        create_dirs=False,
+    )
 
     with pytest.raises(AgentLoopError, match="not a directory"):
         run_pr_loop(runner, pr_number=77, config=config)
@@ -420,6 +497,32 @@ def test_config_allows_coder_in_multiple_reviewers(tmp_path):
     assert config.reviewer == ("claude", "codex")
 
 
+def test_config_accepts_gemini_as_coder_and_reviewer(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "gemini",
+        "--reviewer",
+        "claude",
+        "--reviewer",
+        "gemini",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--gemini-dir",
+        str(tmp_path / "gemini"),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.coder == "gemini"
+    assert config.reviewer == ("claude", "gemini")
+    assert config.gemini_dir == tmp_path / "gemini"
+
+
 def test_config_rejects_duplicate_reviewers(tmp_path):
     parser = build_parser()
     args = parser.parse_args([
@@ -455,6 +558,7 @@ def test_config_defaults_do_not_bypass_agent_permissions(tmp_path):
 
     assert config.claude_args == ()
     assert config.codex_args == ()
+    assert config.gemini_args == ()
 
 
 def test_config_can_opt_into_dangerous_agent_permissions(tmp_path):
@@ -474,6 +578,7 @@ def test_config_can_opt_into_dangerous_agent_permissions(tmp_path):
 
     assert config.claude_args == ("--dangerously-skip-permissions",)
     assert config.codex_args == ("--dangerously-bypass-approvals-and-sandbox",)
+    assert config.gemini_args == ("--yolo",)
 
 
 def test_explicit_agent_args_replace_dangerous_profile(tmp_path):
@@ -492,11 +597,14 @@ def test_explicit_agent_args_replace_dangerous_profile(tmp_path):
         "--claude-arg=acceptEdits",
         "--codex-arg=--sandbox",
         "--codex-arg=workspace-write",
+        "--gemini-arg=--approval-mode",
+        "--gemini-arg=auto_edit",
     ])
     config = config_from_args(args, FakeRunner())
 
     assert config.claude_args == ("--permission-mode", "acceptEdits")
     assert config.codex_args == ("--sandbox", "workspace-write")
+    assert config.gemini_args == ("--approval-mode", "auto_edit")
 
 
 def test_issue_loop_requires_claude_to_report_pr_number(tmp_path):
@@ -775,6 +883,47 @@ def test_codex_task_loop_picks_up_pr_url_when_marker_missing(tmp_path):
     config = make_config(tmp_path, coder="codex", reviewer="claude")
 
     assert run_task_loop(runner, task_text="Tighten rate limiter.", config=config) == 0
+
+
+def test_gemini_issue_loop_creates_pr_then_codex_approves(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=[
+            "Fixed issue.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
+        ],
+        codex_outputs=[
+            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, coder="gemini", reviewer="codex")
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["gemini"], ["codex"])]
+    assert agent_commands == [["gemini", "--prompt"], ["codex", "exec"]]
+    assert len(runner.comments) == 2
+    assert runner.comments[0].startswith("Fixed issue.")
+    assert runner.comments[1].startswith("Looks good.")
+
+
+def test_gemini_review_loop_uses_prompt_and_extra_args(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=[
+            json.dumps({"response": "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"}),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer="gemini",
+        gemini_args=("--output-format", "json", "--model", "gemini-2.5-flash"),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    gemini_call = next(cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"])
+    assert gemini_call[:2] == ["gemini", "--prompt"]
+    assert "--output-format" in gemini_call
+    assert "--model" in gemini_call
+    assert runner.comments == ["LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"]
 
 
 def test_codex_task_loop_rejects_empty_task_text(tmp_path):


### PR DESCRIPTION
## Summary
- add a Gemini CLI backend using headless `gemini --prompt` invocation
- wire Gemini config, CLI flags, registry metadata, workdir validation, and dangerous-permission defaults
- document Gemini setup and add fake-runner tests for config, invocation, marker handling, and workdirs

## Tests
- `python -m pytest`

Closes #4