### PR TITLE
Add pre-review local test gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ short-lived location. If the previous memory commit is unavailable or no longer
 diffable, the loop logs the git failure and treats all tracked files as changed
 for that refresh.
 
+Use `--test-command` to add a local test gate:
+
+```bash
+agent-loop task "Fix the flaky test" --repo OWNER/REPO --test-command "python -m pytest"
+```
+
+By default, the command runs after coder-created or coder-updated changes before
+reviewer rounds, and again after final reviewer approval before auto-merge. Add
+`--no-pre-review-tests` if you only want the final post-approval local test
+gate. The coder prompt also asks the coding agent to report the exact tests it
+ran, or explain why it could not run tests.
+
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -34,7 +34,8 @@ flowchart LR
     Orchestrator --> Protocol[Marker and follow-up parsing<br/>protocol.py]
     Orchestrator --> Registry[Agent registry<br/>agents/registry.py]
     Orchestrator --> GitHubOps[GitHub operations<br/>github.py]
-    Orchestrator --> OptionalTests[Optional local test command<br/>--test-command]
+    Orchestrator --> PreReviewTests[Optional pre-review local test command<br/>--test-command]
+    Orchestrator --> OptionalTests[Optional post-approval local test command<br/>--test-command]
     Orchestrator --> Followups[Approved follow-up handling<br/>summaries / issues / same-PR fixes]
 
     Registry --> Claude[Claude backend<br/>claude]
@@ -45,6 +46,7 @@ flowchart LR
     Codex --> Runner
     Gemini --> Runner
     GitHubOps --> Runner
+    PreReviewTests --> Runner
     OptionalTests --> Runner
 
     Runner --> AgentCLIs[Local agent CLIs]
@@ -335,7 +337,7 @@ agent-loop pr 123 \
   --ci-check-name test
 ```
 
-When enabled, the tool waits for the configured GitHub check-run to pass before merging. Local `--test-command` is an additional local gate, not a replacement for CI.
+When enabled, the tool waits for the configured GitHub check-run to pass before merging. Local `--test-command` is an additional local gate, not a replacement for CI. By default, `--test-command` also runs after coder-created or coder-updated changes before reviewer rounds, so reviewers are less likely to spend rounds on code that already fails the configured local test command. Use `--no-pre-review-tests` to keep `--test-command` as a post-approval gate only.
 
 ## Agent Permission Flags
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -140,7 +140,24 @@ def build_parser() -> argparse.ArgumentParser:
         )
         subparser.add_argument(
             "--test-command",
-            help="Optional command to run after the reviewer approves, before auto-merge.",
+            help=(
+                "Optional command to run as a local test gate. By default it runs after "
+                "coder changes before review and again after reviewer approval before auto-merge."
+            ),
+        )
+        pre_review_tests_group = subparser.add_mutually_exclusive_group()
+        pre_review_tests_group.add_argument(
+            "--pre-review-tests",
+            dest="pre_review_tests",
+            action="store_true",
+            default=True,
+            help="Run --test-command after coder changes before reviewer rounds (default).",
+        )
+        pre_review_tests_group.add_argument(
+            "--no-pre-review-tests",
+            dest="pre_review_tests",
+            action="store_false",
+            help="Do not run --test-command before reviewer rounds.",
         )
         subparser.add_argument(
             "--ci-check-name",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -40,6 +40,7 @@ class AgentLoopConfig:
     codex_args: tuple[str, ...]
     gemini_args: tuple[str, ...]
     test_command: tuple[str, ...] | None
+    pre_review_tests: bool
     ci_check_name: str
     ci_timeout_seconds: int
     ci_poll_interval_seconds: int
@@ -493,6 +494,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
             else default_agent_args("gemini", dangerous=args.dangerous_agent_permissions)
         ),
         test_command=test_command,
+        pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -298,6 +298,14 @@ def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
     log(config, "Local test command passed")
 
 
+def run_pre_review_tests(runner: Runner, config: AgentLoopConfig) -> None:
+    if not config.pre_review_tests or not config.test_command:
+        return
+    log(config, f"Running pre-review test command: {' '.join(config.test_command)}")
+    runner.run(config.test_command, cwd=active_workdir(config))
+    log(config, "Pre-review test command passed")
+
+
 def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFollowup]) -> str:
     lines = [
         f"Approved-review future follow-ups for PR #{pr_number}:",
@@ -644,6 +652,7 @@ def _run_plan_first_loop(
                 issue_context=issue_context,
                 workdirs_ready=True,
                 usage_context=usage_context,
+                pre_review_test_pending=True,
             )
 
         if round_number == config.max_rounds:
@@ -737,6 +746,7 @@ def run_issue_loop(
             issue_context=issue_context,
             workdirs_ready=True,
             usage_context=usage_context,
+            pre_review_test_pending=True,
         )
     finally:
         if owned_usage_context:
@@ -816,6 +826,7 @@ def run_task_loop(
                     coder_session_id=session_id,
                     workdirs_ready=True,
                     usage_context=usage_context,
+                    pre_review_test_pending=True,
                 )
 
             if not interactive:
@@ -856,6 +867,7 @@ def run_pr_loop(
     issue_context: IssueContext | None = None,
     workdirs_ready: bool = False,
     usage_context: RunUsageContext | None = None,
+    pre_review_test_pending: bool = False,
 ) -> int:
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
@@ -877,6 +889,9 @@ def run_pr_loop(
             same_pr_followups: list[ApprovedFollowup] = []
             round_future_followups: list[ApprovedFollowup] = []
             approved_review_outputs: list[tuple[str, str]] = []
+            if pre_review_test_pending:
+                run_pre_review_tests(runner, config)
+                pre_review_test_pending = False
             pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
             pr_metadata = pr_context.metadata
             human_requirements = pr_context.human_requirements
@@ -1070,6 +1085,7 @@ def run_pr_loop(
 
             post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
             log(config, f"Round {round_number}: {coder_name} pushed updates for re-review")
+            pre_review_test_pending = True
 
         raise AgentLoopError(
             f"Reached max rounds ({config.max_rounds}) for PR #{pr_number}; human review required."

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -36,6 +36,15 @@ def _scratch_file_guidance() -> str:
     )
 
 
+def _coder_test_reporting_guidance() -> str:
+    return (
+        "Before opening or updating the PR, run the relevant tests you can run "
+        "locally. In your final response, include a short `Tests:` line listing "
+        "the exact commands run and whether they passed. If you cannot run tests, "
+        "explain why in that `Tests:` line.\n"
+    )
+
+
 def _truncate_issue_text(text: str, *, max_chars: int, label: str) -> str:
     if len(text) <= max_chars:
         return text
@@ -288,6 +297,7 @@ def build_issue_prompt(
 Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_scratch_file_guidance()}
+{_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
@@ -436,6 +446,7 @@ Use this local checkout as your workspace. Create a branch, implement the
 approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_scratch_file_guidance()}
+{_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
@@ -479,6 +490,7 @@ Use this local checkout as your workspace. Decide between two paths:
     will run {reviewer_name} after you create the PR. End your final response
     with both markers:
 {_scratch_file_guidance()}
+{_coder_test_reporting_guidance()}
 
     <!-- AGENT_PR: <number> -->
     <!-- AGENT_STATE: blocking -->
@@ -521,6 +533,7 @@ Now proceed. Strongly prefer to implement the task and open a PR. Only ask
 again if a critical detail is still missing. Use the same response markers as
 before:
 {_scratch_file_guidance()}
+{_coder_test_reporting_guidance()}
 
 - For implementation: include both <!-- AGENT_PR: <number> --> and
   <!-- AGENT_STATE: blocking --> at the end of your final response.
@@ -675,6 +688,7 @@ Address the review below in this local checkout. Pull/sync the PR branch if
 needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_scratch_file_guidance()}
+{_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
 {_human_requirements_block(human_requirements)}
 {_memory_block(memory)}
@@ -714,6 +728,7 @@ These same-PR follow-ups are intended to be small, localized cleanup for the
 current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead.
 {_scratch_file_guidance()}
+{_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
 {_human_requirements_block(human_requirements)}
 {_memory_block(memory)}

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -390,6 +390,7 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         "codex_args": (),
         "gemini_args": (),
         "test_command": None,
+        "pre_review_tests": True,
         "ci_check_name": "test",
         "ci_timeout_seconds": 1200,
         "ci_poll_interval_seconds": 30,
@@ -1371,6 +1372,51 @@ def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
     assert runner.comments[-1].startswith("LGTM.")
 
 
+def test_issue_loop_runs_pre_review_tests_after_coder_changes(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\nTests: pytest passed.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+            "Fixed review.\nTests: pytest passed.\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            "Finding: bug remains.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, test_command=("pytest", "tests/test_agent_loop.py"))
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    first_coder = command_index(runner.commands, ["claude", "--print"])
+    first_test = commands.index(["pytest", "tests/test_agent_loop.py"])
+    first_review = command_index(runner.commands, ["codex", "exec"])
+    assert first_coder < first_test < first_review
+    assert commands.count(["pytest", "tests/test_agent_loop.py"]) == 3
+
+
+def test_pre_review_tests_can_be_disabled(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\nTests: pytest passed.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(
+        tmp_path,
+        test_command=("pytest", "tests/test_agent_loop.py"),
+        pre_review_tests=False,
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    first_test = commands.index(["pytest", "tests/test_agent_loop.py"])
+    first_review = command_index(runner.commands, ["codex", "exec"])
+    assert first_review < first_test
+    assert commands.count(["pytest", "tests/test_agent_loop.py"]) == 1
+
+
 def test_codex_usage_summary_records_exact_tokens_from_jsonl_and_public_response(tmp_path):
     public_response = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
     runner = FakeRunner(
@@ -1770,10 +1816,13 @@ def test_pr_loop_routes_migration_validation_failure_through_coder_followup(tmp_
 
     commands = runner.commands
     pytest_index = command_index(commands, ["pytest", "tests/test_agent_loop.py"])
+    first_review_index = [
+        index for index, (cmd, _cwd) in enumerate(commands) if cmd[:2] == ["codex", "exec"]
+    ][0]
     second_review_index = [
         index for index, (cmd, _cwd) in enumerate(commands) if cmd[:2] == ["codex", "exec"]
     ][1]
-    assert second_review_index < pytest_index
+    assert first_review_index < pytest_index < second_review_index
 
 
 def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
@@ -2782,6 +2831,36 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, t
     assert config.agent_memory_dir == (
         cache_home / "coding-review-agent-loop" / "repos" / "OWNER-REPO" / "memory"
     ).resolve()
+
+
+def test_pre_review_tests_cli_defaults_on_and_can_be_disabled(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+    config = config_from_args(args, FakeRunner())
+    assert config.pre_review_tests is True
+
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+        "--no-pre-review-tests",
+    ])
+    config = config_from_args(args, FakeRunner())
+    assert config.pre_review_tests is False
 
 
 @pytest.mark.parametrize("repo", ["OWNER", "OWNER/", "/REPO", "OWNER/REPO/EXTRA"])


### PR DESCRIPTION
## Summary
- add default-on `--pre-review-tests` / `--no-pre-review-tests` behavior for `--test-command`
- run configured local tests after coder-created or coder-updated PR changes before reviewer rounds
- strengthen coder prompts to require a `Tests:` line with commands/results or an explanation
- document the new test-gate behavior

## Tests
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest /home/wwind123/openai-codex/coding-review-agent-loop-pre-review-tests/tests/test_agent_loop.py -q`
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile /home/wwind123/openai-codex/coding-review-agent-loop-pre-review-tests/src/coding_review_agent_loop/*.py`

-- OpenAI Codex