### PR TITLE
docs: refresh agent memory behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ that this cache is stale-prone orientation only, and that agents must inspect
 source files and PR diffs directly for correctness claims. Disable it with
 `--no-agent-memory`, force a refresh with `--refresh-agent-memory`, customize
 the location with `--agent-memory-dir PATH`, or refresh only test command facts
-with `--refresh-test-profile`.
+with `--refresh-test-profile`. The default `.agent-loop` parent is ignored
+automatically so generated memory files are not accidentally committed. If the
+previous memory commit is unavailable or no longer diffable, the loop logs the
+git failure and treats all tracked files as changed for that refresh.
 
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
@@ -175,6 +178,10 @@ the coder, use:
 ```bash
 agent-loop pr 456 --repo OWNER/REPO --approved-followups summarize
 ```
+
+Only bullets inside the `Non-blocking follow-ups` section are summarized. The
+section ends at the next heading, HTML marker, or agent signature, so final
+protocol markers are not mistaken for follow-up text.
 
 For trusted local automation that must run without approval prompts:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -193,6 +193,37 @@ These temporary checkouts may disappear after reboot or `/tmp` cleanup. Large
 projects and long-lived agent setups should use explicit persistent workdirs to
 avoid repeated clone, dependency setup, and indexing costs.
 
+## Agent Memory
+
+Agent memory is enabled by default. Before an agent prompt is built, the loop
+creates or refreshes advisory repo memory in the active coder checkout under:
+
+```text
+.agent-loop/memory
+```
+
+The memory cache includes a repo summary, architecture map, module index,
+execution/test profile, toolchain facts, and changed files since the previous
+memory commit. This context is included in coder and reviewer prompts as
+orientation only. The prompt explicitly tells agents that cached memory may be
+stale and that correctness, security, and behavior claims must come from the
+actual source files and PR diff.
+
+Use these flags to control it:
+
+```bash
+agent-loop pr 123 --repo OWNER/REPO --no-agent-memory
+agent-loop pr 123 --repo OWNER/REPO --refresh-agent-memory
+agent-loop pr 123 --repo OWNER/REPO --refresh-test-profile
+agent-loop pr 123 --repo OWNER/REPO --agent-memory-dir .cache/agent-loop-memory
+```
+
+Relative `--agent-memory-dir` values are resolved inside the active coder
+checkout. The default `.agent-loop` parent is ignored automatically so generated
+memory files are not accidentally committed. If the previous memory commit
+cannot be diffed against the current commit, the loop logs the git failure and
+treats all tracked files as changed for that refresh.
+
 ## Real Example
 
 This project uses `agent-loop` to improve itself. This command asked Codex to
@@ -289,6 +320,20 @@ Agent responses are parsed using HTML comment markers:
 ```
 
 `AGENT_PR` is required after a coder creates a PR. Review/fix responses must include a final `AGENT_STATE` marker. If a response quotes older markers, the final marker is treated as authoritative.
+
+Approved reviewer responses may also include optional cleanup items under a
+dedicated heading:
+
+```md
+### Non-blocking follow-ups
+- Add a follow-up test.
+```
+
+By default, these do not affect approval. With `--approved-followups summarize`,
+the loop posts a grouped record on the PR instead of sending those items back to
+the coder as blocking work. Only bullets inside the `Non-blocking follow-ups`
+section are summarized; the section ends at the next heading, HTML marker, or
+agent signature.
 
 ## Logs
 


### PR DESCRIPTION
## Summary
- Last docs update found: commit `9607909dc79adcf51c0ca0eeaf146da73f28f221` (`Handle approved review followups`) at 2026-04-29 20:25:08 -0700.
- Document the current default agent-memory cache behavior, generated `.agent-loop` ignore handling, and fallback behavior when the previous memory baseline cannot be diffed.
- Document the approved non-blocking follow-up section boundary used when `--approved-followups summarize` is enabled.

## Tests
- `python -m pytest`