### PR TITLE
Sanitize Gemini CLI preamble from PR comments

### DIFF
--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,24 @@ from ..runner import Runner
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
+
+
+_AGENT_STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(?:approved|blocking)\s*-->", re.I)
+
+
+def _strip_gemini_preamble(raw: str) -> str:
+    """Drop Gemini CLI diagnostics that can appear before the final response."""
+    state_matches = list(_AGENT_STATE_RE.finditer(raw))
+    if not state_matches:
+        return raw
+
+    public_end = state_matches[-1].start()
+    separator = "\n---\n"
+    separator_at = raw.rfind(separator, 0, public_end)
+    if separator_at == -1:
+        return raw
+
+    return raw[separator_at + len(separator) :].lstrip()
 
 
 def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
@@ -26,7 +45,8 @@ def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
             return text, session_id if isinstance(session_id, str) else None
     except (json.JSONDecodeError, ValueError):
         pass
-    return raw, None
+    return _strip_gemini_preamble(raw), None
+
 
 
 class GeminiBackend:

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -3,34 +3,31 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .base import AgentName, AgentResult
 from ..logging import agent_log_path, log
+from ..protocol import CLARIFY_RE, STATE_RE
 from ..runner import Runner
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
 
-_AGENT_STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(?:approved|blocking)\s*-->", re.I)
-
-
 def _strip_gemini_preamble(raw: str) -> str:
     """Drop Gemini CLI diagnostics that can appear before the final response."""
-    state_matches = list(_AGENT_STATE_RE.finditer(raw))
-    if not state_matches:
+    marker_matches = [*STATE_RE.finditer(raw), *CLARIFY_RE.finditer(raw)]
+    if not marker_matches:
         return raw
 
-    public_end = state_matches[-1].start()
+    public_end = max(match.start() for match in marker_matches)
     separator = "\n---\n"
-    separator_at = raw.rfind(separator, 0, public_end)
+    separator_at = raw.find(separator, 0, public_end)
     if separator_at == -1:
         return raw
 
-    return raw[separator_at + len(separator) :].lstrip()
+    return raw[separator_at + len(separator) :].lstrip("\n")
 
 
 def _parse_gemini_output(raw: str) -> tuple[str, str | None]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -239,6 +239,48 @@ Looks good.
     assert sid is None
 
 
+def test_parse_gemini_output_preserves_markdown_rules_after_preamble():
+    raw = """Warning: True color (24-bit) support not detected.
+YOLO mode is enabled.
+
+---
+
+## Summary
+
+Reviewed the change.
+
+---
+
+## Details
+
+Still looks good.
+
+<!-- AGENT_STATE: approved -->
+"""
+    text, sid = _parse_gemini_output(raw)
+    assert text.startswith("## Summary")
+    assert "YOLO mode" not in text
+    assert "## Details" in text
+    assert "\n---\n\n## Details" in text
+    assert sid is None
+
+
+def test_parse_gemini_output_strips_preamble_before_clarification_marker():
+    raw = """Warning: True color (24-bit) support not detected.
+I need to ask a question.
+
+---
+
+    Which endpoint should I update?
+<!-- AGENT_CLARIFY -->
+"""
+    text, sid = _parse_gemini_output(raw)
+    assert text.startswith("    Which endpoint")
+    assert "True color" not in text
+    assert "<!-- AGENT_CLARIFY -->" in text
+    assert sid is None
+
+
 def test_parse_agent_state_accepts_html_marker():
     assert parse_agent_state("looks fine\n<!-- AGENT_STATE: approved -->") == "approved"
     assert parse_agent_state("needs work\n<!-- agent_state: BLOCKING -->") == "blocking"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -210,6 +210,35 @@ def test_parse_gemini_output_falls_back_on_non_string_response():
     assert sid == "gemini-session-1"
 
 
+def test_parse_gemini_output_strips_cli_preamble_before_final_response():
+    raw = """Warning: True color (24-bit) support not detected.
+YOLO mode is enabled. All tool calls will be automatically approved.
+Attempt 1 failed with status 429. Retrying with backoff... _GaxiosError: [{
+  "error": {
+    "code": 429,
+    "message": "No capacity available for model gemini-3-flash-preview on the server"
+  }
+}]
+I am now ready to provide my final response.
+
+---
+
+## Code Review
+
+Looks good.
+
+<!-- AGENT_STATE: approved -->
+
+-- Google Gemini
+"""
+    text, sid = _parse_gemini_output(raw)
+    assert text.startswith("## Code Review")
+    assert "_GaxiosError" not in text
+    assert "YOLO mode" not in text
+    assert "<!-- AGENT_STATE: approved -->" in text
+    assert sid is None
+
+
 def test_parse_agent_state_accepts_html_marker():
     assert parse_agent_state("looks fine\n<!-- AGENT_STATE: approved -->") == "approved"
     assert parse_agent_state("needs work\n<!-- agent_state: BLOCKING -->") == "blocking"
@@ -923,6 +952,8 @@ def test_gemini_issue_loop_resumes_session_for_followup(tmp_path):
                 "response": "Fixed issue.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
                 "session_id": "gemini-session-1",
             }),
+            # Plain-text output intentionally clears the tracked session; a third
+            # Gemini turn would start without --resume.
             "Addressed review.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
         ],
         codex_outputs=[


### PR DESCRIPTION
## Summary
- strip Gemini CLI diagnostic preambles before the final public response when JSON parsing falls back to plain text
- add regression coverage for the noisy Gemini review output shape seen on PR #8
- document the existing plain-text follow-up session behavior in the Gemini resume test

## Notes
- Assumes noisy Gemini final responses are separated from CLI diagnostics by a markdown `---` divider before the required `<!-- AGENT_STATE: ... -->` marker, matching the PR #8 Gemini comment.

## Tests
- `python -m pytest`