### PR TITLE
Ignore empty approved followup placeholders

### DIFF
--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -18,6 +18,10 @@ ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
 BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
+EMPTY_FOLLOWUP_RE = re.compile(
+    r"^(?:none|n/a|no follow[- ]?ups?|no same[- ]pr follow[- ]?ups?|no future follow[- ]?ups?)\.?$",
+    re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -64,7 +68,7 @@ def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
     def flush_current() -> None:
         if active is not None and current:
             item = " ".join(part.strip() for part in current if part.strip()).strip()
-            if item:
+            if item and not EMPTY_FOLLOWUP_RE.match(item):
                 active.append(ApprovedFollowup(reviewer=reviewer, text=item))
             current.clear()
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -482,6 +482,37 @@ def test_parse_approved_followups_extracts_same_pr_and_future_independently():
     ]
 
 
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "None",
+        "none.",
+        "N/A",
+        "No follow-ups",
+        "No same-PR follow-ups.",
+        "No future follow-ups",
+    ],
+)
+def test_parse_approved_followups_ignores_empty_placeholders(placeholder):
+    review = f"""
+    LGTM.
+
+    ### Same-PR follow-ups
+    - {placeholder}
+
+    ### Future follow-ups
+    - {placeholder}
+
+    <!-- AGENT_STATE: approved -->
+    -- Google Gemini
+    """
+
+    followups = parse_approved_followups(review, reviewer="Gemini")
+
+    assert followups.same_pr == ()
+    assert followups.future == ()
+
+
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])
 def test_parse_non_blocking_followups_stops_at_final_markers(terminator):
     review = f"""


### PR DESCRIPTION
## Summary

- Ignore explicit empty approved-followup placeholders such as `None`, `N/A`, and `No follow-ups`.
- Prevent `fix-and-*` loops from sending `- None` back to the coder as an actionable same-PR follow-up.
- Add parser regression coverage for same-PR and future follow-up sections.

## Tests

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -q`

-- OpenAI Codex
