### PR TITLE
Surface approved follow-up issue links

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ the loop.
 
 - `ignore`: ignore non-blocking follow-up bullets from approved reviews. This is the default.
 - `summarize`: post a grouped record on the PR without sending those items back to the coder.
-- `issue`: create GitHub issues for the follow-ups without delaying the PR.
+- `issue`: create GitHub issues for the follow-ups without delaying the PR, then comment with the created issue links.
 
 To keep a grouped record on the PR or create follow-up issues, use:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -345,7 +345,7 @@ By default, these do not affect approval.
 
 - `ignore`: ignore non-blocking follow-up bullets from approved reviews. This is the default.
 - `summarize`: post a grouped record on the PR instead of sending those items back to the coder as blocking work.
-- `issue`: create GitHub issues for the follow-ups instead of delaying the PR.
+- `issue`: create GitHub issues for the follow-ups instead of delaying the PR, then comment with the created issue links.
 
 Only bullets inside the `Non-blocking follow-ups` section are summarized; the
 section ends at the next heading, HTML marker, or agent signature. The same

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -169,10 +169,10 @@ def create_issue(
     config: AgentLoopConfig,
     title: str,
     body: str,
-) -> None:
+) -> str | None:
     log(config, f"Creating GitHub issue: {title}")
     if config.dry_run:
-        runner.run(
+        result = runner.run(
             [
                 config.gh_cmd,
                 "issue",
@@ -186,13 +186,14 @@ def create_issue(
             ],
             cwd=active_workdir(config),
         )
-        return
+        issue_url = result.stdout.strip()
+        return issue_url or None
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
         handle.write(body)
         path = handle.name
     try:
-        runner.run(
+        result = runner.run(
             [
                 config.gh_cmd,
                 "issue",
@@ -206,6 +207,8 @@ def create_issue(
             ],
             cwd=active_workdir(config),
         )
+        issue_url = result.stdout.strip()
+        return issue_url or None
     finally:
         try:
             os.unlink(path)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -86,14 +86,33 @@ def _create_approved_followup_issues(
     config: AgentLoopConfig,
     pr_number: int,
     followups: list[ApprovedFollowup],
-) -> None:
+) -> list[str]:
+    issue_urls: list[str] = []
     for followup in followups:
-        create_issue(
+        issue_url = create_issue(
             runner,
             config=config,
             title=_followup_issue_title(followup),
             body=_followup_issue_body(pr_number, followup),
         )
+        if issue_url is not None:
+            issue_urls.append(issue_url)
+    return issue_urls
+
+
+def _format_created_followup_issue_summary(pr_number: int, issue_urls: list[str]) -> str:
+    lines = [
+        f"Created approved-review follow-up issues for PR #{pr_number}:",
+        "",
+    ]
+    lines.extend(f"- {issue_url}" for issue_url in issue_urls)
+    lines.extend(
+        [
+            "",
+            "These follow-ups were mentioned in approved reviews and did not block merge readiness.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig) -> int:
@@ -284,12 +303,15 @@ def run_pr_loop(
                 body = _format_approved_followup_summary(pr_number, approved_followups)
                 post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
             elif config.approved_followups == "issue" and approved_followups:
-                _create_approved_followup_issues(
+                issue_urls = _create_approved_followup_issues(
                     runner,
                     config=config,
                     pr_number=pr_number,
                     followups=approved_followups,
                 )
+                if issue_urls:
+                    body = _format_created_followup_issue_summary(pr_number, issue_urls)
+                    post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
             run_optional_tests(runner, config)
             if config.auto_merge:
                 wait_for_ci(runner, config, pr_number)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -799,7 +799,7 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    assert len(runner.comments) == 2
+    assert len(runner.comments) == 3
     assert runner.issues == [
         {
             "title": "Follow up approved review note: Add cleanup docs.",
@@ -824,6 +824,10 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
             ),
         },
     ]
+    issue_summary = runner.comments[-1]
+    assert issue_summary.startswith("Created approved-review follow-up issues for PR #77:")
+    assert "- https://github.com/OWNER/REPO/issues/99" in issue_summary
+    assert "did not block merge readiness" in issue_summary
 
 
 def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):


### PR DESCRIPTION
## Summary
- Return the created issue URL from the GitHub issue helper
- Collect approved follow-up issue URLs and comment them back on the PR
- Document the issue-mode record and cover it in tests

Fixes #33

## Tests
- python -m pytest