### PR TITLE
Address PR 44 non-blocking follow-ups

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, run_agent
@@ -116,7 +117,7 @@ def _create_approved_followup_issues(
     )
 
 
-def _format_same_pr_followups(followups: list[ApprovedFollowup]) -> str:
+def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
     lines: list[str] = []
     for followup in followups:
         lines.append(f"{followup.reviewer} same-PR follow-up:")
@@ -362,6 +363,10 @@ def run_pr_loop(
                 memory,
             )
         else:
+            # Future follow-ups are only retained for fully approved same-PR fix
+            # rounds. If any reviewer blocks, future-work suggestions from that
+            # round are discarded so reviewers can restate still-relevant items
+            # after the blocking issues have been resolved.
             if same_pr_followups:
                 blocking_reviews.append(
                     (

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -28,8 +28,8 @@ class ApprovedFollowup:
 
 @dataclass(frozen=True)
 class ApprovedFollowups:
-    same_pr: list[ApprovedFollowup]
-    future: list[ApprovedFollowup]
+    same_pr: tuple[ApprovedFollowup, ...]
+    future: tuple[ApprovedFollowup, ...]
 
 
 def parse_agent_state(text: str) -> str:
@@ -96,9 +96,9 @@ def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
             current.append(line)
 
     flush_current()
-    return ApprovedFollowups(same_pr=same_pr, future=future)
+    return ApprovedFollowups(same_pr=tuple(same_pr), future=tuple(future))
 
 
 def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:
     """Extract legacy non-blocking follow-ups as future follow-ups."""
-    return parse_approved_followups(text, reviewer=reviewer).future
+    return list(parse_approved_followups(text, reviewer=reviewer).future)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -471,6 +471,8 @@ def test_parse_approved_followups_extracts_same_pr_and_future_independently():
 
     followups = parse_approved_followups(review, reviewer="OpenAI Codex")
 
+    assert isinstance(followups.same_pr, tuple)
+    assert isinstance(followups.future, tuple)
     assert [(item.reviewer, item.text) for item in followups.same_pr] == [
         ("OpenAI Codex", "Rename the helper for clarity. Keep the public behavior unchanged.")
     ]


### PR DESCRIPTION
## Summary
- make ApprovedFollowups tuple-backed so frozen instances cannot be mutated through list fields
- keep the legacy parse_non_blocking_followups shim returning a list for compatibility
- document why future follow-ups from mixed blocking rounds are intentionally discarded

## Tests
- python -m pytest