### PR TITLE
Default omitted agent dirs to temp checkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,21 +94,29 @@ Start from a GitHub issue when you want the agent loop to use the issue title
 and body as the implementation task:
 
 ```bash
-agent-loop issue 123 --repo OWNER/REPO --claude-dir /path/to/claude/repo --codex-dir /path/to/codex/repo
+agent-loop issue 123 --repo OWNER/REPO
 ```
 
 Provide a one-off task directly when there is no issue yet:
 
 ```bash
-agent-loop task "Add a health check endpoint" --repo OWNER/REPO --claude-dir /path/to/claude/repo --codex-dir /path/to/codex/repo
+agent-loop task "Add a health check endpoint" --repo OWNER/REPO
 ```
 
 Run the loop against an existing pull request when you want another review and
 iteration pass:
 
 ```bash
-agent-loop pr 456 --repo OWNER/REPO --claude-dir /path/to/claude/repo --codex-dir /path/to/codex/repo
+agent-loop pr 456 --repo OWNER/REPO
 ```
+
+When `--claude-dir`, `--codex-dir`, or `--gemini-dir` is omitted for an active
+agent, the tool creates or reuses a repo-scoped temporary checkout such as
+`/tmp/coding-review-agent-loop/OWNER-REPO/codex/repo`. Existing clean temp
+checkouts are fetched and fast-forwarded on the base branch before the agent
+runs; dirty temp checkouts fail clearly instead of being overwritten. Use
+explicit persistent directories for large repositories, long-lived agent
+worktrees, or setups that should survive `/tmp` cleanup or reboot.
 
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
@@ -122,14 +130,11 @@ Use Gemini as either side of the loop:
 agent-loop task "Improve error handling" \
   --repo OWNER/REPO \
   --coder gemini \
-  --reviewer codex \
-  --gemini-dir /path/to/gemini/repo \
-  --codex-dir /path/to/codex/repo
+  --reviewer codex
 
 agent-loop pr 456 \
   --repo OWNER/REPO \
-  --reviewer gemini \
-  --gemini-dir /path/to/gemini/repo
+  --reviewer gemini
 ```
 
 Repeat `--reviewer` to require approvals from multiple reviewers. The PR is

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -25,35 +25,27 @@ Currently supported local agent CLIs:
 - `claude` is installed and authenticated if either side uses Claude.
 - `codex` is installed and authenticated if either side uses Codex.
 - `gemini` is installed and authenticated if either side uses Gemini.
-- Use separate clones or worktrees for each active agent to avoid local file conflicts. Missing `--claude-dir` / `--codex-dir` / `--gemini-dir` directories are created automatically; paths that already exist as files fail clearly.
+- Use separate clones or worktrees for each active agent to avoid local file conflicts. If you omit `--claude-dir`, `--codex-dir`, or `--gemini-dir` for an active agent, the tool uses a repo-scoped temporary checkout under `/tmp/coding-review-agent-loop/OWNER-REPO/{agent}/repo`.
 
 ## Usage
 
 Fix a GitHub issue:
 
 ```bash
-agent-loop issue 56 \
-  --repo OWNER/REPO \
-  --claude-dir /path/to/claude/worktree \
-  --codex-dir /path/to/codex/worktree
+agent-loop issue 56 --repo OWNER/REPO
 ```
 
 Implement a free-form task:
 
 ```bash
 agent-loop task "Add a /healthz endpoint that returns 200 OK." \
-  --repo OWNER/REPO \
-  --claude-dir /path/to/claude/worktree \
-  --codex-dir /path/to/codex/worktree
+  --repo OWNER/REPO
 ```
 
 Review an existing PR:
 
 ```bash
-agent-loop pr 123 \
-  --repo OWNER/REPO \
-  --claude-dir /path/to/claude/worktree \
-  --codex-dir /path/to/codex/worktree
+agent-loop pr 123 --repo OWNER/REPO
 ```
 
 Reverse the direction so Codex creates/fixes and Claude reviews:
@@ -62,9 +54,7 @@ Reverse the direction so Codex creates/fixes and Claude reviews:
 agent-loop task "Refactor the cache layer" \
   --repo OWNER/REPO \
   --coder codex \
-  --reviewer claude \
-  --claude-dir /path/to/claude/worktree \
-  --codex-dir /path/to/codex/worktree
+  --reviewer claude
 ```
 
 Use Gemini as the coder. Gemini is invoked in headless mode with `gemini --prompt`:
@@ -73,9 +63,7 @@ Use Gemini as the coder. Gemini is invoked in headless mode with `gemini --promp
 agent-loop task "Improve validation errors" \
   --repo OWNER/REPO \
   --coder gemini \
-  --reviewer codex \
-  --gemini-dir /path/to/gemini/worktree \
-  --codex-dir /path/to/codex/worktree
+  --reviewer codex
 ```
 
 Use Gemini as one reviewer:
@@ -84,9 +72,7 @@ Use Gemini as one reviewer:
 agent-loop pr 123 \
   --repo OWNER/REPO \
   --reviewer codex \
-  --reviewer gemini \
-  --codex-dir /path/to/codex/worktree \
-  --gemini-dir /path/to/gemini/worktree
+  --reviewer gemini
 ```
 
 Require both reviewers to approve. The coder may also be listed as a reviewer
@@ -96,10 +82,34 @@ when you want the same agent to work in separate coding and review passes:
 agent-loop pr 123 \
   --repo OWNER/REPO \
   --reviewer codex \
-  --reviewer claude \
-  --claude-dir /path/to/claude/worktree \
-  --codex-dir /path/to/codex/worktree
+  --reviewer claude
 ```
+
+## Workdirs
+
+Explicit `--claude-dir`, `--codex-dir`, and `--gemini-dir` values are used
+exactly as provided. Missing explicit directories are still created for
+backwards compatibility.
+
+When an active agent directory is omitted, the default checkout path is scoped
+by repo and agent:
+
+```text
+/tmp/coding-review-agent-loop/OWNER-REPO/claude/repo
+/tmp/coding-review-agent-loop/OWNER-REPO/codex/repo
+/tmp/coding-review-agent-loop/OWNER-REPO/gemini/repo
+```
+
+The tool prints the selected default workdirs. If a default checkout does not
+exist, it runs `gh repo clone OWNER/REPO <path>`. If it already exists and is a
+clean checkout for the requested repo, it fetches origin and fast-forwards the
+configured base branch. If the checkout is dirty, points at another repo, or is
+not a git checkout, the command fails clearly instead of overwriting local
+work.
+
+These temporary checkouts may disappear after reboot or `/tmp` cleanup. Large
+projects and long-lived agent setups should use explicit persistent workdirs to
+avoid repeated clone, dependency setup, and indexing costs.
 
 ## Real Example
 

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -15,8 +15,39 @@ if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
 
+PUBLIC_RESPONSE_MARKER = "=== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ==="
+
+
+def _with_public_response_marker_instruction(prompt: str) -> str:
+    return f"""{prompt}
+
+IMPORTANT FOR GEMINI CLI OUTPUT FILTERING:
+
+Gemini CLI may print tool-use narration, diagnostics, or internal status text
+before your final answer.
+
+When you are ready to provide the response that should be posted publicly to
+GitHub, print this exact line immediately before it:
+
+{PUBLIC_RESPONSE_MARKER}
+
+Only content after that line will be posted to GitHub. Do not print the marker
+until you are done with all internal reasoning, tool use, and review work.
+"""
+
+
+def _strip_public_response_marker(raw: str) -> str:
+    if PUBLIC_RESPONSE_MARKER not in raw:
+        return raw
+    return raw.rsplit(PUBLIC_RESPONSE_MARKER, 1)[1].lstrip("\n")
+
+
 def _strip_gemini_preamble(raw: str) -> str:
     """Drop Gemini CLI diagnostics that can appear before the final response."""
+    marker_stripped = _strip_public_response_marker(raw)
+    if marker_stripped != raw:
+        return marker_stripped
+
     marker_matches = [*STATE_RE.finditer(raw), *CLARIFY_RE.finditer(raw)]
     if not marker_matches:
         return raw
@@ -39,7 +70,7 @@ def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
             if not isinstance(text, str):
                 text = raw
             session_id = data.get("session_id")
-            return text, session_id if isinstance(session_id, str) else None
+            return _strip_gemini_preamble(text), session_id if isinstance(session_id, str) else None
     except (json.JSONDecodeError, ValueError):
         pass
     return _strip_gemini_preamble(raw), None
@@ -66,7 +97,12 @@ class GeminiBackend:
     ) -> AgentResult:
         log_path = agent_log_path(config, "gemini")
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}")
-        args = [config.gemini_cmd, "--prompt", prompt, *config.gemini_args]
+        args = [
+            config.gemini_cmd,
+            "--prompt",
+            _with_public_response_marker_instruction(prompt),
+            *config.gemini_args,
+        ]
         if session_id:
             args += ["--resume", session_id]
         result = runner.run_with_log(

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -63,9 +63,24 @@ def build_parser() -> argparse.ArgumentParser:
     def add_common(subparser: argparse.ArgumentParser) -> None:
         subparser.add_argument("--repo", help="GitHub repo as owner/name. Defaults to gh repo view.")
         subparser.add_argument("--base", default="main", help="PR base branch for new issue work.")
-        subparser.add_argument("--claude-dir", type=Path, default=Path.cwd())
-        subparser.add_argument("--codex-dir", type=Path, default=Path.cwd())
-        subparser.add_argument("--gemini-dir", type=Path, default=Path.cwd())
+        subparser.add_argument(
+            "--claude-dir",
+            type=Path,
+            default=None,
+            help="Claude checkout. Defaults to a repo-scoped temporary checkout when Claude is active.",
+        )
+        subparser.add_argument(
+            "--codex-dir",
+            type=Path,
+            default=None,
+            help="Codex checkout. Defaults to a repo-scoped temporary checkout when Codex is active.",
+        )
+        subparser.add_argument(
+            "--gemini-dir",
+            type=Path,
+            default=None,
+            help="Gemini checkout. Defaults to a repo-scoped temporary checkout when Gemini is active.",
+        )
         subparser.add_argument(
             "--coder",
             choices=("claude", "codex", "gemini"),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -202,6 +202,11 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         if args.gemini_dir is not None
         else default_agent_workdir(repo, "gemini").resolve()
     )
+    primary_dir = {
+        "claude": claude_dir,
+        "codex": codex_dir,
+        "gemini": gemini_dir,
+    }[args.coder]
     test_command = _split_command(args.test_command)
     if args.ci_timeout_seconds <= 0:
         raise AgentLoopError("--ci-timeout-seconds must be greater than zero.")
@@ -245,7 +250,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
         quiet=args.quiet,
-        log_dir=(codex_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
+        log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
         progress_interval_seconds=args.progress_interval_seconds,
         auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import shlex
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from .agents.base import AgentName
 from .agents.registry import default_agent_args
 from .errors import AgentLoopError
 from .github import detect_repo
+from .logging import log
 from .runner import Runner
 
 
@@ -41,6 +43,7 @@ class AgentLoopConfig:
     quiet: bool
     log_dir: Path
     progress_interval_seconds: int
+    auto_agent_dirs: tuple[AgentName, ...] = ()
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -72,6 +75,15 @@ def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
                 )
 
 
+def default_agent_workdir(repo: str, agent: AgentName) -> Path:
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise AgentLoopError("--repo must use the OWNER/REPO format.")
+    owner, name = parts
+    repo_slug = f"{owner}-{name}"
+    return Path(tempfile.gettempdir()) / "coding-review-agent-loop" / repo_slug / agent / "repo"
+
+
 def ensure_workdir(path: Path, option_name: str) -> None:
     if path.exists():
         if not path.is_dir():
@@ -83,14 +95,73 @@ def ensure_workdir(path: Path, option_name: str) -> None:
         raise AgentLoopError(f"Could not create {option_name} at {path}: {exc}") from exc
 
 
-def ensure_agent_workdirs(config: AgentLoopConfig) -> None:
+def _looks_like_repo_remote(remote_url: str, repo: str) -> bool:
+    normalized = remote_url.strip().removesuffix(".git").lower()
+    repo = repo.lower()
+    return normalized.endswith(f"/{repo}") or normalized.endswith(f":{repo}")
+
+
+def _run_git(runner: Runner, path: Path, args: tuple[str, ...], *, check: bool = True):
+    return runner.run(("git", *args), cwd=path, check=check)
+
+
+def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfig, runner: Runner) -> None:
+    if not path.exists():
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise AgentLoopError(f"Could not create parent directory for {agent} checkout at {path}: {exc}") from exc
+        runner.run((config.gh_cmd, "repo", "clone", config.repo, str(path)), cwd=path.parent)
+        if runner.dry_run:
+            return
+
+    if not path.is_dir():
+        raise AgentLoopError(f"Default {agent} workdir exists but is not a directory: {path}")
+
+    git_check = _run_git(runner, path, ("rev-parse", "--is-inside-work-tree"), check=False)
+    if git_check.returncode != 0 or git_check.stdout.strip() != "true":
+        raise AgentLoopError(
+            f"Default {agent} workdir exists but is not a git checkout: {path}. "
+            "Remove it or pass an explicit agent directory."
+        )
+
+    remote = _run_git(runner, path, ("remote", "get-url", "origin")).stdout.strip()
+    if not _looks_like_repo_remote(remote, config.repo):
+        raise AgentLoopError(
+            f"Default {agent} workdir at {path} uses origin {remote!r}, not {config.repo!r}."
+        )
+
+    status = _run_git(runner, path, ("status", "--porcelain")).stdout.strip()
+    if status:
+        raise AgentLoopError(
+            f"Default {agent} workdir is dirty: {path}. "
+            "Commit, stash, or clean it before rerunning, or pass an explicit agent directory."
+        )
+
+    _run_git(runner, path, ("fetch", "origin"))
+    checkout = _run_git(runner, path, ("checkout", config.base), check=False)
+    if checkout.returncode != 0:
+        _run_git(runner, path, ("checkout", "-B", config.base, f"origin/{config.base}"))
+    _run_git(runner, path, ("pull", "--ff-only", "origin", config.base))
+
+
+def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner | None = None) -> None:
     required: set[AgentName] = {config.coder, *reviewers(config)}
-    if "claude" in required:
-        ensure_workdir(config.claude_dir, "--claude-dir")
-    if "codex" in required:
-        ensure_workdir(config.codex_dir, "--codex-dir")
-    if "gemini" in required:
-        ensure_workdir(config.gemini_dir, "--gemini-dir")
+    paths = {
+        "claude": (config.claude_dir, "--claude-dir"),
+        "codex": (config.codex_dir, "--codex-dir"),
+        "gemini": (config.gemini_dir, "--gemini-dir"),
+    }
+    auto_dirs = set(config.auto_agent_dirs)
+    for agent in required:
+        path, option = paths[agent]
+        if agent in auto_dirs:
+            if runner is None:
+                raise AgentLoopError("Internal error: runner is required for default agent checkouts.")
+            log(config, f"Using default {agent} workdir: {path}")
+            ensure_temp_checkout(path, agent=agent, config=config, runner=runner)
+        else:
+            ensure_workdir(path, option)
     ensure_distinct_workdirs(config)
 
 
@@ -101,8 +172,36 @@ def _split_command(value: str | None) -> tuple[str, ...] | None:
 
 
 def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfig:
-    codex_dir = args.codex_dir.resolve()
-    repo = args.repo or detect_repo(runner, codex_dir, args.gh_cmd)
+    configured_reviewers = tuple(args.reviewer or ["codex"])
+    if len(set(configured_reviewers)) != len(configured_reviewers):
+        raise AgentLoopError("--reviewer cannot include the same agent more than once.")
+
+    detect_dir = args.codex_dir.resolve() if args.codex_dir is not None else Path.cwd().resolve()
+    repo = args.repo or detect_repo(runner, detect_dir, args.gh_cmd)
+    auto_agent_dirs = tuple(
+        agent
+        for agent, value in (
+            ("claude", args.claude_dir),
+            ("codex", args.codex_dir),
+            ("gemini", args.gemini_dir),
+        )
+        if value is None
+    )
+    claude_dir = (
+        args.claude_dir.resolve()
+        if args.claude_dir is not None
+        else default_agent_workdir(repo, "claude").resolve()
+    )
+    codex_dir = (
+        args.codex_dir.resolve()
+        if args.codex_dir is not None
+        else default_agent_workdir(repo, "codex").resolve()
+    )
+    gemini_dir = (
+        args.gemini_dir.resolve()
+        if args.gemini_dir is not None
+        else default_agent_workdir(repo, "gemini").resolve()
+    )
     test_command = _split_command(args.test_command)
     if args.ci_timeout_seconds <= 0:
         raise AgentLoopError("--ci-timeout-seconds must be greater than zero.")
@@ -110,14 +209,11 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
     if args.progress_interval_seconds <= 0:
         raise AgentLoopError("--progress-interval-seconds must be greater than zero.")
-    configured_reviewers = tuple(args.reviewer or ["codex"])
-    if len(set(configured_reviewers)) != len(configured_reviewers):
-        raise AgentLoopError("--reviewer cannot include the same agent more than once.")
     return AgentLoopConfig(
         repo=repo,
-        claude_dir=args.claude_dir.resolve(),
+        claude_dir=claude_dir,
         codex_dir=codex_dir,
-        gemini_dir=args.gemini_dir.resolve(),
+        gemini_dir=gemini_dir,
         coder=args.coder,
         reviewer=configured_reviewers,
         base=args.base,
@@ -151,4 +247,5 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         quiet=args.quiet,
         log_dir=(codex_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
         progress_interval_seconds=args.progress_interval_seconds,
+        auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from .errors import AgentLoopError
 from .logging import log
 from .runner import Runner
+from .workdirs import active_workdir
 
 if TYPE_CHECKING:
     from .config import AgentLoopConfig
@@ -41,7 +42,7 @@ def validate_open_pr(runner: Runner, *, config: AgentLoopConfig, pr_number: int)
             "--json",
             "number,state,url",
         ],
-        cwd=config.codex_dir,
+        cwd=active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
     if data.get("state") != "OPEN":
@@ -61,7 +62,7 @@ def validate_open_issue(runner: Runner, *, config: AgentLoopConfig, issue_number
             "--jq",
             "{number:.number,state:.state,is_pr:has(\"pull_request\"),url:.html_url}",
         ],
-        cwd=config.codex_dir,
+        cwd=active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
     if data.get("is_pr"):
@@ -85,7 +86,7 @@ def post_pr_comment(
     if config.dry_run:
         runner.run(
             [config.gh_cmd, "pr", "comment", str(pr_number), "--repo", config.repo, "--body", body],
-            cwd=config.codex_dir,
+            cwd=active_workdir(config),
         )
         return
 
@@ -104,7 +105,7 @@ def post_pr_comment(
                 "--body-file",
                 path,
             ],
-            cwd=config.codex_dir,
+            cwd=active_workdir(config),
         )
     finally:
         try:
@@ -127,7 +128,7 @@ def get_pr_head_sha(runner: Runner, config: AgentLoopConfig, pr_number: int) -> 
             "--jq",
             ".headRefOid",
         ],
-        cwd=config.codex_dir,
+        cwd=active_workdir(config),
     )
     sha = result.stdout.strip()
     if not sha:
@@ -147,7 +148,7 @@ def get_check_status(runner: Runner, config: AgentLoopConfig, head_sha: str) -> 
                 'if length == 0 then "pending" else .[0].conclusion // .[0].status end'
             ),
         ],
-        cwd=config.codex_dir,
+        cwd=active_workdir(config),
     )
     return result.stdout.strip() or "pending"
 
@@ -172,7 +173,7 @@ def wait_for_ci(runner: Runner, config: AgentLoopConfig, pr_number: int) -> None
         if status in terminal_failures:
             raise AgentLoopError(f"CI check '{config.ci_check_name}' failed with status: {status}")
         if attempt < attempts - 1:
-            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=config.codex_dir)
+            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
     raise AgentLoopError(
         f"CI check '{config.ci_check_name}' did not pass within {config.ci_timeout_seconds}s"
     )
@@ -182,5 +183,5 @@ def merge_pr(runner: Runner, config: AgentLoopConfig, pr_number: int) -> None:
     log(config, f"Merging PR #{pr_number}")
     runner.run(
         [config.gh_cmd, "pr", "merge", str(pr_number), "--repo", config.repo, "--merge"],
-        cwd=config.codex_dir,
+        cwd=active_workdir(config),
     )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -37,7 +37,7 @@ def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
 
 
 def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig) -> int:
-    ensure_agent_workdirs(config)
+    ensure_agent_workdirs(config, runner)
     log(config, f"Validating issue #{issue_number}")
     validate_open_issue(runner, config=config, issue_number=issue_number)
 
@@ -61,6 +61,7 @@ def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig
         pr_number=pr_number,
         config=config,
         coder_session_id=coder_session_id,
+        workdirs_ready=True,
     )
 
 
@@ -91,7 +92,7 @@ def run_task_loop(
     max_clarification_rounds: int = 3,
     clarification_input=None,
 ) -> int:
-    ensure_agent_workdirs(config)
+    ensure_agent_workdirs(config, runner)
     if not task_text.strip():
         raise AgentLoopError("Task text is empty; provide a non-empty description.")
     if max_clarification_rounds < 0:
@@ -125,6 +126,7 @@ def run_task_loop(
                 pr_number=pr_number,
                 config=config,
                 coder_session_id=session_id,
+                workdirs_ready=True,
             )
 
         if not is_clarification_request(coder_output):
@@ -165,8 +167,10 @@ def run_pr_loop(
     config: AgentLoopConfig,
     coder_session_id: str | None = None,
     reviewer_session_id: str | None = None,
+    workdirs_ready: bool = False,
 ) -> int:
-    ensure_agent_workdirs(config)
+    if not workdirs_ready:
+        ensure_agent_workdirs(config, runner)
     log(config, f"Validating PR #{pr_number}")
     validate_open_pr(runner, config=config, pr_number=pr_number)
     reviewer_session_ids: dict[AgentName, str | None] = {}

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -26,13 +26,14 @@ from .prompts import (
 )
 from .protocol import is_clarification_request, parse_agent_state, parse_pr_number
 from .runner import Runner
+from .workdirs import active_workdir
 
 
 def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
     if not config.test_command:
         return
     log(config, f"Running local test command: {' '.join(config.test_command)}")
-    runner.run(config.test_command, cwd=config.codex_dir)
+    runner.run(config.test_command, cwd=active_workdir(config))
     log(config, "Local test command passed")
 
 

--- a/src/coding_review_agent_loop/workdirs.py
+++ b/src/coding_review_agent_loop/workdirs.py
@@ -1,0 +1,24 @@
+"""Helpers for selecting configured agent work directories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .agents.base import AgentName
+
+if TYPE_CHECKING:
+    from .config import AgentLoopConfig
+
+
+def agent_workdir(config: AgentLoopConfig, agent: AgentName) -> Path:
+    return {
+        "claude": config.claude_dir,
+        "codex": config.codex_dir,
+        "gemini": config.gemini_dir,
+    }[agent]
+
+
+def active_workdir(config: AgentLoopConfig) -> Path:
+    """Return an initialized checkout that participates in the current loop."""
+    return agent_workdir(config, config.coder)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -55,6 +55,14 @@ class FakeRunner(Runner):
         self.git_status = git_status
         self.git_remote = git_remote
 
+    def _record_command(self, args, cwd):
+        cmd = [str(arg) for arg in args]
+        cwd_path = Path(cwd)
+        if not cwd_path.is_dir():
+            raise FileNotFoundError(cwd_path)
+        self.commands.append((cmd, cwd_path))
+        return cmd, cwd_path
+
     def run_with_log(
         self,
         args,
@@ -65,15 +73,14 @@ class FakeRunner(Runner):
         progress_interval_seconds,
         check=True,
     ):
-        cmd = [str(arg) for arg in args]
-        self.commands.append((cmd, Path(cwd)))
+        cmd, cwd_path = self._record_command(args, cwd)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_log_dir_ignored(log_path.parent)
 
         if cmd[:1] == ["claude"]:
             output = self.claude_outputs.pop(0)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
-            return CommandResult(cmd, Path(cwd), output, "", 0)
+            return CommandResult(cmd, cwd_path, output, "", 0)
 
         if cmd[:2] == ["codex", "exec"]:
             output = self.codex_outputs.pop(0)
@@ -81,28 +88,27 @@ class FakeRunner(Runner):
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(output, encoding="utf-8")
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
-            return CommandResult(cmd, Path(cwd), "codex completed", "", 0)
+            return CommandResult(cmd, cwd_path, "codex completed", "", 0)
 
         if cmd[:1] == ["gemini"]:
             output = self.gemini_outputs.pop(0)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
-            return CommandResult(cmd, Path(cwd), output, "", 0)
+            return CommandResult(cmd, cwd_path, output, "", 0)
 
         return self.run(args, cwd=cwd, check=check)
 
     def run(self, args, *, cwd, input_text=None, check=True):
-        cmd = [str(arg) for arg in args]
-        self.commands.append((cmd, Path(cwd)))
+        cmd, cwd_path = self._record_command(args, cwd)
 
         if cmd[:1] == ["claude"]:
-            return CommandResult(cmd, Path(cwd), self.claude_outputs.pop(0), "", 0)
+            return CommandResult(cmd, cwd_path, self.claude_outputs.pop(0), "", 0)
 
         if cmd[:2] == ["codex", "exec"]:
             output = self.codex_outputs.pop(0)
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(output, encoding="utf-8")
-            return CommandResult(cmd, Path(cwd), "", "", 0)
+            return CommandResult(cmd, cwd_path, "", "", 0)
 
         if cmd[:3] == ["gh", "pr", "comment"]:
             if "--body-file" in cmd:
@@ -110,36 +116,36 @@ class FakeRunner(Runner):
                 self.comments.append(body_path.read_text(encoding="utf-8"))
             elif "--body" in cmd:
                 self.comments.append(cmd[cmd.index("--body") + 1])
-            return CommandResult(cmd, Path(cwd), "", "", 0)
+            return CommandResult(cmd, cwd_path, "", "", 0)
 
         if cmd[:3] == ["gh", "pr", "view"]:
             if "--jq" in cmd and ".headRefOid" in cmd:
-                return CommandResult(cmd, Path(cwd), "abc123\n", "", 0)
-            return CommandResult(cmd, Path(cwd), json_dumps(self.pr_payload), "", 0)
+                return CommandResult(cmd, cwd_path, "abc123\n", "", 0)
+            return CommandResult(cmd, cwd_path, json_dumps(self.pr_payload), "", 0)
 
         if cmd[:2] == ["gh", "api"] and "/issues/" in cmd[2]:
-            return CommandResult(cmd, Path(cwd), json_dumps(self.issue_payload), "", 0)
+            return CommandResult(cmd, cwd_path, json_dumps(self.issue_payload), "", 0)
 
         if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs"):
-            return CommandResult(cmd, Path(cwd), "success\n", "", 0)
+            return CommandResult(cmd, cwd_path, "success\n", "", 0)
 
         if cmd[:1] == ["sleep"]:
-            return CommandResult(cmd, Path(cwd), "", "", 0)
+            return CommandResult(cmd, cwd_path, "", "", 0)
 
         if cmd[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
-            return CommandResult(cmd, Path(cwd), "true\n", "", 0)
+            return CommandResult(cmd, cwd_path, "true\n", "", 0)
 
         if cmd[:4] == ["git", "remote", "get-url", "origin"]:
-            return CommandResult(cmd, Path(cwd), f"{self.git_remote}\n", "", 0)
+            return CommandResult(cmd, cwd_path, f"{self.git_remote}\n", "", 0)
 
         if cmd[:3] == ["git", "status", "--porcelain"]:
-            return CommandResult(cmd, Path(cwd), self.git_status, "", 0)
+            return CommandResult(cmd, cwd_path, self.git_status, "", 0)
 
         if cmd[:3] == ["gh", "repo", "clone"]:
             Path(cmd[4]).mkdir(parents=True, exist_ok=True)
-            return CommandResult(cmd, Path(cwd), "", "", 0)
+            return CommandResult(cmd, cwd_path, "", "", 0)
 
-        return CommandResult(cmd, Path(cwd), "", "", 0)
+        return CommandResult(cmd, cwd_path, "", "", 0)
 
 
 def json_dumps(value):
@@ -526,6 +532,34 @@ def test_missing_gemini_workdir_is_created_when_configured(tmp_path):
     assert gemini_dir.is_dir()
 
 
+def test_non_codex_loop_uses_active_workdir_for_github_and_tests(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"],
+    )
+    codex_dir = tmp_path / "inactive" / "codex"
+    config = make_config(
+        tmp_path,
+        claude_dir=tmp_path / "missing" / "claude",
+        codex_dir=codex_dir,
+        gemini_dir=tmp_path / "missing" / "gemini",
+        coder="claude",
+        reviewer="gemini",
+        test_command=("pytest", "tests/test_agent_loop.py"),
+        create_dirs=False,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not codex_dir.exists()
+    github_or_test_cwds = [
+        cwd
+        for cmd, cwd in runner.commands
+        if cmd[:1] == ["gh"] or cmd == ["pytest", "tests/test_agent_loop.py"]
+    ]
+    assert github_or_test_cwds
+    assert set(github_or_test_cwds) == {config.claude_dir}
+
+
 def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts():
     parser = build_parser()
     args = parser.parse_args([
@@ -568,6 +602,27 @@ def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):
     assert config.codex_dir == codex_dir
     assert config.claude_dir == default_agent_workdir("OWNER/REPO", "claude").resolve()
     assert set(config.auto_agent_dirs) == {"claude", "gemini"}
+
+
+def test_relative_log_dir_defaults_under_active_coder_workdir(tmp_path):
+    parser = build_parser()
+    claude_dir = tmp_path / "claude"
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "claude",
+        "--reviewer",
+        "gemini",
+        "--claude-dir",
+        str(claude_dir),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.log_dir == claude_dir / ".agent-loop-logs"
 
 
 def test_auto_created_agent_dir_is_cloned_before_use(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -20,6 +20,7 @@ from coding_review_agent_loop.cli import (
     run_pr_loop,
     run_task_loop,
 )
+from coding_review_agent_loop.config import default_agent_workdir
 
 
 class FakeRunner(Runner):
@@ -31,6 +32,8 @@ class FakeRunner(Runner):
         gemini_outputs=None,
         issue_payload=None,
         pr_payload=None,
+        git_status="",
+        git_remote="git@github.com:OWNER/REPO.git",
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -49,6 +52,8 @@ class FakeRunner(Runner):
         }
         self.commands = []
         self.comments = []
+        self.git_status = git_status
+        self.git_remote = git_remote
 
     def run_with_log(
         self,
@@ -119,6 +124,19 @@ class FakeRunner(Runner):
             return CommandResult(cmd, Path(cwd), "success\n", "", 0)
 
         if cmd[:1] == ["sleep"]:
+            return CommandResult(cmd, Path(cwd), "", "", 0)
+
+        if cmd[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return CommandResult(cmd, Path(cwd), "true\n", "", 0)
+
+        if cmd[:4] == ["git", "remote", "get-url", "origin"]:
+            return CommandResult(cmd, Path(cwd), f"{self.git_remote}\n", "", 0)
+
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return CommandResult(cmd, Path(cwd), self.git_status, "", 0)
+
+        if cmd[:3] == ["gh", "repo", "clone"]:
+            Path(cmd[4]).mkdir(parents=True, exist_ok=True)
             return CommandResult(cmd, Path(cwd), "", "", 0)
 
         return CommandResult(cmd, Path(cwd), "", "", 0)
@@ -506,6 +524,117 @@ def test_missing_gemini_workdir_is_created_when_configured(tmp_path):
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
     assert gemini_dir.is_dir()
+
+
+def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts():
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "codex",
+        "--reviewer",
+        "claude",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.codex_dir == default_agent_workdir("OWNER/REPO", "codex").resolve()
+    assert config.claude_dir == default_agent_workdir("OWNER/REPO", "claude").resolve()
+    assert config.gemini_dir == default_agent_workdir("OWNER/REPO", "gemini").resolve()
+    assert set(config.auto_agent_dirs) == {"claude", "codex", "gemini"}
+
+
+def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):
+    parser = build_parser()
+    codex_dir = tmp_path / "codex"
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "codex",
+        "--reviewer",
+        "claude",
+        "--codex-dir",
+        str(codex_dir),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.codex_dir == codex_dir
+    assert config.claude_dir == default_agent_workdir("OWNER/REPO", "claude").resolve()
+    assert set(config.auto_agent_dirs) == {"claude", "gemini"}
+
+
+def test_auto_created_agent_dir_is_cloned_before_use(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    codex_dir = tmp_path / "tmp-root" / "owner-repo" / "codex" / "repo"
+    config = make_config(
+        tmp_path,
+        claude_dir=tmp_path / "explicit-claude",
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert ["gh", "repo", "clone", "OWNER/REPO", str(codex_dir)] in [
+        cmd for cmd, _cwd in runner.commands
+    ]
+    assert codex_dir.is_dir()
+
+
+def test_clean_existing_auto_agent_dir_is_synced(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["git", "fetch", "origin"] in commands
+    assert ["git", "checkout", "main"] in commands
+    assert ["git", "pull", "--ff-only", "origin", "main"] in commands
+
+
+def test_dirty_existing_auto_agent_dir_fails_clearly(tmp_path):
+    runner = FakeRunner(git_status=" M file.py\n")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="dirty"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
 
 
 def test_agent_workdir_existing_file_fails_clearly(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from coding_review_agent_loop.agents.claude import _parse_claude_output
-from coding_review_agent_loop.agents.gemini import _parse_gemini_output
+from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER, _parse_gemini_output
 from coding_review_agent_loop.cli import (
     AgentLoopConfig,
     AgentLoopError,
@@ -231,6 +231,52 @@ def test_parse_gemini_output_falls_back_on_non_string_response():
     raw = json.dumps({"response": 42, "session_id": "gemini-session-1"})
     text, sid = _parse_gemini_output(raw)
     assert text == raw
+    assert sid == "gemini-session-1"
+
+
+def test_parse_gemini_output_prefers_public_response_marker():
+    raw = f"""Warning: True color (24-bit) support not detected.
+YOLO mode is enabled. All tool calls will be automatically approved.
+I will inspect the PR before giving the final answer.
+Error executing tool read_file: Path not in workspace.
+{PUBLIC_RESPONSE_MARKER}
+## Review
+
+No blocking findings.
+
+<!-- AGENT_STATE: approved -->
+
+-- Google Gemini
+"""
+    text, sid = _parse_gemini_output(raw)
+    assert text.startswith("## Review")
+    assert "True color" not in text
+    assert "YOLO mode" not in text
+    assert "I will inspect" not in text
+    assert "Error executing tool" not in text
+    assert "<!-- AGENT_STATE: approved -->" in text
+    assert sid is None
+
+
+def test_parse_gemini_output_uses_last_public_response_marker():
+    raw = f"""Gemini may mention {PUBLIC_RESPONSE_MARKER} while planning.
+{PUBLIC_RESPONSE_MARKER}
+intermediate draft
+{PUBLIC_RESPONSE_MARKER}
+Final answer.
+<!-- AGENT_STATE: approved -->
+"""
+    text, _sid = _parse_gemini_output(raw)
+    assert text == "Final answer.\n<!-- AGENT_STATE: approved -->\n"
+
+
+def test_parse_gemini_json_response_strips_public_response_marker():
+    raw = json.dumps({
+        "response": f"diagnostic\n{PUBLIC_RESPONSE_MARKER}\nReviewed.\n<!-- AGENT_STATE: approved -->",
+        "session_id": "gemini-session-1",
+    })
+    text, sid = _parse_gemini_output(raw)
+    assert text == "Reviewed.\n<!-- AGENT_STATE: approved -->"
     assert sid == "gemini-session-1"
 
 
@@ -1218,6 +1264,8 @@ def test_gemini_review_loop_uses_prompt_and_extra_args(tmp_path):
 
     gemini_call = next(cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"])
     assert gemini_call[:2] == ["gemini", "--prompt"]
+    assert PUBLIC_RESPONSE_MARKER in gemini_call[2]
+    assert "Only content after that line will be posted to GitHub" in gemini_call[2]
     assert "--output-format" in gemini_call
     assert "--model" in gemini_call
     assert runner.comments == ["LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"]


### PR DESCRIPTION
## Summary
- default omitted active agent dirs to repo-scoped temp checkouts under /tmp/coding-review-agent-loop
- clone missing temp checkouts and safely sync clean existing ones before agent execution
- document the shorter command form and temp checkout tradeoffs

Fixes #10

## Tests
- python -m pytest