### PR TITLE
Fetch PR metadata once per review round

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -185,10 +185,10 @@ def run_pr_loop(
     for round_number in range(1, config.max_rounds + 1):
         coder_name = agent_display_name(config.coder)
         blocking_reviews: list[tuple[str, str]] = []
+        pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
-            pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
             review_output, new_session_id = run_agent(
                 runner,
                 agent=reviewer,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -513,6 +513,14 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
     assert agent_commands == [["codex", "exec"], ["claude", "--print"]]
     assert len(runner.comments) == 2
     commands = [cmd for cmd, _cwd in runner.commands]
+    metadata_fetches = [
+        cmd
+        for cmd in commands
+        if cmd[:3] == ["gh", "pr", "view"]
+        and "--json" in cmd
+        and cmd[cmd.index("--json") + 1] == "number,title,headRefName,baseRefName,headRefOid,url"
+    ]
+    assert len(metadata_fetches) == 1
     assert ["pytest", "tests/test_agent_loop.py"] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
 


### PR DESCRIPTION
## Summary
- hoist PR metadata retrieval out of the per-reviewer loop so each review round fetches it once
- add a multi-reviewer regression assertion that the metadata query is not repeated per reviewer

## Tests
- pytest

Addresses a non-blocking review note from PR #16.