### PR TITLE
Address PR 28 cache fallback follow-up

### DIFF
--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -959,6 +959,7 @@ def test_default_cache_root_uses_platform_home_fallbacks(
 ):
     monkeypatch.setattr("coding_review_agent_loop.config.sys.platform", platform)
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("LOCALAPPDATA", raising=False)
 
     assert default_cache_root() == tmp_path.joinpath(*home_parts)


### PR DESCRIPTION
## Summary
- set USERPROFILE alongside HOME in the platform home fallback cache-root test
- keep LOCALAPPDATA cleared so the Windows fallback branch remains deterministic

## Tests
- python -m pytest tests/test_agent_loop.py -k 'default_cache_root'
- python -m pytest