### PR TITLE
Address PR 27 non-blocking test follow-up

### DIFF
--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -958,7 +958,7 @@ def test_default_cache_root_uses_platform_home_fallbacks(
     home_parts,
 ):
     monkeypatch.setattr("coding_review_agent_loop.config.sys.platform", platform)
-    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("LOCALAPPDATA", raising=False)
 
     assert default_cache_root() == tmp_path.joinpath(*home_parts)


### PR DESCRIPTION
## Summary
- replace the cache-root test's global pathlib.Path.home monkeypatch with a HOME environment override
- keep the macOS and Windows fallback assertions deterministic without mutating the Path class

## Tests
- python -m pytest tests/test_agent_loop.py -k 'default_cache_root'
- python -m pytest