### PR TITLE
Support Markdown variants for follow-up headings

### DIFF
--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -12,9 +12,19 @@ PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*--
 PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
-SAME_PR_FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+same[- ]pr follow[- ]ups:?\s*$", re.I)
-FUTURE_FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+future follow[- ]ups:?\s*$", re.I)
-LEGACY_FOLLOWUP_HEADING_RE = re.compile(r"^\s*#{2,6}\s+non[- ]blocking follow[- ]ups:?\s*$", re.I)
+def _followup_heading_re(title: str) -> re.Pattern[str]:
+    title_with_punctuation = rf"{title}[:.]?"
+    return re.compile(
+        rf"^\s*#{{2,6}}\s+"
+        rf"(?:{title_with_punctuation}|\*\*{title}\*\*[:.]?|\*\*{title_with_punctuation}\*\*)"
+        rf"\s*$",
+        re.I,
+    )
+
+
+SAME_PR_FOLLOWUP_HEADING_RE = _followup_heading_re(r"same[- ]pr follow[- ]ups")
+FUTURE_FOLLOWUP_HEADING_RE = _followup_heading_re(r"future follow[- ]ups")
+LEGACY_FOLLOWUP_HEADING_RE = _followup_heading_re(r"non[- ]blocking follow[- ]ups")
 ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -557,6 +557,77 @@ def test_parse_approved_followups_accepts_trailing_colons_on_headings():
 
 
 @pytest.mark.parametrize(
+    ("same_pr_heading", "future_heading", "legacy_heading"),
+    [
+        (
+            "### **Same-PR follow-ups**",
+            "### **Future follow-ups**",
+            "### **Non-blocking follow-ups**",
+        ),
+        (
+            "### **Same-PR follow-ups**:",
+            "### **Future follow-ups.**",
+            "### **Non-blocking follow-ups:**",
+        ),
+        (
+            "### Same-PR follow-ups.",
+            "### Future follow-ups.",
+            "### Non-blocking follow-ups.",
+        ),
+    ],
+)
+def test_parse_approved_followups_accepts_common_markdown_heading_variants(
+    same_pr_heading, future_heading, legacy_heading
+):
+    review = f"""
+    LGTM with follow-ups.
+
+    {same_pr_heading}
+    - Rename the helper for clarity.
+
+    {future_heading}
+    - Add an integration fixture later.
+
+    {legacy_heading}
+    - Legacy future item.
+
+    <!-- AGENT_STATE: approved -->
+    -- Google Gemini
+    """
+
+    followups = parse_approved_followups(review, reviewer="Gemini")
+
+    assert [(item.reviewer, item.text) for item in followups.same_pr] == [
+        ("Gemini", "Rename the helper for clarity.")
+    ]
+    assert [(item.reviewer, item.text) for item in followups.future] == [
+        ("Gemini", "Add an integration fixture later."),
+        ("Gemini", "Legacy future item."),
+    ]
+
+
+def test_parse_approved_followups_stops_at_unrelated_bold_heading():
+    review = """
+    LGTM with follow-ups.
+
+    ### Future follow-ups
+    - Add an integration fixture later.
+
+    ### **Notes**
+    - This is not a follow-up.
+
+    <!-- AGENT_STATE: approved -->
+    -- Google Gemini
+    """
+
+    followups = parse_approved_followups(review, reviewer="Gemini")
+
+    assert [(item.reviewer, item.text) for item in followups.future] == [
+        ("Gemini", "Add an integration fixture later."),
+    ]
+
+
+@pytest.mark.parametrize(
     "placeholder",
     [
         "None",


### PR DESCRIPTION
## Summary
- Share conservative follow-up heading regex construction across same-PR, future, and legacy sections
- Accept full-heading bold markers and a single trailing colon or period for known follow-up headings
- Add regression coverage for bolded headings, period headings, and unrelated bold heading termination

## Tests
- python3 -m pytest tests/test_agent_loop.py -k followups
- python3 -m pytest

Closes #80