### PR TITLE
Treat signed human reviewer comments as requirements

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from .errors import AgentLoopError
 from .logging import log
+from .protocol import parse_signed_human_requirement_body
 from .runner import Runner
 from .workdirs import active_workdir
 
@@ -44,6 +45,15 @@ class IssueContext:
     body: str | None
     url: str | None
     comments: tuple[IssueComment, ...]
+
+
+@dataclass(frozen=True)
+class HumanReviewRequirement:
+    source_type: str
+    author: str | None
+    created_at: str | None
+    url: str | None
+    body: str
 
 
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
@@ -115,6 +125,73 @@ def get_pr_metadata(runner: Runner, *, config: AgentLoopConfig, pr_number: int) 
         head_sha=data.get("headRefOid"),
         url=data.get("url"),
     )
+
+
+def _author_login(raw: object) -> str | None:
+    if isinstance(raw, dict):
+        login = raw.get("login")
+        return str(login) if login else None
+    return None
+
+
+def _human_requirement_sort_key(requirement: HumanReviewRequirement) -> str:
+    return requirement.created_at or ""
+
+
+def get_pr_human_requirements(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+) -> tuple[HumanReviewRequirement, ...]:
+    if config.dry_run:
+        return ()
+
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            "comments,reviews",
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    requirements: list[HumanReviewRequirement] = []
+    for raw_comment in data.get("comments") or []:
+        body = parse_signed_human_requirement_body(raw_comment.get("body"))
+        if body is None:
+            continue
+        requirements.append(
+            HumanReviewRequirement(
+                source_type="PR comment",
+                author=_author_login(raw_comment.get("author")),
+                created_at=raw_comment.get("createdAt") or raw_comment.get("created_at"),
+                url=raw_comment.get("url"),
+                body=body,
+            )
+        )
+    for raw_review in data.get("reviews") or []:
+        body = parse_signed_human_requirement_body(raw_review.get("body"))
+        if body is None:
+            continue
+        requirements.append(
+            HumanReviewRequirement(
+                source_type="PR review",
+                author=_author_login(raw_review.get("author")),
+                created_at=raw_review.get("submittedAt")
+                or raw_review.get("submitted_at")
+                or raw_review.get("createdAt")
+                or raw_review.get("created_at"),
+                url=raw_review.get("url"),
+                body=body,
+            )
+        )
+    return tuple(sorted(requirements, key=_human_requirement_sort_key))
 
 
 def validate_open_issue(runner: Runner, *, config: AgentLoopConfig, issue_number: int) -> None:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -21,6 +21,7 @@ from .github import (
     IssueContext,
     create_issue,
     get_issue_context,
+    get_pr_human_requirements,
     get_pr_metadata,
     merge_pr,
     post_issue_comment,
@@ -44,7 +45,13 @@ from .prompts import (
     build_task_prompt,
     format_agent_list,
 )
-from .protocol import is_clarification_request, parse_agent_state, parse_plan_state, parse_pr_number
+from .protocol import (
+    human_requirements_resolved,
+    is_clarification_request,
+    parse_agent_state,
+    parse_plan_state,
+    parse_pr_number,
+)
 from .protocol import ApprovedFollowup, parse_approved_followups
 from .runner import Runner
 from .workdirs import active_workdir
@@ -565,7 +572,9 @@ def run_pr_loop(
         blocking_reviews: list[tuple[str, str]] = []
         same_pr_followups: list[ApprovedFollowup] = []
         round_future_followups: list[ApprovedFollowup] = []
+        approved_review_outputs: list[tuple[str, str]] = []
         pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
+        human_requirements = get_pr_human_requirements(runner, config=config, pr_number=pr_number)
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
@@ -582,6 +591,7 @@ def run_pr_loop(
                     pr_metadata=pr_metadata,
                     memory=memory,
                     issue_context=issue_context,
+                    human_requirements=human_requirements,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
             )
@@ -594,7 +604,10 @@ def run_pr_loop(
             log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
             if review_state == "blocking":
                 blocking_reviews.append((reviewer_name, review_output))
-            elif config.approved_followups != "ignore":
+                continue
+
+            approved_review_outputs.append((reviewer_name, review_output))
+            if config.approved_followups != "ignore":
                 followups = parse_approved_followups(review_output, reviewer=reviewer_name)
                 round_future_followups.extend(followups.future)
                 if followups.same_pr:
@@ -617,6 +630,19 @@ def run_pr_loop(
                         )
 
         if not blocking_reviews and not same_pr_followups:
+            if human_requirements:
+                missing_acknowledgements = [
+                    reviewer_name
+                    for reviewer_name, review_output in approved_review_outputs
+                    if not human_requirements_resolved(review_output)
+                ]
+                if missing_acknowledgements:
+                    raise AgentLoopError(
+                        "Signed human reviewer requirements remain unresolved or "
+                        "unacknowledged by approved reviewer response(s): "
+                        f"{', '.join(missing_acknowledgements)}. "
+                        "Human intervention is required."
+                    )
             approved_followups = round_future_followups
             if config.approved_followups in ("summarize", "fix-and-summarize") and approved_followups:
                 body = _format_approved_followup_summary(pr_number, approved_followups)
@@ -652,6 +678,7 @@ def run_pr_loop(
                 config,
                 memory,
                 issue_context=issue_context,
+                human_requirements=human_requirements,
             )
         else:
             # Discard future-work suggestions from non-final rounds so reviewers
@@ -673,6 +700,7 @@ def run_pr_loop(
                 config,
                 memory,
                 issue_context=issue_context,
+                human_requirements=human_requirements,
             )
         log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
         coder_output, coder_session_id = run_agent(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -7,7 +7,7 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
-from .github import IssueContext, PullRequestMetadata
+from .github import HumanReviewRequirement, IssueContext, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
 
 
@@ -127,6 +127,118 @@ def format_issue_context(issue_context: IssueContext, *, max_chars: int = 24_000
             "Fetch the issue discussion directly if those details are needed."
         )
     return "\n".join([*lines, "", "(none)"])
+
+
+def format_human_requirements(
+    human_requirements: Sequence[HumanReviewRequirement],
+    *,
+    max_chars: int = 12_000,
+) -> str:
+    if not human_requirements:
+        return ""
+
+    header = "\n".join(
+        [
+            "Signed Human Reviewer Requirements",
+            "",
+            "Treat these signed human reviewer comments as high-priority PR requirements. "
+            "Later human comments may supersede earlier ones; the latest human instruction wins. "
+            "If a requirement is unsafe, impossible, or contradicted by a later human instruction, "
+            "explain that explicitly instead of ignoring it.",
+        ]
+    )
+    entries = [
+        "\n".join(
+            [
+                "",
+                f"Requirement {index}:",
+                f"- Source: {requirement.source_type}",
+                f"- Author: {requirement.author or '(unknown)'}",
+                f"- Created: {requirement.created_at or '(unknown time)'}",
+                f"- URL: {requirement.url or '(unavailable)'}",
+                "",
+                requirement.body,
+            ]
+        )
+        for index, requirement in enumerate(human_requirements, start=1)
+    ]
+    full_text = header + "\n".join(entries)
+    if len(full_text) <= max_chars:
+        return full_text
+
+    kept_entries: list[str] = []
+    omitted_count = 0
+    for entry in reversed(entries):
+        candidate_entries = [entry, *kept_entries]
+        notice = (
+            "\n\n"
+            f"Older signed human requirement(s) omitted: {len(entries) - len(candidate_entries)}. "
+            "Newest requirements were kept preferentially."
+        )
+        candidate = header + notice + "".join(candidate_entries)
+        if len(candidate) <= max_chars:
+            kept_entries = candidate_entries
+            omitted_count = len(entries) - len(candidate_entries)
+        elif not kept_entries:
+            omitted_count = len(entries) - 1
+            notice = (
+                "\n\n"
+                f"Older signed human requirement(s) omitted: {omitted_count}. "
+                "Newest requirements were kept preferentially."
+            )
+            prefix = header + notice
+            remaining_chars = max_chars - len(prefix)
+            if remaining_chars > 0:
+                truncated_entry = _truncate_issue_text(
+                    entry,
+                    max_chars=remaining_chars,
+                    label="Newest signed human requirement",
+                )
+                if len(prefix) + len(truncated_entry) <= max_chars:
+                    return prefix + truncated_entry
+            omitted_count = len(entries)
+            break
+        else:
+            break
+    if kept_entries:
+        return (
+            header
+            + "\n\n"
+            + f"Older signed human requirement(s) omitted: {omitted_count}. "
+            "Newest requirements were kept preferentially."
+            + "".join(kept_entries)
+        )
+    return (
+        header
+        + "\n\n"
+        + f"All {omitted_count} signed human requirement(s) were omitted to keep this prompt bounded. "
+        "Fetch the PR discussion directly before approving."
+    )
+
+
+def _human_requirements_block(
+    human_requirements: Sequence[HumanReviewRequirement] | None,
+) -> str:
+    if not human_requirements:
+        return ""
+    return f"{format_human_requirements(human_requirements)}\n"
+
+
+def _human_requirements_review_guidance(
+    human_requirements: Sequence[HumanReviewRequirement] | None,
+) -> str:
+    if not human_requirements:
+        return ""
+    return """Signed human reviewer requirements override AI reviewer preferences unless they
+are unsafe, impossible, or contradicted by a later signed human instruction.
+Verify every signed human reviewer requirement before approving. If all signed
+human reviewer requirements are addressed or explicitly resolved, an approved
+review must include exactly:
+
+<!-- HUMAN_REQUIREMENTS_RESOLVED -->
+
+If any signed human reviewer requirement is unresolved, return blocking.
+"""
 
 
 def _issue_context_block(issue_context: IssueContext | None) -> str:
@@ -405,6 +517,7 @@ def build_review_prompt(
     pr_metadata: PullRequestMetadata | None = None,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    human_requirements: Sequence[HumanReviewRequirement] | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
@@ -423,6 +536,7 @@ def build_review_prompt(
     base_branch = metadata.base_branch or "(unknown)"
     head_sha = metadata.head_sha or "(unknown)"
     url_line = f"- URL: {metadata.url}\n" if metadata.url else ""
+    human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
     if config.approved_followups == "ignore":
         followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
 Non-blocking follow-ups sections in approved reviews; this run is configured to
@@ -478,6 +592,7 @@ branch. Do not report findings based on untracked files unless those files are
 present in the PR diff.
 {_scratch_file_guidance()}
 {_issue_context_block(issue_context)}
+{_human_requirements_block(human_requirements)}
 {_memory_block(memory)}
 
 Suggested commands:
@@ -491,6 +606,7 @@ commands, or produce a blocking review explaining the limitation.
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this
 review step; report blocking findings if {coder_name} needs to fix anything.
+{human_requirements_guidance}
 {followup_guidance}
 Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
@@ -516,6 +632,7 @@ def build_followup_prompt(
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    human_requirements: Sequence[HumanReviewRequirement] | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
@@ -526,6 +643,7 @@ needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_scratch_file_guidance()}
 {_issue_context_block(issue_context)}
+{_human_requirements_block(human_requirements)}
 {_memory_block(memory)}
 
 {reviewer_name} review:
@@ -550,6 +668,7 @@ def build_same_pr_followup_prompt(
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    human_requirements: Sequence[HumanReviewRequirement] | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
@@ -563,6 +682,7 @@ current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead.
 {_scratch_file_guidance()}
 {_issue_context_block(issue_context)}
+{_human_requirements_block(human_requirements)}
 {_memory_block(memory)}
 
 Same-PR follow-ups:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -175,7 +175,7 @@ def format_human_requirements(
             f"Older signed human requirement(s) omitted: {len(entries) - len(candidate_entries)}. "
             "Newest requirements were kept preferentially."
         )
-        candidate = header + notice + "".join(candidate_entries)
+        candidate = header + notice + "\n".join(candidate_entries)
         if len(candidate) <= max_chars:
             kept_entries = candidate_entries
             omitted_count = len(entries) - len(candidate_entries)
@@ -206,7 +206,7 @@ def format_human_requirements(
             + "\n\n"
             + f"Older signed human requirement(s) omitted: {omitted_count}. "
             "Newest requirements were kept preferentially."
-            + "".join(kept_entries)
+            + "\n".join(kept_entries)
         )
     return (
         header

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -12,6 +12,13 @@ PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*--
 PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
+HUMAN_REVIEWER_SIGNATURE_RE = re.compile(r"^\s*--\s*Human Reviewer\s*$", re.I | re.M)
+HUMAN_REQUIREMENTS_RESOLVED_RE = re.compile(
+    r"<!--\s*HUMAN_REQUIREMENTS_RESOLVED\s*-->",
+    re.I,
+)
+
+
 def _followup_heading_re(title: str) -> re.Pattern[str]:
     title_with_punctuation = rf"{title}[:.]?"
     return re.compile(
@@ -76,6 +83,21 @@ def parse_pr_number(text: str) -> int | None:
 
 def is_clarification_request(text: str) -> bool:
     return bool(CLARIFY_RE.search(text))
+
+
+def parse_signed_human_requirement_body(text: str | None) -> str | None:
+    """Return comment body before a standalone ``-- Human Reviewer`` signature."""
+    if not text:
+        return None
+    match = HUMAN_REVIEWER_SIGNATURE_RE.search(text)
+    if not match:
+        return None
+    body = text[: match.start()].strip()
+    return body or None
+
+
+def human_requirements_resolved(text: str) -> bool:
+    return bool(HUMAN_REQUIREMENTS_RESOLVED_RE.search(text))
 
 
 def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -896,6 +896,40 @@ def test_format_human_requirements_uses_distinct_high_priority_section():
     assert "Please use the absolute URL." in text
 
 
+def test_format_human_requirements_preserves_entry_spacing_when_truncated():
+    requirements = (
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+            body="Oldest requirement.",
+        ),
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T11:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-2",
+            body="Middle requirement.",
+        ),
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T12:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-3",
+            body="Newest requirement.",
+        ),
+    )
+    full_text = format_human_requirements(requirements)
+
+    text = format_human_requirements(requirements, max_chars=len(full_text) - 1)
+
+    assert "Older signed human requirement(s) omitted: 1." in text
+    assert "Oldest requirement." not in text
+    assert "Middle requirement.\n\nRequirement 3:" in text
+    assert "Newest requirement." in text
+
+
 def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -26,9 +26,13 @@ from coding_review_agent_loop.config import (
     default_agent_workdir,
     default_cache_root,
 )
-from coding_review_agent_loop.github import IssueComment, IssueContext
-from coding_review_agent_loop.prompts import format_issue_context
-from coding_review_agent_loop.protocol import parse_approved_followups, parse_non_blocking_followups
+from coding_review_agent_loop.github import HumanReviewRequirement, IssueComment, IssueContext
+from coding_review_agent_loop.prompts import format_human_requirements, format_issue_context
+from coding_review_agent_loop.protocol import (
+    parse_approved_followups,
+    parse_non_blocking_followups,
+    parse_signed_human_requirement_body,
+)
 
 
 class FakeRunner(Runner):
@@ -73,6 +77,8 @@ class FakeRunner(Runner):
             "headRefName": "feature/review-context",
             "baseRefName": "main",
             "headRefOid": "abc123",
+            "comments": [],
+            "reviews": [],
         }
         self.commands = []
         self.comments = []
@@ -483,6 +489,43 @@ def test_parse_agent_state_requires_marker():
         parse_agent_state("LGTM")
 
 
+def test_parse_signed_human_requirement_body_extracts_text_before_signature():
+    body = parse_signed_human_requirement_body(
+        "Please use the absolute URL.\n\n-- Human Reviewer\n\nExtra text ignored."
+    )
+
+    assert body == "Please use the absolute URL."
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        "-- Human Reviewer",
+        "  -- Human Reviewer  ",
+        "-- human reviewer",
+        "-- HUMAN REVIEWER",
+    ],
+)
+def test_parse_signed_human_requirement_body_accepts_standalone_signature_variants(signature):
+    assert parse_signed_human_requirement_body(f"Required change.\n{signature}\n") == "Required change."
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        "-- OpenAI Codex",
+        "-- Anthropic Claude",
+        "-- Google Gemini",
+        "-- coding-review-agent-loop",
+        "Inline text -- Human Reviewer",
+    ],
+)
+def test_parse_signed_human_requirement_body_rejects_agent_and_non_standalone_signatures(
+    signature,
+):
+    assert parse_signed_human_requirement_body(f"Comment body.\n{signature}\n") is None
+
+
 def test_parse_non_blocking_followups_extracts_bullets_only_from_section():
     review = """
     Looks good.
@@ -832,6 +875,27 @@ def test_format_issue_context_truncates_oversized_newest_comment():
     assert "Older detail should not be kept instead of the newest comment." not in text
 
 
+def test_format_human_requirements_uses_distinct_high_priority_section():
+    text = format_human_requirements(
+        (
+            HumanReviewRequirement(
+                source_type="PR comment",
+                author="reviewer",
+                created_at="2026-05-18T10:00:00Z",
+                url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                body="Please use the absolute URL.",
+            ),
+        )
+    )
+
+    assert text.startswith("Signed Human Reviewer Requirements")
+    assert "high-priority PR requirements" in text
+    assert "latest human instruction wins" in text
+    assert "- Source: PR comment" in text
+    assert "- Author: reviewer" in text
+    assert "Please use the absolute URL." in text
+
+
 def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
@@ -891,6 +955,76 @@ def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
 
 
+def test_pr_loop_blocks_approval_without_human_requirement_resolution_marker(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        test_command=("pytest", "tests/test_agent_loop.py"),
+        approved_followups="summarize",
+    )
+
+    with pytest.raises(AgentLoopError, match="Signed human reviewer requirements"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["pytest", "tests/test_agent_loop.py"] not in commands
+    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] not in commands
+    assert not any(comment.startswith("Approved-review future follow-ups") for comment in runner.comments)
+
+
+def test_pr_loop_allows_approval_with_human_requirement_resolution_marker(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path, test_command=("pytest", "tests/test_agent_loop.py"))
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["pytest", "tests/test_agent_loop.py"] in commands
+
+
 def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
     config = make_config(tmp_path)
@@ -921,6 +1055,42 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     assert "### Future follow-ups" not in prompt
     assert "legacy heading `### Non-blocking follow-ups`" not in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt
+
+
+def test_review_prompt_includes_signed_human_requirements(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Signed Human Reviewer Requirements" in prompt
+    assert "Please use the absolute URL." in prompt
+    assert "Signed human reviewer requirements override AI reviewer preferences" in prompt
+    assert "Verify every signed human reviewer requirement before approving." in prompt
+    assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in prompt
 
 
 def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):
@@ -955,6 +1125,46 @@ def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):
     assert "Issue context from GitHub" in followup_prompt
     assert "Title:\nSupport issue comments" in followup_prompt
     assert "Clarifying issue comment." in followup_prompt
+    assert "Needs a fix." in followup_prompt
+
+
+def test_blocking_followup_prompt_includes_human_requirements_before_ai_feedback(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Needs a fix.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    followup_prompt = next(
+        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Address the review below" in cmd[-1]
+    )
+    assert followup_prompt.index("Signed Human Reviewer Requirements") < followup_prompt.index(
+        "Codex review:"
+    )
+    assert "Please use the absolute URL." in followup_prompt
     assert "Needs a fix." in followup_prompt
 
 


### PR DESCRIPTION
## Summary
- Detect standalone signed `-- Human Reviewer` PR comments and reviews as structured human requirements.
- Surface signed human requirements in reviewer and coder follow-up prompts ahead of AI feedback.
- Gate final PR approval until every approved reviewer response includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->` when signed human requirements exist.

## Tests
- `python3 -m pytest`
- `git diff --check`

Closes #91