### PR TITLE
Address PR 19 agent memory follow-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 dist/
 build/
 .agent-loop-logs/
+.agent-loop/

--- a/src/coding_review_agent_loop/memory.py
+++ b/src/coding_review_agent_loop/memory.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .logging import log
-from .runner import Runner
+from .runner import Runner, ensure_log_dir_ignored
 from .workdirs import active_workdir
 
 if TYPE_CHECKING:
@@ -50,11 +50,14 @@ def prepare_agent_memory(runner: Runner, config: AgentLoopConfig) -> AgentMemory
     last_analyzed_commit = _read_optional(memory_dir / "last-analyzed-commit")
     changed_files = _changed_files(
         runner,
+        config,
         workdir,
         last_analyzed_commit=last_analyzed_commit,
         current_commit=current_commit,
     )
     tracked_files = _git_lines(runner, workdir, ("ls-files",))
+    tracked_file_set = set(tracked_files)
+    _ensure_memory_parent_ignored(memory_dir)
 
     if config.refresh_agent_memory or not (memory_dir / "repo-summary.md").exists():
         _write_repo_summary(memory_dir / "repo-summary.md", config, current_commit, tracked_files)
@@ -73,7 +76,7 @@ def prepare_agent_memory(runner: Runner, config: AgentLoopConfig) -> AgentMemory
         _write_toolchain(memory_dir / "toolchain.json", tracked_files)
 
     for rel_path in changed_files[:25]:
-        if rel_path in tracked_files:
+        if rel_path in tracked_file_set:
             _write_file_summary(memory_dir / "file-summaries", workdir, rel_path)
 
     context = load_agent_memory(config)
@@ -172,6 +175,7 @@ def _read_optional(path: Path) -> str | None:
 
 def _changed_files(
     runner: Runner,
+    config: AgentLoopConfig,
     cwd: Path,
     *,
     last_analyzed_commit: str | None,
@@ -187,8 +191,20 @@ def _changed_files(
         check=False,
     )
     if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no command output"
+        log(
+            config,
+            "Could not diff agent memory baseline "
+            f"{last_analyzed_commit}..{current_commit}; treating all tracked files as changed. "
+            f"git output: {_trim_text(detail, max_chars=500)}",
+        )
         return tuple(_git_lines(runner, cwd, ("ls-files",)))
     return tuple(line for line in result.stdout.splitlines() if line.strip())
+
+
+def _ensure_memory_parent_ignored(memory_dir: Path) -> None:
+    if memory_dir.parent.name == ".agent-loop":
+        ensure_log_dir_ignored(memory_dir.parent)
 
 
 def _write_repo_summary(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -24,7 +24,7 @@ def _memory_block(memory: AgentMemoryContext | None) -> str:
     text = format_agent_memory_context(memory)
     if not text:
         return ""
-    return f"\n\nAgent memory context:\n{text}\n"
+    return f"Agent memory context:\n{text}\n"
 
 
 def build_issue_prompt(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -38,6 +38,8 @@ class FakeRunner(Runner):
         git_head="abc123",
         tracked_files=None,
         changed_files=None,
+        diff_returncode=0,
+        diff_stderr="",
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -71,6 +73,8 @@ class FakeRunner(Runner):
             "tests/test_agent_loop.py",
         ]
         self.changed_files = changed_files or ["src/coding_review_agent_loop/cli.py"]
+        self.diff_returncode = diff_returncode
+        self.diff_stderr = diff_stderr
 
     def _record_command(self, args, cwd):
         cmd = [str(arg) for arg in args]
@@ -161,7 +165,8 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, "\n".join(self.tracked_files) + "\n", "", 0)
 
         if cmd[:3] == ["git", "diff", "--name-only"]:
-            return CommandResult(cmd, cwd_path, "\n".join(self.changed_files) + "\n", "", 0)
+            stdout = "\n".join(self.changed_files) + "\n" if self.diff_returncode == 0 else ""
+            return CommandResult(cmd, cwd_path, stdout, self.diff_stderr, self.diff_returncode)
 
         if cmd[:4] == ["git", "remote", "get-url", "origin"]:
             return CommandResult(cmd, cwd_path, f"{self.git_remote}\n", "", 0)
@@ -541,6 +546,26 @@ def test_agent_memory_is_created_and_added_to_review_prompt(tmp_path):
     assert "src/coding_review_agent_loop/cli.py" in prompt
 
 
+def test_agent_memory_default_parent_ignores_generated_contents(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    gitignore = tmp_path / "claude" / ".agent-loop" / ".gitignore"
+    assert gitignore.read_text(encoding="utf-8") == "*\n!.gitignore\n"
+
+
+def test_agent_memory_does_not_ignore_custom_parent_directory(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    memory_dir = tmp_path / "custom-memory"
+    config = make_config(tmp_path, agent_memory_dir=memory_dir)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not (tmp_path / ".gitignore").exists()
+
+
 def test_agent_memory_detects_changed_files_since_previous_commit(tmp_path):
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
@@ -560,6 +585,27 @@ def test_agent_memory_detects_changed_files_since_previous_commit(tmp_path):
     assert "src/coding_review_agent_loop/prompts.py" in prompt
     assert "tests/test_agent_loop.py" in prompt
     assert (memory_dir / "last-analyzed-commit").read_text(encoding="utf-8") == "def456\n"
+
+
+def test_agent_memory_logs_when_changed_file_diff_falls_back(tmp_path, capsys):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        git_head="def456",
+        diff_returncode=128,
+        diff_stderr="fatal: bad revision 'abc123..def456'",
+    )
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "last-analyzed-commit").write_text("abc123\n", encoding="utf-8")
+    config = make_config(tmp_path, agent_memory_dir=memory_dir, quiet=False)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    captured = capsys.readouterr()
+    assert "Could not diff agent memory baseline abc123..def456" in captured.err
+    assert "treating all tracked files as changed" in captured.err
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "README.md" in prompt
 
 
 def test_test_profile_records_provided_test_command(tmp_path):


### PR DESCRIPTION
## Summary
- ignore this repo's generated .agent-loop cache directory
- create .agent-loop/.gitignore for default agent memory directories while avoiding arbitrary custom parent directories
- log git diff fallback details, use a set for changed-file membership checks, and trim extra memory prompt spacing

## Tests
- python -m pytest -q
- python -m compileall -q src

Notes: the auto-generated .gitignore is scoped to memory directories whose parent is named .agent-loop, so custom --agent-memory-dir parents are not accidentally ignored.