### PR TITLE
Prevent posting invalid agent diagnostics

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -367,7 +367,7 @@ agent-loop issue 56 \
   --gemini-arg=--approval-mode --gemini-arg=auto_edit
 ```
 
-Providing any `--claude-arg`, `--codex-arg`, or `--gemini-arg` replaces that agent's default entirely. Claude and Gemini prompts include a tool-owned response-file path under `/tmp/coding-review-agent-loop/responses/`; when the file exists and is non-empty, the loop posts that file instead of stdout so CLI diagnostics and tool narration do not leak into GitHub comments. Gemini still supports stdout marker filtering as a fallback. If you pass `--gemini-arg=--output-format --gemini-arg=json`, the loop extracts the JSON `response` field before parsing markers when no response file was written.
+Providing any `--claude-arg`, `--codex-arg`, or `--gemini-arg` replaces that agent's default entirely. Claude and Gemini prompts include a tool-owned response-file path under `/tmp/coding-review-agent-loop/responses/`; when the file exists and is non-empty, the loop validates and posts that file instead of stdout so CLI diagnostics and tool narration do not leak into GitHub comments. Gemini still supports stdout marker filtering as a fallback. If you pass `--gemini-arg=--output-format --gemini-arg=json`, the loop extracts the JSON `response` field before parsing markers when no response file was written. Fallback stdout is never posted unless the required protocol marker validates.
 
 ## Protocol
 
@@ -386,6 +386,18 @@ Agent responses are parsed using HTML comment markers:
 include a final `AGENT_STATE` marker. Plan-first coder/reviewer responses use
 `AGENT_PLAN_STATE` instead. If a response quotes older markers, the final
 matching marker is treated as authoritative.
+
+The loop validates required markers before posting agent output to GitHub. If
+an agent exits or returns only diagnostics, empty output, or normal prose
+without the required marker, the loop fails locally with `AgentLoopError` and
+the attempt log path instead of posting that raw output as a review.
+
+Known transient agent/model failures are retried before local failure. The
+default is two retries with bounded backoff; tune this with
+`--agent-max-retries` and `--agent-retry-backoff-seconds`. Retry matching is
+narrow and intended for stream/tool-call failures, empty responses, network
+timeouts/resets, and provider 5xx errors. Auth, credit, quota, dirty workdir,
+and normal missing-marker responses are not retried.
 
 When `--approved-followups` is set to `summarize`, `issue`, or a `fix-and-*`
 mode, approved reviewer responses may also include optional future-work items
@@ -452,5 +464,6 @@ Use `tail -f` on the displayed path to see live output. Logs are diagnostic
 output and may include CLI status text or tool narration. For Claude and
 Gemini, prompts also include a public response-file path under
 `/tmp/coding-review-agent-loop/responses/`; when that file exists and is
-non-empty, the loop posts the file contents to GitHub instead of stdout. The log
-directory gets its own `.gitignore` on first use.
+non-empty, the loop validates and posts the file contents to GitHub instead of
+stdout. Fallback stdout is still validated before posting. The log directory
+gets its own `.gitignore` on first use.

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -20,6 +20,8 @@ AgentName = Literal["claude", "codex", "gemini"]
 class AgentResult:
     text: str
     session_id: str | None = None
+    log_path: Path | None = None
+    returncode: int = 0
 
 
 class AgentBackend(Protocol):

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -65,10 +65,16 @@ class ClaudeBackend:
             log_path=log_path,
             label="Claude",
             progress_interval_seconds=config.progress_interval_seconds,
+            check=False,
         )
         log(config, f"Claude finished; log: {log_path}")
         text, new_session_id = _parse_claude_output(result.stdout)
-        return AgentResult(text=read_public_response_file(response_path) or text, session_id=new_session_id)
+        return AgentResult(
+            text=read_public_response_file(response_path) or text,
+            session_id=new_session_id,
+            log_path=log_path,
+            returncode=result.returncode,
+        )
 
 
 BACKEND = ClaudeBackend()

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -48,12 +48,12 @@ class CodexBackend:
                 cwd=config.codex_dir,
             )
             log(config, f"Codex finished; log: {log_path}")
-            return AgentResult(text=result.stdout)
+            return AgentResult(text=result.stdout, log_path=log_path, returncode=result.returncode)
 
         with tempfile.NamedTemporaryFile("r", encoding="utf-8", delete=False) as handle:
             output_path = handle.name
         try:
-            runner.run_with_log(
+            result = runner.run_with_log(
                 [
                     config.codex_cmd,
                     "exec",
@@ -68,10 +68,13 @@ class CodexBackend:
                 log_path=log_path,
                 label="Codex",
                 progress_interval_seconds=config.progress_interval_seconds,
+                check=False,
             )
-            output = Path(output_path).read_text(encoding="utf-8")
+            output = Path(output_path).read_text(encoding="utf-8") if Path(output_path).exists() else ""
+            if not output:
+                output = result.stdout
             log(config, f"Codex finished; log: {log_path}")
-            return AgentResult(text=output)
+            return AgentResult(text=output, log_path=log_path, returncode=result.returncode)
         finally:
             try:
                 os.unlink(output_path)

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -119,10 +119,16 @@ class GeminiBackend:
             log_path=log_path,
             label="Gemini",
             progress_interval_seconds=config.progress_interval_seconds,
+            check=False,
         )
         log(config, f"Gemini finished; log: {log_path}")
         text, new_session_id = _parse_gemini_output(result.stdout)
-        return AgentResult(text=read_public_response_file(response_path) or text, session_id=new_session_id)
+        return AgentResult(
+            text=read_public_response_file(response_path) or text,
+            session_id=new_session_id,
+            log_path=log_path,
+            returncode=result.returncode,
+        )
 
 
 BACKEND = GeminiBackend()

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -40,30 +40,6 @@ def default_agent_args(agent: AgentName, *, dangerous: bool) -> tuple[str, ...]:
     return get_backend(agent).default_args(dangerous=dangerous)
 
 
-def run_agent(
-    runner: Runner,
-    *,
-    agent: AgentName,
-    config: AgentLoopConfig,
-    prompt: str,
-    session_id: str | None = None,
-) -> tuple[str, str | None]:
-    result = run_agent_result(
-        runner,
-        agent=agent,
-        config=config,
-        prompt=prompt,
-        session_id=session_id,
-    )
-    if result.returncode != 0:
-        log_context = f"\nlog: {result.log_path}" if result.log_path is not None else ""
-        raise AgentLoopError(
-            f"{agent_display_name(agent)} failed before producing a valid response "
-            f"(exit {result.returncode}).{log_context}"
-        )
-    return result.text, result.session_id
-
-
 def run_agent_result(
     runner: Runner,
     *,
@@ -73,22 +49,3 @@ def run_agent_result(
     session_id: str | None = None,
 ) -> AgentResult:
     return get_backend(agent).run(runner, config, prompt, session_id=session_id)
-
-
-def run_claude(
-    runner: Runner,
-    *,
-    config: AgentLoopConfig,
-    prompt: str,
-    session_id: str | None = None,
-) -> tuple[str, str | None]:
-    result = CLAUDE_BACKEND.run(runner, config, prompt, session_id=session_id)
-    return result.text, result.session_id
-
-
-def run_codex(runner: Runner, *, config: AgentLoopConfig, prompt: str) -> str:
-    return CODEX_BACKEND.run(runner, config, prompt).text
-
-
-def run_gemini(runner: Runner, *, config: AgentLoopConfig, prompt: str) -> str:
-    return GEMINI_BACKEND.run(runner, config, prompt).text

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .base import AgentBackend, AgentName
+from .base import AgentBackend, AgentName, AgentResult
 from .claude import BACKEND as CLAUDE_BACKEND
 from .codex import BACKEND as CODEX_BACKEND
 from .gemini import BACKEND as GEMINI_BACKEND
@@ -48,8 +48,31 @@ def run_agent(
     prompt: str,
     session_id: str | None = None,
 ) -> tuple[str, str | None]:
-    result = get_backend(agent).run(runner, config, prompt, session_id=session_id)
+    result = run_agent_result(
+        runner,
+        agent=agent,
+        config=config,
+        prompt=prompt,
+        session_id=session_id,
+    )
+    if result.returncode != 0:
+        log_context = f"\nlog: {result.log_path}" if result.log_path is not None else ""
+        raise AgentLoopError(
+            f"{agent_display_name(agent)} failed before producing a valid response "
+            f"(exit {result.returncode}).{log_context}"
+        )
     return result.text, result.session_id
+
+
+def run_agent_result(
+    runner: Runner,
+    *,
+    agent: AgentName,
+    config: AgentLoopConfig,
+    prompt: str,
+    session_id: str | None = None,
+) -> AgentResult:
+    return get_backend(agent).run(runner, config, prompt, session_id=session_id)
 
 
 def run_claude(

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -180,6 +180,22 @@ def build_parser() -> argparse.ArgumentParser:
             default=30,
             help="How often to print long-running agent heartbeats (default: 30).",
         )
+        subparser.add_argument(
+            "--agent-max-retries",
+            type=int,
+            default=2,
+            help="Maximum retries for narrow transient agent/model failures (default: 2).",
+        )
+        subparser.add_argument(
+            "--agent-retry-backoff-seconds",
+            type=int,
+            nargs="+",
+            default=[15, 45],
+            help=(
+                "Backoff delays for transient agent retries. The final value is reused "
+                "when retries exceed the number of provided delays (default: 15 45)."
+            ),
+        )
         memory_group = subparser.add_mutually_exclusive_group()
         memory_group.add_argument(
             "--agent-memory",

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -11,10 +11,6 @@ from typing import Sequence
 from .agents.registry import (
     agent_display_name,
     agent_signature,
-    run_agent,
-    run_claude,
-    run_codex,
-    run_gemini,
 )
 from .config import (
     AgentLoopConfig,

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -46,6 +46,8 @@ class AgentLoopConfig:
     quiet: bool
     log_dir: Path
     progress_interval_seconds: int
+    agent_max_retries: int
+    agent_retry_backoff_seconds: tuple[int, ...]
     agent_memory: bool
     refresh_agent_memory: bool
     agent_memory_dir: Path
@@ -410,6 +412,10 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
     if args.progress_interval_seconds <= 0:
         raise AgentLoopError("--progress-interval-seconds must be greater than zero.")
+    if args.agent_max_retries < 0:
+        raise AgentLoopError("--agent-max-retries must be zero or positive.")
+    if any(delay <= 0 for delay in args.agent_retry_backoff_seconds):
+        raise AgentLoopError("--agent-retry-backoff-seconds values must be greater than zero.")
     return AgentLoopConfig(
         repo=repo,
         claude_dir=claude_dir,
@@ -448,6 +454,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         quiet=args.quiet,
         log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
         progress_interval_seconds=args.progress_interval_seconds,
+        agent_max_retries=args.agent_max_retries,
+        agent_retry_backoff_seconds=tuple(args.agent_retry_backoff_seconds),
         agent_memory=args.agent_memory,
         refresh_agent_memory=args.refresh_agent_memory,
         agent_memory_dir=_resolve_agent_memory_dir(

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -19,5 +19,5 @@ def log(config: AgentLoopConfig, message: str) -> None:
 
 
 def agent_log_path(config: AgentLoopConfig, agent: str) -> Path:
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     return config.log_dir / f"{stamp}-{agent}.log"

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import re
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
-from .agents.base import AgentName
-from .agents.registry import agent_display_name, run_agent
+from .agents.base import AgentName, AgentResult
+from .agents.registry import agent_display_name, run_agent_result
 from .config import (
     AgentLoopConfig,
     ensure_agent_workdirs,
@@ -57,6 +57,161 @@ from .runner import Runner
 from .workdirs import active_workdir
 
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
+
+TRANSIENT_AGENT_OUTPUT_RE = re.compile(
+    r"Invalid stream|empty response|malformed tool call|"
+    r"network (?:reset|timeout)|connection (?:reset|timed out|timeout)|"
+    r"\btimed out\b|\btimeout\b|"
+    r"\b5\d\d\b|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout",
+    re.I,
+)
+NON_RETRYABLE_AGENT_OUTPUT_RE = re.compile(
+    r"auth(?:entication|orization)?|unauthorized|forbidden|invalid api key|"
+    r"credit|quota|rate limit|billing|dirty (?:checkout|workdir|working tree)",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class ValidatedAgentResponse:
+    text: str
+    session_id: str | None
+    marker_value: object
+
+
+def _agent_log_context(log_paths: Sequence[object]) -> str:
+    paths = [str(path) for path in log_paths if path is not None]
+    if not paths:
+        return ""
+    return "\nAttempt logs:\n" + "\n".join(f"- {path}" for path in paths)
+
+
+def _is_transient_agent_output(text: str) -> bool:
+    return bool(TRANSIENT_AGENT_OUTPUT_RE.search(text)) and not bool(
+        NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
+    )
+
+
+def _retry_delay(config: AgentLoopConfig, retry_index: int) -> int:
+    delays = config.agent_retry_backoff_seconds
+    if not delays:
+        return 1
+    return delays[min(retry_index - 1, len(delays) - 1)]
+
+
+def _format_invalid_agent_response_error(
+    *,
+    agent_name: str,
+    marker_description: str,
+    reason: str,
+    result: AgentResult | None,
+    log_paths: Sequence[object],
+) -> str:
+    exit_context = ""
+    if result is not None and result.returncode != 0:
+        exit_context = f" Agent exit code: {result.returncode}."
+    log_context = _agent_log_context(log_paths)
+    return (
+        f"{agent_name} failed before producing a valid public response. "
+        "No review result was recorded. "
+        f"Required marker: {marker_description}. Reason: {reason}.{exit_context}"
+        f"{log_context}"
+    )
+
+
+def _run_validated_agent(
+    runner: Runner,
+    *,
+    agent: AgentName,
+    config: AgentLoopConfig,
+    prompt: str,
+    marker_description: str,
+    validate: Callable[[str], object],
+    session_id: str | None = None,
+) -> ValidatedAgentResponse:
+    agent_name = agent_display_name(agent)
+    log_paths: list[object] = []
+    max_attempts = config.agent_max_retries + 1
+    last_error = f"{agent_name} produced no output."
+    last_result: AgentResult | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        result = run_agent_result(
+            runner,
+            agent=agent,
+            config=config,
+            prompt=prompt,
+            session_id=session_id,
+        )
+        last_result = result
+        if result.log_path is not None:
+            log_paths.append(result.log_path)
+        text = result.text
+
+        should_retry = False
+        if result.returncode != 0:
+            last_error = f"agent command exited with {result.returncode}"
+            should_retry = _is_transient_agent_output(text)
+        elif not text.strip():
+            last_error = "agent response was empty"
+            should_retry = _is_transient_agent_output(text)
+        else:
+            try:
+                marker_value = validate(text)
+            except AgentLoopError as exc:
+                last_error = str(exc)
+                should_retry = _is_transient_agent_output(text)
+            else:
+                return ValidatedAgentResponse(
+                    text=text,
+                    session_id=result.session_id,
+                    marker_value=marker_value,
+                )
+
+        if should_retry and attempt < max_attempts:
+            delay = _retry_delay(config, attempt)
+            log(
+                config,
+                f"{agent_name} produced a transient invalid response; "
+                f"retrying in {delay}s (attempt {attempt + 1}/{max_attempts})",
+            )
+            runner.run(("sleep", str(delay)), cwd=active_workdir(config))
+            continue
+        break
+
+    raise AgentLoopError(
+        _format_invalid_agent_response_error(
+            agent_name=agent_name,
+            marker_description=marker_description,
+            reason=last_error,
+            result=last_result,
+            log_paths=log_paths,
+        )
+    )
+
+
+def _require_pr_number(text: str) -> int:
+    pr_number = parse_pr_number(text)
+    if pr_number is None:
+        raise AgentLoopError("Agent response did not include a PR marker or PR URL.")
+    return pr_number
+
+
+def _require_pr_number_or_clarification(text: str) -> int | str:
+    pr_number = parse_pr_number(text)
+    if pr_number is not None:
+        return pr_number
+    if is_clarification_request(text):
+        return "clarification"
+    raise AgentLoopError(
+        "Agent response did not include a PR marker, PR URL, or clarification marker."
+    )
+
+
+def _require_plan_state_or_clarification(text: str) -> str:
+    if is_clarification_request(text):
+        return "clarification"
+    return parse_plan_state(text)
 
 
 @dataclass(frozen=True)
@@ -272,20 +427,21 @@ def _run_plan_first_loop(
     reviewer_session_ids: dict[AgentName, str | None] = {}
 
     log(config, f"Planning issue #{issue_number}: invoking {coder_name}")
-    plan_output, coder_session_id = run_agent(
+    plan_response = _run_validated_agent(
         runner,
         agent=config.coder,
         config=config,
         prompt=build_issue_plan_prompt(issue_number, config, memory, issue_context=issue_context),
+        marker_description="<!-- AGENT_PLAN_STATE: approved|blocking --> or <!-- AGENT_CLARIFY -->",
+        validate=_require_plan_state_or_clarification,
     )
-    if not plan_output.strip():
-        raise AgentLoopError(f"{coder_name} produced an empty response.")
+    plan_output = plan_response.text
+    coder_session_id = plan_response.session_id
     if is_clarification_request(plan_output):
         raise AgentLoopError(
             f"{coder_name} requested clarification during planning; human intervention required.\n\n"
             f"{coder_name}'s questions:\n{plan_output}"
         )
-    parse_plan_state(plan_output)
     post_issue_comment(runner, config=config, issue_number=issue_number, body=plan_output)
     current_plan = plan_output
 
@@ -294,7 +450,7 @@ def _run_plan_first_loop(
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Planning round {round_number}: {reviewer_name} reviewing issue #{issue_number}")
-            review_output, new_session_id = run_agent(
+            review_response = _run_validated_agent(
                 runner,
                 agent=reviewer,
                 config=config,
@@ -308,12 +464,13 @@ def _run_plan_first_loop(
                     issue_context=issue_context,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
+                marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                validate=parse_plan_state,
             )
-            reviewer_session_ids[reviewer] = new_session_id
-            if not review_output.strip():
-                raise AgentLoopError(f"{reviewer_name} produced an empty response.")
+            review_output = review_response.text
+            reviewer_session_ids[reviewer] = review_response.session_id
+            review_state = str(review_response.marker_value)
             post_issue_comment(runner, config=config, issue_number=issue_number, body=review_output)
-            review_state = parse_plan_state(review_output)
             log(config, f"Planning round {round_number}: {reviewer_name} state is {review_state}")
             if review_state == "blocking":
                 blocking_reviews.append((reviewer_name, review_output))
@@ -333,7 +490,7 @@ def _run_plan_first_loop(
 
             sync_coder_base_before_implementation(config, runner)
             log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
-            coder_output, coder_session_id = run_agent(
+            coder_response = _run_validated_agent(
                 runner,
                 agent=config.coder,
                 config=config,
@@ -345,12 +502,12 @@ def _run_plan_first_loop(
                     issue_context=issue_context,
                 ),
                 session_id=coder_session_id,
+                marker_description="<!-- AGENT_PR: <number> --> or PR URL",
+                validate=_require_pr_number,
             )
-            pr_number = parse_pr_number(coder_output)
-            if pr_number is None:
-                raise AgentLoopError(
-                    f"{coder_name} output did not include a PR marker or PR URL."
-                )
+            coder_output = coder_response.text
+            coder_session_id = coder_response.session_id
+            pr_number = int(coder_response.marker_value)
             log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
             validate_open_pr(runner, config=config, pr_number=pr_number)
             post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
@@ -373,7 +530,7 @@ def _run_plan_first_loop(
             f"{name} plan review:\n\n{review}" for name, review in blocking_reviews
         )
         log(config, f"Planning round {round_number}: {coder_name} revising the plan")
-        current_plan, coder_session_id = run_agent(
+        plan_response = _run_validated_agent(
             runner,
             agent=config.coder,
             config=config,
@@ -387,10 +544,11 @@ def _run_plan_first_loop(
                 issue_context=issue_context,
             ),
             session_id=coder_session_id,
+            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+            validate=parse_plan_state,
         )
-        if not current_plan.strip():
-            raise AgentLoopError(f"{coder_name} produced an empty response.")
-        parse_plan_state(current_plan)
+        current_plan = plan_response.text
+        coder_session_id = plan_response.session_id
         post_issue_comment(runner, config=config, issue_number=issue_number, body=current_plan)
 
     raise AgentLoopError(
@@ -423,17 +581,17 @@ def run_issue_loop(
         )
 
     sync_coder_base_before_implementation(config, runner)
-    coder_output, coder_session_id = run_agent(
+    coder_response = _run_validated_agent(
         runner,
         agent=config.coder,
         config=config,
         prompt=build_issue_prompt(issue_number, config, memory, issue_context=issue_context),
+        marker_description="<!-- AGENT_PR: <number> --> or PR URL",
+        validate=_require_pr_number,
     )
-    pr_number = parse_pr_number(coder_output)
-    if pr_number is None:
-        raise AgentLoopError(
-            f"{agent_display_name(config.coder)} output did not include a PR marker or PR URL."
-        )
+    coder_output = coder_response.text
+    coder_session_id = coder_response.session_id
+    pr_number = int(coder_response.marker_value)
     log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
     validate_open_pr(runner, config=config, pr_number=pr_number)
 
@@ -492,18 +650,20 @@ def run_task_loop(
         if attempt == 0:
             sync_coder_base_before_implementation(config, runner)
         log(config, f"Task attempt {attempt + 1}: invoking {coder_name}")
-        coder_output, session_id = run_agent(
+        coder_response = _run_validated_agent(
             runner,
             agent=config.coder,
             config=config,
             prompt=prompt,
             session_id=session_id,
+            marker_description="<!-- AGENT_PR: <number> -->, PR URL, or <!-- AGENT_CLARIFY -->",
+            validate=_require_pr_number_or_clarification,
         )
-        if not coder_output.strip():
-            raise AgentLoopError(f"{coder_name} produced an empty response.")
+        coder_output = coder_response.text
+        session_id = coder_response.session_id
 
-        pr_number = parse_pr_number(coder_output)
-        if pr_number is not None:
+        if isinstance(coder_response.marker_value, int):
+            pr_number = coder_response.marker_value
             log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
             validate_open_pr(runner, config=config, pr_number=pr_number)
             post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
@@ -513,12 +673,6 @@ def run_task_loop(
                 config=config,
                 coder_session_id=session_id,
                 workdirs_ready=True,
-            )
-
-        if not is_clarification_request(coder_output):
-            raise AgentLoopError(
-                f"{coder_name} output did not include a PR marker, PR URL, "
-                "or clarification marker."
             )
 
         if not interactive:
@@ -579,7 +733,7 @@ def run_pr_loop(
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
             sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
-            review_output, new_session_id = run_agent(
+            review_response = _run_validated_agent(
                 runner,
                 agent=reviewer,
                 config=config,
@@ -594,13 +748,14 @@ def run_pr_loop(
                     human_requirements=human_requirements,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
+                marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                validate=parse_agent_state,
             )
-            reviewer_session_ids[reviewer] = new_session_id
-            if not review_output.strip():
-                raise AgentLoopError(f"{reviewer_name} produced an empty response.")
+            review_output = review_response.text
+            reviewer_session_ids[reviewer] = review_response.session_id
+            review_state = str(review_response.marker_value)
 
             post_pr_comment(runner, config=config, pr_number=pr_number, body=review_output)
-            review_state = parse_agent_state(review_output)
             log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
             if review_state == "blocking":
                 blocking_reviews.append((reviewer_name, review_output))
@@ -703,19 +858,19 @@ def run_pr_loop(
                 human_requirements=human_requirements,
             )
         log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
-        coder_output, coder_session_id = run_agent(
+        coder_response = _run_validated_agent(
             runner,
             agent=config.coder,
             config=config,
             prompt=followup_prompt,
             session_id=coder_session_id,
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=parse_agent_state,
         )
-        if not coder_output.strip():
-            raise AgentLoopError(f"{coder_name} produced an empty response.")
+        coder_output = coder_response.text
+        coder_session_id = coder_response.session_id
 
         post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
-        # Validate marker presence; reviewer remains the merge gate on the next round.
-        parse_agent_state(coder_output)
         log(config, f"Round {round_number}: {coder_name} pushed updates for re-review")
 
     raise AgentLoopError(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -99,6 +99,12 @@ class FakeRunner(Runner):
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
 
+    def _next_agent_output(self, outputs):
+        output = outputs.pop(0)
+        if isinstance(output, tuple):
+            return output
+        return output, 0
+
     def _record_command(self, args, cwd):
         cmd = [str(arg) for arg in args]
         cwd_path = Path(cwd)
@@ -133,24 +139,24 @@ class FakeRunner(Runner):
         ensure_log_dir_ignored(log_path.parent)
 
         if cmd[:1] == ["claude"]:
-            output = self.claude_outputs.pop(0)
+            output, returncode = self._next_agent_output(self.claude_outputs)
             self._maybe_write_public_response_file(cmd)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
-            return CommandResult(cmd, cwd_path, output, "", 0)
+            return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
-            output = self.codex_outputs.pop(0)
+            output, returncode = self._next_agent_output(self.codex_outputs)
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(output, encoding="utf-8")
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
-            return CommandResult(cmd, cwd_path, "codex completed", "", 0)
+            return CommandResult(cmd, cwd_path, "codex completed", "", returncode)
 
         if cmd[:1] == ["gemini"]:
-            output = self.gemini_outputs.pop(0)
+            output, returncode = self._next_agent_output(self.gemini_outputs)
             self._maybe_write_public_response_file(cmd)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
-            return CommandResult(cmd, cwd_path, output, "", 0)
+            return CommandResult(cmd, cwd_path, output, "", returncode)
 
         return self.run(args, cwd=cwd, check=check)
 
@@ -158,14 +164,15 @@ class FakeRunner(Runner):
         cmd, cwd_path = self._record_command(args, cwd)
 
         if cmd[:1] == ["claude"]:
-            return CommandResult(cmd, cwd_path, self.claude_outputs.pop(0), "", 0)
+            output, returncode = self._next_agent_output(self.claude_outputs)
+            return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
-            output = self.codex_outputs.pop(0)
+            output, returncode = self._next_agent_output(self.codex_outputs)
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(output, encoding="utf-8")
-            return CommandResult(cmd, cwd_path, "", "", 0)
+            return CommandResult(cmd, cwd_path, "", "", returncode)
 
         if cmd[:3] == ["gh", "pr", "comment"]:
             if "--body-file" in cmd:
@@ -295,6 +302,8 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         "quiet": True,
         "log_dir": tmp_path / "logs",
         "progress_interval_seconds": 30,
+        "agent_max_retries": 2,
+        "agent_retry_backoff_seconds": (1, 1),
         "agent_memory": True,
         "refresh_agent_memory": False,
         "agent_memory_dir": tmp_path / "claude" / ".agent-loop" / "memory",
@@ -987,6 +996,91 @@ def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
         '[.check_runs[] | select(.name == "test")] | if length == 0 then "pending" else .[0].conclusion // .[0].status end',
     ] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+
+
+def test_pr_loop_does_not_post_gemini_diagnostics_without_agent_state(tmp_path):
+    diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
+    runner = FakeRunner(gemini_outputs=[diagnostic, diagnostic, diagnostic])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    with pytest.raises(AgentLoopError, match="No review result was recorded"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert runner.comments == []
+    assert not any(diagnostic in comment for comment in runner.comments)
+    sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
+    assert sleep_commands == [["sleep", "1"], ["sleep", "1"]]
+
+
+def test_plan_review_does_not_post_diagnostics_without_plan_state(tmp_path):
+    diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Update the CLI.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        gemini_outputs=[diagnostic, diagnostic, diagnostic],
+    )
+    config = make_config(tmp_path, reviewer="gemini")
+
+    with pytest.raises(AgentLoopError, match="AGENT_PLAN_STATE"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert len(runner.comments) == 1
+    assert runner.comments[0].startswith("Plan:")
+    assert not any(diagnostic in comment for comment in runner.comments)
+
+
+def test_pr_loop_retries_transient_gemini_diagnostic_and_posts_only_valid_response(tmp_path):
+    diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
+    valid = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(gemini_outputs=[diagnostic, valid])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments == [valid]
+    assert diagnostic not in runner.comments[0]
+    sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
+    assert sleep_commands == [["sleep", "1"]]
+
+
+def test_pr_loop_exhausted_transient_retry_reports_attempt_logs(tmp_path):
+    diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
+    runner = FakeRunner(gemini_outputs=[(diagnostic, 1), (diagnostic, 1), (diagnostic, 1)])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    with pytest.raises(AgentLoopError) as exc_info:
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    message = str(exc_info.value)
+    assert "No review result was recorded" in message
+    assert "Attempt logs:" in message
+    assert "gemini.log" in message
+    assert runner.comments == []
+
+
+def test_pr_loop_does_not_retry_quota_failure(tmp_path):
+    output = "Quota exceeded: billing credits are exhausted."
+    runner = FakeRunner(gemini_outputs=[output])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    with pytest.raises(AgentLoopError, match="No review result was recorded"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert runner.comments == []
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
+def test_pr_loop_does_not_retry_normal_missing_marker_response(tmp_path):
+    output = "I reviewed the PR and it looks fine."
+    runner = FakeRunner(gemini_outputs=[output])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    with pytest.raises(AgentLoopError, match="AGENT_STATE"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert runner.comments == []
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
 def test_pr_loop_blocks_approval_without_human_requirement_resolution_marker(tmp_path):


### PR DESCRIPTION
## Summary
- validate required agent protocol markers before posting reviewer/coder output
- retry narrow transient agent/model failures with bounded configurable backoff
- include attempt log paths in local failures and document safe stdout fallback behavior

## Tests
- python3 -m pytest

Closes #96