### PR TITLE
Refresh PR 35 follow-up issue links

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ the loop.
 
 - `ignore`: ignore approved follow-up sections. This is the default.
 - `summarize`: post future follow-ups as a grouped PR comment.
-- `issue`: create GitHub issues for future follow-ups.
+- `issue`: create GitHub issues for future follow-ups, then comment with the created issue links.
 - `fix-and-summarize`: send same-PR follow-ups to the coder for another review round, then summarize future follow-ups after final approval.
-- `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval.
+- `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval and comment with the created issue links.
 
 To keep a grouped record on the PR or create follow-up issues, use:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -363,9 +363,9 @@ By default, these do not affect approval.
 
 - `ignore`: ignore approved follow-up sections. This is the default.
 - `summarize`: post future follow-ups as a grouped PR comment.
-- `issue`: create GitHub issues for up to three future follow-ups.
+- `issue`: create GitHub issues for up to three future follow-ups, then comment with the created issue links.
 - `fix-and-summarize`: send same-PR follow-ups to the coder for another review round, then summarize future follow-ups after final approval.
-- `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval.
+- `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval and comment with the created issue links.
 
 Only bullets inside the `Same-PR follow-ups`, `Future follow-ups`, and legacy
 `Non-blocking follow-ups` sections are parsed; each section ends at the next

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -90,29 +90,51 @@ def _create_approved_followup_issues(
     config: AgentLoopConfig,
     pr_number: int,
     followups: list[ApprovedFollowup],
-) -> None:
+) -> tuple[list[str], int]:
+    issue_urls: list[str] = []
     selected_followups = followups[:MAX_APPROVED_FOLLOWUP_ISSUES]
     for followup in selected_followups:
-        create_issue(
+        issue_url = create_issue(
             runner,
             config=config,
             title=_followup_issue_title(followup),
             body=_followup_issue_body(pr_number, followup),
         )
+        if issue_url is not None:
+            issue_urls.append(issue_url)
     skipped_count = len(followups) - len(selected_followups)
-    if skipped_count <= 0:
-        return
-    post_pr_comment(
-        runner,
-        config=config,
-        pr_number=pr_number,
-        body=(
-            f"Created follow-up issues for the first {len(selected_followups)} "
-            f"approved-review future items. Skipped {skipped_count} additional "
-            "item(s) to avoid issue noise; reviewers should reserve this section for "
-            "substantial independent follow-up work.\n\n-- coding-review-agent-loop"
-        ),
+    return issue_urls, skipped_count
+
+
+def _format_created_followup_issue_summary(
+    pr_number: int,
+    issue_urls: list[str],
+    skipped_count: int,
+) -> str:
+    lines = [
+        f"Created approved-review future follow-up issues for PR #{pr_number}:",
+        "",
+    ]
+    if issue_urls:
+        lines.extend(f"- {issue_url}" for issue_url in issue_urls)
+    else:
+        lines.append("- Created issue URL unavailable from GitHub CLI output.")
+    lines.extend(
+        [
+            "",
+            "These were mentioned in approved reviews as future work and did not block merge readiness.",
+        ]
     )
+    if skipped_count > 0:
+        lines.extend(
+            [
+                "",
+                f"Skipped {skipped_count} additional item(s) to avoid issue noise; reviewers should reserve "
+                "this section for substantial independent follow-up work.",
+            ]
+        )
+    lines.extend(["", "-- coding-review-agent-loop"])
+    return "\n".join(lines)
 
 
 def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
@@ -332,12 +354,14 @@ def run_pr_loop(
                 body = _format_approved_followup_summary(pr_number, approved_followups)
                 post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
             elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
-                _create_approved_followup_issues(
+                issue_urls, skipped_count = _create_approved_followup_issues(
                     runner,
                     config=config,
                     pr_number=pr_number,
                     followups=approved_followups,
                 )
+                body = _format_created_followup_issue_summary(pr_number, issue_urls, skipped_count)
+                post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
             run_optional_tests(runner, config)
             if config.auto_merge:
                 wait_for_ci(runner, config, pr_number)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -844,7 +844,7 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    assert len(runner.comments) == 2
+    assert len(runner.comments) == 3
     assert runner.issues == [
         {
             "title": "Follow up future review note: Add cleanup docs.",
@@ -867,6 +867,11 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
             ),
         },
     ]
+    issue_summary = runner.comments[-1]
+    assert issue_summary.startswith("Created approved-review future follow-up issues for PR #77:")
+    assert "- https://github.com/OWNER/REPO/issues/99" in issue_summary
+    assert "future work and did not block merge readiness" in issue_summary
+    assert issue_summary.endswith("-- coding-review-agent-loop")
 
 
 def test_pr_loop_creates_no_issues_without_approved_followups(tmp_path):
@@ -937,8 +942,10 @@ def test_pr_loop_caps_approved_followup_issues(tmp_path):
         "Follow up future review note: Follow up three.",
     ]
     assert len(runner.comments) == 2
-    assert "Skipped 1 additional item(s) to avoid issue noise" in runner.comments[-1]
-    assert runner.comments[-1].endswith("-- coding-review-agent-loop")
+    issue_summary = runner.comments[-1]
+    assert "- https://github.com/OWNER/REPO/issues/99" in issue_summary
+    assert "Skipped 1 additional item(s) to avoid issue noise" in issue_summary
+    assert issue_summary.endswith("-- coding-review-agent-loop")
 
 
 def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rereviews(tmp_path):
@@ -989,6 +996,7 @@ def test_pr_loop_fix_and_issue_retains_future_followups_across_same_pr_round(tmp
 
     assert len(runner.issues) == 1
     assert runner.issues[0]["title"] == "Follow up future review note: Add a separate migration dry-run command."
+    assert "- https://github.com/OWNER/REPO/issues/99" in runner.comments[-1]
     commands = [cmd[:3] for cmd, _cwd in runner.commands]
     assert commands.count(["gh", "issue", "create"]) == 1
 


### PR DESCRIPTION
## Summary
- Keep PR 35's remaining useful behavior by commenting created follow-up issue links back on the PR
- Rebase the behavior onto current follow-up handling, including issue caps and fix-and-issue mode
- Update docs and tests for the issue-link summary comment

Supersedes #35.

## Tests
- python -m pytest