### PR TITLE
Handle approved review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ separate coding and review passes:
 agent-loop pr 456 --repo OWNER/REPO --reviewer codex --reviewer claude
 ```
 
+Approved reviews may include non-blocking cleanup under:
+
+```md
+### Non-blocking follow-ups
+- Add a follow-up test.
+```
+
+By default those follow-ups do not change approval semantics and are ignored by
+the loop. To keep a grouped record on the PR without sending the work back to
+the coder, use:
+
+```bash
+agent-loop pr 456 --repo OWNER/REPO --approved-followups summarize
+```
+
 For trusted local automation that must run without approval prompts:
 
 ```bash

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -210,6 +210,15 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="Regenerate the cached execution/test profile before invoking agents.",
         )
+        subparser.add_argument(
+            "--approved-followups",
+            choices=("ignore", "summarize"),
+            default="ignore",
+            help=(
+                "How to handle structured non-blocking follow-ups in approved reviews "
+                "(default: ignore)."
+            ),
+        )
 
     issue = subparsers.add_parser("issue", help="Ask the coder to fix an issue, then review it.")
     issue.add_argument("issue_number", type=int)

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -47,6 +47,7 @@ class AgentLoopConfig:
     refresh_agent_memory: bool
     agent_memory_dir: Path
     refresh_test_profile: bool
+    approved_followups: str = "ignore"
     auto_agent_dirs: tuple[AgentName, ...] = ()
 
     def __post_init__(self) -> None:
@@ -218,6 +219,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
     if args.progress_interval_seconds <= 0:
         raise AgentLoopError("--progress-interval-seconds must be greater than zero.")
+    if args.approved_followups not in {"ignore", "summarize"}:
+        raise AgentLoopError("--approved-followups must be one of: ignore, summarize.")
     return AgentLoopConfig(
         repo=repo,
         claude_dir=claude_dir,
@@ -264,5 +267,6 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
             else args.agent_memory_dir
         ),
         refresh_test_profile=args.refresh_test_profile,
+        approved_followups=args.approved_followups,
         auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -27,6 +27,7 @@ from .prompts import (
     format_agent_list,
 )
 from .protocol import is_clarification_request, parse_agent_state, parse_pr_number
+from .protocol import ApprovedFollowup, parse_non_blocking_followups
 from .runner import Runner
 from .workdirs import active_workdir
 
@@ -37,6 +38,22 @@ def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
     log(config, f"Running local test command: {' '.join(config.test_command)}")
     runner.run(config.test_command, cwd=active_workdir(config))
     log(config, "Local test command passed")
+
+
+def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFollowup]) -> str:
+    lines = [
+        f"Approved-review non-blocking follow-ups for PR #{pr_number}:",
+        "",
+    ]
+    for followup in followups:
+        lines.append(f"- {followup.text} ({followup.reviewer})")
+    lines.extend(
+        [
+            "",
+            "These were mentioned in approved reviews and did not block merge readiness.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig) -> int:
@@ -189,6 +206,7 @@ def run_pr_loop(
     for round_number in range(1, config.max_rounds + 1):
         coder_name = agent_display_name(config.coder)
         blocking_reviews: list[tuple[str, str]] = []
+        approved_followups: list[ApprovedFollowup] = []
         pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
@@ -216,8 +234,15 @@ def run_pr_loop(
             log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
             if review_state == "blocking":
                 blocking_reviews.append((reviewer_name, review_output))
+            elif config.approved_followups != "ignore":
+                approved_followups.extend(
+                    parse_non_blocking_followups(review_output, reviewer=reviewer_name)
+                )
 
         if not blocking_reviews:
+            if config.approved_followups == "summarize" and approved_followups:
+                body = _format_approved_followup_summary(pr_number, approved_followups)
+                post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
             run_optional_tests(runner, config)
             if config.auto_merge:
                 wait_for_ci(runner, config, pr_number)

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -178,6 +178,12 @@ commands, or produce a blocking review explaining the limitation.
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this
 review step; report blocking findings if {coder_name} needs to fix anything.
+If you approve but notice worthwhile non-blocking cleanup, list it under this
+exact heading:
+
+### Non-blocking follow-ups
+
+Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 from .errors import AgentLoopError
 
@@ -10,6 +11,17 @@ STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->", re.I)
 PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
+FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+non[- ]blocking follow[- ]ups\s*$", re.I)
+ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
+HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
+SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
+BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class ApprovedFollowup:
+    reviewer: str
+    text: str
 
 
 def parse_agent_state(text: str) -> str:
@@ -32,3 +44,42 @@ def parse_pr_number(text: str) -> int | None:
 
 def is_clarification_request(text: str) -> bool:
     return bool(CLARIFY_RE.search(text))
+
+
+def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:
+    """Extract bullets from reviewer-approved non-blocking follow-up sections."""
+    followups: list[ApprovedFollowup] = []
+    in_section = False
+    current: list[str] = []
+
+    def flush_current() -> None:
+        if current:
+            item = " ".join(part.strip() for part in current if part.strip()).strip()
+            if item:
+                followups.append(ApprovedFollowup(reviewer=reviewer, text=item))
+            current.clear()
+
+    for line in text.splitlines():
+        if FOLLOWUP_HEADING_RE.match(line):
+            flush_current()
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if ANY_HEADING_RE.match(line):
+            flush_current()
+            in_section = False
+            continue
+        if HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
+            flush_current()
+            continue
+        bullet = BULLET_RE.match(line)
+        if bullet:
+            flush_current()
+            current.append(bullet.group("text"))
+            continue
+        if current and line.strip():
+            current.append(line)
+
+    flush_current()
+    return followups

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -21,6 +21,7 @@ from coding_review_agent_loop.cli import (
     run_task_loop,
 )
 from coding_review_agent_loop.config import default_agent_workdir
+from coding_review_agent_loop.protocol import parse_non_blocking_followups
 
 
 class FakeRunner(Runner):
@@ -403,6 +404,39 @@ def test_parse_agent_state_requires_marker():
         parse_agent_state("LGTM")
 
 
+def test_parse_non_blocking_followups_extracts_bullets_only_from_section():
+    review = """
+    Looks good.
+
+    ### Non-blocking follow-ups
+    - Add `.agent-loop/` to `.gitignore`.
+    1. Add regression coverage for stale memory refresh.
+       Include multiple reviewers.
+
+    ### Notes
+    - This is not a follow-up.
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    followups = parse_non_blocking_followups(review, reviewer="OpenAI Codex")
+
+    assert [(item.reviewer, item.text) for item in followups] == [
+        ("OpenAI Codex", "Add `.agent-loop/` to `.gitignore`."),
+        (
+            "OpenAI Codex",
+            "Add regression coverage for stale memory refresh. Include multiple reviewers.",
+        ),
+    ]
+
+
+def test_parse_non_blocking_followups_returns_empty_without_section():
+    review = "LGTM.\n- A normal bullet outside the section.\n<!-- AGENT_STATE: approved -->"
+
+    assert parse_non_blocking_followups(review, reviewer="OpenAI Codex") == []
+
+
 def test_parse_pr_number_accepts_marker_and_url():
     assert parse_pr_number("opened\n<!-- AGENT_PR: 61 -->") == 61
     assert parse_pr_number("https://github.com/OWNER/REPO/pull/62") == 62
@@ -517,6 +551,8 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     ) in prompt
     assert "gh pr diff 77 --repo OWNER/REPO" in prompt
     assert "requires confirmation in non-interactive mode" in prompt
+    assert "### Non-blocking follow-ups" in prompt
+    assert "Use blocking only for issues that should prevent merge." in prompt
 
 
 def test_agent_memory_is_created_and_added_to_review_prompt(tmp_path):
@@ -619,6 +655,50 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
     assert len(metadata_fetches) == 1
     assert ["pytest", "tests/test_agent_loop.py"] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+
+
+def test_pr_loop_ignores_approved_followups_by_default(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n\n### Non-blocking follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments == [
+        "LGTM.\n\n### Non-blocking follow-ups\n- Add cleanup docs.\n"
+        "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    ]
+
+
+def test_pr_loop_summarizes_approved_followups_from_multiple_reviewers(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves.\n\n### Non-blocking follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        claude_outputs=[
+            "Claude approves.\n\n### Non-blocking follow-ups\n- Add regression coverage.\n"
+            "<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        approved_followups="summarize",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.comments) == 3
+    summary = runner.comments[-1]
+    assert summary.startswith("Approved-review non-blocking follow-ups for PR #77:")
+    assert "- Add cleanup docs. (Codex)" in summary
+    assert "- Add regression coverage. (Claude)" in summary
+    assert "did not block merge readiness" in summary
 
 
 def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
@@ -769,6 +849,28 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts():
 def test_default_agent_workdir_rejects_invalid_repo_formats(repo):
     with pytest.raises(AgentLoopError, match="OWNER/REPO"):
         default_agent_workdir(repo, "codex")
+
+
+def test_approved_followups_cli_mode_is_configurable(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--approved-followups",
+        "summarize",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+        "--gemini-dir",
+        str(tmp_path / "gemini"),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.approved_followups == "summarize"
 
 
 def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):


### PR DESCRIPTION
## Summary
- Ask reviewers to place approved-review cleanup under a structured non-blocking follow-up heading
- Add parsing for approved review follow-up bullets and a configurable --approved-followups summarize mode
- Post a grouped PR summary comment when summarize mode is enabled, without sending follow-ups back to the coder by default

## Tests
- python -m pytest

Fixes #21