### PR TITLE
Sync coder checkout before implementation

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -180,7 +180,7 @@ def _sync_base_branch(
     runner: Runner,
 ) -> None:
     if not path.is_dir():
-        raise AgentLoopError(f"{label} exists but is not a directory: {path}")
+        raise AgentLoopError(f"{label} does not exist or is not a directory: {path}")
 
     git_check = _run_git(runner, path, ("rev-parse", "--is-inside-work-tree"), check=False)
     if git_check.returncode != 0 or git_check.stdout.strip() != "true":

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -16,6 +16,7 @@ from .errors import AgentLoopError
 from .github import detect_repo
 from .logging import log
 from .runner import Runner
+from .workdirs import active_workdir
 
 
 @dataclass(frozen=True)
@@ -132,6 +133,88 @@ def _run_git(runner: Runner, path: Path, args: tuple[str, ...], *, check: bool =
     return runner.run(("git", *args), cwd=path, check=check)
 
 
+def _agent_dir_option(agent: AgentName) -> str:
+    return {
+        "claude": "--claude-dir",
+        "codex": "--codex-dir",
+        "gemini": "--gemini-dir",
+    }[agent]
+
+
+def _validate_repo_remote(
+    path: Path,
+    *,
+    label: str,
+    config: AgentLoopConfig,
+    runner: Runner,
+) -> None:
+    remote = _run_git(runner, path, ("remote", "get-url", "origin")).stdout.strip()
+    if not _looks_like_repo_remote(remote, config.repo):
+        raise AgentLoopError(f"{label} at {path} uses origin {remote!r}, not {config.repo!r}.")
+
+
+def _clean_or_reject_checkout(
+    path: Path,
+    *,
+    label: str,
+    default_owned: bool,
+    config: AgentLoopConfig,
+    runner: Runner,
+) -> None:
+    status = _run_git(runner, path, ("status", "--porcelain")).stdout.strip()
+    if not status:
+        return
+    if not default_owned:
+        raise AgentLoopError(f"{label} is dirty: {path}. Commit, stash, or clean it before rerunning.")
+    log(config, f"Cleaning dirty {label[0].lower()}{label[1:]}: {path}")
+    _run_git(runner, path, ("reset", "--hard"))
+    _run_git(runner, path, ("clean", "-fd"))
+
+
+def _sync_base_branch(
+    path: Path,
+    *,
+    label: str,
+    default_owned: bool,
+    config: AgentLoopConfig,
+    runner: Runner,
+) -> None:
+    if not path.is_dir():
+        raise AgentLoopError(f"{label} exists but is not a directory: {path}")
+
+    git_check = _run_git(runner, path, ("rev-parse", "--is-inside-work-tree"), check=False)
+    if git_check.returncode != 0 or git_check.stdout.strip() != "true":
+        if not default_owned:
+            raise AgentLoopError(
+                f"{label} is not a git checkout: {path}. "
+                "Use a clean checkout for issue or task implementation."
+            )
+        raise AgentLoopError(
+            f"{label} exists but is not a git checkout: {path}. "
+            "Remove it or pass an explicit agent directory."
+        )
+
+    _validate_repo_remote(path, label=label, config=config, runner=runner)
+    _clean_or_reject_checkout(
+        path,
+        label=label,
+        default_owned=default_owned,
+        config=config,
+        runner=runner,
+    )
+
+    _run_git(runner, path, ("fetch", "origin"))
+    switch = _run_git(runner, path, ("switch", config.base), check=False)
+    if switch.returncode != 0:
+        if not default_owned:
+            raise AgentLoopError(
+                f"{label} could not switch to base branch {config.base!r}. "
+                "Create the branch locally or use a clean checkout on the base branch."
+            )
+        _run_git(runner, path, ("switch", "-C", config.base, f"origin/{config.base}"))
+    _run_git(runner, path, ("pull", "--ff-only", "origin", config.base))
+
+
 def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfig, runner: Runner) -> None:
     if not path.exists():
         try:
@@ -144,33 +227,13 @@ def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfi
         # Fresh clones still flow through validation and sync below so the
         # same remote, cleanliness, and base-branch checks apply to every run.
 
-    if not path.is_dir():
-        raise AgentLoopError(f"Default {agent} workdir exists but is not a directory: {path}")
-
-    git_check = _run_git(runner, path, ("rev-parse", "--is-inside-work-tree"), check=False)
-    if git_check.returncode != 0 or git_check.stdout.strip() != "true":
-        raise AgentLoopError(
-            f"Default {agent} workdir exists but is not a git checkout: {path}. "
-            "Remove it or pass an explicit agent directory."
-        )
-
-    remote = _run_git(runner, path, ("remote", "get-url", "origin")).stdout.strip()
-    if not _looks_like_repo_remote(remote, config.repo):
-        raise AgentLoopError(
-            f"Default {agent} workdir at {path} uses origin {remote!r}, not {config.repo!r}."
-        )
-
-    status = _run_git(runner, path, ("status", "--porcelain")).stdout.strip()
-    if status:
-        log(config, f"Cleaning dirty default {agent} workdir: {path}")
-        _run_git(runner, path, ("reset", "--hard"))
-        _run_git(runner, path, ("clean", "-fd"))
-
-    _run_git(runner, path, ("fetch", "origin"))
-    checkout = _run_git(runner, path, ("checkout", config.base), check=False)
-    if checkout.returncode != 0:
-        _run_git(runner, path, ("checkout", "-B", config.base, f"origin/{config.base}"))
-    _run_git(runner, path, ("pull", "--ff-only", "origin", config.base))
+    _sync_base_branch(
+        path,
+        label=f"Default {agent} workdir",
+        default_owned=True,
+        config=config,
+        runner=runner,
+    )
 
 
 def validate_explicit_workdir(path: Path, option_name: str, config: AgentLoopConfig, runner: Runner) -> None:
@@ -178,17 +241,29 @@ def validate_explicit_workdir(path: Path, option_name: str, config: AgentLoopCon
     if git_check.returncode != 0 or git_check.stdout.strip() != "true":
         return
 
-    status = _run_git(runner, path, ("status", "--porcelain")).stdout.strip()
-    if status:
-        raise AgentLoopError(
-            f"{option_name} is dirty: {path}. Commit, stash, or clean it before rerunning."
-        )
+    _clean_or_reject_checkout(
+        path,
+        label=option_name,
+        default_owned=False,
+        config=config,
+        runner=runner,
+    )
+    _validate_repo_remote(path, label=option_name, config=config, runner=runner)
 
-    remote = _run_git(runner, path, ("remote", "get-url", "origin")).stdout.strip()
-    if not _looks_like_repo_remote(remote, config.repo):
-        raise AgentLoopError(
-            f"{option_name} at {path} uses origin {remote!r}, not {config.repo!r}."
-        )
+
+def sync_coder_base_before_implementation(config: AgentLoopConfig, runner: Runner) -> None:
+    """Sync the active coder checkout to the configured base branch just before implementation."""
+    path = active_workdir(config)
+    option_name = _agent_dir_option(config.coder)
+    default_owned = config.coder in set(config.auto_agent_dirs)
+    label = f"Default {config.coder} workdir" if default_owned else option_name
+    _sync_base_branch(
+        path,
+        label=label,
+        default_owned=default_owned,
+        config=config,
+        runner=runner,
+    )
 
 
 def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -9,7 +9,12 @@ from dataclasses import dataclass
 
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, run_agent
-from .config import AgentLoopConfig, ensure_agent_workdirs, reviewers
+from .config import (
+    AgentLoopConfig,
+    ensure_agent_workdirs,
+    reviewers,
+    sync_coder_base_before_implementation,
+)
 from .errors import AgentLoopError
 from .github import (
     IssueContext,
@@ -318,6 +323,7 @@ def _run_plan_first_loop(
                 )
                 return 0
 
+            sync_coder_base_before_implementation(config, runner)
             log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
             coder_output, coder_session_id = run_agent(
                 runner,
@@ -408,6 +414,7 @@ def run_issue_loop(
             implement_after_approval=implement_after_approval,
         )
 
+    sync_coder_base_before_implementation(config, runner)
     coder_output, coder_session_id = run_agent(
         runner,
         agent=config.coder,
@@ -474,6 +481,8 @@ def run_task_loop(
     session_id: str | None = None
 
     for attempt in range(max_clarification_rounds + 1):
+        if attempt == 0:
+            sync_coder_base_before_implementation(config, runner)
         log(config, f"Task attempt {attempt + 1}: invoking {coder_name}")
         coder_output, session_id = run_agent(
             runner,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -249,6 +249,14 @@ def json_dumps(value):
     return json.dumps(value) + "\n"
 
 
+def command_index(commands, prefix, *, start=0):
+    for index in range(start, len(commands)):
+        cmd = commands[index][0]
+        if cmd[: len(prefix)] == prefix:
+            return index
+    raise AssertionError(f"Command with prefix {prefix!r} not found.")
+
+
 def make_config(tmp_path, *, create_dirs=True, **overrides):
     config = {
         "repo": "OWNER/REPO",
@@ -711,6 +719,32 @@ def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     assert list((tmp_path / "logs").glob("*-claude.log"))
     assert list((tmp_path / "logs").glob("*-codex.log"))
     assert (tmp_path / "logs" / ".gitignore").read_text(encoding="utf-8") == "*\n!.gitignore\n"
+
+
+def test_issue_loop_syncs_coder_base_after_memory_before_coder(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+    config.agent_memory_dir.mkdir(parents=True)
+    (config.agent_memory_dir / "last-analyzed-commit").write_text("base123\n", encoding="utf-8")
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    commands = runner.commands
+    issue_context_index = command_index(commands, ["gh", "issue", "view"])
+    memory_index = command_index(commands, ["git", "diff", "--name-only"])
+    fetch_index = command_index(commands, ["git", "fetch", "origin"])
+    switch_index = command_index(commands, ["git", "switch", "main"])
+    pull_index = command_index(commands, ["git", "pull", "--ff-only", "origin", "main"])
+    coder_index = command_index(commands, ["claude", "--print"])
+
+    assert issue_context_index < memory_index < fetch_index < switch_index < pull_index < coder_index
 
 
 def test_issue_loop_includes_issue_comments_in_coder_and_review_prompts(tmp_path):
@@ -1870,7 +1904,7 @@ def test_clean_existing_auto_agent_dir_is_synced(tmp_path):
 
     commands = [cmd for cmd, _cwd in runner.commands]
     assert ["git", "fetch", "origin"] in commands
-    assert ["git", "checkout", "main"] in commands
+    assert ["git", "switch", "main"] in commands
     assert ["git", "pull", "--ff-only", "origin", "main"] in commands
 
 
@@ -1917,6 +1951,35 @@ def test_dirty_explicit_agent_dir_fails_clearly(tmp_path):
 
     with pytest.raises(AgentLoopError, match="--codex-dir is dirty"):
         run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+@pytest.mark.parametrize("loop_name", ["issue", "task"])
+def test_dirty_explicit_coder_dir_fails_before_issue_or_task_coder_invocation(tmp_path, loop_name):
+    runner = FakeRunner(
+        git_status=" M file.py\n",
+        codex_outputs=[
+            "Implemented.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        ],
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        coder="codex",
+        reviewer="codex",
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="--codex-dir is dirty"):
+        if loop_name == "issue":
+            run_issue_loop(runner, issue_number=56, config=config)
+        else:
+            run_task_loop(runner, task_text="Add /healthz endpoint.", config=config)
 
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
 
@@ -2224,6 +2287,8 @@ def test_issue_loop_plan_first_stops_after_approved_plan(tmp_path):
     assert runner.comments[0].startswith("Plan:")
     assert runner.comments[1].startswith("Plan looks sound.")
     assert "Outcome: implement" in runner.comments[2]
+    assert not any(cmd[:2] == ["git", "fetch"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:2] == ["git", "switch"] for cmd, _cwd in runner.commands)
 
 
 def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
@@ -2275,6 +2340,11 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert len(claude_calls) == 2
     assert "Approved implementation plan" in claude_calls[1][-1]
+    first_claude_index = command_index(runner.commands, ["claude", "--print"])
+    fetch_index = command_index(runner.commands, ["git", "fetch", "origin"])
+    switch_index = command_index(runner.commands, ["git", "switch", "main"])
+    second_claude_index = command_index(runner.commands, ["claude", "--print"], start=first_claude_index + 1)
+    assert first_claude_index < fetch_index < switch_index < second_claude_index
     assert len(runner.comments) == 5
     assert runner.comments[3].startswith("Implemented approved plan.")
     assert runner.comments[4].startswith("LGTM.")
@@ -2319,6 +2389,36 @@ def test_task_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     assert len(runner.comments) == 4
     assert runner.comments[0].startswith("Implemented.")
     assert runner.comments[-1].startswith("LGTM.")
+
+
+def test_task_loop_syncs_coder_base_before_first_implementation_attempt(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented.\n<!-- AGENT_PR: 91 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={
+            "number": 91,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/91",
+        },
+    )
+    config = make_config(tmp_path)
+    config.agent_memory_dir.mkdir(parents=True)
+    (config.agent_memory_dir / "last-analyzed-commit").write_text("base123\n", encoding="utf-8")
+
+    assert run_task_loop(runner, task_text="Add a /healthz endpoint.", config=config) == 0
+
+    commands = runner.commands
+    memory_index = command_index(commands, ["git", "diff", "--name-only"])
+    fetch_index = command_index(commands, ["git", "fetch", "origin"])
+    switch_index = command_index(commands, ["git", "switch", "main"])
+    pull_index = command_index(commands, ["git", "pull", "--ff-only", "origin", "main"])
+    coder_index = command_index(commands, ["claude", "--print"])
+
+    assert memory_index < fetch_index < switch_index < pull_index < coder_index
 
 
 def test_task_loop_picks_up_pr_url_when_marker_missing(tmp_path):
@@ -2443,6 +2543,20 @@ def test_pr_loop_rejects_non_open_pr_before_running_codex(tmp_path):
 
     with pytest.raises(AgentLoopError, match="provide an open PR"):
         run_pr_loop(runner, pr_number=62, config=config)
+
+
+def test_pr_loop_does_not_perform_just_in_time_base_sync(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["git", "fetch", "origin"] not in commands
+    assert ["git", "switch", "main"] not in commands
+    assert ["git", "pull", "--ff-only", "origin", "main"] not in commands
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a just-in-time coder base-branch sync helper for issue/task implementation flows
- sync before issue implementation, task implementation, and plan-first implement-after-approval
- preserve PR mode branch state and dirty explicit workdir failures

## Tests
- python3 -m pytest