### PR TITLE
Split approved follow-ups into same-PR and future work

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,28 @@ separate coding and review passes:
 agent-loop pr 456 --repo OWNER/REPO --reviewer codex --reviewer claude
 ```
 
-Approved reviews may include non-blocking cleanup under:
+Approved reviews may include future work under:
 
 ```md
-### Non-blocking follow-ups
+### Future follow-ups
 - Add a follow-up test.
 ```
 
 Reviewers should use that section only for substantial work that is better
-handled in a separate issue or PR. Same-PR cleanup should be marked blocking
-instead, and the issue mode creates at most three follow-up issues per approved
+handled in a separate issue or PR. The legacy heading
+`### Non-blocking follow-ups` is still parsed as future work for compatibility.
+
+When `--approved-followups` uses a `fix-and-*` mode, approved reviews may also
+include small, low-risk current-PR cleanup under:
+
+```md
+### Same-PR follow-ups
+- Rename a helper before merge.
+```
+
+Same-PR follow-ups are sent back to the coder in the existing PR and require a
+new review round. Future follow-ups are retained and processed only after final
+approval. The issue modes create at most three follow-up issues per approved
 round to avoid issue noise.
 
 By default those follow-ups do not change approval semantics and are ignored by
@@ -186,20 +198,24 @@ the loop.
 
 `--approved-followups` accepts:
 
-- `ignore`: ignore non-blocking follow-up bullets from approved reviews. This is the default.
-- `summarize`: post a grouped record on the PR without sending those items back to the coder.
-- `issue`: create GitHub issues for the follow-ups without delaying the PR.
+- `ignore`: ignore approved follow-up sections. This is the default.
+- `summarize`: post future follow-ups as a grouped PR comment.
+- `issue`: create GitHub issues for future follow-ups.
+- `fix-and-summarize`: send same-PR follow-ups to the coder for another review round, then summarize future follow-ups after final approval.
+- `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval.
 
 To keep a grouped record on the PR or create follow-up issues, use:
 
 ```bash
 agent-loop pr 456 --repo OWNER/REPO --approved-followups summarize
 agent-loop pr 456 --repo OWNER/REPO --approved-followups issue
+agent-loop pr 456 --repo OWNER/REPO --approved-followups fix-and-summarize
 ```
 
-Only bullets inside the `Non-blocking follow-ups` section are summarized. The
-section ends at the next heading, HTML marker, or agent signature, so final
-protocol markers are not mistaken for follow-up text.
+Only bullets inside the `Same-PR follow-ups`, `Future follow-ups`, and legacy
+`Non-blocking follow-ups` sections are parsed. Each section ends at the next
+heading, HTML marker, or agent signature, so final protocol markers are not
+mistaken for follow-up text.
 
 For trusted local automation that must run without approval prompts:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -331,30 +331,47 @@ Agent responses are parsed using HTML comment markers:
 
 `AGENT_PR` is required after a coder creates a PR. Review/fix responses must include a final `AGENT_STATE` marker. If a response quotes older markers, the final marker is treated as authoritative.
 
-Approved reviewer responses may also include optional cleanup items under a
+Approved reviewer responses may also include optional future-work items under a
 dedicated heading:
 
 ```md
-### Non-blocking follow-ups
+### Future follow-ups
 - Add a follow-up test.
 ```
 
 Reviewers should use this section only for substantial work that is better
-handled in a separate issue or PR. If a small or local cleanup should be fixed
-in the current PR, the reviewer should mark the review blocking instead.
+handled in a separate issue or PR. The legacy heading
+`### Non-blocking follow-ups` is still accepted as future work for
+compatibility.
+
+When `--approved-followups` is set to a `fix-and-*` mode, approved reviewers
+can put small, low-risk cleanup that should land in the current PR under:
+
+```md
+### Same-PR follow-ups
+- Rename a helper before merge.
+```
+
+Same-PR follow-ups are sent back to the coder in the existing PR and require a
+new review round. Future follow-ups are retained and processed only after the
+final approval round. Without a `fix-and-*` mode, reviewers should mark
+same-PR cleanup blocking instead.
 
 By default, these do not affect approval.
 
 `--approved-followups` accepts:
 
-- `ignore`: ignore non-blocking follow-up bullets from approved reviews. This is the default.
-- `summarize`: post a grouped record on the PR instead of sending those items back to the coder as blocking work.
-- `issue`: create GitHub issues for up to three follow-ups instead of delaying the PR.
+- `ignore`: ignore approved follow-up sections. This is the default.
+- `summarize`: post future follow-ups as a grouped PR comment.
+- `issue`: create GitHub issues for up to three future follow-ups.
+- `fix-and-summarize`: send same-PR follow-ups to the coder for another review round, then summarize future follow-ups after final approval.
+- `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval.
 
-Only bullets inside the `Non-blocking follow-ups` section are summarized; the
-section ends at the next heading, HTML marker, or agent signature. The same
-parsing is used when creating follow-up issues. The issue cap keeps one
-approved review from creating a large batch of low-value issues.
+Only bullets inside the `Same-PR follow-ups`, `Future follow-ups`, and legacy
+`Non-blocking follow-ups` sections are parsed; each section ends at the next
+heading, HTML marker, or agent signature. The same parsing is used when
+creating follow-up issues. The issue cap keeps one approved review from
+creating a large batch of low-value issues.
 
 ## Logs
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -215,11 +215,12 @@ def build_parser() -> argparse.ArgumentParser:
         )
         subparser.add_argument(
             "--approved-followups",
-            choices=("ignore", "summarize", "issue"),
+            choices=("ignore", "summarize", "issue", "fix-and-summarize", "fix-and-issue"),
             default="ignore",
             help=(
-                "How to handle structured non-blocking follow-ups in approved reviews "
-                "('ignore', 'summarize', or 'issue'; default: ignore)."
+                "How to handle structured follow-ups in approved reviews "
+                "('ignore', 'summarize', 'issue', 'fix-and-summarize', or "
+                "'fix-and-issue'; default: ignore)."
             ),
         )
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -23,12 +23,13 @@ from .prompts import (
     build_followup_prompt,
     build_issue_prompt,
     build_review_prompt,
+    build_same_pr_followup_prompt,
     build_task_clarification_prompt,
     build_task_prompt,
     format_agent_list,
 )
 from .protocol import is_clarification_request, parse_agent_state, parse_pr_number
-from .protocol import ApprovedFollowup, parse_non_blocking_followups
+from .protocol import ApprovedFollowup, parse_approved_followups
 from .runner import Runner
 from .workdirs import active_workdir
 
@@ -45,7 +46,7 @@ def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
 
 def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFollowup]) -> str:
     lines = [
-        f"Approved-review non-blocking follow-ups for PR #{pr_number}:",
+        f"Approved-review future follow-ups for PR #{pr_number}:",
         "",
     ]
     for followup in followups:
@@ -53,7 +54,7 @@ def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFo
     lines.extend(
         [
             "",
-            "These were mentioned in approved reviews and did not block merge readiness.",
+            "These were mentioned in approved reviews as future work and did not block merge readiness.",
             "",
             "-- coding-review-agent-loop",
         ]
@@ -63,21 +64,21 @@ def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFo
 
 def _followup_issue_title(followup: ApprovedFollowup) -> str:
     text = " ".join(followup.text.split())
-    title = f"Follow up approved review note: {text}"
+    title = f"Follow up future review note: {text}"
     return title[:120]
 
 
 def _followup_issue_body(pr_number: int, followup: ApprovedFollowup) -> str:
     return "\n".join(
         [
-            f"Non-blocking follow-up from approved review on PR #{pr_number}.",
+            f"Future follow-up from approved review on PR #{pr_number}.",
             "",
             f"Reviewer: {followup.reviewer}",
             "",
             "Follow-up:",
             f"- {followup.text}",
             "",
-            "This was mentioned in an approved review and did not block merge readiness.",
+            "This was mentioned in an approved review as future work and did not block merge readiness.",
             "",
             "-- OpenAI Codex",
         ]
@@ -108,11 +109,20 @@ def _create_approved_followup_issues(
         pr_number=pr_number,
         body=(
             f"Created follow-up issues for the first {len(selected_followups)} "
-            f"approved-review non-blocking items. Skipped {skipped_count} additional "
+            f"approved-review future items. Skipped {skipped_count} additional "
             "item(s) to avoid issue noise; reviewers should reserve this section for "
             "substantial independent follow-up work.\n\n-- coding-review-agent-loop"
         ),
     )
+
+
+def _format_same_pr_followups(followups: list[ApprovedFollowup]) -> str:
+    lines: list[str] = []
+    for followup in followups:
+        lines.append(f"{followup.reviewer} same-PR follow-up:")
+        lines.append(f"- {followup.text}")
+        lines.append("")
+    return "\n".join(lines).strip()
 
 
 def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig) -> int:
@@ -261,11 +271,13 @@ def run_pr_loop(
         # Backward-compatible single-reviewer resume support: older callers
         # pass one reviewer session, so attach it to the first configured reviewer.
         reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
+    pending_future_followups: list[ApprovedFollowup] = []
 
     for round_number in range(1, config.max_rounds + 1):
         coder_name = agent_display_name(config.coder)
         blocking_reviews: list[tuple[str, str]] = []
-        approved_followups: list[ApprovedFollowup] = []
+        same_pr_followups: list[ApprovedFollowup] = []
+        round_future_followups: list[ApprovedFollowup] = []
         pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
@@ -294,15 +306,33 @@ def run_pr_loop(
             if review_state == "blocking":
                 blocking_reviews.append((reviewer_name, review_output))
             elif config.approved_followups != "ignore":
-                approved_followups.extend(
-                    parse_non_blocking_followups(review_output, reviewer=reviewer_name)
-                )
+                followups = parse_approved_followups(review_output, reviewer=reviewer_name)
+                round_future_followups.extend(followups.future)
+                if followups.same_pr:
+                    if config.approved_followups.startswith("fix-and-"):
+                        same_pr_followups.extend(followups.same_pr)
+                    else:
+                        blocking_reviews.append(
+                            (
+                                reviewer_name,
+                                "\n".join(
+                                    [
+                                        "Approved review included Same-PR follow-ups, "
+                                        f"but --approved-followups={config.approved_followups} "
+                                        "does not enable a same-PR fix path.",
+                                        "",
+                                        _format_same_pr_followups(followups.same_pr),
+                                    ]
+                                ),
+                            )
+                        )
 
-        if not blocking_reviews:
-            if config.approved_followups == "summarize" and approved_followups:
+        if not blocking_reviews and not same_pr_followups:
+            approved_followups = [*pending_future_followups, *round_future_followups]
+            if config.approved_followups in ("summarize", "fix-and-summarize") and approved_followups:
                 body = _format_approved_followup_summary(pr_number, approved_followups)
                 post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-            elif config.approved_followups == "issue" and approved_followups:
+            elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
                 _create_approved_followup_issues(
                     runner,
                     config=config,
@@ -321,15 +351,40 @@ def run_pr_loop(
                 "human review required."
             )
 
-        combined_review = "\n\n".join(
-            f"{name} review:\n\n{review}" for name, review in blocking_reviews
-        )
+        if same_pr_followups and not blocking_reviews:
+            pending_future_followups.extend(round_future_followups)
+            combined_review = _format_same_pr_followups(same_pr_followups)
+            followup_prompt = build_same_pr_followup_prompt(
+                pr_number,
+                round_number,
+                combined_review,
+                config,
+                memory,
+            )
+        else:
+            if same_pr_followups:
+                blocking_reviews.append(
+                    (
+                        "Approved same-PR follow-ups",
+                        _format_same_pr_followups(same_pr_followups),
+                    )
+                )
+            combined_review = "\n\n".join(
+                f"{name} review:\n\n{review}" for name, review in blocking_reviews
+            )
+            followup_prompt = build_followup_prompt(
+                pr_number,
+                round_number,
+                combined_review,
+                config,
+                memory,
+            )
         log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
         coder_output, coder_session_id = run_agent(
             runner,
             agent=config.coder,
             config=config,
-            prompt=build_followup_prompt(pr_number, round_number, combined_review, config, memory),
+            prompt=followup_prompt,
             session_id=coder_session_id,
         )
         if not coder_output.strip():

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -153,6 +153,34 @@ def build_review_prompt(
     base_branch = metadata.base_branch or "(unknown)"
     head_sha = metadata.head_sha or "(unknown)"
     url_line = f"- URL: {metadata.url}\n" if metadata.url else ""
+    if config.approved_followups.startswith("fix-and-"):
+        followup_guidance = f"""If you approve but notice small, low-risk cleanup worth fixing before merge,
+list those items under this exact heading:
+
+### Same-PR follow-ups
+
+If you approve but notice substantial work that is better handled separately in
+a future issue or PR, list at most three highest-value items under this exact
+heading:
+
+### Future follow-ups
+
+Same-PR follow-ups will be sent back to {coder_name} and require another review
+round before final approval. Do not put trivial style nits in either follow-up
+section.
+"""
+    else:
+        followup_guidance = """If you approve but notice substantial work that is better handled separately in
+a future issue or PR, list at most three highest-value items under this exact
+heading:
+
+### Future follow-ups
+
+Do not use the Same-PR follow-ups section in this mode; mark the review blocking
+instead when small or local cleanup should be fixed before merge.
+The legacy heading `### Non-blocking follow-ups` is still accepted as future
+follow-ups for compatibility, but prefer `### Future follow-ups`.
+"""
     return f"""Review pull request #{pr_number} in {config.repo} (round {round_number}).
 
 PR metadata:
@@ -178,16 +206,7 @@ commands, or produce a blocking review explaining the limitation.
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this
 review step; report blocking findings if {coder_name} needs to fix anything.
-If a concern is small, local to this PR, and should be fixed before merge, mark
-the review blocking instead of treating it as a follow-up.
-If you approve but notice substantial work that is better handled separately in
-a future issue or PR, list at most three highest-value items under this exact
-heading:
-
-### Non-blocking follow-ups
-
-Do not put trivial style nits, small test gaps, or same-PR cleanup in the
-non-blocking follow-up section.
+{followup_guidance}
 Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.
@@ -231,6 +250,37 @@ This is round {round_number}. End your final response with exactly one marker:
 
 Use blocking to hand the updated PR back to {reviewer_name}. If you cannot safely address
 the review, explain why and still use the blocking marker so a human can
+intervene. Sign the response as:
+-- {coder_signature}
+"""
+
+
+def build_same_pr_followup_prompt(
+    pr_number: int,
+    round_number: int,
+    review: str,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
+) -> str:
+    reviewer_name = format_agent_list(reviewers(config))
+    coder_signature = agent_signature(config.coder)
+    return f"""{reviewer_name} approved pull request #{pr_number} in {config.repo} with same-PR follow-ups.
+
+Address the follow-up items below in this local checkout. Pull/sync the PR
+branch if needed, implement fixes, run relevant tests, commit, and push to the
+same PR. Do not create a new PR.
+{_memory_block(memory)}
+
+Same-PR follow-ups:
+
+{review}
+
+This is round {round_number}. End your final response with exactly one marker:
+
+<!-- AGENT_STATE: blocking -->
+
+Use blocking to hand the updated PR back to {reviewer_name}. If you cannot safely address
+the follow-ups, explain why and still use the blocking marker so a human can
 intervene. Sign the response as:
 -- {coder_signature}
 """

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -11,7 +11,9 @@ STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->", re.I)
 PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
-FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+non[- ]blocking follow[- ]ups\s*$", re.I)
+SAME_PR_FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+same[- ]pr follow[- ]ups\s*$", re.I)
+FUTURE_FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+future follow[- ]ups\s*$", re.I)
+LEGACY_FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+non[- ]blocking follow[- ]ups\s*$", re.I)
 ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
@@ -22,6 +24,12 @@ BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
 class ApprovedFollowup:
     reviewer: str
     text: str
+
+
+@dataclass(frozen=True)
+class ApprovedFollowups:
+    same_pr: list[ApprovedFollowup]
+    future: list[ApprovedFollowup]
 
 
 def parse_agent_state(text: str) -> str:
@@ -46,33 +54,38 @@ def is_clarification_request(text: str) -> bool:
     return bool(CLARIFY_RE.search(text))
 
 
-def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:
-    """Extract bullets from reviewer-approved non-blocking follow-up sections."""
-    followups: list[ApprovedFollowup] = []
-    in_section = False
+def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
+    """Extract same-PR and future follow-up bullets from an approved review."""
+    same_pr: list[ApprovedFollowup] = []
+    future: list[ApprovedFollowup] = []
+    active: list[ApprovedFollowup] | None = None
     current: list[str] = []
 
     def flush_current() -> None:
-        if current:
+        if active is not None and current:
             item = " ".join(part.strip() for part in current if part.strip()).strip()
             if item:
-                followups.append(ApprovedFollowup(reviewer=reviewer, text=item))
+                active.append(ApprovedFollowup(reviewer=reviewer, text=item))
             current.clear()
 
     for line in text.splitlines():
-        if FOLLOWUP_HEADING_RE.match(line):
+        if SAME_PR_FOLLOWUP_HEADING_RE.match(line):
             flush_current()
-            in_section = True
+            active = same_pr
             continue
-        if not in_section:
+        if FUTURE_FOLLOWUP_HEADING_RE.match(line) or LEGACY_FOLLOWUP_HEADING_RE.match(line):
+            flush_current()
+            active = future
+            continue
+        if active is None:
             continue
         if ANY_HEADING_RE.match(line):
             flush_current()
-            in_section = False
+            active = None
             continue
         if HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
             flush_current()
-            in_section = False
+            active = None
             continue
         bullet = BULLET_RE.match(line)
         if bullet:
@@ -83,4 +96,9 @@ def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFo
             current.append(line)
 
     flush_current()
-    return followups
+    return ApprovedFollowups(same_pr=same_pr, future=future)
+
+
+def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:
+    """Extract legacy non-blocking follow-ups as future follow-ups."""
+    return parse_approved_followups(text, reviewer=reviewer).future

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -25,7 +25,7 @@ from coding_review_agent_loop.config import (
     default_agent_workdir,
     default_cache_root,
 )
-from coding_review_agent_loop.protocol import parse_non_blocking_followups
+from coding_review_agent_loop.protocol import parse_approved_followups, parse_non_blocking_followups
 
 
 class FakeRunner(Runner):
@@ -451,6 +451,35 @@ def test_parse_non_blocking_followups_extracts_bullets_only_from_section():
     ]
 
 
+def test_parse_approved_followups_extracts_same_pr_and_future_independently():
+    review = """
+    LGTM with cleanup.
+
+    ### Same-PR follow-ups
+    - Rename the helper for clarity.
+      Keep the public behavior unchanged.
+
+    ### Future follow-ups
+    1. Add an integration fixture later.
+
+    ### Non-blocking follow-ups
+    - Legacy future item.
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    followups = parse_approved_followups(review, reviewer="OpenAI Codex")
+
+    assert [(item.reviewer, item.text) for item in followups.same_pr] == [
+        ("OpenAI Codex", "Rename the helper for clarity. Keep the public behavior unchanged.")
+    ]
+    assert [(item.reviewer, item.text) for item in followups.future] == [
+        ("OpenAI Codex", "Add an integration fixture later."),
+        ("OpenAI Codex", "Legacy future item."),
+    ]
+
+
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])
 def test_parse_non_blocking_followups_stops_at_final_markers(terminator):
     review = f"""
@@ -589,8 +618,21 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     ) in prompt
     assert "gh pr diff 77 --repo OWNER/REPO" in prompt
     assert "requires confirmation in non-interactive mode" in prompt
-    assert "### Non-blocking follow-ups" in prompt
+    assert "### Future follow-ups" in prompt
+    assert "legacy heading `### Non-blocking follow-ups`" in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt
+
+
+def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "### Same-PR follow-ups" in prompt
+    assert "### Future follow-ups" in prompt
+    assert "will be sent back to Claude and require another review" in prompt
 
 
 def test_agent_memory_is_created_and_added_to_review_prompt(tmp_path):
@@ -774,10 +816,10 @@ def test_pr_loop_summarizes_approved_followups_from_multiple_reviewers(tmp_path)
 
     assert len(runner.comments) == 3
     summary = runner.comments[-1]
-    assert summary.startswith("Approved-review non-blocking follow-ups for PR #77:")
+    assert summary.startswith("Approved-review future follow-ups for PR #77:")
     assert "- Add cleanup docs. (Codex)" in summary
     assert "- Add regression coverage. (Claude)" in summary
-    assert "did not block merge readiness" in summary
+    assert "future work and did not block merge readiness" in summary
     assert summary.endswith("-- coding-review-agent-loop")
 
 
@@ -803,28 +845,48 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
     assert len(runner.comments) == 2
     assert runner.issues == [
         {
-            "title": "Follow up approved review note: Add cleanup docs.",
+            "title": "Follow up future review note: Add cleanup docs.",
             "body": (
-                "Non-blocking follow-up from approved review on PR #77.\n\n"
+                "Future follow-up from approved review on PR #77.\n\n"
                 "Reviewer: Codex\n\n"
                 "Follow-up:\n"
                 "- Add cleanup docs.\n\n"
-                "This was mentioned in an approved review and did not block merge readiness.\n\n"
+                "This was mentioned in an approved review as future work and did not block merge readiness.\n\n"
                 "-- OpenAI Codex"
             ),
         },
         {
-            "title": "Follow up approved review note: Add regression coverage.",
+            "title": "Follow up future review note: Add regression coverage.",
             "body": (
-                "Non-blocking follow-up from approved review on PR #77.\n\n"
+                "Future follow-up from approved review on PR #77.\n\n"
                 "Reviewer: Claude\n\n"
                 "Follow-up:\n"
                 "- Add regression coverage.\n\n"
-                "This was mentioned in an approved review and did not block merge readiness.\n\n"
+                "This was mentioned in an approved review as future work and did not block merge readiness.\n\n"
                 "-- OpenAI Codex"
             ),
         },
     ]
+
+
+@pytest.mark.parametrize("mode", ["summarize", "issue"])
+def test_pr_loop_treats_same_pr_followups_as_blocking_without_fix_mode(tmp_path, mode):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with cleanup.\n\n"
+            "### Same-PR follow-ups\n"
+            "- Rename the helper before merge.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+    )
+    config = make_config(tmp_path, approved_followups=mode, max_rounds=1)
+
+    with pytest.raises(AgentLoopError, match="still reported blocking"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(runner.comments) == 1
+    assert not runner.issues
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
 
 def test_pr_loop_caps_approved_followup_issues(tmp_path):
@@ -843,13 +905,107 @@ def test_pr_loop_caps_approved_followup_issues(tmp_path):
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert [issue["title"] for issue in runner.issues] == [
-        "Follow up approved review note: Follow up one.",
-        "Follow up approved review note: Follow up two.",
-        "Follow up approved review note: Follow up three.",
+        "Follow up future review note: Follow up one.",
+        "Follow up future review note: Follow up two.",
+        "Follow up future review note: Follow up three.",
     ]
     assert len(runner.comments) == 2
     assert "Skipped 1 additional item(s) to avoid issue noise" in runner.comments[-1]
     assert runner.comments[-1].endswith("-- coding-review-agent-loop")
+
+
+def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rereviews(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with cleanup.\n\n"
+            "### Same-PR follow-ups\n"
+            "- Rename the helper before merge.\n\n"
+            "### Future follow-ups\n"
+            "- Add broader integration coverage later.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Renamed helper.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"])]
+    assert agent_commands == [["codex", "exec"], ["claude", "--print"], ["codex", "exec"]]
+    assert len(runner.comments) == 4
+    followup_prompt = next(
+        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Same-PR follow-ups" in cmd[-1]
+    )
+    assert "Rename the helper before merge." in followup_prompt
+    summary = runner.comments[-1]
+    assert summary.startswith("Approved-review future follow-ups for PR #77:")
+    assert "- Add broader integration coverage later. (Codex)" in summary
+
+
+def test_pr_loop_fix_and_issue_retains_future_followups_across_same_pr_round(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with cleanup.\n\n"
+            "### Same-PR follow-ups\n"
+            "- Tighten the validation message.\n\n"
+            "### Future follow-ups\n"
+            "- Add a separate migration dry-run command.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(tmp_path, approved_followups="fix-and-issue")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "Follow up future review note: Add a separate migration dry-run command."
+    commands = [cmd[:3] for cmd, _cwd in runner.commands]
+    assert commands.count(["gh", "issue", "create"]) == 1
+
+
+def test_pr_loop_fix_and_summarize_retains_future_followups_from_multiple_reviewers(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with cleanup.\n\n"
+            "### Same-PR follow-ups\n"
+            "- Add a small assertion before merge.\n\n"
+            "### Future follow-ups\n"
+            "- Add Codex's larger follow-up later.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Claude approves.\n\n"
+            "### Future follow-ups\n"
+            "- Add Claude's larger follow-up later.\n"
+            "<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+            "Claude approves final pass.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        gemini_outputs=["Added assertion.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        approved_followups="fix-and-summarize",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"], ["gemini"])]
+    assert agent_commands == [
+        ["codex", "exec"],
+        ["claude", "--print"],
+        ["gemini", "--prompt"],
+        ["codex", "exec"],
+        ["claude", "--print"],
+    ]
+    summary = runner.comments[-1]
+    assert "- Add Codex's larger follow-up later. (Codex)" in summary
+    assert "- Add Claude's larger follow-up later. (Claude)" in summary
 
 
 def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
@@ -1070,7 +1226,7 @@ def test_default_agent_memory_dir_rejects_invalid_repo_formats(repo):
         default_agent_memory_dir(repo)
 
 
-@pytest.mark.parametrize("mode", ["ignore", "summarize", "issue"])
+@pytest.mark.parametrize("mode", ["ignore", "summarize", "issue", "fix-and-summarize", "fix-and-issue"])
 def test_approved_followups_cli_mode_is_configurable(tmp_path, mode):
     parser = build_parser()
     args = parser.parse_args([


### PR DESCRIPTION
## Summary
- add Same-PR and Future follow-up parsing, keeping legacy Non-blocking follow-ups as future work
- add fix-and-summarize and fix-and-issue modes that send same-PR items back to the coder and require re-review
- update review prompts, docs, and regression coverage for all follow-up modes

Fixes #43

## Tests
- python -m pytest