### PR TITLE
Add repo-level agent memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ runs; dirty temp checkouts fail clearly instead of being overwritten. Use
 explicit persistent directories for large repositories, long-lived agent
 worktrees, or setups that should survive `/tmp` cleanup or reboot.
 
+Agent memory is enabled by default. Before invoking agents, the loop creates or
+refreshes advisory repo memory under `.agent-loop/memory` in the coder checkout:
+repo summary, architecture map, module index, execution/test profile, toolchain
+facts, and changed files since the previous memory commit. Agent prompts state
+that this cache is stale-prone orientation only, and that agents must inspect
+source files and PR diffs directly for correctness claims. Disable it with
+`--no-agent-memory`, force a refresh with `--refresh-agent-memory`, customize
+the location with `--agent-memory-dir PATH`, or refresh only test command facts
+with `--refresh-test-profile`.
+
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
 ```bash

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -180,6 +180,36 @@ def build_parser() -> argparse.ArgumentParser:
             default=30,
             help="How often to print long-running agent heartbeats (default: 30).",
         )
+        memory_group = subparser.add_mutually_exclusive_group()
+        memory_group.add_argument(
+            "--agent-memory",
+            dest="agent_memory",
+            action="store_true",
+            default=True,
+            help="Enable repo-local advisory agent memory (default).",
+        )
+        memory_group.add_argument(
+            "--no-agent-memory",
+            dest="agent_memory",
+            action="store_false",
+            help="Disable repo-local advisory agent memory.",
+        )
+        subparser.add_argument(
+            "--refresh-agent-memory",
+            action="store_true",
+            help="Force regeneration of repo-level memory files before invoking agents.",
+        )
+        subparser.add_argument(
+            "--agent-memory-dir",
+            type=Path,
+            default=Path(".agent-loop") / "memory",
+            help="Directory for repo memory, relative to the coder checkout by default.",
+        )
+        subparser.add_argument(
+            "--refresh-test-profile",
+            action="store_true",
+            help="Regenerate the cached execution/test profile before invoking agents.",
+        )
 
     issue = subparsers.add_parser("issue", help="Ask the coder to fix an issue, then review it.")
     issue.add_argument("issue_number", type=int)

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -43,6 +43,10 @@ class AgentLoopConfig:
     quiet: bool
     log_dir: Path
     progress_interval_seconds: int
+    agent_memory: bool
+    refresh_agent_memory: bool
+    agent_memory_dir: Path
+    refresh_test_profile: bool
     auto_agent_dirs: tuple[AgentName, ...] = ()
 
     def __post_init__(self) -> None:
@@ -252,5 +256,13 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         quiet=args.quiet,
         log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
         progress_interval_seconds=args.progress_interval_seconds,
+        agent_memory=args.agent_memory,
+        refresh_agent_memory=args.refresh_agent_memory,
+        agent_memory_dir=(
+            primary_dir / args.agent_memory_dir
+            if not args.agent_memory_dir.is_absolute()
+            else args.agent_memory_dir
+        ),
+        refresh_test_profile=args.refresh_test_profile,
         auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/memory.py
+++ b/src/coding_review_agent_loop/memory.py
@@ -1,0 +1,311 @@
+"""Repo-local advisory memory for repeated agent loop runs."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .logging import log
+from .runner import Runner
+from .workdirs import active_workdir
+
+if TYPE_CHECKING:
+    from .config import AgentLoopConfig
+
+
+ADVISORY_RULE = (
+    "Use cached repo memory and execution memory only for orientation. They may be stale. "
+    "For correctness, security, and behavior claims, inspect the actual source files and PR "
+    "diff directly. If you run tests, prefer verified test commands from the execution profile. "
+    "Do not search the whole filesystem for test tools."
+)
+
+
+@dataclass(frozen=True)
+class AgentMemoryContext:
+    memory_dir: Path
+    current_commit: str | None
+    last_analyzed_commit: str | None
+    changed_files: tuple[str, ...]
+    repo_summary: str | None
+    architecture_map: str | None
+    test_profile: str | None
+    toolchain: str | None
+
+
+def prepare_agent_memory(runner: Runner, config: AgentLoopConfig) -> AgentMemoryContext | None:
+    if not config.agent_memory:
+        return None
+
+    workdir = active_workdir(config)
+    memory_dir = config.agent_memory_dir
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / "file-summaries").mkdir(exist_ok=True)
+
+    current_commit = _git_output(runner, workdir, ("rev-parse", "HEAD"))
+    last_analyzed_commit = _read_optional(memory_dir / "last-analyzed-commit")
+    changed_files = _changed_files(
+        runner,
+        workdir,
+        last_analyzed_commit=last_analyzed_commit,
+        current_commit=current_commit,
+    )
+    tracked_files = _git_lines(runner, workdir, ("ls-files",))
+
+    if config.refresh_agent_memory or not (memory_dir / "repo-summary.md").exists():
+        _write_repo_summary(memory_dir / "repo-summary.md", config, current_commit, tracked_files)
+    if config.refresh_agent_memory or not (memory_dir / "architecture-map.md").exists():
+        _write_architecture_map(memory_dir / "architecture-map.md", tracked_files)
+    _write_module_index(memory_dir / "module-index.json", tracked_files, changed_files, current_commit)
+
+    if (
+        config.refresh_agent_memory
+        or config.refresh_test_profile
+        or config.test_command
+        or not (memory_dir / "test-profile.md").exists()
+    ):
+        _write_test_profile(memory_dir / "test-profile.md", config, current_commit, tracked_files)
+    if config.refresh_agent_memory or not (memory_dir / "toolchain.json").exists():
+        _write_toolchain(memory_dir / "toolchain.json", tracked_files)
+
+    for rel_path in changed_files[:25]:
+        if rel_path in tracked_files:
+            _write_file_summary(memory_dir / "file-summaries", workdir, rel_path)
+
+    context = load_agent_memory(config)
+    if current_commit:
+        (memory_dir / "last-analyzed-commit").write_text(f"{current_commit}\n", encoding="utf-8")
+    log(config, f"Prepared agent memory at {memory_dir}")
+    return context
+
+
+def load_agent_memory(config: AgentLoopConfig) -> AgentMemoryContext | None:
+    if not config.agent_memory:
+        return None
+
+    memory_dir = config.agent_memory_dir
+    if not memory_dir.exists():
+        return None
+
+    module_index = _read_optional(memory_dir / "module-index.json")
+    changed_files: tuple[str, ...] = ()
+    current_commit: str | None = None
+    if module_index:
+        try:
+            data = json.loads(module_index)
+        except json.JSONDecodeError:
+            data = {}
+        changed_files = tuple(data.get("changed_files") or ())
+        current_commit = data.get("current_commit")
+
+    return AgentMemoryContext(
+        memory_dir=memory_dir,
+        current_commit=current_commit,
+        last_analyzed_commit=_read_optional(memory_dir / "last-analyzed-commit"),
+        changed_files=changed_files,
+        repo_summary=_read_optional(memory_dir / "repo-summary.md"),
+        architecture_map=_read_optional(memory_dir / "architecture-map.md"),
+        test_profile=_read_optional(memory_dir / "test-profile.md"),
+        toolchain=_read_optional(memory_dir / "toolchain.json"),
+    )
+
+
+def format_agent_memory_context(memory: AgentMemoryContext | None) -> str:
+    if memory is None:
+        return ""
+
+    parts = [
+        "Cached repo memory is available for this checkout.",
+        "",
+        ADVISORY_RULE,
+        "",
+        f"Memory directory: {memory.memory_dir}",
+    ]
+    if memory.current_commit:
+        parts.append(f"Current memory commit: {memory.current_commit}")
+    if memory.last_analyzed_commit:
+        parts.append(f"Last analyzed commit: {memory.last_analyzed_commit}")
+    if memory.changed_files:
+        parts.extend(["", "Changed files since previous memory commit:"])
+        parts.extend(f"- {path}" for path in memory.changed_files[:50])
+    else:
+        parts.extend(["", "Changed files since previous memory commit: none detected."])
+
+    for heading, text in (
+        ("Repo Summary", memory.repo_summary),
+        ("Architecture Map", memory.architecture_map),
+        ("Execution/Test Profile", memory.test_profile),
+        ("Toolchain", memory.toolchain),
+    ):
+        if text:
+            parts.extend(["", f"## {heading}", _trim_text(text)])
+
+    return "\n".join(parts).strip()
+
+
+def _git_output(runner: Runner, cwd: Path, args: tuple[str, ...]) -> str | None:
+    result = runner.run(("git", *args), cwd=cwd, check=False)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _git_lines(runner: Runner, cwd: Path, args: tuple[str, ...]) -> list[str]:
+    output = _git_output(runner, cwd, args)
+    if not output:
+        return []
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def _read_optional(path: Path) -> str | None:
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    return value or None
+
+
+def _changed_files(
+    runner: Runner,
+    cwd: Path,
+    *,
+    last_analyzed_commit: str | None,
+    current_commit: str | None,
+) -> tuple[str, ...]:
+    if not current_commit:
+        return ()
+    if not last_analyzed_commit:
+        return tuple(_git_lines(runner, cwd, ("ls-files",)))
+    result = runner.run(
+        ("git", "diff", "--name-only", f"{last_analyzed_commit}..{current_commit}"),
+        cwd=cwd,
+        check=False,
+    )
+    if result.returncode != 0:
+        return tuple(_git_lines(runner, cwd, ("ls-files",)))
+    return tuple(line for line in result.stdout.splitlines() if line.strip())
+
+
+def _write_repo_summary(
+    path: Path,
+    config: AgentLoopConfig,
+    current_commit: str | None,
+    tracked_files: list[str],
+) -> None:
+    top_level = sorted({file.split("/", 1)[0] for file in tracked_files})
+    text = [
+        "# Repo Summary",
+        "",
+        f"- Repo: {config.repo}",
+        f"- Base branch: {config.base}",
+        f"- Last generated: {date.today().isoformat()}",
+        f"- Commit: {current_commit or 'unknown'}",
+        f"- Tracked files: {len(tracked_files)}",
+        f"- Top-level paths: {', '.join(top_level) if top_level else '(none detected)'}",
+    ]
+    path.write_text("\n".join(text) + "\n", encoding="utf-8")
+
+
+def _write_architecture_map(path: Path, tracked_files: list[str]) -> None:
+    buckets: dict[str, list[str]] = {}
+    for file in tracked_files:
+        head = file.split("/", 1)[0]
+        buckets.setdefault(head, []).append(file)
+    lines = ["# Architecture Map", ""]
+    for head in sorted(buckets):
+        examples = ", ".join(buckets[head][:8])
+        lines.append(f"- `{head}`: {len(buckets[head])} tracked file(s); examples: {examples}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_module_index(
+    path: Path,
+    tracked_files: list[str],
+    changed_files: tuple[str, ...],
+    current_commit: str | None,
+) -> None:
+    suffix_counts: dict[str, int] = {}
+    for file in tracked_files:
+        suffix = Path(file).suffix or "(none)"
+        suffix_counts[suffix] = suffix_counts.get(suffix, 0) + 1
+    data = {
+        "tracked_file_count": len(tracked_files),
+        "top_level_paths": sorted({file.split("/", 1)[0] for file in tracked_files}),
+        "suffix_counts": dict(sorted(suffix_counts.items())),
+        "changed_files": list(changed_files),
+        "current_commit": current_commit,
+    }
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_test_profile(
+    path: Path,
+    config: AgentLoopConfig,
+    current_commit: str | None,
+    tracked_files: list[str],
+) -> None:
+    lines = [
+        "# Test Profile",
+        "",
+        "Verified test commands:",
+    ]
+    if config.test_command:
+        lines.append(f"- `{shlex.join(config.test_command)}`")
+    else:
+        lines.append("- None recorded yet.")
+    lines.extend(["", "Suggested commands to verify when needed:"])
+    if "pyproject.toml" in tracked_files:
+        lines.append("- `python -m pytest`")
+    if "package.json" in tracked_files:
+        lines.append("- `npm test`")
+    lines.extend(
+        [
+            "",
+            "Do not use by default:",
+            "- Broad filesystem searches such as `find / -name pytest`.",
+            "- Unverified tool-discovery commands that scan outside the checkout.",
+            "",
+            "Last verified:",
+            f"- Commit: {current_commit or 'unknown'}",
+            f"- Date: {date.today().isoformat()}",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_toolchain(path: Path, tracked_files: list[str]) -> None:
+    data = {
+        "python": "pyproject.toml" in tracked_files or any(file.endswith(".py") for file in tracked_files),
+        "node": "package.json" in tracked_files,
+        "github_actions": any(file.startswith(".github/workflows/") for file in tracked_files),
+    }
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_file_summary(file_summary_dir: Path, workdir: Path, rel_path: str) -> None:
+    source = workdir / rel_path
+    if not source.is_file():
+        return
+    try:
+        size = source.stat().st_size
+    except OSError:
+        return
+    safe_name = rel_path.replace("/", "__") + ".md"
+    text = [
+        f"# {rel_path}",
+        "",
+        f"- Size: {size} bytes",
+        "- Summary: Refresh needed. Inspect the source file directly before relying on this note.",
+    ]
+    (file_summary_dir / safe_name).write_text("\n".join(text) + "\n", encoding="utf-8")
+
+
+def _trim_text(text: str, *, max_chars: int = 4000) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "\n... (truncated)"

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -17,6 +17,7 @@ from .github import (
     wait_for_ci,
 )
 from .logging import log
+from .memory import prepare_agent_memory
 from .prompts import (
     build_followup_prompt,
     build_issue_prompt,
@@ -42,12 +43,13 @@ def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig
     ensure_agent_workdirs(config, runner)
     log(config, f"Validating issue #{issue_number}")
     validate_open_issue(runner, config=config, issue_number=issue_number)
+    memory = prepare_agent_memory(runner, config)
 
     coder_output, coder_session_id = run_agent(
         runner,
         agent=config.coder,
         config=config,
-        prompt=build_issue_prompt(issue_number, config),
+        prompt=build_issue_prompt(issue_number, config, memory),
     )
     pr_number = parse_pr_number(coder_output)
     if pr_number is None:
@@ -94,14 +96,15 @@ def run_task_loop(
     max_clarification_rounds: int = 3,
     clarification_input=None,
 ) -> int:
-    ensure_agent_workdirs(config, runner)
     if not task_text.strip():
         raise AgentLoopError("Task text is empty; provide a non-empty description.")
     if max_clarification_rounds < 0:
         raise AgentLoopError("--max-clarification-rounds must be zero or positive.")
+    ensure_agent_workdirs(config, runner)
+    memory = prepare_agent_memory(runner, config)
 
     history: list[tuple[str, str]] = []
-    prompt = build_task_prompt(task_text, config)
+    prompt = build_task_prompt(task_text, config, memory)
     read_clarification = clarification_input or _read_clarification_from_stdin
     coder_name = agent_display_name(config.coder)
     session_id: str | None = None
@@ -157,7 +160,7 @@ def run_task_loop(
         if not answers.strip():
             raise AgentLoopError("Empty clarification reply; aborting task.")
         history.append((coder_output, answers))
-        prompt = build_task_clarification_prompt(task_text, history, config)
+        prompt = build_task_clarification_prompt(task_text, history, config, memory)
 
     raise AgentLoopError("run_task_loop exited unexpectedly without producing a PR.")
 
@@ -175,6 +178,7 @@ def run_pr_loop(
         ensure_agent_workdirs(config, runner)
     log(config, f"Validating PR #{pr_number}")
     validate_open_pr(runner, config=config, pr_number=pr_number)
+    memory = prepare_agent_memory(runner, config)
     reviewer_session_ids: dict[AgentName, str | None] = {}
     configured_reviewers = reviewers(config)
     if reviewer_session_id is not None and configured_reviewers:
@@ -199,6 +203,7 @@ def run_pr_loop(
                     config,
                     reviewer=reviewer,
                     pr_metadata=pr_metadata,
+                    memory=memory,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
             )
@@ -233,7 +238,7 @@ def run_pr_loop(
             runner,
             agent=config.coder,
             config=config,
-            prompt=build_followup_prompt(pr_number, round_number, combined_review, config),
+            prompt=build_followup_prompt(pr_number, round_number, combined_review, config, memory),
             session_id=coder_session_id,
         )
         if not coder_output.strip():

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -8,6 +8,7 @@ from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
 from .github import PullRequestMetadata
+from .memory import AgentMemoryContext, format_agent_memory_context
 
 
 def format_agent_list(agents: Sequence[AgentName]) -> str:
@@ -19,13 +20,25 @@ def format_agent_list(agents: Sequence[AgentName]) -> str:
     return f"{', '.join(names[:-1])}, and {names[-1]}"
 
 
-def build_issue_prompt(issue_number: int, config: AgentLoopConfig) -> str:
+def _memory_block(memory: AgentMemoryContext | None) -> str:
+    text = format_agent_memory_context(memory)
+    if not text:
+        return ""
+    return f"\n\nAgent memory context:\n{text}\n"
+
+
+def build_issue_prompt(
+    issue_number: int,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
+) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
     return f"""Fix GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
+{_memory_block(memory)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
 you create the PR. In your final response, include the PR number using exactly
@@ -42,13 +55,18 @@ Use blocking here to hand the PR to {reviewer_name} for review. Sign the respons
 """
 
 
-def build_task_prompt(task_text: str, config: AgentLoopConfig) -> str:
+def build_task_prompt(
+    task_text: str,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
+) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
     return f"""You have been given a free-form task to implement in {config.repo}.
 
 Task:
 {task_text}
+{_memory_block(memory)}
 
 Use this local checkout as your workspace. Decide between two paths:
 
@@ -77,6 +95,7 @@ def build_task_clarification_prompt(
     task_text: str,
     history: Sequence[tuple[str, str]],
     config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
 ) -> str:
     coder_signature = agent_signature(config.coder)
     qa_blocks = "\n\n".join(
@@ -88,6 +107,7 @@ def build_task_clarification_prompt(
 
 Original task:
 {task_text}
+{_memory_block(memory)}
 
 Clarification so far:
 
@@ -114,6 +134,7 @@ def build_review_prompt(
     *,
     reviewer: AgentName,
     pr_metadata: PullRequestMetadata | None = None,
+    memory: AgentMemoryContext | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
@@ -144,6 +165,7 @@ PR metadata:
 {url_line}
 Use this PR metadata as authoritative. Do not spend time discovering the PR
 branch.
+{_memory_block(memory)}
 
 Suggested commands:
 - {config.gh_cmd} pr view {metadata.number} --repo {metadata.repo} --json title,body,headRefName,baseRefName,headRefOid,comments,reviews
@@ -177,6 +199,7 @@ def build_followup_prompt(
     round_number: int,
     review: str,
     config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
@@ -185,6 +208,7 @@ def build_followup_prompt(
 Address the review below in this local checkout. Pull/sync the PR branch if
 needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
+{_memory_block(memory)}
 
 {reviewer_name} review:
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -35,6 +35,9 @@ class FakeRunner(Runner):
         git_status="",
         git_remote="git@github.com:OWNER/REPO.git",
         git_inside=True,
+        git_head="abc123",
+        tracked_files=None,
+        changed_files=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -60,6 +63,14 @@ class FakeRunner(Runner):
         self.git_status = git_status
         self.git_remote = git_remote
         self.git_inside = git_inside
+        self.git_head = git_head
+        self.tracked_files = tracked_files or [
+            "pyproject.toml",
+            "README.md",
+            "src/coding_review_agent_loop/cli.py",
+            "tests/test_agent_loop.py",
+        ]
+        self.changed_files = changed_files or ["src/coding_review_agent_loop/cli.py"]
 
     def _record_command(self, args, cwd):
         cmd = [str(arg) for arg in args]
@@ -143,6 +154,15 @@ class FakeRunner(Runner):
                 return CommandResult(cmd, cwd_path, "true\n", "", 0)
             return CommandResult(cmd, cwd_path, "false\n", "", 1)
 
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return CommandResult(cmd, cwd_path, f"{self.git_head}\n", "", 0)
+
+        if cmd[:2] == ["git", "ls-files"]:
+            return CommandResult(cmd, cwd_path, "\n".join(self.tracked_files) + "\n", "", 0)
+
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return CommandResult(cmd, cwd_path, "\n".join(self.changed_files) + "\n", "", 0)
+
         if cmd[:4] == ["git", "remote", "get-url", "origin"]:
             return CommandResult(cmd, cwd_path, f"{self.git_remote}\n", "", 0)
 
@@ -189,6 +209,10 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         "quiet": True,
         "log_dir": tmp_path / "logs",
         "progress_interval_seconds": 30,
+        "agent_memory": True,
+        "refresh_agent_memory": False,
+        "agent_memory_dir": tmp_path / "claude" / ".agent-loop" / "memory",
+        "refresh_test_profile": False,
     }
     config.update(overrides)
     if create_dirs:
@@ -495,6 +519,78 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     assert "requires confirmation in non-interactive mode" in prompt
 
 
+def test_agent_memory_is_created_and_added_to_review_prompt(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    memory_dir = tmp_path / "memory"
+    config = make_config(tmp_path, agent_memory_dir=memory_dir)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert (memory_dir / "repo-summary.md").exists()
+    assert (memory_dir / "architecture-map.md").exists()
+    assert (memory_dir / "module-index.json").exists()
+    assert (memory_dir / "test-profile.md").exists()
+    assert (memory_dir / "toolchain.json").exists()
+    assert (memory_dir / "last-analyzed-commit").read_text(encoding="utf-8") == "abc123\n"
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Agent memory context:" in prompt
+    assert "Use cached repo memory and execution memory only for orientation." in prompt
+    assert "inspect the actual source files and PR diff directly" in prompt
+    assert "Do not search the whole filesystem for test tools." in prompt
+    assert "src/coding_review_agent_loop/cli.py" in prompt
+
+
+def test_agent_memory_detects_changed_files_since_previous_commit(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        git_head="def456",
+        changed_files=["src/coding_review_agent_loop/prompts.py", "tests/test_agent_loop.py"],
+    )
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "last-analyzed-commit").write_text("abc123\n", encoding="utf-8")
+    config = make_config(tmp_path, agent_memory_dir=memory_dir)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    diff_commands = [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["git", "diff", "--name-only"]]
+    assert diff_commands == [["git", "diff", "--name-only", "abc123..def456"]]
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "src/coding_review_agent_loop/prompts.py" in prompt
+    assert "tests/test_agent_loop.py" in prompt
+    assert (memory_dir / "last-analyzed-commit").read_text(encoding="utf-8") == "def456\n"
+
+
+def test_test_profile_records_provided_test_command(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    memory_dir = tmp_path / "memory"
+    config = make_config(
+        tmp_path,
+        agent_memory_dir=memory_dir,
+        test_command=("python", "-m", "pytest", "-q"),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    profile = (memory_dir / "test-profile.md").read_text(encoding="utf-8")
+    assert "`python -m pytest -q`" in profile
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "prefer verified test commands from the execution profile" in prompt
+
+
+def test_agent_memory_can_be_disabled(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    memory_dir = tmp_path / "memory"
+    config = make_config(tmp_path, agent_memory=False, agent_memory_dir=memory_dir)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not memory_dir.exists()
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Agent memory context:" not in prompt
+
+
 def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
     runner = FakeRunner(
         codex_outputs=["Codex approves.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
@@ -717,6 +813,35 @@ def test_relative_log_dir_defaults_under_active_coder_workdir(tmp_path):
     config = config_from_args(args, FakeRunner())
 
     assert config.log_dir == claude_dir / ".agent-loop-logs"
+
+
+def test_agent_memory_flags_configure_memory_dir_and_refresh(tmp_path):
+    parser = build_parser()
+    codex_dir = tmp_path / "codex"
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "codex",
+        "--reviewer",
+        "claude",
+        "--codex-dir",
+        str(codex_dir),
+        "--no-agent-memory",
+        "--refresh-agent-memory",
+        "--refresh-test-profile",
+        "--agent-memory-dir",
+        "custom-memory",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.agent_memory is False
+    assert config.refresh_agent_memory is True
+    assert config.refresh_test_profile is True
+    assert config.agent_memory_dir == codex_dir / "custom-memory"
 
 
 def test_auto_created_agent_dir_is_cloned_before_use(tmp_path):


### PR DESCRIPTION
## Summary
- add repo-local advisory agent memory under .agent-loop/memory with repo summaries, module index, test profile, toolchain facts, changed-file tracking, and file summary placeholders
- add CLI flags to disable, force refresh, customize the memory directory, and refresh the test profile
- include stale-memory safety wording and verified-test-command guidance in coder/reviewer prompts

Fixes #18

## Tests
- python -m pytest -q
- python -m compileall -q src
- PYTHONPATH=src python -m coding_review_agent_loop.cli pr --help | rg -- '--agent-memory|--no-agent-memory|--refresh-agent-memory|--agent-memory-dir|--refresh-test-profile'