### PR TITLE
Tighten same-PR followup scope guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ handled in a separate issue or PR. The legacy heading
 `### Non-blocking follow-ups` is still parsed as future work for compatibility.
 
 When `--approved-followups` uses a `fix-and-*` mode, approved reviews may also
-include small, low-risk current-PR cleanup under:
+include small, localized, low-risk current-PR cleanup under:
 
 ```md
 ### Same-PR follow-ups
@@ -190,9 +190,11 @@ include small, low-risk current-PR cleanup under:
 ```
 
 Same-PR follow-ups are sent back to the coder in the existing PR and require a
-new review round. Future follow-ups are retained and processed only after final
-approval. The issue modes create at most three follow-up issues per approved
-round to avoid issue noise.
+new review round. They should stay narrowly scoped to files already touched by
+the PR or directly adjacent code; larger redesigns and independent work belong
+under Future follow-ups. Future follow-ups are retained and processed only after
+final approval. The issue modes create at most three follow-up issues per
+approved round to avoid issue noise.
 
 By default, `--approved-followups=ignore` asks reviewers not to include
 approved-review follow-up sections. Reviewers should mark the review blocking

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -346,7 +346,8 @@ handled in a separate issue or PR. The legacy heading
 compatibility.
 
 When `--approved-followups` is set to a `fix-and-*` mode, approved reviewers
-can put small, low-risk cleanup that should land in the current PR under:
+can put small, localized, low-risk cleanup that should land in the current PR
+under:
 
 ```md
 ### Same-PR follow-ups
@@ -354,9 +355,11 @@ can put small, low-risk cleanup that should land in the current PR under:
 ```
 
 Same-PR follow-ups are sent back to the coder in the existing PR and require a
-new review round. Future follow-ups are retained and processed only after the
-final approval round. Without a `fix-and-*` mode, reviewers should mark
-same-PR cleanup blocking instead.
+new review round. They should stay narrowly scoped to files already touched by
+the PR or directly adjacent code; larger redesigns and independent work belong
+under Future follow-ups. Future follow-ups are retained and processed only
+after the final approval round. Without a `fix-and-*` mode, reviewers should
+mark same-PR cleanup blocking instead.
 
 By default, `--approved-followups=ignore` asks reviewers not to include these
 sections. Reviewers should mark the review blocking instead when cleanup should

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -160,10 +160,14 @@ ignore approved-review follow-up sections. Mark the review blocking instead
 when cleanup should be fixed before merge.
 """
     elif config.approved_followups.startswith("fix-and-"):
-        followup_guidance = f"""If you approve but notice small, low-risk cleanup worth fixing before merge,
-list those items under this exact heading:
+        followup_guidance = f"""If you approve but notice small, localized, low-risk cleanup worth fixing
+before merge, list those items under this exact heading:
 
 ### Same-PR follow-ups
+
+Use Same-PR follow-ups only for narrow current-PR cleanup in files already
+touched by this PR or directly adjacent code. Do not use this section for
+larger redesigns, broad refactors, or independent future work.
 
 If you approve but notice substantial work that is better handled separately in
 a future issue or PR, list at most three highest-value items under this exact
@@ -275,6 +279,9 @@ def build_same_pr_followup_prompt(
 Address the follow-up items below in this local checkout. Pull/sync the PR
 branch if needed, implement fixes, run relevant tests, commit, and push to the
 same PR. Do not create a new PR.
+These same-PR follow-ups are intended to be small, localized cleanup for the
+current PR. Keep the change narrowly scoped to the listed items. Do not take on
+larger redesigns or unrelated future work; call that out instead.
 {_memory_block(memory)}
 
 Same-PR follow-ups:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -647,6 +647,8 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
     assert "### Same-PR follow-ups" in prompt
     assert "### Future follow-ups" in prompt
+    assert "small, localized, low-risk cleanup" in prompt
+    assert "narrow current-PR cleanup in files already\ntouched by this PR or directly adjacent code" in prompt
     assert "will be sent back to Claude and require another review" in prompt
 
 
@@ -985,6 +987,9 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
         cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Same-PR follow-ups" in cmd[-1]
     )
     assert "Rename the helper before merge." in followup_prompt
+    assert "small, localized cleanup for the\ncurrent PR" in followup_prompt
+    assert "Keep the change narrowly scoped to the listed items" in followup_prompt
+    assert "Do not take on\nlarger redesigns or unrelated future work" in followup_prompt
     summary = runner.comments[-1]
     assert summary.startswith("Approved-review future follow-ups for PR #77:")
     assert "- Add broader integration coverage later. (Codex)" in summary


### PR DESCRIPTION
## Summary

- Tighten reviewer guidance so `Same-PR follow-ups` are explicitly small, localized, low-risk current-PR cleanup.
- Tell coders handling same-PR follow-ups to keep changes narrowly scoped and avoid larger redesigns or unrelated future work.
- Update README and detailed docs with the same scope distinction.
- Add tests that assert the stricter prompt wording is present.

## Tests

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -q`

-- OpenAI Codex
