### PR TITLE
Persist agent memory outside temp worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,22 @@ explicit persistent directories for large repositories, long-lived agent
 worktrees, or setups that should survive `/tmp` cleanup or reboot.
 
 Agent memory is enabled by default. Before invoking agents, the loop creates or
-refreshes advisory repo memory under `.agent-loop/memory` in the coder checkout:
+refreshes advisory repo memory in a durable, repo-scoped user cache directory
+such as `~/.cache/coding-review-agent-loop/repos/OWNER-REPO/memory` on Linux:
 repo summary, architecture map, module index, execution/test profile, toolchain
-facts, and changed files since the previous memory commit. Agent prompts state
-that this cache is stale-prone orientation only, and that agents must inspect
-source files and PR diffs directly for correctness claims. Disable it with
-`--no-agent-memory`, force a refresh with `--refresh-agent-memory`, customize
-the location with `--agent-memory-dir PATH`, or refresh only test command facts
-with `--refresh-test-profile`. The default `.agent-loop` parent is ignored
-automatically so generated memory files are not accidentally committed. If the
-previous memory commit is unavailable or no longer diffable, the loop logs the
-git failure and treats all tracked files as changed for that refresh.
+facts, and changed files since the previous memory commit. On macOS the default
+root is `~/Library/Caches/coding-review-agent-loop`; on Windows it is
+`%LOCALAPPDATA%/coding-review-agent-loop/Cache`. Agent prompts state that this
+cache is stale-prone orientation only, and that agents must inspect source files
+and PR diffs directly for correctness claims. The cache is local-only. Disable
+it with `--no-agent-memory`, force a refresh with `--refresh-agent-memory`,
+customize the location with `--agent-memory-dir PATH`, or refresh only test
+command facts with `--refresh-test-profile`. Relative `--agent-memory-dir`
+values are resolved inside the coder checkout. If you keep sensitive repo
+details out of local cache retention, use `--no-agent-memory` or a custom
+short-lived location. If the previous memory commit is unavailable or no longer
+diffable, the loop logs the git failure and treats all tracked files as changed
+for that refresh.
 
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -196,18 +196,25 @@ avoid repeated clone, dependency setup, and indexing costs.
 ## Agent Memory
 
 Agent memory is enabled by default. Before an agent prompt is built, the loop
-creates or refreshes advisory repo memory in the active coder checkout under:
+creates or refreshes advisory repo memory in a durable, repo-scoped user cache
+directory. On Linux the default is:
 
 ```text
-.agent-loop/memory
+~/.cache/coding-review-agent-loop/repos/OWNER-REPO/memory
 ```
+
+If `$XDG_CACHE_HOME` is set on Linux, the root is
+`$XDG_CACHE_HOME/coding-review-agent-loop`. On macOS the default root is
+`~/Library/Caches/coding-review-agent-loop`; on Windows it is
+`%LOCALAPPDATA%/coding-review-agent-loop/Cache`.
 
 The memory cache includes a repo summary, architecture map, module index,
 execution/test profile, toolchain facts, and changed files since the previous
 memory commit. This context is included in coder and reviewer prompts as
 orientation only. The prompt explicitly tells agents that cached memory may be
 stale and that correctness, security, and behavior claims must come from the
-actual source files and PR diff.
+actual source files and PR diff. The cache is local-only, but it can contain
+repo structure, local paths, test command notes, and advisory summaries.
 
 Use these flags to control it:
 
@@ -219,10 +226,13 @@ agent-loop pr 123 --repo OWNER/REPO --agent-memory-dir .cache/agent-loop-memory
 ```
 
 Relative `--agent-memory-dir` values are resolved inside the active coder
-checkout. The default `.agent-loop` parent is ignored automatically so generated
-memory files are not accidentally committed. If the previous memory commit
-cannot be diffed against the current commit, the loop logs the git failure and
-treats all tracked files as changed for that refresh.
+checkout. Use `--no-agent-memory` or a custom short-lived
+`--agent-memory-dir` for sensitive repositories where local cache retention is
+undesirable. If a custom memory directory uses the repo-local `.agent-loop`
+parent, that parent is ignored automatically so generated memory files are not
+accidentally committed. If the previous memory commit cannot be diffed against
+the current commit, the loop logs the git failure and treats all tracked files
+as changed for that refresh.
 
 ## Real Example
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -186,7 +186,7 @@ def build_parser() -> argparse.ArgumentParser:
             dest="agent_memory",
             action="store_true",
             default=True,
-            help="Enable repo-local advisory agent memory (default).",
+            help="Enable repo-scoped advisory agent memory (default).",
         )
         memory_group.add_argument(
             "--no-agent-memory",
@@ -202,8 +202,11 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument(
             "--agent-memory-dir",
             type=Path,
-            default=Path(".agent-loop") / "memory",
-            help="Directory for repo memory, relative to the coder checkout by default.",
+            default=None,
+            help=(
+                "Directory for repo memory. Defaults to a repo-scoped user cache; "
+                "relative explicit paths are resolved inside the coder checkout."
+            ),
         )
         subparser.add_argument(
             "--refresh-test-profile",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import os
 import shlex
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -79,12 +81,34 @@ def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
 
 
 def default_agent_workdir(repo: str, agent: AgentName) -> Path:
+    repo_slug = repo_cache_slug(repo)
+    return Path(tempfile.gettempdir()) / "coding-review-agent-loop" / repo_slug / agent / "repo"
+
+
+def repo_cache_slug(repo: str) -> str:
     parts = repo.split("/")
     if len(parts) != 2 or not all(parts):
         raise AgentLoopError("--repo must use the OWNER/REPO format.")
     owner, name = parts
-    repo_slug = f"{owner}-{name}"
-    return Path(tempfile.gettempdir()) / "coding-review-agent-loop" / repo_slug / agent / "repo"
+    return f"{owner}-{name}"
+
+
+def default_cache_root() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "coding-review-agent-loop"
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            return Path(local_app_data) / "coding-review-agent-loop" / "Cache"
+        return Path.home() / "AppData" / "Local" / "coding-review-agent-loop" / "Cache"
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return Path(xdg_cache_home) / "coding-review-agent-loop"
+    return Path.home() / ".cache" / "coding-review-agent-loop"
+
+
+def default_agent_memory_dir(repo: str) -> Path:
+    return default_cache_root() / "repos" / repo_cache_slug(repo) / "memory"
 
 
 def ensure_workdir(path: Path, option_name: str) -> None:
@@ -260,9 +284,13 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         agent_memory=args.agent_memory,
         refresh_agent_memory=args.refresh_agent_memory,
         agent_memory_dir=(
-            primary_dir / args.agent_memory_dir
-            if not args.agent_memory_dir.is_absolute()
-            else args.agent_memory_dir
+            default_agent_memory_dir(repo).resolve()
+            if args.agent_memory_dir is None
+            else (
+                primary_dir / args.agent_memory_dir
+                if not args.agent_memory_dir.is_absolute()
+                else args.agent_memory_dir
+            )
         ),
         refresh_test_profile=args.refresh_test_profile,
         approved_followups=args.approved_followups,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -20,7 +20,7 @@ from coding_review_agent_loop.cli import (
     run_pr_loop,
     run_task_loop,
 )
-from coding_review_agent_loop.config import default_agent_workdir
+from coding_review_agent_loop.config import default_agent_memory_dir, default_agent_workdir
 from coding_review_agent_loop.protocol import parse_non_blocking_followups
 
 
@@ -916,12 +916,29 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts():
     assert config.claude_dir == default_agent_workdir("OWNER/REPO", "claude").resolve()
     assert config.gemini_dir == default_agent_workdir("OWNER/REPO", "gemini").resolve()
     assert set(config.auto_agent_dirs) == {"claude", "codex", "gemini"}
+    assert config.agent_memory_dir == default_agent_memory_dir("OWNER/REPO").resolve()
 
 
 @pytest.mark.parametrize("repo", ["OWNER", "OWNER/", "/REPO", "OWNER/REPO/EXTRA"])
 def test_default_agent_workdir_rejects_invalid_repo_formats(repo):
     with pytest.raises(AgentLoopError, match="OWNER/REPO"):
         default_agent_workdir(repo, "codex")
+
+
+def test_default_agent_memory_dir_uses_xdg_cache_and_repo_scope(monkeypatch, tmp_path):
+    cache_home = tmp_path / "xdg-cache"
+    monkeypatch.setattr("coding_review_agent_loop.config.sys.platform", "linux")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
+
+    assert default_agent_memory_dir("OWNER/REPO") == (
+        cache_home / "coding-review-agent-loop" / "repos" / "OWNER-REPO" / "memory"
+    )
+
+
+@pytest.mark.parametrize("repo", ["OWNER", "OWNER/", "/REPO", "OWNER/REPO/EXTRA"])
+def test_default_agent_memory_dir_rejects_invalid_repo_formats(repo):
+    with pytest.raises(AgentLoopError, match="OWNER/REPO"):
+        default_agent_memory_dir(repo)
 
 
 def test_approved_followups_cli_mode_is_configurable(tmp_path):
@@ -1017,6 +1034,33 @@ def test_agent_memory_flags_configure_memory_dir_and_refresh(tmp_path):
     assert config.refresh_agent_memory is True
     assert config.refresh_test_profile is True
     assert config.agent_memory_dir == codex_dir / "custom-memory"
+
+
+def test_agent_memory_default_ignores_active_coder_workdir(tmp_path, monkeypatch):
+    parser = build_parser()
+    cache_home = tmp_path / "cache"
+    codex_dir = tmp_path / "codex"
+    monkeypatch.setattr("coding_review_agent_loop.config.sys.platform", "linux")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "codex",
+        "--reviewer",
+        "claude",
+        "--codex-dir",
+        str(codex_dir),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.agent_memory_dir == (
+        cache_home / "coding-review-agent-loop" / "repos" / "OWNER-REPO" / "memory"
+    ).resolve()
+    assert codex_dir not in config.agent_memory_dir.parents
 
 
 def test_auto_created_agent_dir_is_cloned_before_use(tmp_path):


### PR DESCRIPTION
## Summary
- move the default agent memory path to a repo-scoped durable user cache directory
- preserve explicit --agent-memory-dir override behavior, including relative paths under the coder checkout
- document default cache locations, local-only privacy notes, and disable/customize options

Fixes #25.

## Tests
- python -m pytest tests/test_agent_loop.py -k 'agent_memory or default_agent_workdir or omitted_agent_dirs'
- python -m pytest