### PR TITLE
Clean up agent loop validation and docs

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -284,7 +284,7 @@ Agent responses are parsed using HTML comment markers:
 <!-- AGENT_CLARIFY -->
 ```
 
-`AGENT_PR` is required after a coder creates a PR. Review/fix responses must include exactly one `AGENT_STATE` marker. If a response quotes older markers, the final marker is treated as authoritative.
+`AGENT_PR` is required after a coder creates a PR. Review/fix responses must include a final `AGENT_STATE` marker. If a response quotes older markers, the final marker is treated as authoritative.
 
 ## Logs
 

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -76,7 +76,6 @@ def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
     return _strip_gemini_preamble(raw), None
 
 
-
 class GeminiBackend:
     name: AgentName = "gemini"
     display_name = "Gemini"

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -206,6 +206,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         "gemini": gemini_dir,
     }[args.coder]
     test_command = _split_command(args.test_command)
+    if args.max_rounds <= 0:
+        raise AgentLoopError("--max-rounds must be greater than zero.")
     if args.ci_timeout_seconds <= 0:
         raise AgentLoopError("--ci-timeout-seconds must be greater than zero.")
     if args.ci_poll_interval_seconds <= 0:

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -67,7 +67,7 @@ def validate_open_issue(runner: Runner, *, config: AgentLoopConfig, issue_number
     data = json.loads(result.stdout or "{}")
     if data.get("is_pr"):
         raise AgentLoopError(
-            f"#{issue_number} is a pull request, not an issue. Use `agent_loop.py pr {issue_number}`."
+            f"#{issue_number} is a pull request, not an issue. Use `agent-loop pr {issue_number}`."
         )
     if data.get("state") != "open":
         raise AgentLoopError(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -904,6 +904,25 @@ def test_config_rejects_duplicate_reviewers(tmp_path):
         config_from_args(args, FakeRunner())
 
 
+def test_config_rejects_non_positive_max_rounds(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--max-rounds",
+        "0",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+
+    with pytest.raises(AgentLoopError, match="--max-rounds must be greater than zero"):
+        config_from_args(args, FakeRunner())
+
+
 def test_config_defaults_do_not_bypass_agent_permissions(tmp_path):
     parser = build_parser()
     args = parser.parse_args([


### PR DESCRIPTION
## Summary
- validate `--max-rounds` during config construction so invalid values fail before orchestration starts
- update a stale user-facing command reference from `agent_loop.py` to `agent-loop`
- align protocol docs with the parser behavior that treats the final state marker as authoritative

## Tests
- `python -m pytest`