### PR TITLE
Refresh reviewer checkouts before PR reviews

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -13,10 +13,10 @@ from pathlib import Path
 from .agents.base import AgentName
 from .agents.registry import default_agent_args
 from .errors import AgentLoopError
-from .github import detect_repo
+from .github import PullRequestMetadata, detect_repo
 from .logging import log
 from .runner import Runner
-from .workdirs import active_workdir
+from .workdirs import active_workdir, agent_workdir
 
 
 @dataclass(frozen=True)
@@ -264,6 +264,72 @@ def sync_coder_base_before_implementation(config: AgentLoopConfig, runner: Runne
         config=config,
         runner=runner,
     )
+
+
+def sync_reviewer_pr_before_review(
+    config: AgentLoopConfig,
+    runner: Runner,
+    reviewer: AgentName,
+    pr_number: int,
+    pr_metadata: PullRequestMetadata,
+) -> None:
+    """Refresh a reviewer checkout to the current PR head before invoking the reviewer."""
+    path = agent_workdir(config, reviewer)
+    option_name = _agent_dir_option(reviewer)
+    default_owned = reviewer in set(config.auto_agent_dirs)
+    label = f"Default {reviewer} workdir" if default_owned else option_name
+    pr_ref = f"refs/remotes/origin/pr/{pr_number}"
+
+    if runner.dry_run:
+        _run_git(runner, path, ("fetch", "origin"))
+        _run_git(runner, path, ("fetch", "origin", f"pull/{pr_number}/head:{pr_ref}"))
+        _run_git(runner, path, ("checkout", "--detach", pr_ref))
+        _run_git(runner, path, ("rev-parse", "HEAD"))
+        _run_git(runner, path, ("status", "--short", "--branch"))
+        log(config, f"{label} would refresh PR #{pr_number} before review")
+        return
+
+    if not path.is_dir():
+        raise AgentLoopError(f"{label} does not exist or is not a directory: {path}")
+
+    git_check = _run_git(runner, path, ("rev-parse", "--is-inside-work-tree"), check=False)
+    if git_check.returncode != 0 or git_check.stdout.strip() != "true":
+        if not default_owned:
+            raise AgentLoopError(
+                f"{label} is not a git checkout: {path}. "
+                "Use a clean checkout for PR review."
+            )
+        raise AgentLoopError(
+            f"{label} exists but is not a git checkout: {path}. "
+            "Remove it or pass an explicit agent directory."
+        )
+
+    _validate_repo_remote(path, label=label, config=config, runner=runner)
+    _clean_or_reject_checkout(
+        path,
+        label=label,
+        default_owned=default_owned,
+        config=config,
+        runner=runner,
+    )
+
+    _run_git(runner, path, ("fetch", "origin"))
+    _run_git(runner, path, ("fetch", "origin", f"pull/{pr_number}/head:{pr_ref}"))
+    _run_git(runner, path, ("checkout", "--detach", pr_ref))
+    local_head = _run_git(runner, path, ("rev-parse", "HEAD")).stdout.strip()
+    branch_state = _run_git(runner, path, ("status", "--short", "--branch")).stdout.strip()
+    advertised_head = (pr_metadata.head_sha or "").strip()
+    if advertised_head and local_head != advertised_head and not runner.dry_run:
+        raise AgentLoopError(
+            f"{label} at {path} is at {local_head or '(unknown)'}, "
+            f"but PR #{pr_number} metadata advertises head SHA {advertised_head}."
+        )
+    if advertised_head:
+        log(config, f"{label} refreshed for PR #{pr_number}: HEAD {local_head} (expected {advertised_head})")
+    else:
+        log(config, f"{label} refreshed for PR #{pr_number}: HEAD {local_head}; no PR head SHA available")
+    if branch_state:
+        log(config, f"{label} branch state before review: {branch_state}")
 
 
 def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -319,7 +319,7 @@ def sync_reviewer_pr_before_review(
     local_head = _run_git(runner, path, ("rev-parse", "HEAD")).stdout.strip()
     branch_state = _run_git(runner, path, ("status", "--short", "--branch")).stdout.strip()
     advertised_head = (pr_metadata.head_sha or "").strip()
-    if advertised_head and local_head != advertised_head and not runner.dry_run:
+    if advertised_head and local_head != advertised_head:
         raise AgentLoopError(
             f"{label} at {path} is at {local_head or '(unknown)'}, "
             f"but PR #{pr_number} metadata advertises head SHA {advertised_head}."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -14,6 +14,7 @@ from .config import (
     ensure_agent_workdirs,
     reviewers,
     sync_coder_base_before_implementation,
+    sync_reviewer_pr_before_review,
 )
 from .errors import AgentLoopError
 from .github import (
@@ -568,6 +569,7 @@ def run_pr_loop(
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
+            sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
             review_output, new_session_id = run_agent(
                 runner,
                 agent=reviewer,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -471,8 +471,11 @@ PR metadata:
 - Base branch: {base_branch}
 - Head SHA: {head_sha}
 {url_line}
-Use this PR metadata as authoritative. Do not spend time discovering the PR
-branch.
+Use this PR metadata as authoritative. The Head SHA above is the PR head this
+review round is about. If local files do not match that SHA, refresh/fetch the
+checkout before reviewing. Do not spend time discovering the PR
+branch. Do not report findings based on untracked files unless those files are
+present in the PR diff.
 {_scratch_file_guidance()}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -223,6 +223,11 @@ class FakeRunner(Runner):
         if cmd[:3] == ["git", "rev-parse", "HEAD"]:
             return CommandResult(cmd, cwd_path, f"{self.git_head}\n", "", 0)
 
+        if cmd[:3] == ["git", "checkout", "--detach"]:
+            if len(cmd) > 3 and cmd[3].startswith("refs/remotes/origin/pr/"):
+                self.git_head = self.pr_payload.get("headRefOid", self.git_head)
+            return CommandResult(cmd, cwd_path, "", "", 0)
+
         if cmd[:2] == ["git", "ls-files"]:
             return CommandResult(cmd, cwd_path, "\n".join(self.tracked_files) + "\n", "", 0)
 
@@ -1908,6 +1913,112 @@ def test_clean_existing_auto_agent_dir_is_synced(tmp_path):
     assert ["git", "pull", "--ff-only", "origin", "main"] in commands
 
 
+def test_reviewer_checkout_is_refreshed_to_pr_head_before_review(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    review_index = command_index(runner.commands, ["codex", "exec"])
+    fetch_index = command_index(runner.commands, ["git", "fetch", "origin"], start=0)
+    pr_fetch_index = command_index(
+        runner.commands,
+        ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"],
+    )
+    checkout_index = command_index(
+        runner.commands,
+        ["git", "checkout", "--detach", "refs/remotes/origin/pr/77"],
+    )
+    head_index = command_index(runner.commands, ["git", "rev-parse", "HEAD"], start=checkout_index)
+
+    assert commands[pr_fetch_index] == ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"]
+    assert fetch_index < pr_fetch_index < checkout_index < head_index < review_index
+
+
+def test_reviewer_checkout_refreshes_each_round_before_review(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Fixed.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=[
+            "Please fix it.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    pr_fetches = [
+        index
+        for index, cmd in enumerate(commands)
+        if cmd == ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"]
+    ]
+    review_indices = [index for index, cmd in enumerate(commands) if cmd[:2] == ["codex", "exec"]]
+
+    assert len(pr_fetches) == 2
+    assert len(review_indices) == 2
+    assert pr_fetches[0] < review_indices[0]
+    assert pr_fetches[1] < review_indices[1]
+
+
+def test_dirty_default_reviewer_checkout_is_cleaned_before_review(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        git_status=" M stale.py\n",
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        coder="claude",
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config, workdirs_ready=True) == 0
+
+    reset_index = command_index(runner.commands, ["git", "reset", "--hard"])
+    clean_index = command_index(runner.commands, ["git", "clean", "-fd"])
+    review_index = command_index(runner.commands, ["codex", "exec"])
+
+    assert reset_index < clean_index < review_index
+
+
+def test_dirty_explicit_reviewer_checkout_fails_before_review_invocation(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["This should not run.\n<!-- AGENT_STATE: approved -->"],
+        git_status=" M stale.py\n",
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", agent_memory=False)
+
+    with pytest.raises(AgentLoopError, match="--codex-dir is dirty"):
+        run_pr_loop(runner, pr_number=77, config=config, workdirs_ready=True)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_review_prompt_warns_that_pr_head_sha_is_authoritative(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    codex_command = next(cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    prompt = codex_command[-1]
+    assert "The Head SHA above is the PR head this\nreview round is about." in prompt
+    assert "If local files do not match that SHA, refresh/fetch the\ncheckout before reviewing." in prompt
+    assert "Do not report findings based on untracked files unless those files are\npresent in the PR diff." in prompt
+
+
 def test_dirty_existing_auto_agent_dir_is_cleaned_before_sync(tmp_path, capsys):
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
@@ -2545,7 +2656,7 @@ def test_pr_loop_rejects_non_open_pr_before_running_codex(tmp_path):
         run_pr_loop(runner, pr_number=62, config=config)
 
 
-def test_pr_loop_does_not_perform_just_in_time_base_sync(tmp_path):
+def test_pr_loop_refreshes_pr_head_without_just_in_time_base_sync(tmp_path):
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
     )
@@ -2554,7 +2665,8 @@ def test_pr_loop_does_not_perform_just_in_time_base_sync(tmp_path):
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     commands = [cmd for cmd, _cwd in runner.commands]
-    assert ["git", "fetch", "origin"] not in commands
+    assert ["git", "fetch", "origin"] in commands
+    assert ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"] in commands
     assert ["git", "switch", "main"] not in commands
     assert ["git", "pull", "--ff-only", "origin", "main"] not in commands
 


### PR DESCRIPTION
## Summary
- refresh each reviewer checkout to the current PR ref immediately before review
- clean dirty tool-owned reviewer dirs and fail on dirty explicit reviewer dirs
- harden reviewer prompts against stale checkouts and untracked-file findings

## Tests
- python3 -m pytest

Fixes #87