### PR TITLE
Address remaining non-blocking review nits

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -288,7 +288,11 @@ Agent responses are parsed using HTML comment markers:
 
 ## Logs
 
-Agent stdout/stderr is written to `.agent-loop-logs/` under the Codex checkout by default. The CLI prints heartbeat messages with the log path while agents run:
+Agent stdout/stderr is written to `.agent-loop-logs/` under the active coder
+checkout by default. If that coder directory was omitted, the relative default
+log path is also under the repo-scoped temporary checkout and may disappear
+with `/tmp` cleanup. The CLI prints heartbeat messages with the log path while
+agents run:
 
 ```text
 [agent-loop 12:00:31] Claude still running (30s); log: /path/to/.agent-loop-logs/20260425-120001-claude.log

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -23,7 +23,7 @@ class AgentLoopConfig:
     codex_dir: Path
     gemini_dir: Path
     coder: AgentName
-    reviewer: AgentName | tuple[AgentName, ...]
+    reviewer: tuple[AgentName, ...]
     base: str
     max_rounds: int
     auto_merge: bool
@@ -51,8 +51,6 @@ class AgentLoopConfig:
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
-    if isinstance(config.reviewer, str):
-        return (config.reviewer,)
     return config.reviewer
 
 
@@ -114,6 +112,8 @@ def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfi
         runner.run((config.gh_cmd, "repo", "clone", config.repo, str(path)), cwd=path.parent)
         if runner.dry_run:
             return
+        # Fresh clones still flow through validation and sync below so the
+        # same remote, cleanliness, and base-branch checks apply to every run.
 
     if not path.is_dir():
         raise AgentLoopError(f"Default {agent} workdir exists but is not a directory: {path}")
@@ -145,7 +145,7 @@ def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfi
     _run_git(runner, path, ("pull", "--ff-only", "origin", config.base))
 
 
-def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner | None = None) -> None:
+def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:
     required: set[AgentName] = {config.coder, *reviewers(config)}
     paths = {
         "claude": (config.claude_dir, "--claude-dir"),
@@ -156,8 +156,6 @@ def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner | None = None)
     for agent in required:
         path, option = paths[agent]
         if agent in auto_dirs:
-            if runner is None:
-                raise AgentLoopError("Internal error: runner is required for default agent checkouts.")
             log(config, f"Using default {agent} workdir: {path}")
             ensure_temp_checkout(path, agent=agent, config=config, runner=runner)
         else:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -177,6 +177,8 @@ def run_pr_loop(
     reviewer_session_ids: dict[AgentName, str | None] = {}
     configured_reviewers = reviewers(config)
     if reviewer_session_id is not None and configured_reviewers:
+        # Backward-compatible single-reviewer resume support: older callers
+        # pass one reviewer session, so attach it to the first configured reviewer.
         reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
 
     for round_number in range(1, config.max_rounds + 1):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -34,6 +34,7 @@ class FakeRunner(Runner):
         pr_payload=None,
         git_status="",
         git_remote="git@github.com:OWNER/REPO.git",
+        git_inside=True,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -54,6 +55,7 @@ class FakeRunner(Runner):
         self.comments = []
         self.git_status = git_status
         self.git_remote = git_remote
+        self.git_inside = git_inside
 
     def _record_command(self, args, cwd):
         cmd = [str(arg) for arg in args]
@@ -133,7 +135,9 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, "", "", 0)
 
         if cmd[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
-            return CommandResult(cmd, cwd_path, "true\n", "", 0)
+            if self.git_inside:
+                return CommandResult(cmd, cwd_path, "true\n", "", 0)
+            return CommandResult(cmd, cwd_path, "false\n", "", 1)
 
         if cmd[:4] == ["git", "remote", "get-url", "origin"]:
             return CommandResult(cmd, cwd_path, f"{self.git_remote}\n", "", 0)
@@ -627,6 +631,12 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts():
     assert set(config.auto_agent_dirs) == {"claude", "codex", "gemini"}
 
 
+@pytest.mark.parametrize("repo", ["OWNER", "OWNER/", "/REPO", "OWNER/REPO/EXTRA"])
+def test_default_agent_workdir_rejects_invalid_repo_formats(repo):
+    with pytest.raises(AgentLoopError, match="OWNER/REPO"):
+        default_agent_workdir(repo, "codex")
+
+
 def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):
     parser = build_parser()
     codex_dir = tmp_path / "codex"
@@ -733,6 +743,46 @@ def test_dirty_existing_auto_agent_dir_fails_clearly(tmp_path):
     config.gemini_dir.mkdir(parents=True)
 
     with pytest.raises(AgentLoopError, match="dirty"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_existing_auto_agent_dir_must_be_git_checkout(tmp_path):
+    runner = FakeRunner(git_inside=False)
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="not a git checkout"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_existing_auto_agent_dir_must_match_requested_repo(tmp_path):
+    runner = FakeRunner(git_remote="git@github.com:OTHER/REPO.git")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="not 'OWNER/REPO'"):
         run_pr_loop(runner, pr_number=77, config=config)
 
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)


### PR DESCRIPTION
## Summary
- tighten reviewer config typing and remove the unreachable reviewer normalization branch
- make default checkout setup require a runner, document fresh-clone validation, and clarify legacy reviewer session handoff
- document active-coder log directory behavior and add coverage for invalid default checkout paths/remotes

## Review notes addressed
- PR #2/#3: reviewer tuple invariant and session handoff documentation
- PR #11: default checkout fall-through clarity, non-optional runner API, log-dir documentation, and missing temp-checkout error-path tests

## Tests
- python -m pytest
- git diff --check