### PR TITLE
Address actionable follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,12 @@ When `--claude-dir`, `--codex-dir`, or `--gemini-dir` is omitted for an active
 agent, the tool creates or reuses a repo-scoped temporary checkout such as
 `/tmp/coding-review-agent-loop/OWNER-REPO/codex/repo`. Existing clean temp
 checkouts are fetched and fast-forwarded on the base branch before the agent
-runs; dirty temp checkouts fail clearly instead of being overwritten. Use
-explicit persistent directories for large repositories, long-lived agent
-worktrees, or setups that should survive `/tmp` cleanup or reboot.
+runs. Default temp checkouts are tool-owned and disposable; if one is dirty,
+the tool resets and cleans it before reuse. Explicit persistent directories are
+kept conservative: dirty explicit workdirs fail clearly, and existing git
+checkouts must point at the requested repository. Use explicit persistent
+directories for large repositories, long-lived agent worktrees, or setups that
+should survive `/tmp` cleanup or reboot.
 
 Agent memory is enabled by default. Before invoking agents, the loop creates or
 refreshes advisory repo memory in a durable, repo-scoped user cache directory

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -185,9 +185,15 @@ by repo and agent:
 The tool prints the selected default workdirs. If a default checkout does not
 exist, it runs `gh repo clone OWNER/REPO <path>`. If it already exists and is a
 clean checkout for the requested repo, it fetches origin and fast-forwards the
-configured base branch. If the checkout is dirty, points at another repo, or is
-not a git checkout, the command fails clearly instead of overwriting local
-work.
+configured base branch. Default checkouts are tool-owned and disposable; if one
+is dirty, the tool logs the cleanup, runs `git reset --hard` and `git clean -fd`,
+then syncs the configured base branch. If a default checkout points at another
+repo or is not a git checkout, the command fails clearly instead of overwriting
+local work.
+
+Explicit workdirs remain conservative. A dirty explicit git checkout fails
+clearly, and an explicit checkout whose origin does not match `--repo` is
+rejected.
 
 These temporary checkouts may disappear after reboot or `/tmp` cleanup. Large
 projects and long-lived agent setups should use explicit persistent workdirs to

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -162,16 +162,33 @@ def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfi
 
     status = _run_git(runner, path, ("status", "--porcelain")).stdout.strip()
     if status:
-        raise AgentLoopError(
-            f"Default {agent} workdir is dirty: {path}. "
-            "Commit, stash, or clean it before rerunning, or pass an explicit agent directory."
-        )
+        log(config, f"Cleaning dirty default {agent} workdir: {path}")
+        _run_git(runner, path, ("reset", "--hard"))
+        _run_git(runner, path, ("clean", "-fd"))
 
     _run_git(runner, path, ("fetch", "origin"))
     checkout = _run_git(runner, path, ("checkout", config.base), check=False)
     if checkout.returncode != 0:
         _run_git(runner, path, ("checkout", "-B", config.base, f"origin/{config.base}"))
     _run_git(runner, path, ("pull", "--ff-only", "origin", config.base))
+
+
+def validate_explicit_workdir(path: Path, option_name: str, config: AgentLoopConfig, runner: Runner) -> None:
+    git_check = _run_git(runner, path, ("rev-parse", "--is-inside-work-tree"), check=False)
+    if git_check.returncode != 0 or git_check.stdout.strip() != "true":
+        return
+
+    status = _run_git(runner, path, ("status", "--porcelain")).stdout.strip()
+    if status:
+        raise AgentLoopError(
+            f"{option_name} is dirty: {path}. Commit, stash, or clean it before rerunning."
+        )
+
+    remote = _run_git(runner, path, ("remote", "get-url", "origin")).stdout.strip()
+    if not _looks_like_repo_remote(remote, config.repo):
+        raise AgentLoopError(
+            f"{option_name} at {path} uses origin {remote!r}, not {config.repo!r}."
+        )
 
 
 def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:
@@ -189,6 +206,7 @@ def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:
             ensure_temp_checkout(path, agent=agent, config=config, runner=runner)
         else:
             ensure_workdir(path, option)
+            validate_explicit_workdir(path, option, config, runner)
     ensure_distinct_workdirs(config)
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, run_agent
@@ -35,6 +37,20 @@ from .runner import Runner
 from .workdirs import active_workdir
 
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
+
+
+@dataclass(frozen=True)
+class GroupedApprovedFollowup:
+    text: str
+    items: tuple[ApprovedFollowup, ...]
+
+    @property
+    def reviewers(self) -> tuple[str, ...]:
+        reviewers: list[str] = []
+        for item in self.items:
+            if item.reviewer not in reviewers:
+                reviewers.append(item.reviewer)
+        return tuple(reviewers)
 
 
 def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
@@ -69,19 +85,74 @@ def _followup_issue_title(followup: ApprovedFollowup) -> str:
     return title[:120]
 
 
-def _followup_issue_body(pr_number: int, followup: ApprovedFollowup) -> str:
-    return "\n".join(
+def _normalize_followup_key(text: str) -> str:
+    key = re.sub(r"`([^`]+)`", r"\1", text)
+    key = re.sub(r"\*\*([^*]+)\*\*", r"\1", key)
+    key = re.sub(r"[_*#>]+", " ", key)
+    key = re.sub(r"[^\w\s]+", " ", key.lower())
+    return " ".join(key.split())
+
+
+def _followup_heading_key(text: str) -> str | None:
+    heading_match = re.match(r"^\s*\*\*(?P<title>[^*]+)\*\*\s*:?", text)
+    if heading_match:
+        return _normalize_followup_key(heading_match.group("title"))
+    first_clause = re.split(r"\s+-\s+|:\s+", text, maxsplit=1)[0]
+    if first_clause != text and 3 <= len(first_clause.split()) <= 12:
+        return _normalize_followup_key(first_clause)
+    return None
+
+
+def _dedupe_approved_followups(followups: Sequence[ApprovedFollowup]) -> list[GroupedApprovedFollowup]:
+    grouped: list[GroupedApprovedFollowup] = []
+    indexes: dict[str, int] = {}
+    for followup in followups:
+        keys = [_normalize_followup_key(followup.text)]
+        heading_key = _followup_heading_key(followup.text)
+        if heading_key:
+            keys.append(heading_key)
+        existing_index = next((indexes[key] for key in keys if key in indexes), None)
+        if existing_index is None:
+            indexes.update((key, len(grouped)) for key in keys if key)
+            grouped.append(GroupedApprovedFollowup(text=followup.text, items=(followup,)))
+            continue
+        existing = grouped[existing_index]
+        grouped[existing_index] = GroupedApprovedFollowup(
+            text=existing.text,
+            items=(*existing.items, followup),
+        )
+        indexes.update((key, existing_index) for key in keys if key)
+    return grouped
+
+
+def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> str:
+    lines = [
+        f"Future follow-up from approved review on PR #{pr_number}.",
+        "",
+    ]
+    reviewers = followup.reviewers
+    if len(reviewers) == 1:
+        lines.append(f"Reviewer: {reviewers[0]}")
+    else:
+        lines.append("Reviewers:")
+        lines.extend(f"- {reviewer}" for reviewer in reviewers)
+    lines.extend(
         [
-            f"Future follow-up from approved review on PR #{pr_number}.",
-            "",
-            f"Reviewer: {followup.reviewer}",
             "",
             "Follow-up:",
             f"- {followup.text}",
+        ]
+    )
+    if len(followup.items) > 1:
+        lines.extend(["", "Original reviewer notes:"])
+        lines.extend(f"- {item.reviewer}: {item.text}" for item in followup.items)
+    lines.extend(
+        [
             "",
             "This was mentioned in an approved review as future work and did not block merge readiness.",
         ]
     )
+    return "\n".join(lines)
 
 
 def _create_approved_followup_issues(
@@ -92,17 +163,20 @@ def _create_approved_followup_issues(
     followups: list[ApprovedFollowup],
 ) -> tuple[list[str], int]:
     issue_urls: list[str] = []
-    selected_followups = followups[:MAX_APPROVED_FOLLOWUP_ISSUES]
+    deduped_followups = _dedupe_approved_followups(followups)
+    selected_followups = deduped_followups[:MAX_APPROVED_FOLLOWUP_ISSUES]
     for followup in selected_followups:
         issue_url = create_issue(
             runner,
             config=config,
-            title=_followup_issue_title(followup),
+            title=_followup_issue_title(
+                ApprovedFollowup(reviewer=followup.reviewers[0], text=followup.text)
+            ),
             body=_followup_issue_body(pr_number, followup),
         )
         if issue_url is not None:
             issue_urls.append(issue_url)
-    skipped_count = len(followups) - len(selected_followups)
+    skipped_count = len(deduped_followups) - len(selected_followups)
     return issue_urls, skipped_count
 
 
@@ -111,12 +185,13 @@ def _format_created_followup_issue_summary(
     issue_urls: list[str],
     skipped_count: int,
 ) -> str:
+    unique_issue_urls = list(dict.fromkeys(issue_urls))
     lines = [
         f"Created approved-review future follow-up issues for PR #{pr_number}:",
         "",
     ]
-    if issue_urls:
-        lines.extend(f"- {issue_url}" for issue_url in issue_urls)
+    if unique_issue_urls:
+        lines.extend(f"- {issue_url}" for issue_url in unique_issue_urls)
     else:
         lines.append("- Created issue URL unavailable from GitHub CLI output.")
     lines.extend(
@@ -360,8 +435,9 @@ def run_pr_loop(
                     pr_number=pr_number,
                     followups=approved_followups,
                 )
-                body = _format_created_followup_issue_summary(pr_number, issue_urls, skipped_count)
-                post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+                if issue_urls:
+                    body = _format_created_followup_issue_summary(pr_number, issue_urls, skipped_count)
+                    post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
             run_optional_tests(runner, config)
             if config.auto_merge:
                 wait_for_ci(runner, config, pr_number)

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -27,6 +27,15 @@ def _memory_block(memory: AgentMemoryContext | None) -> str:
     return f"Agent memory context:\n{text}\n"
 
 
+def _scratch_file_guidance() -> str:
+    return (
+        "If you need temporary scratch files while inspecting diffs or command output, "
+        "write them outside the repository checkout, for example under "
+        "/tmp/coding-review-agent-loop/scratch/. Do not create temporary files in the "
+        "repo worktree unless they are intended project changes.\n"
+    )
+
+
 def build_issue_prompt(
     issue_number: int,
     config: AgentLoopConfig,
@@ -38,6 +47,7 @@ def build_issue_prompt(
 
 Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
+{_scratch_file_guidance()}
 {_memory_block(memory)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
@@ -75,6 +85,7 @@ Use this local checkout as your workspace. Decide between two paths:
     {config.base}. Do not wait for {reviewer_name}; this local orchestrator
     will run {reviewer_name} after you create the PR. End your final response
     with both markers:
+{_scratch_file_guidance()}
 
     <!-- AGENT_PR: <number> -->
     <!-- AGENT_STATE: blocking -->
@@ -116,6 +127,7 @@ Clarification so far:
 Now proceed. Strongly prefer to implement the task and open a PR. Only ask
 again if a critical detail is still missing. Use the same response markers as
 before:
+{_scratch_file_guidance()}
 
 - For implementation: include both <!-- AGENT_PR: <number> --> and
   <!-- AGENT_STATE: blocking --> at the end of your final response.
@@ -203,6 +215,7 @@ PR metadata:
 {url_line}
 Use this PR metadata as authoritative. Do not spend time discovering the PR
 branch.
+{_scratch_file_guidance()}
 {_memory_block(memory)}
 
 Suggested commands:
@@ -248,6 +261,7 @@ def build_followup_prompt(
 Address the review below in this local checkout. Pull/sync the PR branch if
 needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
+{_scratch_file_guidance()}
 {_memory_block(memory)}
 
 {reviewer_name} review:
@@ -282,6 +296,7 @@ same PR. Do not create a new PR.
 These same-PR follow-ups are intended to be small, localized cleanup for the
 current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead.
+{_scratch_file_guidance()}
 {_memory_block(memory)}
 
 Same-PR follow-ups:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -45,6 +45,7 @@ class FakeRunner(Runner):
         changed_files=None,
         diff_returncode=0,
         diff_stderr="",
+        issue_urls=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -81,6 +82,7 @@ class FakeRunner(Runner):
         self.changed_files = changed_files or ["src/coding_review_agent_loop/cli.py"]
         self.diff_returncode = diff_returncode
         self.diff_stderr = diff_stderr
+        self.issue_urls = list(issue_urls) if issue_urls is not None else None
 
     def _record_command(self, args, cwd):
         cmd = [str(arg) for arg in args]
@@ -153,7 +155,11 @@ class FakeRunner(Runner):
             else:
                 body = cmd[cmd.index("--body") + 1]
             self.issues.append({"title": title, "body": body})
-            return CommandResult(cmd, cwd_path, "https://github.com/OWNER/REPO/issues/99\n", "", 0)
+            if self.issue_urls is None:
+                issue_url = "https://github.com/OWNER/REPO/issues/99"
+            else:
+                issue_url = self.issue_urls.pop(0)
+            return CommandResult(cmd, cwd_path, f"{issue_url or ''}\n", "", 0)
 
         if cmd[:3] == ["gh", "pr", "view"]:
             if "--jq" in cmd and ".headRefOid" in cmd:
@@ -620,6 +626,8 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     ) in prompt
     assert "gh pr diff 77 --repo OWNER/REPO" in prompt
     assert "requires confirmation in non-interactive mode" in prompt
+    assert "write them outside the repository checkout" in prompt
+    assert "/tmp/coding-review-agent-loop/scratch/" in prompt
     assert "ignore approved-review follow-up sections" in prompt
     assert "### Future follow-ups" not in prompt
     assert "legacy heading `### Non-blocking follow-ups`" not in prompt
@@ -885,8 +893,69 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
     issue_summary = runner.comments[-1]
     assert issue_summary.startswith("Created approved-review future follow-up issues for PR #77:")
     assert "- https://github.com/OWNER/REPO/issues/99" in issue_summary
+    assert issue_summary.count("https://github.com/OWNER/REPO/issues/99") == 1
     assert "future work and did not block merge readiness" in issue_summary
     assert issue_summary.endswith("-- coding-review-agent-loop")
+
+
+def test_pr_loop_deduplicates_approved_followup_issues_across_reviewers(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves.\n\n### Future follow-ups\n"
+            "- **Remote validation**: Validate explicit workdir git remotes against the target repo.\n"
+            "- Add a distinct dry-run smoke test.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        claude_outputs=[
+            "Claude approves.\n\n### Future follow-ups\n"
+            "- **Remote validation**: Validate explicit workdir git remotes against the target repo.\n"
+            "- Document cache cleanup behavior.\n"
+            "<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"
+        ],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/99",
+            "https://github.com/OWNER/REPO/issues/100",
+            "https://github.com/OWNER/REPO/issues/101",
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        approved_followups="issue",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert [issue["title"] for issue in runner.issues] == [
+        "Follow up future review note: **Remote validation**: Validate explicit workdir git remotes against the target repo.",
+        "Follow up future review note: Add a distinct dry-run smoke test.",
+        "Follow up future review note: Document cache cleanup behavior.",
+    ]
+    remote_body = runner.issues[0]["body"]
+    assert "Reviewers:\n- Codex\n- Claude" in remote_body
+    assert "Original reviewer notes:" in remote_body
+    assert "- Codex: **Remote validation**" in remote_body
+    assert "- Claude: **Remote validation**" in remote_body
+    issue_summary = runner.comments[-1]
+    assert "- https://github.com/OWNER/REPO/issues/99" in issue_summary
+    assert "- https://github.com/OWNER/REPO/issues/100" in issue_summary
+    assert "- https://github.com/OWNER/REPO/issues/101" in issue_summary
+
+
+def test_pr_loop_suppresses_followup_issue_summary_when_no_urls_returned(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        issue_urls=[None],
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.comments) == 1
+    assert len(runner.issues) == 1
 
 
 def test_pr_loop_creates_no_issues_without_approved_followups(tmp_path):
@@ -1466,21 +1535,67 @@ def test_clean_existing_auto_agent_dir_is_synced(tmp_path):
     assert ["git", "pull", "--ff-only", "origin", "main"] in commands
 
 
-def test_dirty_existing_auto_agent_dir_fails_clearly(tmp_path):
+def test_dirty_existing_auto_agent_dir_is_cleaned_before_sync(tmp_path, capsys):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        git_status=" M file.py\n",
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        coder="codex",
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+        quiet=False,
+    )
+    config.gemini_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["git", "reset", "--hard"] in commands
+    assert ["git", "clean", "-fd"] in commands
+    assert ["git", "pull", "--ff-only", "origin", "main"] in commands
+    captured = capsys.readouterr()
+    assert f"Cleaning dirty default codex workdir: {codex_dir}" in captured.err
+
+
+def test_dirty_explicit_agent_dir_fails_clearly(tmp_path):
     runner = FakeRunner(git_status=" M file.py\n")
     codex_dir = tmp_path / "codex"
     codex_dir.mkdir()
     config = make_config(
         tmp_path,
         codex_dir=codex_dir,
+        coder="codex",
         reviewer="codex",
-        auto_agent_dirs=("codex",),
         create_dirs=False,
     )
-    config.claude_dir.mkdir(parents=True)
     config.gemini_dir.mkdir(parents=True)
 
-    with pytest.raises(AgentLoopError, match="dirty"):
+    with pytest.raises(AgentLoopError, match="--codex-dir is dirty"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_explicit_agent_dir_must_match_requested_repo(tmp_path):
+    runner = FakeRunner(git_remote="git@github.com:OTHER/REPO.git")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        coder="codex",
+        reviewer="codex",
+        create_dirs=False,
+    )
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="not 'OWNER/REPO'"):
         run_pr_loop(runner, pr_number=77, config=config)
 
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)


### PR DESCRIPTION
## Summary

- Deduplicate approved-review future follow-up issues across reviewers, preserve merged reviewer attribution, and de-duplicate created issue links in the PR summary.
- Keep explicit workdirs conservative while cleaning dirty tool-owned default temp checkouts before reuse.
- Add scratch-file prompt guidance and update docs for disposable default temp workdirs.

## Issue handling

Closes #52
Closes #50
Closes #47
Closes #40
Closes #38
Closes #37

Open issues #33 and #34 are already addressed by current URL surfacing on main. Open issues #36 and #39 are already addressed by the current follow-up issue body, which no longer hardcodes an OpenAI Codex footer. I left #41 alone because the dry-run behavior is consistent with the existing dry-run contract and does not warrant more issue-mode special casing in this pass.

## Tests

- python -m pytest -q
- python -m compileall -q src tests
- git diff --check