### PR TITLE
Force-refresh cached PR refs before reviewer runs

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -281,10 +281,11 @@ def sync_reviewer_pr_before_review(
     default_owned = reviewer in set(config.auto_agent_dirs)
     label = f"Default {reviewer} workdir" if default_owned else option_name
     pr_ref = f"refs/remotes/origin/pr/{pr_number}"
+    pr_fetch_refspec = f"+pull/{pr_number}/head:{pr_ref}"
 
     if runner.dry_run:
         _run_git(runner, path, ("fetch", "origin"))
-        _run_git(runner, path, ("fetch", "origin", f"pull/{pr_number}/head:{pr_ref}"))
+        _run_git(runner, path, ("fetch", "origin", pr_fetch_refspec))
         _run_git(runner, path, ("checkout", "--detach", pr_ref))
         _run_git(runner, path, ("rev-parse", "HEAD"))
         _run_git(runner, path, ("status", "--short", "--branch"))
@@ -316,7 +317,7 @@ def sync_reviewer_pr_before_review(
     )
 
     _run_git(runner, path, ("fetch", "origin"))
-    _run_git(runner, path, ("fetch", "origin", f"pull/{pr_number}/head:{pr_ref}"))
+    _run_git(runner, path, ("fetch", "origin", pr_fetch_refspec))
     _run_git(runner, path, ("checkout", "--detach", pr_ref))
     local_head = _run_git(runner, path, ("rev-parse", "HEAD")).stdout.strip()
     branch_state = _run_git(runner, path, ("status", "--short", "--branch")).stdout.strip()

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2331,7 +2331,7 @@ def test_reviewer_checkout_is_refreshed_to_pr_head_before_review(tmp_path):
     fetch_index = command_index(runner.commands, ["git", "fetch", "origin"], start=0)
     pr_fetch_index = command_index(
         runner.commands,
-        ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"],
+        ["git", "fetch", "origin", "+pull/77/head:refs/remotes/origin/pr/77"],
     )
     checkout_index = command_index(
         runner.commands,
@@ -2339,7 +2339,7 @@ def test_reviewer_checkout_is_refreshed_to_pr_head_before_review(tmp_path):
     )
     head_index = command_index(runner.commands, ["git", "rev-parse", "HEAD"], start=checkout_index)
 
-    assert commands[pr_fetch_index] == ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"]
+    assert commands[pr_fetch_index] == ["git", "fetch", "origin", "+pull/77/head:refs/remotes/origin/pr/77"]
     assert fetch_index < pr_fetch_index < checkout_index < head_index < review_index
 
 
@@ -2359,7 +2359,7 @@ def test_reviewer_checkout_refreshes_each_round_before_review(tmp_path):
     pr_fetches = [
         index
         for index, cmd in enumerate(commands)
-        if cmd == ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"]
+        if cmd == ["git", "fetch", "origin", "+pull/77/head:refs/remotes/origin/pr/77"]
     ]
     review_indices = [index for index, cmd in enumerate(commands) if cmd[:2] == ["codex", "exec"]]
 
@@ -3071,7 +3071,7 @@ def test_pr_loop_refreshes_pr_head_without_just_in_time_base_sync(tmp_path):
 
     commands = [cmd for cmd, _cwd in runner.commands]
     assert ["git", "fetch", "origin"] in commands
-    assert ["git", "fetch", "origin", "pull/77/head:refs/remotes/origin/pr/77"] in commands
+    assert ["git", "fetch", "origin", "+pull/77/head:refs/remotes/origin/pr/77"] in commands
     assert ["git", "switch", "main"] not in commands
     assert ["git", "pull", "--ff-only", "origin", "main"] not in commands
 


### PR DESCRIPTION
## Summary
- force-update cached `origin/pr/<number>` refs when refreshing reviewer workdirs
- keeps reviewer checkout refresh working after a PR branch is force-pushed or rewritten
- updates tests to expect the forced PR refspec

## Tests
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest /home/wwind123/openai-codex/coding-review-agent-loop/tests/test_agent_loop.py -q`

## Manual verification
- `git -C /tmp/coding-review-agent-loop/wwind123-llm-dialectic/gemini/repo fetch origin +pull/144/head:refs/remotes/origin/pr/144` updated stale PR #144 ref from `34f1b4d` to `e40a5b0`.

-- OpenAI Codex