### PR TITLE
Add PR metadata to review prompts

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,17 @@ from .workdirs import active_workdir
 
 if TYPE_CHECKING:
     from .config import AgentLoopConfig
+
+
+@dataclass(frozen=True)
+class PullRequestMetadata:
+    number: int
+    repo: str
+    title: str | None
+    head_branch: str | None
+    base_branch: str | None
+    head_sha: str | None
+    url: str | None
 
 
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
@@ -49,6 +61,43 @@ def validate_open_pr(runner: Runner, *, config: AgentLoopConfig, pr_number: int)
         raise AgentLoopError(
             f"PR #{pr_number} is {data.get('state', 'not open')}; provide an open PR number."
         )
+
+
+def get_pr_metadata(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> PullRequestMetadata:
+    if config.dry_run:
+        return PullRequestMetadata(
+            number=pr_number,
+            repo=config.repo,
+            title=None,
+            head_branch=None,
+            base_branch=None,
+            head_sha=None,
+            url=None,
+        )
+
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            "number,title,headRefName,baseRefName,headRefOid,url",
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    return PullRequestMetadata(
+        number=int(data.get("number") or pr_number),
+        repo=config.repo,
+        title=data.get("title"),
+        head_branch=data.get("headRefName"),
+        base_branch=data.get("baseRefName"),
+        head_sha=data.get("headRefOid"),
+        url=data.get("url"),
+    )
 
 
 def validate_open_issue(runner: Runner, *, config: AgentLoopConfig, issue_number: int) -> None:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -9,6 +9,7 @@ from .agents.registry import agent_display_name, run_agent
 from .config import AgentLoopConfig, ensure_agent_workdirs, reviewers
 from .errors import AgentLoopError
 from .github import (
+    get_pr_metadata,
     merge_pr,
     post_pr_comment,
     validate_open_issue,
@@ -187,6 +188,7 @@ def run_pr_loop(
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
+            pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
             review_output, new_session_id = run_agent(
                 runner,
                 agent=reviewer,
@@ -196,6 +198,7 @@ def run_pr_loop(
                     round_number,
                     config,
                     reviewer=reviewer,
+                    pr_metadata=pr_metadata,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
             )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -7,6 +7,7 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
+from .github import PullRequestMetadata
 
 
 def format_agent_list(agents: Sequence[AgentName]) -> str:
@@ -112,11 +113,45 @@ def build_review_prompt(
     config: AgentLoopConfig,
     *,
     reviewer: AgentName,
+    pr_metadata: PullRequestMetadata | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
     reviewer_group = format_agent_list(reviewers(config))
+    metadata = pr_metadata or PullRequestMetadata(
+        number=pr_number,
+        repo=config.repo,
+        title=None,
+        head_branch=None,
+        base_branch=None,
+        head_sha=None,
+        url=None,
+    )
+    title = metadata.title or "(unknown)"
+    head_branch = metadata.head_branch or "(unknown)"
+    base_branch = metadata.base_branch or "(unknown)"
+    head_sha = metadata.head_sha or "(unknown)"
+    url_line = f"- URL: {metadata.url}\n" if metadata.url else ""
     return f"""Review pull request #{pr_number} in {config.repo} (round {round_number}).
+
+PR metadata:
+- Repo: {metadata.repo}
+- PR: #{metadata.number}
+- Title: {title}
+- Head branch: {head_branch}
+- Base branch: {base_branch}
+- Head SHA: {head_sha}
+{url_line}
+Use this PR metadata as authoritative. Do not spend time discovering the PR
+branch.
+
+Suggested commands:
+- {config.gh_cmd} pr view {metadata.number} --repo {metadata.repo} --json title,body,headRefName,baseRefName,headRefOid,comments,reviews
+- {config.gh_cmd} pr diff {metadata.number} --repo {metadata.repo}
+
+If a shell/tool command requires confirmation in non-interactive mode, do not
+retry repeatedly. Use the PR metadata above and the suggested GitHub CLI
+commands, or produce a blocking review explaining the limitation.
 
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -50,6 +50,10 @@ class FakeRunner(Runner):
             "number": 77,
             "state": "OPEN",
             "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
         }
         self.commands = []
         self.comments = []
@@ -463,6 +467,32 @@ def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
         '[.check_runs[] | select(.name == "test")] | if length == 0 then "pending" else .[0].conclusion // .[0].status end',
     ] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+
+
+def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(prompts) == 1
+    prompt = prompts[0]
+    assert "PR metadata:" in prompt
+    assert "- Repo: OWNER/REPO" in prompt
+    assert "- PR: #77" in prompt
+    assert "- Title: Improve review prompt context" in prompt
+    assert "- Head branch: feature/review-context" in prompt
+    assert "- Base branch: main" in prompt
+    assert "- Head SHA: abc123" in prompt
+    assert "Use this PR metadata as authoritative." in prompt
+    assert "Do not spend time discovering the PR\nbranch." in prompt
+    assert (
+        "gh pr view 77 --repo OWNER/REPO --json "
+        "title,body,headRefName,baseRefName,headRefOid,comments,reviews"
+    ) in prompt
+    assert "gh pr diff 77 --repo OWNER/REPO" in prompt
+    assert "requires confirmation in non-interactive mode" in prompt
 
 
 def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):


### PR DESCRIPTION
## Summary
- fetch PR metadata through the shared GitHub helper before review prompt generation
- include repo, title, head/base branches, head SHA, and suggested gh review commands in review prompts
- tell reviewers to avoid repeated non-interactive confirmation retries and use the supplied PR context

## Tests
- pytest

Fixes #15