### PR TITLE
Cap approved followup issue noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Approved reviews may include non-blocking cleanup under:
 - Add a follow-up test.
 ```
 
+Reviewers should use that section only for substantial work that is better
+handled in a separate issue or PR. Same-PR cleanup should be marked blocking
+instead, and the issue mode creates at most three follow-up issues per approved
+round to avoid issue noise.
+
 By default those follow-ups do not change approval semantics and are ignored by
 the loop.
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -339,17 +339,22 @@ dedicated heading:
 - Add a follow-up test.
 ```
 
+Reviewers should use this section only for substantial work that is better
+handled in a separate issue or PR. If a small or local cleanup should be fixed
+in the current PR, the reviewer should mark the review blocking instead.
+
 By default, these do not affect approval.
 
 `--approved-followups` accepts:
 
 - `ignore`: ignore non-blocking follow-up bullets from approved reviews. This is the default.
 - `summarize`: post a grouped record on the PR instead of sending those items back to the coder as blocking work.
-- `issue`: create GitHub issues for the follow-ups instead of delaying the PR.
+- `issue`: create GitHub issues for up to three follow-ups instead of delaying the PR.
 
 Only bullets inside the `Non-blocking follow-ups` section are summarized; the
 section ends at the next heading, HTML marker, or agent signature. The same
-parsing is used when creating follow-up issues.
+parsing is used when creating follow-up issues. The issue cap keeps one
+approved review from creating a large batch of low-value issues.
 
 ## Logs
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -32,6 +32,8 @@ from .protocol import ApprovedFollowup, parse_non_blocking_followups
 from .runner import Runner
 from .workdirs import active_workdir
 
+MAX_APPROVED_FOLLOWUP_ISSUES = 3
+
 
 def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
     if not config.test_command:
@@ -52,6 +54,8 @@ def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFo
         [
             "",
             "These were mentioned in approved reviews and did not block merge readiness.",
+            "",
+            "-- coding-review-agent-loop",
         ]
     )
     return "\n".join(lines)
@@ -87,13 +91,28 @@ def _create_approved_followup_issues(
     pr_number: int,
     followups: list[ApprovedFollowup],
 ) -> None:
-    for followup in followups:
+    selected_followups = followups[:MAX_APPROVED_FOLLOWUP_ISSUES]
+    for followup in selected_followups:
         create_issue(
             runner,
             config=config,
             title=_followup_issue_title(followup),
             body=_followup_issue_body(pr_number, followup),
         )
+    skipped_count = len(followups) - len(selected_followups)
+    if skipped_count <= 0:
+        return
+    post_pr_comment(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        body=(
+            f"Created follow-up issues for the first {len(selected_followups)} "
+            f"approved-review non-blocking items. Skipped {skipped_count} additional "
+            "item(s) to avoid issue noise; reviewers should reserve this section for "
+            "substantial independent follow-up work.\n\n-- coding-review-agent-loop"
+        ),
+    )
 
 
 def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig) -> int:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -178,11 +178,16 @@ commands, or produce a blocking review explaining the limitation.
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this
 review step; report blocking findings if {coder_name} needs to fix anything.
-If you approve but notice worthwhile non-blocking cleanup, list it under this
-exact heading:
+If a concern is small, local to this PR, and should be fixed before merge, mark
+the review blocking instead of treating it as a follow-up.
+If you approve but notice substantial work that is better handled separately in
+a future issue or PR, list at most three highest-value items under this exact
+heading:
 
 ### Non-blocking follow-ups
 
+Do not put trivial style nits, small test gaps, or same-PR cleanup in the
+non-blocking follow-up section.
 Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -778,6 +778,7 @@ def test_pr_loop_summarizes_approved_followups_from_multiple_reviewers(tmp_path)
     assert "- Add cleanup docs. (Codex)" in summary
     assert "- Add regression coverage. (Claude)" in summary
     assert "did not block merge readiness" in summary
+    assert summary.endswith("-- coding-review-agent-loop")
 
 
 def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
@@ -824,6 +825,31 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
             ),
         },
     ]
+
+
+def test_pr_loop_caps_approved_followup_issues(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves.\n\n### Non-blocking follow-ups\n"
+            "- Follow up one.\n"
+            "- Follow up two.\n"
+            "- Follow up three.\n"
+            "- Follow up four.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert [issue["title"] for issue in runner.issues] == [
+        "Follow up approved review note: Follow up one.",
+        "Follow up approved review note: Follow up two.",
+        "Follow up approved review note: Follow up three.",
+    ]
+    assert len(runner.comments) == 2
+    assert "Skipped 1 additional item(s) to avoid issue noise" in runner.comments[-1]
+    assert runner.comments[-1].endswith("-- coding-review-agent-loop")
 
 
 def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):


### PR DESCRIPTION
## Summary

- Tighten reviewer guidance so same-PR cleanup should be marked blocking, while `Non-blocking follow-ups` is reserved for substantial independent work.
- Cap `--approved-followups issue` creation to the first three follow-up bullets per approved round.
- Post a PR note when additional approved follow-up bullets are skipped to avoid issue noise.

## Tests

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -q`

-- OpenAI Codex
