### PR TITLE
Include issue comments in issue-mode context

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ python -m pytest
 
 ## Quick Start
 
-Start from a GitHub issue when you want the agent loop to use the issue title
-and body as the implementation task:
+Start from a GitHub issue when you want the agent loop to use the issue title,
+body, and comments as the implementation task. Comments are included oldest to
+newest, and prompts tell agents that later comments may refine or supersede the
+original issue body:
 
 ```bash
 agent-loop issue 123 --repo OWNER/REPO

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -136,6 +136,10 @@ Fix a GitHub issue:
 agent-loop issue 56 --repo OWNER/REPO
 ```
 
+Issue mode includes the issue title, body, and comments in the coder prompt and
+issue-origin review prompts. Comments are ordered oldest to newest so later
+discussion can refine or supersede the original body.
+
 Implement a free-form task:
 
 ```bash

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -29,6 +29,23 @@ class PullRequestMetadata:
     url: str | None
 
 
+@dataclass(frozen=True)
+class IssueComment:
+    author: str | None
+    created_at: str | None
+    body: str | None
+
+
+@dataclass(frozen=True)
+class IssueContext:
+    number: int
+    repo: str
+    title: str | None
+    body: str | None
+    url: str | None
+    comments: tuple[IssueComment, ...]
+
+
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
     result = runner.run(
         [gh_cmd, "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
@@ -122,6 +139,60 @@ def validate_open_issue(runner: Runner, *, config: AgentLoopConfig, issue_number
         raise AgentLoopError(
             f"Issue #{issue_number} is {data.get('state', 'not open')}; provide an open issue number."
         )
+
+
+def _comment_sort_key(comment: IssueComment) -> str:
+    return comment.created_at or ""
+
+
+def get_issue_context(runner: Runner, *, config: AgentLoopConfig, issue_number: int) -> IssueContext:
+    if config.dry_run:
+        return IssueContext(
+            number=issue_number,
+            repo=config.repo,
+            title=None,
+            body=None,
+            url=None,
+            comments=(),
+        )
+
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            config.repo,
+            "--comments",
+            "--json",
+            "number,title,body,url,comments",
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    comments: list[IssueComment] = []
+    for raw_comment in data.get("comments") or []:
+        author = raw_comment.get("author")
+        if isinstance(author, dict):
+            author_name = author.get("login")
+        else:
+            author_name = None
+        comments.append(
+            IssueComment(
+                author=author_name,
+                created_at=raw_comment.get("createdAt") or raw_comment.get("created_at"),
+                body=raw_comment.get("body"),
+            )
+        )
+    return IssueContext(
+        number=int(data.get("number") or issue_number),
+        repo=config.repo,
+        title=data.get("title"),
+        body=data.get("body"),
+        url=data.get("url"),
+        comments=tuple(sorted(comments, key=_comment_sort_key)),
+    )
 
 
 def post_pr_comment(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -12,7 +12,9 @@ from .agents.registry import agent_display_name, run_agent
 from .config import AgentLoopConfig, ensure_agent_workdirs, reviewers
 from .errors import AgentLoopError
 from .github import (
+    IssueContext,
     create_issue,
+    get_issue_context,
     get_pr_metadata,
     merge_pr,
     post_pr_comment,
@@ -225,13 +227,14 @@ def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig
     ensure_agent_workdirs(config, runner)
     log(config, f"Validating issue #{issue_number}")
     validate_open_issue(runner, config=config, issue_number=issue_number)
+    issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
     memory = prepare_agent_memory(runner, config)
 
     coder_output, coder_session_id = run_agent(
         runner,
         agent=config.coder,
         config=config,
-        prompt=build_issue_prompt(issue_number, config, memory),
+        prompt=build_issue_prompt(issue_number, config, memory, issue_context=issue_context),
     )
     pr_number = parse_pr_number(coder_output)
     if pr_number is None:
@@ -247,6 +250,7 @@ def run_issue_loop(runner: Runner, *, issue_number: int, config: AgentLoopConfig
         pr_number=pr_number,
         config=config,
         coder_session_id=coder_session_id,
+        issue_context=issue_context,
         workdirs_ready=True,
     )
 
@@ -354,6 +358,7 @@ def run_pr_loop(
     config: AgentLoopConfig,
     coder_session_id: str | None = None,
     reviewer_session_id: str | None = None,
+    issue_context: IssueContext | None = None,
     workdirs_ready: bool = False,
 ) -> int:
     if not workdirs_ready:
@@ -389,6 +394,7 @@ def run_pr_loop(
                     reviewer=reviewer,
                     pr_metadata=pr_metadata,
                     memory=memory,
+                    issue_context=issue_context,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
             )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -465,6 +465,7 @@ def run_pr_loop(
                 combined_review,
                 config,
                 memory,
+                issue_context=issue_context,
             )
         else:
             # Future follow-ups are only retained for fully approved same-PR fix
@@ -487,6 +488,7 @@ def run_pr_loop(
                 combined_review,
                 config,
                 memory,
+                issue_context=issue_context,
             )
         log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
         coder_output, coder_session_id = run_agent(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -92,7 +92,24 @@ def format_issue_context(issue_context: IssueContext, *, max_chars: int = 24_000
                 kept_comments = candidate_comments
                 omitted_count = len(comments) - len(candidate_comments)
             elif not kept_comments:
+                omitted_count = len(comments) - 1
+                notice = (
+                    "\n\n"
+                    f"Older comments omitted: {omitted_count} comment(s) were omitted to keep "
+                    "this prompt bounded. Newest comments were kept preferentially."
+                )
+                prefix = issue_header + notice
+                remaining_chars = max_chars - len(prefix)
+                if remaining_chars > 0:
+                    truncated_comment = _truncate_issue_text(
+                        comment_text,
+                        max_chars=remaining_chars,
+                        label="Newest comment",
+                    )
+                    if len(prefix) + len(truncated_comment) <= max_chars:
+                        return prefix + truncated_comment
                 omitted_count = len(comments)
+                break
             else:
                 break
         if kept_comments:
@@ -343,6 +360,7 @@ def build_followup_prompt(
     review: str,
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
@@ -352,6 +370,7 @@ Address the review below in this local checkout. Pull/sync the PR branch if
 needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_scratch_file_guidance()}
+{_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
 {reviewer_name} review:
@@ -375,6 +394,7 @@ def build_same_pr_followup_prompt(
     review: str,
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
@@ -387,6 +407,7 @@ These same-PR follow-ups are intended to be small, localized cleanup for the
 current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead.
 {_scratch_file_guidance()}
+{_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
 Same-PR follow-ups:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -7,7 +7,7 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
-from .github import PullRequestMetadata
+from .github import IssueContext, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
 
 
@@ -36,10 +36,97 @@ def _scratch_file_guidance() -> str:
     )
 
 
+def _truncate_issue_text(text: str, *, max_chars: int, label: str) -> str:
+    if len(text) <= max_chars:
+        return text
+    suffix = f"\n\n[{label} truncated to keep this prompt bounded.]"
+    return text[: max(0, max_chars - len(suffix))].rstrip() + suffix
+
+
+def format_issue_context(issue_context: IssueContext, *, max_chars: int = 24_000) -> str:
+    raw_body = issue_context.body if issue_context.body else "(none)"
+    body = _truncate_issue_text(raw_body, max_chars=max_chars // 3, label="Issue body")
+    title = issue_context.title if issue_context.title else "(unknown)"
+    lines = [
+        f"GitHub issue #{issue_context.number}",
+        "",
+        "Title:",
+        title,
+        "",
+        "Body:",
+        body,
+        "",
+        "Comments, oldest to newest:",
+    ]
+    if issue_context.comments:
+        comments = [
+            "\n".join(
+                [
+                    "",
+                    (
+                        f"Comment by {comment.author or '(unknown)'} "
+                        f"at {comment.created_at or '(unknown time)'}:"
+                    ),
+                    comment.body if comment.body else "(none)",
+                ]
+            )
+            for comment in issue_context.comments
+        ]
+        issue_header = "\n".join(lines)
+        full_text = issue_header + "\n".join(comments)
+        if len(full_text) <= max_chars:
+            return full_text
+
+        kept_comments: list[str] = []
+        omitted_count = 0
+        for comment_text in reversed(comments):
+            candidate_comments = [comment_text, *kept_comments]
+            notice = (
+                "\n\n"
+                f"Older comments omitted: {len(comments) - len(candidate_comments)} "
+                "comment(s) were omitted to keep this prompt bounded. "
+                "Newest comments were kept preferentially."
+            )
+            candidate = issue_header + notice + "".join(candidate_comments)
+            if len(candidate) <= max_chars:
+                kept_comments = candidate_comments
+                omitted_count = len(comments) - len(candidate_comments)
+            elif not kept_comments:
+                omitted_count = len(comments)
+            else:
+                break
+        if kept_comments:
+            return (
+                issue_header
+                + "\n\n"
+                + f"Older comments omitted: {omitted_count} comment(s) were omitted to keep "
+                "this prompt bounded. Newest comments were kept preferentially."
+                + "".join(kept_comments)
+            )
+        return (
+            issue_header
+            + "\n\n"
+            + f"All {omitted_count} comment(s) were omitted to keep this prompt bounded. "
+            "Fetch the issue discussion directly if those details are needed."
+        )
+    return "\n".join([*lines, "", "(none)"])
+
+
+def _issue_context_block(issue_context: IssueContext | None) -> str:
+    if issue_context is None:
+        return ""
+    return (
+        "Issue context from GitHub. Later comments may refine or supersede the "
+        "original issue body:\n"
+        f"{format_issue_context(issue_context)}\n"
+    )
+
+
 def build_issue_prompt(
     issue_number: int,
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
@@ -48,6 +135,7 @@ def build_issue_prompt(
 Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_scratch_file_guidance()}
+{_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
@@ -147,6 +235,7 @@ def build_review_prompt(
     reviewer: AgentName,
     pr_metadata: PullRequestMetadata | None = None,
     memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
@@ -216,6 +305,7 @@ PR metadata:
 Use this PR metadata as authoritative. Do not spend time discovering the PR
 branch.
 {_scratch_file_guidance()}
+{_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
 Suggested commands:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -26,6 +26,8 @@ from coding_review_agent_loop.config import (
     default_agent_workdir,
     default_cache_root,
 )
+from coding_review_agent_loop.github import IssueComment, IssueContext
+from coding_review_agent_loop.prompts import format_issue_context
 from coding_review_agent_loop.protocol import parse_approved_followups, parse_non_blocking_followups
 
 
@@ -653,6 +655,37 @@ def test_issue_loop_includes_issue_comments_in_coder_and_review_prompts(tmp_path
         assert "Later comment should come second." in prompt
 
 
+def test_format_issue_context_truncates_oversized_newest_comment():
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="first-user",
+                created_at="2026-05-17T09:00:00Z",
+                body="Older detail should not be kept instead of the newest comment.",
+            ),
+            IssueComment(
+                author="second-user",
+                created_at="2026-05-17T10:00:00Z",
+                body="Newest detail. " + ("x" * 1000),
+            ),
+        ),
+    )
+
+    text = format_issue_context(issue_context, max_chars=700)
+
+    assert len(text) <= 700
+    assert "Older comments omitted: 1 comment(s)" in text
+    assert "Comment by second-user at 2026-05-17T10:00:00Z" in text
+    assert "Newest detail." in text
+    assert "[Newest comment truncated to keep this prompt bounded.]" in text
+    assert "Older detail should not be kept instead of the newest comment." not in text
+
+
 def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
@@ -742,6 +775,41 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     assert "### Future follow-ups" not in prompt
     assert "legacy heading `### Non-blocking follow-ups`" not in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt
+
+
+def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Needs a fix.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(tmp_path)
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="commenter",
+                created_at="2026-05-17T10:00:00Z",
+                body="Clarifying issue comment.",
+            ),
+        ),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config, issue_context=issue_context) == 0
+
+    followup_prompt = next(
+        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Address the review below" in cmd[-1]
+    )
+    assert "Issue context from GitHub" in followup_prompt
+    assert "Title:\nSupport issue comments" in followup_prompt
+    assert "Clarifying issue comment." in followup_prompt
+    assert "Needs a fix." in followup_prompt
 
 
 def test_review_prompt_requests_future_followups_when_processed(tmp_path):
@@ -1161,8 +1229,22 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
         claude_outputs=["Renamed helper.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
     config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="commenter",
+                created_at="2026-05-17T10:00:00Z",
+                body="Clarifying issue comment.",
+            ),
+        ),
+    )
 
-    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert run_pr_loop(runner, pr_number=77, config=config, issue_context=issue_context) == 0
 
     agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"])]
     assert agent_commands == [["codex", "exec"], ["claude", "--print"], ["codex", "exec"]]
@@ -1171,6 +1253,9 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
         cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Same-PR follow-ups" in cmd[-1]
     )
     assert "Rename the helper before merge." in followup_prompt
+    assert "Issue context from GitHub" in followup_prompt
+    assert "Title:\nSupport issue comments" in followup_prompt
+    assert "Clarifying issue comment." in followup_prompt
     assert "small, localized cleanup for the\ncurrent PR" in followup_prompt
     assert "Keep the change narrowly scoped to the listed items" in followup_prompt
     assert "Do not take on\nlarger redesigns or unrelated future work" in followup_prompt

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -37,6 +37,7 @@ class FakeRunner(Runner):
         codex_outputs=None,
         gemini_outputs=None,
         issue_payload=None,
+        issue_comments=None,
         pr_payload=None,
         git_status="",
         git_remote="git@github.com:OWNER/REPO.git",
@@ -58,7 +59,10 @@ class FakeRunner(Runner):
             "state": "open",
             "is_pr": False,
             "url": "https://github.com/OWNER/REPO/issues/56",
+            "title": "Fix issue-mode context",
+            "body": "Original issue body.",
         }
+        self.issue_comments = list(issue_comments or [])
         self.pr_payload = pr_payload or {
             "number": 77,
             "state": "OPEN",
@@ -181,6 +185,16 @@ class FakeRunner(Runner):
             if "--jq" in cmd and ".headRefOid" in cmd:
                 return CommandResult(cmd, cwd_path, "abc123\n", "", 0)
             return CommandResult(cmd, cwd_path, json_dumps(self.pr_payload), "", 0)
+
+        if cmd[:3] == ["gh", "issue", "view"]:
+            payload = {
+                "number": self.issue_payload.get("number", 56),
+                "title": self.issue_payload.get("title"),
+                "body": self.issue_payload.get("body"),
+                "url": self.issue_payload.get("url"),
+                "comments": self.issue_comments,
+            }
+            return CommandResult(cmd, cwd_path, json_dumps(payload), "", 0)
 
         if cmd[:2] == ["gh", "api"] and "/issues/" in cmd[2]:
             return CommandResult(cmd, cwd_path, json_dumps(self.issue_payload), "", 0)
@@ -588,6 +602,55 @@ def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     assert list((tmp_path / "logs").glob("*-claude.log"))
     assert list((tmp_path / "logs").glob("*-codex.log"))
     assert (tmp_path / "logs" / ".gitignore").read_text(encoding="utf-8") == "*\n!.gitignore\n"
+
+
+def test_issue_loop_includes_issue_comments_in_coder_and_review_prompts(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "number": 56,
+            "state": "open",
+            "is_pr": False,
+            "url": "https://github.com/OWNER/REPO/issues/56",
+            "title": "Support issue comments",
+            "body": "Original request.",
+        },
+        issue_comments=[
+            {
+                "author": {"login": "second-user"},
+                "createdAt": "2026-05-17T10:00:00Z",
+                "body": "Later comment should come second.",
+            },
+            {
+                "author": {"login": "first-user"},
+                "createdAt": "2026-05-17T09:00:00Z",
+                "body": "Earlier comment refines the request.",
+            },
+        ],
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    claude_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    codex_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    for prompt in (claude_prompt, codex_prompt):
+        assert "Issue context from GitHub" in prompt
+        assert "Later comments may refine or supersede the original issue body" in prompt
+        assert "GitHub issue #56" in prompt
+        assert "Title:\nSupport issue comments" in prompt
+        assert "Body:\nOriginal request." in prompt
+        assert "Comments, oldest to newest:" in prompt
+        assert prompt.index("Comment by first-user at 2026-05-17T09:00:00Z") < prompt.index(
+            "Comment by second-user at 2026-05-17T10:00:00Z"
+        )
+        assert "Earlier comment refines the request." in prompt
+        assert "Later comment should come second." in prompt
 
 
 def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):


### PR DESCRIPTION
## Summary
- fetch issue title, body, and comments for issue-mode runs
- include bounded issue context in coder prompts and issue-origin review prompts
- document issue comment handling and add regression coverage

Fixes #68

## Tests
- /tmp/coding-review-agent-loop/scratch/issue68-venv/bin/python -m pytest -q