### PR TITLE
Refresh PR 32 follow-up issue fixes

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -169,10 +169,10 @@ def create_issue(
     config: AgentLoopConfig,
     title: str,
     body: str,
-) -> None:
+) -> str | None:
     log(config, f"Creating GitHub issue: {title}")
     if config.dry_run:
-        runner.run(
+        result = runner.run(
             [
                 config.gh_cmd,
                 "issue",
@@ -186,13 +186,16 @@ def create_issue(
             ],
             cwd=active_workdir(config),
         )
-        return
+        issue_url = result.stdout.strip() or None
+        if issue_url:
+            log(config, f"Created GitHub issue: {issue_url}")
+        return issue_url
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
         handle.write(body)
         path = handle.name
     try:
-        runner.run(
+        result = runner.run(
             [
                 config.gh_cmd,
                 "issue",
@@ -206,6 +209,10 @@ def create_issue(
             ],
             cwd=active_workdir(config),
         )
+        issue_url = result.stdout.strip() or None
+        if issue_url:
+            log(config, f"Created GitHub issue: {issue_url}")
+        return issue_url
     finally:
         try:
             os.unlink(path)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -80,8 +80,6 @@ def _followup_issue_body(pr_number: int, followup: ApprovedFollowup) -> str:
             f"- {followup.text}",
             "",
             "This was mentioned in an approved review as future work and did not block merge readiness.",
-            "",
-            "-- OpenAI Codex",
         ]
     )
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -853,8 +853,7 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
                 "Reviewer: Codex\n\n"
                 "Follow-up:\n"
                 "- Add cleanup docs.\n\n"
-                "This was mentioned in an approved review as future work and did not block merge readiness.\n\n"
-                "-- OpenAI Codex"
+                "This was mentioned in an approved review as future work and did not block merge readiness."
             ),
         },
         {
@@ -864,11 +863,37 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
                 "Reviewer: Claude\n\n"
                 "Follow-up:\n"
                 "- Add regression coverage.\n\n"
-                "This was mentioned in an approved review as future work and did not block merge readiness.\n\n"
-                "-- OpenAI Codex"
+                "This was mentioned in an approved review as future work and did not block merge readiness."
             ),
         },
     ]
+
+
+def test_pr_loop_creates_no_issues_without_approved_followups(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["Codex approves.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.comments) == 1
+    assert runner.issues == []
+
+
+def test_pr_loop_logs_created_followup_issue_url(tmp_path, capsys):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+    )
+    config = make_config(tmp_path, approved_followups="issue", quiet=False)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    captured = capsys.readouterr()
+    assert "Created GitHub issue: https://github.com/OWNER/REPO/issues/99" in captured.err
 
 
 @pytest.mark.parametrize("mode", ["summarize", "issue"])


### PR DESCRIPTION
## Summary

- Reapply the still-relevant PR 32 follow-up issue fixes on current main.
- Remove the hardcoded Codex signature from generated approved-review follow-up issue bodies while preserving the newer future-work wording.
- Log the issue URL returned by `gh issue create` and add regression coverage for issue mode with and without follow-ups.

## PR 32 assessment

PR #32 is still worth merging in substance, but the branch itself is stale and conflicting after later follow-up handling changes. The needed update is to rebase/conflict-resolve it against current main and keep the newer "future follow-ups" behavior, issue cap, and same-PR follow-up flow.

## Tests

- `python -m pytest tests/test_agent_loop.py -q`
- `python -m pytest`

-- OpenAI Codex