### PR TITLE
Combine PR view calls per review round

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -56,6 +56,16 @@ class HumanReviewRequirement:
     body: str
 
 
+@dataclass(frozen=True)
+class PullRequestReviewContext:
+    metadata: PullRequestMetadata
+    human_requirements: tuple[HumanReviewRequirement, ...]
+
+
+PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url"
+PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
+
+
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
     result = runner.run(
         [gh_cmd, "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
@@ -111,19 +121,25 @@ def get_pr_metadata(runner: Runner, *, config: AgentLoopConfig, pr_number: int) 
             "--repo",
             config.repo,
             "--json",
-            "number,title,headRefName,baseRefName,headRefOid,url",
+            PR_METADATA_FIELDS,
         ],
         cwd=active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
+    return _parse_pr_metadata(data, config=config, pr_number=pr_number)
+
+
+def _parse_pr_metadata(
+    data: dict[str, object], *, config: AgentLoopConfig, pr_number: int
+) -> PullRequestMetadata:
     return PullRequestMetadata(
         number=int(data.get("number") or pr_number),
         repo=config.repo,
-        title=data.get("title"),
-        head_branch=data.get("headRefName"),
-        base_branch=data.get("baseRefName"),
-        head_sha=data.get("headRefOid"),
-        url=data.get("url"),
+        title=_optional_str(data.get("title")),
+        head_branch=_optional_str(data.get("headRefName")),
+        base_branch=_optional_str(data.get("baseRefName")),
+        head_sha=_optional_str(data.get("headRefOid")),
+        url=_optional_str(data.get("url")),
     )
 
 
@@ -136,6 +152,10 @@ def _author_login(raw: object) -> str | None:
 
 def _human_requirement_sort_key(requirement: HumanReviewRequirement) -> str:
     return requirement.created_at or ""
+
+
+def _optional_str(raw: object) -> str | None:
+    return str(raw) if raw is not None else None
 
 
 def get_pr_human_requirements(
@@ -161,8 +181,54 @@ def get_pr_human_requirements(
         cwd=active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
+    return _parse_pr_human_requirements(data)
+
+
+def get_pr_review_context(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+) -> PullRequestReviewContext:
+    if config.dry_run:
+        return PullRequestReviewContext(
+            metadata=PullRequestMetadata(
+                number=pr_number,
+                repo=config.repo,
+                title=None,
+                head_branch=None,
+                base_branch=None,
+                head_sha=None,
+                url=None,
+            ),
+            human_requirements=(),
+        )
+
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            PR_REVIEW_CONTEXT_FIELDS,
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    return PullRequestReviewContext(
+        metadata=_parse_pr_metadata(data, config=config, pr_number=pr_number),
+        human_requirements=_parse_pr_human_requirements(data),
+    )
+
+
+def _parse_pr_human_requirements(data: dict[str, object]) -> tuple[HumanReviewRequirement, ...]:
     requirements: list[HumanReviewRequirement] = []
     for raw_comment in data.get("comments") or []:
+        if not isinstance(raw_comment, dict):
+            continue
         body = parse_signed_human_requirement_body(raw_comment.get("body"))
         if body is None:
             continue
@@ -176,6 +242,8 @@ def get_pr_human_requirements(
             )
         )
     for raw_review in data.get("reviews") or []:
+        if not isinstance(raw_review, dict):
+            continue
         body = parse_signed_human_requirement_body(raw_review.get("body"))
         if body is None:
             continue

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -100,35 +100,6 @@ def validate_open_pr(runner: Runner, *, config: AgentLoopConfig, pr_number: int)
         )
 
 
-def get_pr_metadata(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> PullRequestMetadata:
-    if config.dry_run:
-        return PullRequestMetadata(
-            number=pr_number,
-            repo=config.repo,
-            title=None,
-            head_branch=None,
-            base_branch=None,
-            head_sha=None,
-            url=None,
-        )
-
-    result = runner.run(
-        [
-            config.gh_cmd,
-            "pr",
-            "view",
-            str(pr_number),
-            "--repo",
-            config.repo,
-            "--json",
-            PR_METADATA_FIELDS,
-        ],
-        cwd=active_workdir(config),
-    )
-    data = json.loads(result.stdout or "{}")
-    return _parse_pr_metadata(data, config=config, pr_number=pr_number)
-
-
 def _parse_pr_metadata(
     data: dict[str, object], *, config: AgentLoopConfig, pr_number: int
 ) -> PullRequestMetadata:
@@ -156,32 +127,6 @@ def _human_requirement_sort_key(requirement: HumanReviewRequirement) -> str:
 
 def _optional_str(raw: object) -> str | None:
     return str(raw) if raw is not None else None
-
-
-def get_pr_human_requirements(
-    runner: Runner,
-    *,
-    config: AgentLoopConfig,
-    pr_number: int,
-) -> tuple[HumanReviewRequirement, ...]:
-    if config.dry_run:
-        return ()
-
-    result = runner.run(
-        [
-            config.gh_cmd,
-            "pr",
-            "view",
-            str(pr_number),
-            "--repo",
-            config.repo,
-            "--json",
-            "comments,reviews",
-        ],
-        cwd=active_workdir(config),
-    )
-    data = json.loads(result.stdout or "{}")
-    return _parse_pr_human_requirements(data)
 
 
 def get_pr_review_context(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -21,8 +21,7 @@ from .github import (
     IssueContext,
     create_issue,
     get_issue_context,
-    get_pr_human_requirements,
-    get_pr_metadata,
+    get_pr_review_context,
     merge_pr,
     post_issue_comment,
     post_pr_comment,
@@ -739,8 +738,9 @@ def run_pr_loop(
         same_pr_followups: list[ApprovedFollowup] = []
         round_future_followups: list[ApprovedFollowup] = []
         approved_review_outputs: list[tuple[str, str]] = []
-        pr_metadata = get_pr_metadata(runner, config=config, pr_number=pr_number)
-        human_requirements = get_pr_human_requirements(runner, config=config, pr_number=pr_number)
+        pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
+        pr_metadata = pr_context.metadata
+        human_requirements = pr_context.human_requirements
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1528,7 +1528,8 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
         for cmd in commands
         if cmd[:3] == ["gh", "pr", "view"]
         and "--json" in cmd
-        and cmd[cmd.index("--json") + 1] == "number,title,headRefName,baseRefName,headRefOid,url"
+        and cmd[cmd.index("--json") + 1]
+        == "number,title,headRefName,baseRefName,headRefOid,url,comments,reviews"
     ]
     assert len(metadata_fetches) == 1
     assert ["pytest", "tests/test_agent_loop.py"] in commands
@@ -1939,7 +1940,8 @@ def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
         for cmd in commands
         if cmd[:3] == ["gh", "pr", "view"]
         and "--json" in cmd
-        and cmd[cmd.index("--json") + 1] == "number,title,headRefName,baseRefName,headRefOid,url"
+        and cmd[cmd.index("--json") + 1]
+        == "number,title,headRefName,baseRefName,headRefOid,url,comments,reviews"
     ]
     assert len(metadata_fetches) == 2
 


### PR DESCRIPTION
## Summary
- add a combined PR review context fetch for metadata plus signed human requirements
- use the combined context in the PR review loop so each round only fetches PR view data once
- update tests to assert the combined field request per round

## Tests
- python3 -m pytest tests/test_agent_loop.py
- python3 -m pytest

Fixes #94