### PR TITLE
Align approved follow-up prompts with ignore mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ separate coding and review passes:
 agent-loop pr 456 --repo OWNER/REPO --reviewer codex --reviewer claude
 ```
 
-Approved reviews may include future work under:
+When `--approved-followups` is set to `summarize`, `issue`, or a `fix-and-*`
+mode, approved reviews may include future work under:
 
 ```md
 ### Future follow-ups
@@ -193,8 +194,9 @@ new review round. Future follow-ups are retained and processed only after final
 approval. The issue modes create at most three follow-up issues per approved
 round to avoid issue noise.
 
-By default those follow-ups do not change approval semantics and are ignored by
-the loop.
+By default, `--approved-followups=ignore` asks reviewers not to include
+approved-review follow-up sections. Reviewers should mark the review blocking
+instead when cleanup should be fixed before merge.
 
 `--approved-followups` accepts:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -331,8 +331,9 @@ Agent responses are parsed using HTML comment markers:
 
 `AGENT_PR` is required after a coder creates a PR. Review/fix responses must include a final `AGENT_STATE` marker. If a response quotes older markers, the final marker is treated as authoritative.
 
-Approved reviewer responses may also include optional future-work items under a
-dedicated heading:
+When `--approved-followups` is set to `summarize`, `issue`, or a `fix-and-*`
+mode, approved reviewer responses may also include optional future-work items
+under a dedicated heading:
 
 ```md
 ### Future follow-ups
@@ -357,7 +358,9 @@ new review round. Future follow-ups are retained and processed only after the
 final approval round. Without a `fix-and-*` mode, reviewers should mark
 same-PR cleanup blocking instead.
 
-By default, these do not affect approval.
+By default, `--approved-followups=ignore` asks reviewers not to include these
+sections. Reviewers should mark the review blocking instead when cleanup should
+be fixed before merge.
 
 `--approved-followups` accepts:
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -153,7 +153,13 @@ def build_review_prompt(
     base_branch = metadata.base_branch or "(unknown)"
     head_sha = metadata.head_sha or "(unknown)"
     url_line = f"- URL: {metadata.url}\n" if metadata.url else ""
-    if config.approved_followups.startswith("fix-and-"):
+    if config.approved_followups == "ignore":
+        followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
+Non-blocking follow-ups sections in approved reviews; this run is configured to
+ignore approved-review follow-up sections. Mark the review blocking instead
+when cleanup should be fixed before merge.
+"""
+    elif config.approved_followups.startswith("fix-and-"):
         followup_guidance = f"""If you approve but notice small, low-risk cleanup worth fixing before merge,
 list those items under this exact heading:
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -620,6 +620,19 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     ) in prompt
     assert "gh pr diff 77 --repo OWNER/REPO" in prompt
     assert "requires confirmation in non-interactive mode" in prompt
+    assert "ignore approved-review follow-up sections" in prompt
+    assert "### Future follow-ups" not in prompt
+    assert "legacy heading `### Non-blocking follow-ups`" not in prompt
+    assert "Use blocking only for issues that should prevent merge." in prompt
+
+
+def test_review_prompt_requests_future_followups_when_processed(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    config = make_config(tmp_path, approved_followups="summarize")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
     assert "### Future follow-ups" in prompt
     assert "legacy heading `### Non-blocking follow-ups`" in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt


### PR DESCRIPTION
## Summary
- stop asking reviewers for approved-review follow-up sections when --approved-followups=ignore will discard them
- keep future follow-up prompt guidance for modes that summarize or create issues
- update docs and prompt tests for the mode-specific behavior

Fixes #43

## Tests
- python -m pytest

-- OpenAI Codex