### PR TITLE
Address post-PR 11 approved review follow-ups

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -219,8 +219,6 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
     if args.progress_interval_seconds <= 0:
         raise AgentLoopError("--progress-interval-seconds must be greater than zero.")
-    if args.approved_followups not in {"ignore", "summarize"}:
-        raise AgentLoopError("--approved-followups must be one of: ignore, summarize.")
     return AgentLoopConfig(
         repo=repo,
         claude_dir=claude_dir,

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -72,6 +72,7 @@ def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFo
             continue
         if HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
             flush_current()
+            in_section = False
             continue
         bullet = BULLET_RE.match(line)
         if bullet:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -436,6 +436,24 @@ def test_parse_non_blocking_followups_extracts_bullets_only_from_section():
     ]
 
 
+@pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])
+def test_parse_non_blocking_followups_stops_at_final_markers(terminator):
+    review = f"""
+    Looks good.
+
+    ### Non-blocking follow-ups
+    - Add cleanup docs.
+    {terminator}
+    - This is outside the follow-up section.
+    """
+
+    followups = parse_non_blocking_followups(review, reviewer="OpenAI Codex")
+
+    assert [(item.reviewer, item.text) for item in followups] == [
+        ("OpenAI Codex", "Add cleanup docs."),
+    ]
+
+
 def test_parse_non_blocking_followups_returns_empty_without_section():
     review = "LGTM.\n- A normal bullet outside the section.\n<!-- AGENT_STATE: approved -->"
 
@@ -769,6 +787,15 @@ def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
     )
     assert "Needs a regression test." in followup_prompt
     assert "Codex approves first pass." not in followup_prompt
+    commands = [cmd for cmd, _cwd in runner.commands]
+    metadata_fetches = [
+        cmd
+        for cmd in commands
+        if cmd[:3] == ["gh", "pr", "view"]
+        and "--json" in cmd
+        and cmd[cmd.index("--json") + 1] == "number,title,headRefName,baseRefName,headRefOid,url"
+    ]
+    assert len(metadata_fetches) == 2
 
 
 def test_pr_loop_does_not_run_claude_after_final_blocking_round(tmp_path):
@@ -1215,7 +1242,8 @@ def test_config_rejects_duplicate_reviewers(tmp_path):
         config_from_args(args, FakeRunner())
 
 
-def test_config_rejects_non_positive_max_rounds(tmp_path):
+@pytest.mark.parametrize("max_rounds", ["0", "-1"])
+def test_config_rejects_non_positive_max_rounds(tmp_path, max_rounds):
     parser = build_parser()
     args = parser.parse_args([
         "pr",
@@ -1223,7 +1251,7 @@ def test_config_rejects_non_positive_max_rounds(tmp_path):
         "--repo",
         "OWNER/REPO",
         "--max-rounds",
-        "0",
+        max_rounds,
         "--claude-dir",
         str(tmp_path / "claude"),
         "--codex-dir",


### PR DESCRIPTION
## Summary
- stop approved follow-up parsing when final markers or reviewer signatures are reached
- remove unreachable approved-followups validation already enforced by argparse choices
- add regressions for negative max rounds and per-round PR metadata fetches across multiple rounds

## Context
I reviewed merged PRs after #11 and picked the remaining non-blocking notes that were still concrete and worth addressing: PR #14's negative max-rounds coverage, PR #17's multi-round metadata assertion, and PR #22's parser robustness plus dead validation cleanup.

## Tests
- python -m pytest tests/test_agent_loop.py -q
- python -m pytest -q
- python -m compileall -q src
- git diff --check