### PR TITLE
Harden Gemini response handling

### DIFF
--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -46,12 +46,22 @@ def _safe_repo_slug(repo: str) -> str:
     return repo.replace("/", "-").replace(":", "-")
 
 
-def public_response_path(config: AgentLoopConfig, agent: AgentName) -> Path:
-    path = (
-        Path(tempfile.gettempdir())
+def public_response_path(
+    config: AgentLoopConfig,
+    agent: AgentName,
+    *,
+    root: Path | None = None,
+) -> Path:
+    base_dir = (
+        root
+        if root is not None
+        else Path(tempfile.gettempdir())
         / "coding-review-agent-loop"
         / "responses"
         / _safe_repo_slug(config.repo)
+    )
+    path = (
+        base_dir
         / agent
         / f"{uuid.uuid4().hex}.md"
     )

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -100,7 +100,15 @@ class GeminiBackend:
         prompt: str,
         session_id: str | None = None,
     ) -> AgentResult:
-        response_path = public_response_path(config, "gemini")
+        # Gemini CLI only allows file writes inside the trusted workspace (or
+        # its own private temp dir, whose path we do not know ahead of time).
+        # Keep the response file inside .git so it is writable but never dirties
+        # the reviewed worktree.
+        response_path = public_response_path(
+            config,
+            "gemini",
+            root=config.gemini_dir / ".git" / "agent-loop" / "responses",
+        )
         log_path = agent_log_path(config, "gemini")
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")
         args = [

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -82,6 +82,24 @@ def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
     return _strip_gemini_preamble(raw), None
 
 
+def _gemini_public_response_root(gemini_dir: Path) -> Path:
+    git_marker = gemini_dir / ".git"
+    if git_marker.is_file():
+        gitdir_prefix = "gitdir:"
+        try:
+            gitdir_text = git_marker.read_text(encoding="utf-8").strip()
+        except OSError:
+            gitdir_text = ""
+        if gitdir_text.lower().startswith(gitdir_prefix):
+            git_dir = Path(gitdir_text[len(gitdir_prefix) :].strip())
+            if not git_dir.is_absolute():
+                git_dir = gemini_dir / git_dir
+            return git_dir.resolve() / "agent-loop" / "responses"
+        return gemini_dir / ".agent-loop-responses"
+
+    return git_marker / "agent-loop" / "responses"
+
+
 class GeminiBackend:
     name: AgentName = "gemini"
     display_name = "Gemini"
@@ -102,12 +120,13 @@ class GeminiBackend:
     ) -> AgentResult:
         # Gemini CLI only allows file writes inside the trusted workspace (or
         # its own private temp dir, whose path we do not know ahead of time).
-        # Keep the response file inside .git so it is writable but never dirties
-        # the reviewed worktree.
+        # Keep the response file inside the git dir so it is writable but never
+        # dirties the reviewed worktree. In linked worktrees, .git is a pointer
+        # file, so resolve it before creating children beneath it.
         response_path = public_response_path(
             config,
             "gemini",
-            root=config.gemini_dir / ".git" / "agent-loop" / "responses",
+            root=_gemini_public_response_root(config.gemini_dir),
         )
         log_path = agent_log_path(config, "gemini")
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -70,6 +70,10 @@ NON_RETRYABLE_AGENT_OUTPUT_RE = re.compile(
     r"credit|quota|rate limit|billing|dirty (?:checkout|workdir|working tree)",
     re.I,
 )
+NEAR_MISS_AGENT_STATE_RE = re.compile(
+    r"(?m)^\s*AGENT_STATE:\s*(?:approved|blocking)\s*$",
+    re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -88,6 +92,12 @@ def _agent_log_context(log_paths: Sequence[object]) -> str:
 
 def _is_transient_agent_output(text: str) -> bool:
     return bool(TRANSIENT_AGENT_OUTPUT_RE.search(text)) and not bool(
+        NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
+    )
+
+
+def _is_retryable_marker_near_miss(text: str) -> bool:
+    return bool(NEAR_MISS_AGENT_STATE_RE.search(text)) and not bool(
         NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
     )
 
@@ -160,7 +170,9 @@ def _run_validated_agent(
                 marker_value = validate(text)
             except AgentLoopError as exc:
                 last_error = str(exc)
-                should_retry = _is_transient_agent_output(text)
+                should_retry = _is_transient_agent_output(text) or (
+                    attempt == 1 and _is_retryable_marker_near_miss(text)
+                )
             else:
                 return ValidatedAgentResponse(
                     text=text,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -70,8 +70,8 @@ NON_RETRYABLE_AGENT_OUTPUT_RE = re.compile(
     r"credit|quota|rate limit|billing|dirty (?:checkout|workdir|working tree)",
     re.I,
 )
-NEAR_MISS_AGENT_STATE_RE = re.compile(
-    r"(?m)^\s*AGENT_STATE:\s*(?:approved|blocking)\s*$",
+NEAR_MISS_AGENT_MARKER_RE = re.compile(
+    r"(?m)^[ \t]*AGENT_(?:PLAN_)?STATE:[ \t]*(?:approved|blocking)[ \t.]*$",
     re.I,
 )
 
@@ -97,7 +97,7 @@ def _is_transient_agent_output(text: str) -> bool:
 
 
 def _is_retryable_marker_near_miss(text: str) -> bool:
-    return bool(NEAR_MISS_AGENT_STATE_RE.search(text)) and not bool(
+    return bool(NEAR_MISS_AGENT_MARKER_RE.search(text)) and not bool(
         NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
     )
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1044,8 +1044,9 @@ def test_pr_loop_retries_transient_gemini_diagnostic_and_posts_only_valid_respon
     assert sleep_commands == [["sleep", "1"]]
 
 
-def test_pr_loop_retries_plain_agent_state_near_miss_once(tmp_path):
-    near_miss = "LGTM.\nAGENT_STATE: approved\n-- Google Gemini"
+@pytest.mark.parametrize("terminator", ["", "."])
+def test_pr_loop_retries_plain_agent_state_near_miss_once(tmp_path, terminator):
+    near_miss = f"LGTM.\nAGENT_STATE: approved{terminator}\n-- Google Gemini"
     valid = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
     runner = FakeRunner(gemini_outputs=[near_miss, valid])
     config = make_config(tmp_path, reviewer="gemini")
@@ -1053,6 +1054,25 @@ def test_pr_loop_retries_plain_agent_state_near_miss_once(tmp_path):
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert runner.comments == [valid]
+    sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
+    assert sleep_commands == [["sleep", "1"]]
+
+
+def test_plan_loop_retries_plain_agent_plan_state_near_miss_once(tmp_path):
+    near_miss = "Plan looks sound.\nAGENT_PLAN_STATE: approved.\n-- Google Gemini"
+    valid = "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Update the CLI.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        gemini_outputs=[near_miss, valid],
+    )
+    config = make_config(tmp_path, reviewer="gemini")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert near_miss not in runner.comments
+    assert any(comment == valid for comment in runner.comments)
     sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
     assert sleep_commands == [["sleep", "1"]]
 
@@ -1071,6 +1091,22 @@ def test_gemini_public_response_file_is_inside_git_dir(tmp_path):
     expected_prefix = str(config.gemini_dir / ".git" / "agent-loop" / "responses" / "gemini")
     assert expected_prefix in prompt
     assert "/tmp/coding-review-agent-loop/responses/" not in prompt
+
+
+def test_gemini_public_response_file_resolves_worktree_git_dir(tmp_path):
+    valid = "LGTM from response file.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(gemini_outputs=["stdout should be ignored"], public_response_outputs=[valid])
+    config = make_config(tmp_path, reviewer="gemini")
+    git_dir = tmp_path / "main-repo" / ".git" / "worktrees" / "gemini"
+    git_dir.mkdir(parents=True)
+    (config.gemini_dir / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments == [valid]
+    gemini_call = next(cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"])
+    assert str(git_dir / "agent-loop" / "responses" / "gemini") in gemini_call[2]
+    assert str(config.gemini_dir / ".git" / "agent-loop") not in gemini_call[2]
 
 
 def test_pr_loop_exhausted_transient_retry_reports_attempt_logs(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1044,6 +1044,35 @@ def test_pr_loop_retries_transient_gemini_diagnostic_and_posts_only_valid_respon
     assert sleep_commands == [["sleep", "1"]]
 
 
+def test_pr_loop_retries_plain_agent_state_near_miss_once(tmp_path):
+    near_miss = "LGTM.\nAGENT_STATE: approved\n-- Google Gemini"
+    valid = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(gemini_outputs=[near_miss, valid])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments == [valid]
+    sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
+    assert sleep_commands == [["sleep", "1"]]
+
+
+def test_gemini_public_response_file_is_inside_git_dir(tmp_path):
+    valid = "LGTM from response file.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(gemini_outputs=["stdout should be ignored"], public_response_outputs=[valid])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments == [valid]
+    gemini_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"]]
+    assert len(gemini_commands) == 1
+    prompt = "\n".join(gemini_commands[0])
+    expected_prefix = str(config.gemini_dir / ".git" / "agent-loop" / "responses" / "gemini")
+    assert expected_prefix in prompt
+    assert "/tmp/coding-review-agent-loop/responses/" not in prompt
+
+
 def test_pr_loop_exhausted_transient_retry_reports_attempt_logs(tmp_path):
     diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
     runner = FakeRunner(gemini_outputs=[(diagnostic, 1), (diagnostic, 1), (diagnostic, 1)])
@@ -3192,7 +3221,7 @@ def test_gemini_review_loop_prefers_public_response_file_over_stdout(tmp_path):
 
     gemini_call = next(cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"])
     assert "PUBLIC RESPONSE FILE:" in gemini_call[2]
-    assert "/coding-review-agent-loop/responses/OWNER-REPO/gemini/" in gemini_call[2]
+    assert str(config.gemini_dir / ".git" / "agent-loop" / "responses" / "gemini") in gemini_call[2]
     assert runner.comments == ["LGTM from response file.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"]
 
 


### PR DESCRIPTION
Fixes two Gemini response handling problems seen in local agent-loop runs:\n\n- Put Gemini public response files under the Gemini checkout's .git/agent-loop/responses directory, so Gemini can write them without dirtying the reviewed worktree or hitting /tmp workspace restrictions.\n- Retry once when an agent response contains a near-miss plain AGENT_STATE marker instead of the required HTML comment marker.\n\nTests:\n- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest /home/wwind123/openai-codex/coding-review-agent-loop/tests/test_agent_loop.py -q\n- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile /home/wwind123/openai-codex/coding-review-agent-loop/src/coding_review_agent_loop/agents/base.py /home/wwind123/openai-codex/coding-review-agent-loop/src/coding_review_agent_loop/agents/gemini.py /home/wwind123/openai-codex/coding-review-agent-loop/src/coding_review_agent_loop/orchestrator.py\n\n-- OpenAI Codex