### PR TITLE
Record per-call agent usage with fallback estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ By default, `--approved-followups=ignore` asks reviewers not to include
 approved-review follow-up sections. Reviewers should mark the review blocking
 instead when cleanup should be fixed before merge.
 
+Each top-level `issue`, `task`, or `pr` run also writes a machine-readable
+usage summary beside the normal agent logs in `--log-dir` as
+`<run-id>-usage-summary.json`. The file aggregates per-call, per-agent, and
+whole-run usage, including retries. When a backend exposes token counters, the
+summary records them as `exact` or `partial`; when a backend exposes no usable
+usage data, the loop falls back to a clearly labeled estimate based on prompt
+and public-response size. `--dry-run` does not fabricate token usage.
+
 `--approved-followups` accepts:
 
 - `ignore`: ignore approved follow-up sections. This is the default.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -467,3 +467,12 @@ Gemini, prompts also include a public response-file path under
 non-empty, the loop validates and posts the file contents to GitHub instead of
 stdout. Fallback stdout is still validated before posting. The log directory
 gets its own `.gitignore` on first use.
+
+Each top-level run also writes `<run-id>-usage-summary.json` in the same
+directory. That sidecar aggregates usage by call, by agent, and for the full
+run, including retries and marker-near-miss attempts. Backend-provided token
+counts are normalized as `exact` when the counters are complete or `partial`
+when only some counters are available. When a backend exposes no usable usage
+data, the orchestrator records an `estimated` fallback based on prompt and
+public-response size, along with raw character and byte counts. `--dry-run`
+does not invent token usage records.

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -9,6 +9,7 @@ import uuid
 from typing import TYPE_CHECKING, Literal, Protocol
 
 from ..runner import Runner
+from ..usage import UsageMetadata
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -22,6 +23,8 @@ class AgentResult:
     session_id: str | None = None
     log_path: Path | None = None
     returncode: int = 0
+    usage: UsageMetadata | None = None
+    raw_usage: object | None = None
 
 
 class AgentBackend(Protocol):
@@ -39,6 +42,7 @@ class AgentBackend(Protocol):
         config: AgentLoopConfig,
         prompt: str,
         session_id: str | None = None,
+        run_id: str | None = None,
     ) -> AgentResult: ...
 
 

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -15,31 +15,20 @@ from .base import (
 )
 from ..logging import agent_log_path, log
 from ..runner import Runner
-from ..usage import UsageMetadata
+from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
-
-def _coerce_int(value: object) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float) and value.is_integer():
-        return int(value)
-    return None
-
-
 def _normalize_claude_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
         return None
-    input_tokens = _coerce_int(payload.get("input_tokens") or payload.get("inputTokens"))
-    cached_input_tokens = _coerce_int(
-        payload.get("cached_input_tokens") or payload.get("cache_read_input_tokens")
+    input_tokens = coerce_int(first_present(payload, "input_tokens", "inputTokens"))
+    cached_input_tokens = coerce_int(
+        first_present(payload, "cached_input_tokens", "cache_read_input_tokens")
     )
-    output_tokens = _coerce_int(payload.get("output_tokens") or payload.get("outputTokens"))
-    total_tokens = _coerce_int(payload.get("total_tokens"))
+    output_tokens = coerce_int(first_present(payload, "output_tokens", "outputTokens"))
+    total_tokens = coerce_int(payload.get("total_tokens"))
     if total_tokens is None and any(value is not None for value in (input_tokens, output_tokens)):
         total_tokens = sum(value or 0 for value in (input_tokens, output_tokens))
     if not any(

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -15,12 +15,47 @@ from .base import (
 )
 from ..logging import agent_log_path, log
 from ..runner import Runner
+from ..usage import UsageMetadata
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
 
-def _parse_claude_output(raw: str) -> tuple[str, str | None]:
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _normalize_claude_usage(payload: object) -> UsageMetadata | None:
+    if not isinstance(payload, dict):
+        return None
+    input_tokens = _coerce_int(payload.get("input_tokens") or payload.get("inputTokens"))
+    cached_input_tokens = _coerce_int(
+        payload.get("cached_input_tokens") or payload.get("cache_read_input_tokens")
+    )
+    output_tokens = _coerce_int(payload.get("output_tokens") or payload.get("outputTokens"))
+    total_tokens = _coerce_int(payload.get("total_tokens"))
+    if total_tokens is None and any(value is not None for value in (input_tokens, output_tokens)):
+        total_tokens = sum(value or 0 for value in (input_tokens, output_tokens))
+    if not any(
+        value is not None for value in (input_tokens, cached_input_tokens, output_tokens, total_tokens)
+    ):
+        return None
+    return UsageMetadata(
+        mode="partial" if cached_input_tokens is None else "exact",
+        input_tokens=input_tokens,
+        cached_input_tokens=cached_input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _parse_claude_output(raw: str) -> tuple[str, str | None, UsageMetadata | None, object | None]:
     """Extract (text, session_id) from Claude's --output-format json response."""
     try:
         data = json.loads(raw)
@@ -28,10 +63,13 @@ def _parse_claude_output(raw: str) -> tuple[str, str | None]:
             text = data.get("result", raw)
             if not isinstance(text, str):
                 text = raw
-            return text, data.get("session_id")
+            raw_usage = data.get("usage")
+            if raw_usage is None and isinstance(data.get("result_message"), dict):
+                raw_usage = data["result_message"].get("usage")
+            return text, data.get("session_id"), _normalize_claude_usage(raw_usage), raw_usage
     except (json.JSONDecodeError, ValueError):
         pass
-    return raw, None
+    return raw, None, None, None
 
 
 class ClaudeBackend:
@@ -51,13 +89,14 @@ class ClaudeBackend:
         config: AgentLoopConfig,
         prompt: str,
         session_id: str | None = None,
+        run_id: str | None = None,
     ) -> AgentResult:
         response_path = public_response_path(config, "claude")
         args = [config.claude_cmd, "--print", "--output-format", "json", *config.claude_args]
         if session_id:
             args += ["--resume", session_id]
         args.append(with_public_response_file_instruction(prompt, response_path))
-        log_path = agent_log_path(config, "claude")
+        log_path = agent_log_path(config, "claude", run_id=run_id)
         log(config, f"Starting Claude in {config.claude_dir}; log: {log_path}; response: {response_path}")
         result = runner.run_with_log(
             args,
@@ -68,12 +107,14 @@ class ClaudeBackend:
             check=False,
         )
         log(config, f"Claude finished; log: {log_path}")
-        text, new_session_id = _parse_claude_output(result.stdout)
+        text, new_session_id, usage, raw_usage = _parse_claude_output(result.stdout)
         return AgentResult(
             text=read_public_response_file(response_path) or text,
             session_id=new_session_id,
             log_path=log_path,
             returncode=result.returncode,
+            usage=usage,
+            raw_usage=raw_usage,
         )
 
 

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -11,32 +11,21 @@ from typing import TYPE_CHECKING
 from .base import AgentName, AgentResult
 from ..logging import agent_log_path, log
 from ..runner import Runner
-from ..usage import UsageMetadata
+from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
-
-def _coerce_int(value: object) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float) and value.is_integer():
-        return int(value)
-    return None
-
-
 def _normalize_codex_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
         return None
-    input_tokens = _coerce_int(payload.get("input_tokens"))
-    cached_input_tokens = _coerce_int(payload.get("cached_input_tokens"))
-    output_tokens = _coerce_int(payload.get("output_tokens"))
-    reasoning_tokens = _coerce_int(
-        payload.get("reasoning_tokens") or payload.get("reasoning_output_tokens")
+    input_tokens = coerce_int(payload.get("input_tokens"))
+    cached_input_tokens = coerce_int(payload.get("cached_input_tokens"))
+    output_tokens = coerce_int(payload.get("output_tokens"))
+    reasoning_tokens = coerce_int(
+        first_present(payload, "reasoning_tokens", "reasoning_output_tokens")
     )
-    total_tokens = _coerce_int(payload.get("total_tokens"))
+    total_tokens = coerce_int(payload.get("total_tokens"))
     if total_tokens is None and any(
         value is not None for value in (input_tokens, output_tokens, reasoning_tokens)
     ):

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -10,9 +11,80 @@ from typing import TYPE_CHECKING
 from .base import AgentName, AgentResult
 from ..logging import agent_log_path, log
 from ..runner import Runner
+from ..usage import UsageMetadata
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _normalize_codex_usage(payload: object) -> UsageMetadata | None:
+    if not isinstance(payload, dict):
+        return None
+    input_tokens = _coerce_int(payload.get("input_tokens"))
+    cached_input_tokens = _coerce_int(payload.get("cached_input_tokens"))
+    output_tokens = _coerce_int(payload.get("output_tokens"))
+    reasoning_tokens = _coerce_int(
+        payload.get("reasoning_tokens") or payload.get("reasoning_output_tokens")
+    )
+    total_tokens = _coerce_int(payload.get("total_tokens"))
+    if total_tokens is None and any(
+        value is not None for value in (input_tokens, output_tokens, reasoning_tokens)
+    ):
+        total_tokens = sum(value or 0 for value in (input_tokens, output_tokens, reasoning_tokens))
+    if not any(
+        value is not None
+        for value in (
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            reasoning_tokens,
+            total_tokens,
+        )
+    ):
+        return None
+    return UsageMetadata(
+        mode="exact",
+        input_tokens=input_tokens,
+        cached_input_tokens=cached_input_tokens,
+        output_tokens=output_tokens,
+        reasoning_tokens=reasoning_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _extract_codex_usage(raw: str) -> tuple[UsageMetadata | None, object | None]:
+    last_usage: object | None = None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type") or event.get("event")
+        if event_type != "turn.completed":
+            continue
+        usage_payload = event.get("usage")
+        if usage_payload is None and isinstance(event.get("turn"), dict):
+            usage_payload = event["turn"].get("usage")
+        usage = _normalize_codex_usage(usage_payload)
+        if usage is not None:
+            last_usage = usage_payload
+            return usage, usage_payload
+    return None, last_usage
 
 
 class CodexBackend:
@@ -32,8 +104,9 @@ class CodexBackend:
         config: AgentLoopConfig,
         prompt: str,
         session_id: str | None = None,
+        run_id: str | None = None,
     ) -> AgentResult:
-        log_path = agent_log_path(config, "codex")
+        log_path = agent_log_path(config, "codex", run_id=run_id)
         log(config, f"Starting Codex in {config.codex_dir}; log: {log_path}")
         if config.dry_run:
             result = runner.run(
@@ -59,6 +132,7 @@ class CodexBackend:
                     "exec",
                     "--cd",
                     str(config.codex_dir),
+                    "--json",
                     "--output-last-message",
                     output_path,
                     *config.codex_args,
@@ -73,8 +147,15 @@ class CodexBackend:
             output = Path(output_path).read_text(encoding="utf-8") if Path(output_path).exists() else ""
             if not output:
                 output = result.stdout
+            usage, raw_usage = _extract_codex_usage(result.stdout)
             log(config, f"Codex finished; log: {log_path}")
-            return AgentResult(text=output, log_path=log_path, returncode=result.returncode)
+            return AgentResult(
+                text=output,
+                log_path=log_path,
+                returncode=result.returncode,
+                usage=usage,
+                raw_usage=raw_usage,
+            )
         finally:
             try:
                 os.unlink(output_path)

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -16,7 +16,7 @@ from .base import (
 from ..logging import agent_log_path, log
 from ..protocol import CLARIFY_RE, STATE_RE
 from ..runner import Runner
-from ..usage import UsageMetadata
+from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -67,51 +67,19 @@ def _strip_gemini_preamble(raw: str) -> str:
 
     return raw[separator_at + len(separator) :].lstrip("\n")
 
-
-def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
-    """Extract (text, session_id) from Gemini's optional --output-format json response."""
-    try:
-        data = json.loads(raw)
-        if isinstance(data, dict):
-            text = data.get("response", raw)
-            if not isinstance(text, str):
-                text = raw
-            session_id = data.get("session_id")
-            return _strip_gemini_preamble(text), session_id if isinstance(session_id, str) else None
-    except (json.JSONDecodeError, ValueError):
-        pass
-    return _strip_gemini_preamble(raw), None
-
-
-def _coerce_int(value: object) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float) and value.is_integer():
-        return int(value)
-    return None
-
-
 def _normalize_gemini_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
         return None
-    input_tokens = _coerce_int(
-        payload.get("input_tokens")
-        or payload.get("inputTokenCount")
-        or payload.get("promptTokenCount")
+    input_tokens = coerce_int(
+        first_present(payload, "input_tokens", "inputTokenCount", "promptTokenCount")
     )
-    cached_input_tokens = _coerce_int(
-        payload.get("cached_input_tokens") or payload.get("cachedInputTokenCount")
+    cached_input_tokens = coerce_int(
+        first_present(payload, "cached_input_tokens", "cachedInputTokenCount")
     )
-    output_tokens = _coerce_int(
-        payload.get("output_tokens")
-        or payload.get("outputTokenCount")
-        or payload.get("candidatesTokenCount")
+    output_tokens = coerce_int(
+        first_present(payload, "output_tokens", "outputTokenCount", "candidatesTokenCount")
     )
-    total_tokens = _coerce_int(
-        payload.get("total_tokens") or payload.get("totalTokenCount")
-    )
+    total_tokens = coerce_int(first_present(payload, "total_tokens", "totalTokenCount"))
     if total_tokens is None and any(value is not None for value in (input_tokens, output_tokens)):
         total_tokens = sum(value or 0 for value in (input_tokens, output_tokens))
     if not any(
@@ -139,7 +107,7 @@ def _parse_gemini_payload(
             if not isinstance(text, str):
                 text = raw
             session_id = data.get("session_id")
-            raw_usage = data.get("stats") or data.get("usage") or data.get("usageMetadata")
+            raw_usage = first_present(data, "stats", "usage", "usageMetadata")
             return (
                 _strip_gemini_preamble(text),
                 session_id if isinstance(session_id, str) else None,

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -16,6 +16,7 @@ from .base import (
 from ..logging import agent_log_path, log
 from ..protocol import CLARIFY_RE, STATE_RE
 from ..runner import Runner
+from ..usage import UsageMetadata
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -82,6 +83,74 @@ def _parse_gemini_output(raw: str) -> tuple[str, str | None]:
     return _strip_gemini_preamble(raw), None
 
 
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _normalize_gemini_usage(payload: object) -> UsageMetadata | None:
+    if not isinstance(payload, dict):
+        return None
+    input_tokens = _coerce_int(
+        payload.get("input_tokens")
+        or payload.get("inputTokenCount")
+        or payload.get("promptTokenCount")
+    )
+    cached_input_tokens = _coerce_int(
+        payload.get("cached_input_tokens") or payload.get("cachedInputTokenCount")
+    )
+    output_tokens = _coerce_int(
+        payload.get("output_tokens")
+        or payload.get("outputTokenCount")
+        or payload.get("candidatesTokenCount")
+    )
+    total_tokens = _coerce_int(
+        payload.get("total_tokens") or payload.get("totalTokenCount")
+    )
+    if total_tokens is None and any(value is not None for value in (input_tokens, output_tokens)):
+        total_tokens = sum(value or 0 for value in (input_tokens, output_tokens))
+    if not any(
+        value is not None for value in (input_tokens, cached_input_tokens, output_tokens, total_tokens)
+    ):
+        return None
+    mode = "exact" if all(value is not None for value in (input_tokens, output_tokens, total_tokens)) else "partial"
+    return UsageMetadata(
+        mode=mode,
+        input_tokens=input_tokens,
+        cached_input_tokens=cached_input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _parse_gemini_payload(
+    raw: str,
+) -> tuple[str, str | None, UsageMetadata | None, object | None]:
+    """Extract (text, session_id, usage, raw_usage) from Gemini output."""
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            text = data.get("response", raw)
+            if not isinstance(text, str):
+                text = raw
+            session_id = data.get("session_id")
+            raw_usage = data.get("stats") or data.get("usage") or data.get("usageMetadata")
+            return (
+                _strip_gemini_preamble(text),
+                session_id if isinstance(session_id, str) else None,
+                _normalize_gemini_usage(raw_usage),
+                raw_usage,
+            )
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return _strip_gemini_preamble(raw), None, None, None
+
+
 def _gemini_public_response_root(gemini_dir: Path) -> Path:
     git_marker = gemini_dir / ".git"
     if git_marker.is_file():
@@ -117,6 +186,7 @@ class GeminiBackend:
         config: AgentLoopConfig,
         prompt: str,
         session_id: str | None = None,
+        run_id: str | None = None,
     ) -> AgentResult:
         # Gemini CLI only allows file writes inside the trusted workspace (or
         # its own private temp dir, whose path we do not know ahead of time).
@@ -128,7 +198,7 @@ class GeminiBackend:
             "gemini",
             root=_gemini_public_response_root(config.gemini_dir),
         )
-        log_path = agent_log_path(config, "gemini")
+        log_path = agent_log_path(config, "gemini", run_id=run_id)
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")
         args = [
             config.gemini_cmd,
@@ -149,12 +219,14 @@ class GeminiBackend:
             check=False,
         )
         log(config, f"Gemini finished; log: {log_path}")
-        text, new_session_id = _parse_gemini_output(result.stdout)
+        text, new_session_id, usage, raw_usage = _parse_gemini_payload(result.stdout)
         return AgentResult(
             text=read_public_response_file(response_path) or text,
             session_id=new_session_id,
             log_path=log_path,
             returncode=result.returncode,
+            usage=usage,
+            raw_usage=raw_usage,
         )
 
 

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -47,5 +47,6 @@ def run_agent_result(
     config: AgentLoopConfig,
     prompt: str,
     session_id: str | None = None,
+    run_id: str | None = None,
 ) -> AgentResult:
-    return get_backend(agent).run(runner, config, prompt, session_id=session_id)
+    return get_backend(agent).run(runner, config, prompt, session_id=session_id, run_id=run_id)

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -18,6 +18,15 @@ def log(config: AgentLoopConfig, message: str) -> None:
     print(f"[agent-loop {now}] {message}", file=sys.stderr, flush=True)
 
 
-def agent_log_path(config: AgentLoopConfig, agent: str) -> Path:
+def new_run_id() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+
+
+def agent_log_path(config: AgentLoopConfig, agent: str, *, run_id: str | None = None) -> Path:
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
-    return config.log_dir / f"{stamp}-{agent}.log"
+    prefix = f"{run_id}-" if run_id else ""
+    return config.log_dir / f"{prefix}{stamp}-{agent}.log"
+
+
+def run_usage_summary_path(config: AgentLoopConfig, run_id: str) -> Path:
+    return config.log_dir / f"{run_id}-usage-summary.json"

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -29,7 +29,7 @@ from .github import (
     validate_open_pr,
     wait_for_ci,
 )
-from .logging import log
+from .logging import log, new_run_id, run_usage_summary_path
 from .memory import prepare_agent_memory
 from .prompts import (
     build_followup_prompt,
@@ -53,6 +53,7 @@ from .protocol import (
 )
 from .protocol import ApprovedFollowup, parse_approved_followups
 from .runner import Runner
+from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
 
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
@@ -80,6 +81,7 @@ class ValidatedAgentResponse:
     text: str
     session_id: str | None
     marker_value: object
+    usage: UsageMetadata | None = None
 
 
 def _agent_log_context(log_paths: Sequence[object]) -> str:
@@ -128,6 +130,36 @@ def _format_invalid_agent_response_error(
     )
 
 
+def _new_usage_context(config: AgentLoopConfig) -> RunUsageContext:
+    run_id = new_run_id()
+    return RunUsageContext(run_id=run_id, summary_path=run_usage_summary_path(config, run_id))
+
+
+def _resolve_usage_metadata(
+    *,
+    config: AgentLoopConfig,
+    prompt: str,
+    result: AgentResult,
+) -> UsageMetadata | None:
+    if result.usage is not None:
+        return result.usage.with_io_sizes(prompt=prompt, response=result.text)
+    if config.dry_run:
+        return None
+    return estimate_usage(prompt, result.text)
+
+
+def _persist_usage_summary(config: AgentLoopConfig, usage_context: RunUsageContext) -> None:
+    usage_context.write_summary()
+    totals = usage_context.totals()
+    log(
+        config,
+        "Usage summary written to "
+        f"{usage_context.summary_path} "
+        f"(calls={totals.call_count}, exact={totals.exact_calls}, "
+        f"partial={totals.partial_calls}, estimated={totals.estimated_calls})",
+    )
+
+
 def _run_validated_agent(
     runner: Runner,
     *,
@@ -137,6 +169,7 @@ def _run_validated_agent(
     marker_description: str,
     validate: Callable[[str], object],
     session_id: str | None = None,
+    usage_context: RunUsageContext | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -151,11 +184,22 @@ def _run_validated_agent(
             config=config,
             prompt=prompt,
             session_id=session_id,
+            run_id=usage_context.run_id if usage_context is not None else None,
         )
         last_result = result
         if result.log_path is not None:
             log_paths.append(result.log_path)
         text = result.text
+        usage = _resolve_usage_metadata(config=config, prompt=prompt, result=result)
+        usage_record = None
+        if usage_context is not None and usage is not None:
+            usage_record = usage_context.add_record(
+                agent=agent,
+                session_id=result.session_id,
+                returncode=result.returncode,
+                usage=usage,
+                raw_backend_usage=result.raw_usage,
+            )
 
         should_retry = False
         if result.returncode != 0:
@@ -173,10 +217,13 @@ def _run_validated_agent(
                     attempt == 1 and _is_retryable_marker_near_miss(text)
                 )
             else:
+                if usage_record is not None:
+                    usage_record.validation_status = "validated"
                 return ValidatedAgentResponse(
                     text=text,
                     session_id=result.session_id,
                     marker_value=marker_value,
+                    usage=usage,
                 )
 
         if should_retry and attempt < max_attempts:
@@ -431,6 +478,7 @@ def _run_plan_first_loop(
     memory,
     issue_context: IssueContext,
     implement_after_approval: bool,
+    usage_context: RunUsageContext,
 ) -> int:
     coder_name = agent_display_name(config.coder)
     configured_reviewers = reviewers(config)
@@ -445,6 +493,7 @@ def _run_plan_first_loop(
         prompt=build_issue_plan_prompt(issue_number, config, memory, issue_context=issue_context),
         marker_description="<!-- AGENT_PLAN_STATE: approved|blocking --> or <!-- AGENT_CLARIFY -->",
         validate=_require_plan_state_or_clarification,
+        usage_context=usage_context,
     )
     plan_output = plan_response.text
     coder_session_id = plan_response.session_id
@@ -477,6 +526,7 @@ def _run_plan_first_loop(
                 session_id=reviewer_session_ids.get(reviewer),
                 marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
                 validate=parse_plan_state,
+                usage_context=usage_context,
             )
             review_output = review_response.text
             reviewer_session_ids[reviewer] = review_response.session_id
@@ -515,6 +565,7 @@ def _run_plan_first_loop(
                 session_id=coder_session_id,
                 marker_description="<!-- AGENT_PR: <number> --> or PR URL",
                 validate=_require_pr_number,
+                usage_context=usage_context,
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id
@@ -529,6 +580,7 @@ def _run_plan_first_loop(
                 coder_session_id=coder_session_id,
                 issue_context=issue_context,
                 workdirs_ready=True,
+                usage_context=usage_context,
             )
 
         if round_number == config.max_rounds:
@@ -557,6 +609,7 @@ def _run_plan_first_loop(
             session_id=coder_session_id,
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
             validate=parse_plan_state,
+            usage_context=usage_context,
         )
         current_plan = plan_response.text
         coder_session_id = plan_response.session_id
@@ -575,46 +628,56 @@ def run_issue_loop(
     config: AgentLoopConfig,
     plan_first: bool = False,
     implement_after_approval: bool = False,
+    usage_context: RunUsageContext | None = None,
 ) -> int:
-    ensure_agent_workdirs(config, runner)
-    log(config, f"Validating issue #{issue_number}")
-    validate_open_issue(runner, config=config, issue_number=issue_number)
-    issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
-    memory = prepare_agent_memory(runner, config)
-    if plan_first:
-        return _run_plan_first_loop(
+    owned_usage_context = usage_context is None
+    usage_context = usage_context or _new_usage_context(config)
+    try:
+        ensure_agent_workdirs(config, runner)
+        log(config, f"Validating issue #{issue_number}")
+        validate_open_issue(runner, config=config, issue_number=issue_number)
+        issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
+        memory = prepare_agent_memory(runner, config)
+        if plan_first:
+            return _run_plan_first_loop(
+                runner,
+                issue_number=issue_number,
+                config=config,
+                memory=memory,
+                issue_context=issue_context,
+                implement_after_approval=implement_after_approval,
+                usage_context=usage_context,
+            )
+
+        sync_coder_base_before_implementation(config, runner)
+        coder_response = _run_validated_agent(
             runner,
-            issue_number=issue_number,
+            agent=config.coder,
             config=config,
-            memory=memory,
-            issue_context=issue_context,
-            implement_after_approval=implement_after_approval,
+            prompt=build_issue_prompt(issue_number, config, memory, issue_context=issue_context),
+            marker_description="<!-- AGENT_PR: <number> --> or PR URL",
+            validate=_require_pr_number,
+            usage_context=usage_context,
         )
+        coder_output = coder_response.text
+        coder_session_id = coder_response.session_id
+        pr_number = int(coder_response.marker_value)
+        log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
+        validate_open_pr(runner, config=config, pr_number=pr_number)
 
-    sync_coder_base_before_implementation(config, runner)
-    coder_response = _run_validated_agent(
-        runner,
-        agent=config.coder,
-        config=config,
-        prompt=build_issue_prompt(issue_number, config, memory, issue_context=issue_context),
-        marker_description="<!-- AGENT_PR: <number> --> or PR URL",
-        validate=_require_pr_number,
-    )
-    coder_output = coder_response.text
-    coder_session_id = coder_response.session_id
-    pr_number = int(coder_response.marker_value)
-    log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
-    validate_open_pr(runner, config=config, pr_number=pr_number)
-
-    post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
-    return run_pr_loop(
-        runner,
-        pr_number=pr_number,
-        config=config,
-        coder_session_id=coder_session_id,
-        issue_context=issue_context,
-        workdirs_ready=True,
-    )
+        post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
+        return run_pr_loop(
+            runner,
+            pr_number=pr_number,
+            config=config,
+            coder_session_id=coder_session_id,
+            issue_context=issue_context,
+            workdirs_ready=True,
+            usage_context=usage_context,
+        )
+    finally:
+        if owned_usage_context:
+            _persist_usage_summary(config, usage_context)
 
 
 def _read_clarification_from_stdin() -> str:
@@ -643,72 +706,81 @@ def run_task_loop(
     interactive: bool = False,
     max_clarification_rounds: int = 3,
     clarification_input=None,
+    usage_context: RunUsageContext | None = None,
 ) -> int:
-    if not task_text.strip():
-        raise AgentLoopError("Task text is empty; provide a non-empty description.")
-    if max_clarification_rounds < 0:
-        raise AgentLoopError("--max-clarification-rounds must be zero or positive.")
-    ensure_agent_workdirs(config, runner)
-    memory = prepare_agent_memory(runner, config)
+    owned_usage_context = usage_context is None
+    usage_context = usage_context or _new_usage_context(config)
+    try:
+        if not task_text.strip():
+            raise AgentLoopError("Task text is empty; provide a non-empty description.")
+        if max_clarification_rounds < 0:
+            raise AgentLoopError("--max-clarification-rounds must be zero or positive.")
+        ensure_agent_workdirs(config, runner)
+        memory = prepare_agent_memory(runner, config)
 
-    history: list[tuple[str, str]] = []
-    prompt = build_task_prompt(task_text, config, memory)
-    read_clarification = clarification_input or _read_clarification_from_stdin
-    coder_name = agent_display_name(config.coder)
-    session_id: str | None = None
+        history: list[tuple[str, str]] = []
+        prompt = build_task_prompt(task_text, config, memory)
+        read_clarification = clarification_input or _read_clarification_from_stdin
+        coder_name = agent_display_name(config.coder)
+        session_id: str | None = None
 
-    for attempt in range(max_clarification_rounds + 1):
-        if attempt == 0:
-            sync_coder_base_before_implementation(config, runner)
-        log(config, f"Task attempt {attempt + 1}: invoking {coder_name}")
-        coder_response = _run_validated_agent(
-            runner,
-            agent=config.coder,
-            config=config,
-            prompt=prompt,
-            session_id=session_id,
-            marker_description="<!-- AGENT_PR: <number> -->, PR URL, or <!-- AGENT_CLARIFY -->",
-            validate=_require_pr_number_or_clarification,
-        )
-        coder_output = coder_response.text
-        session_id = coder_response.session_id
-
-        if isinstance(coder_response.marker_value, int):
-            pr_number = coder_response.marker_value
-            log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
-            validate_open_pr(runner, config=config, pr_number=pr_number)
-            post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
-            return run_pr_loop(
+        for attempt in range(max_clarification_rounds + 1):
+            if attempt == 0:
+                sync_coder_base_before_implementation(config, runner)
+            log(config, f"Task attempt {attempt + 1}: invoking {coder_name}")
+            coder_response = _run_validated_agent(
                 runner,
-                pr_number=pr_number,
+                agent=config.coder,
                 config=config,
-                coder_session_id=session_id,
-                workdirs_ready=True,
+                prompt=prompt,
+                session_id=session_id,
+                marker_description="<!-- AGENT_PR: <number> -->, PR URL, or <!-- AGENT_CLARIFY -->",
+                validate=_require_pr_number_or_clarification,
+                usage_context=usage_context,
             )
+            coder_output = coder_response.text
+            session_id = coder_response.session_id
 
-        if not interactive:
-            raise AgentLoopError(
-                f"{coder_name} requested clarification but the loop is non-interactive. "
-                "Add the missing details to the task text or rerun with --interactive.\n\n"
-                f"{coder_name}'s questions:\n{coder_output}"
-            )
+            if isinstance(coder_response.marker_value, int):
+                pr_number = coder_response.marker_value
+                log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
+                validate_open_pr(runner, config=config, pr_number=pr_number)
+                post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
+                return run_pr_loop(
+                    runner,
+                    pr_number=pr_number,
+                    config=config,
+                    coder_session_id=session_id,
+                    workdirs_ready=True,
+                    usage_context=usage_context,
+                )
 
-        if attempt >= max_clarification_rounds:
-            raise AgentLoopError(
-                f"{coder_name} still requested clarification after "
-                f"{max_clarification_rounds} rounds; "
-                "human intervention required."
-            )
+            if not interactive:
+                raise AgentLoopError(
+                    f"{coder_name} requested clarification but the loop is non-interactive. "
+                    "Add the missing details to the task text or rerun with --interactive.\n\n"
+                    f"{coder_name}'s questions:\n{coder_output}"
+                )
 
-        log(config, f"{coder_name} requested clarification (round {attempt + 1}); awaiting user input")
-        print(coder_output, flush=True)
-        answers = read_clarification()
-        if not answers.strip():
-            raise AgentLoopError("Empty clarification reply; aborting task.")
-        history.append((coder_output, answers))
-        prompt = build_task_clarification_prompt(task_text, history, config, memory)
+            if attempt >= max_clarification_rounds:
+                raise AgentLoopError(
+                    f"{coder_name} still requested clarification after "
+                    f"{max_clarification_rounds} rounds; "
+                    "human intervention required."
+                )
 
-    raise AgentLoopError("run_task_loop exited unexpectedly without producing a PR.")
+            log(config, f"{coder_name} requested clarification (round {attempt + 1}); awaiting user input")
+            print(coder_output, flush=True)
+            answers = read_clarification()
+            if not answers.strip():
+                raise AgentLoopError("Empty clarification reply; aborting task.")
+            history.append((coder_output, answers))
+            prompt = build_task_clarification_prompt(task_text, history, config, memory)
+
+        raise AgentLoopError("run_task_loop exited unexpectedly without producing a PR.")
+    finally:
+        if owned_usage_context:
+            _persist_usage_summary(config, usage_context)
 
 
 def run_pr_loop(
@@ -720,171 +792,185 @@ def run_pr_loop(
     reviewer_session_id: str | None = None,
     issue_context: IssueContext | None = None,
     workdirs_ready: bool = False,
+    usage_context: RunUsageContext | None = None,
 ) -> int:
-    if not workdirs_ready:
-        ensure_agent_workdirs(config, runner)
-    log(config, f"Validating PR #{pr_number}")
-    validate_open_pr(runner, config=config, pr_number=pr_number)
-    memory = prepare_agent_memory(runner, config)
-    reviewer_session_ids: dict[AgentName, str | None] = {}
-    configured_reviewers = reviewers(config)
-    if reviewer_session_id is not None and configured_reviewers:
-        # Backward-compatible single-reviewer resume support: older callers
-        # pass one reviewer session, so attach it to the first configured reviewer.
-        reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
-    for round_number in range(1, config.max_rounds + 1):
-        coder_name = agent_display_name(config.coder)
-        blocking_reviews: list[tuple[str, str]] = []
-        same_pr_followups: list[ApprovedFollowup] = []
-        round_future_followups: list[ApprovedFollowup] = []
-        approved_review_outputs: list[tuple[str, str]] = []
-        pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
-        pr_metadata = pr_context.metadata
-        human_requirements = pr_context.human_requirements
-        for reviewer in configured_reviewers:
-            reviewer_name = agent_display_name(reviewer)
-            log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
-            sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
-            review_response = _run_validated_agent(
-                runner,
-                agent=reviewer,
-                config=config,
-                prompt=build_review_prompt(
+    owned_usage_context = usage_context is None
+    usage_context = usage_context or _new_usage_context(config)
+    try:
+        if not workdirs_ready:
+            ensure_agent_workdirs(config, runner)
+        log(config, f"Validating PR #{pr_number}")
+        validate_open_pr(runner, config=config, pr_number=pr_number)
+        memory = prepare_agent_memory(runner, config)
+        reviewer_session_ids: dict[AgentName, str | None] = {}
+        configured_reviewers = reviewers(config)
+        if reviewer_session_id is not None and configured_reviewers:
+            # Backward-compatible single-reviewer resume support: older callers
+            # pass one reviewer session, so attach it to the first configured reviewer.
+            reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
+        for round_number in range(1, config.max_rounds + 1):
+            coder_name = agent_display_name(config.coder)
+            blocking_reviews: list[tuple[str, str]] = []
+            same_pr_followups: list[ApprovedFollowup] = []
+            round_future_followups: list[ApprovedFollowup] = []
+            approved_review_outputs: list[tuple[str, str]] = []
+            pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
+            pr_metadata = pr_context.metadata
+            human_requirements = pr_context.human_requirements
+            for reviewer in configured_reviewers:
+                reviewer_name = agent_display_name(reviewer)
+                log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
+                sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
+                review_response = _run_validated_agent(
+                    runner,
+                    agent=reviewer,
+                    config=config,
+                    prompt=build_review_prompt(
+                        pr_number,
+                        round_number,
+                        config,
+                        reviewer=reviewer,
+                        pr_metadata=pr_metadata,
+                        memory=memory,
+                        issue_context=issue_context,
+                        human_requirements=human_requirements,
+                    ),
+                    session_id=reviewer_session_ids.get(reviewer),
+                    marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                    validate=parse_agent_state,
+                    usage_context=usage_context,
+                )
+                review_output = review_response.text
+                reviewer_session_ids[reviewer] = review_response.session_id
+                review_state = str(review_response.marker_value)
+
+                post_pr_comment(runner, config=config, pr_number=pr_number, body=review_output)
+                log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
+                if review_state == "blocking":
+                    blocking_reviews.append((reviewer_name, review_output))
+                    continue
+
+                approved_review_outputs.append((reviewer_name, review_output))
+                if config.approved_followups != "ignore":
+                    followups = parse_approved_followups(review_output, reviewer=reviewer_name)
+                    round_future_followups.extend(followups.future)
+                    if followups.same_pr:
+                        if config.approved_followups.startswith("fix-and-"):
+                            same_pr_followups.extend(followups.same_pr)
+                        else:
+                            blocking_reviews.append(
+                                (
+                                    reviewer_name,
+                                    "\n".join(
+                                        [
+                                            "Approved review included Same-PR follow-ups, "
+                                            f"but --approved-followups={config.approved_followups} "
+                                            "does not enable a same-PR fix path.",
+                                            "",
+                                            _format_same_pr_followups(followups.same_pr),
+                                        ]
+                                    ),
+                                )
+                            )
+
+            if not blocking_reviews and not same_pr_followups:
+                if human_requirements:
+                    missing_acknowledgements = [
+                        reviewer_name
+                        for reviewer_name, review_output in approved_review_outputs
+                        if not human_requirements_resolved(review_output)
+                    ]
+                    if missing_acknowledgements:
+                        raise AgentLoopError(
+                            "Signed human reviewer requirements remain unresolved or "
+                            "unacknowledged by approved reviewer response(s): "
+                            f"{', '.join(missing_acknowledgements)}. "
+                            "Human intervention is required."
+                        )
+                approved_followups = round_future_followups
+                if (
+                    config.approved_followups in ("summarize", "fix-and-summarize")
+                    and approved_followups
+                ):
+                    body = _format_approved_followup_summary(pr_number, approved_followups)
+                    post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+                elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
+                    issue_urls, skipped_count = _create_approved_followup_issues(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        followups=approved_followups,
+                    )
+                    if issue_urls:
+                        body = _format_created_followup_issue_summary(
+                            pr_number, issue_urls, skipped_count
+                        )
+                        post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+                run_optional_tests(runner, config)
+                if config.auto_merge:
+                    wait_for_ci(runner, config, pr_number)
+                    merge_pr(runner, config, pr_number)
+                print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
+                return 0
+            if round_number == config.max_rounds:
+                raise AgentLoopError(
+                    f"One or more reviewers still reported blocking issues after round {round_number}; "
+                    "human review required."
+                )
+
+            if same_pr_followups and not blocking_reviews:
+                combined_review = _format_same_pr_followups(same_pr_followups)
+                followup_prompt = build_same_pr_followup_prompt(
                     pr_number,
                     round_number,
+                    combined_review,
                     config,
-                    reviewer=reviewer,
-                    pr_metadata=pr_metadata,
-                    memory=memory,
+                    memory,
                     issue_context=issue_context,
                     human_requirements=human_requirements,
-                ),
-                session_id=reviewer_session_ids.get(reviewer),
+                )
+            else:
+                # Discard future-work suggestions from non-final rounds so reviewers
+                # can restate still-relevant items after the PR has been updated.
+                if same_pr_followups:
+                    blocking_reviews.append(
+                        (
+                            "Approved same-PR follow-ups",
+                            _format_same_pr_followups(same_pr_followups),
+                        )
+                    )
+                combined_review = "\n\n".join(
+                    f"{name} review:\n\n{review}" for name, review in blocking_reviews
+                )
+                followup_prompt = build_followup_prompt(
+                    pr_number,
+                    round_number,
+                    combined_review,
+                    config,
+                    memory,
+                    issue_context=issue_context,
+                    human_requirements=human_requirements,
+                )
+            log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
+            coder_response = _run_validated_agent(
+                runner,
+                agent=config.coder,
+                config=config,
+                prompt=followup_prompt,
+                session_id=coder_session_id,
                 marker_description="<!-- AGENT_STATE: approved|blocking -->",
                 validate=parse_agent_state,
+                usage_context=usage_context,
             )
-            review_output = review_response.text
-            reviewer_session_ids[reviewer] = review_response.session_id
-            review_state = str(review_response.marker_value)
+            coder_output = coder_response.text
+            coder_session_id = coder_response.session_id
 
-            post_pr_comment(runner, config=config, pr_number=pr_number, body=review_output)
-            log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
-            if review_state == "blocking":
-                blocking_reviews.append((reviewer_name, review_output))
-                continue
+            post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
+            log(config, f"Round {round_number}: {coder_name} pushed updates for re-review")
 
-            approved_review_outputs.append((reviewer_name, review_output))
-            if config.approved_followups != "ignore":
-                followups = parse_approved_followups(review_output, reviewer=reviewer_name)
-                round_future_followups.extend(followups.future)
-                if followups.same_pr:
-                    if config.approved_followups.startswith("fix-and-"):
-                        same_pr_followups.extend(followups.same_pr)
-                    else:
-                        blocking_reviews.append(
-                            (
-                                reviewer_name,
-                                "\n".join(
-                                    [
-                                        "Approved review included Same-PR follow-ups, "
-                                        f"but --approved-followups={config.approved_followups} "
-                                        "does not enable a same-PR fix path.",
-                                        "",
-                                        _format_same_pr_followups(followups.same_pr),
-                                    ]
-                                ),
-                            )
-                        )
-
-        if not blocking_reviews and not same_pr_followups:
-            if human_requirements:
-                missing_acknowledgements = [
-                    reviewer_name
-                    for reviewer_name, review_output in approved_review_outputs
-                    if not human_requirements_resolved(review_output)
-                ]
-                if missing_acknowledgements:
-                    raise AgentLoopError(
-                        "Signed human reviewer requirements remain unresolved or "
-                        "unacknowledged by approved reviewer response(s): "
-                        f"{', '.join(missing_acknowledgements)}. "
-                        "Human intervention is required."
-                    )
-            approved_followups = round_future_followups
-            if config.approved_followups in ("summarize", "fix-and-summarize") and approved_followups:
-                body = _format_approved_followup_summary(pr_number, approved_followups)
-                post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-            elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
-                issue_urls, skipped_count = _create_approved_followup_issues(
-                    runner,
-                    config=config,
-                    pr_number=pr_number,
-                    followups=approved_followups,
-                )
-                if issue_urls:
-                    body = _format_created_followup_issue_summary(pr_number, issue_urls, skipped_count)
-                    post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-            run_optional_tests(runner, config)
-            if config.auto_merge:
-                wait_for_ci(runner, config, pr_number)
-                merge_pr(runner, config, pr_number)
-            print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
-            return 0
-        if round_number == config.max_rounds:
-            raise AgentLoopError(
-                f"One or more reviewers still reported blocking issues after round {round_number}; "
-                "human review required."
-            )
-
-        if same_pr_followups and not blocking_reviews:
-            combined_review = _format_same_pr_followups(same_pr_followups)
-            followup_prompt = build_same_pr_followup_prompt(
-                pr_number,
-                round_number,
-                combined_review,
-                config,
-                memory,
-                issue_context=issue_context,
-                human_requirements=human_requirements,
-            )
-        else:
-            # Discard future-work suggestions from non-final rounds so reviewers
-            # can restate still-relevant items after the PR has been updated.
-            if same_pr_followups:
-                blocking_reviews.append(
-                    (
-                        "Approved same-PR follow-ups",
-                        _format_same_pr_followups(same_pr_followups),
-                    )
-                )
-            combined_review = "\n\n".join(
-                f"{name} review:\n\n{review}" for name, review in blocking_reviews
-            )
-            followup_prompt = build_followup_prompt(
-                pr_number,
-                round_number,
-                combined_review,
-                config,
-                memory,
-                issue_context=issue_context,
-                human_requirements=human_requirements,
-            )
-        log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
-        coder_response = _run_validated_agent(
-            runner,
-            agent=config.coder,
-            config=config,
-            prompt=followup_prompt,
-            session_id=coder_session_id,
-            marker_description="<!-- AGENT_STATE: approved|blocking -->",
-            validate=parse_agent_state,
+        raise AgentLoopError(
+            f"Reached max rounds ({config.max_rounds}) for PR #{pr_number}; human review required."
         )
-        coder_output = coder_response.text
-        coder_session_id = coder_response.session_id
-
-        post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
-        log(config, f"Round {round_number}: {coder_name} pushed updates for re-review")
-
-    raise AgentLoopError(
-        f"Reached max rounds ({config.max_rounds}) for PR #{pr_number}; human review required."
-    )
+    finally:
+        if owned_usage_context:
+            _persist_usage_summary(config, usage_context)

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -1,0 +1,211 @@
+"""Per-call usage normalization and run-level aggregation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+AgentName = Literal["claude", "codex", "gemini"]
+UsageMode = Literal["exact", "partial", "estimated"]
+
+NUMERIC_USAGE_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "total_tokens",
+    "input_chars",
+    "output_chars",
+    "input_bytes",
+    "output_bytes",
+)
+
+
+def estimate_token_count(text: str) -> int:
+    byte_count = len(text.encode("utf-8"))
+    if byte_count == 0:
+        return 0
+    return max(1, (byte_count + 3) // 4)
+
+
+@dataclass(frozen=True)
+class UsageMetadata:
+    mode: UsageMode
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    total_tokens: int | None = None
+    input_chars: int | None = None
+    output_chars: int | None = None
+    input_bytes: int | None = None
+    output_bytes: int | None = None
+
+    def with_io_sizes(self, *, prompt: str, response: str) -> UsageMetadata:
+        return UsageMetadata(
+            mode=self.mode,
+            input_tokens=self.input_tokens,
+            cached_input_tokens=self.cached_input_tokens,
+            output_tokens=self.output_tokens,
+            reasoning_tokens=self.reasoning_tokens,
+            total_tokens=self.total_tokens,
+            input_chars=len(prompt),
+            output_chars=len(response),
+            input_bytes=len(prompt.encode("utf-8")),
+            output_bytes=len(response.encode("utf-8")),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+@dataclass
+class UsageCallRecord:
+    call_id: int
+    agent: AgentName
+    session_id: str | None
+    returncode: int
+    usage: UsageMetadata
+    validation_status: Literal["validated", "invalid"] = "invalid"
+    raw_backend_usage: object | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "call_id": self.call_id,
+            "agent": self.agent,
+            "session_id": self.session_id,
+            "returncode": self.returncode,
+            "validation_status": self.validation_status,
+            "usage": self.usage.to_dict(),
+        }
+        if self.raw_backend_usage is not None:
+            payload["raw_backend_usage"] = self.raw_backend_usage
+        return payload
+
+
+@dataclass(frozen=True)
+class UsageTotals:
+    call_count: int = 0
+    success_count: int = 0
+    exact_calls: int = 0
+    partial_calls: int = 0
+    estimated_calls: int = 0
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    total_tokens: int | None = None
+    input_chars: int | None = None
+    output_chars: int | None = None
+    input_bytes: int | None = None
+    output_bytes: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+def _add_optional(left: int | None, right: int | None) -> int | None:
+    if right is None:
+        return left
+    if left is None:
+        return right
+    return left + right
+
+
+def accumulate_usage_totals(records: list[UsageCallRecord]) -> UsageTotals:
+    totals = UsageTotals()
+    for record in records:
+        usage = record.usage
+        totals = UsageTotals(
+            call_count=totals.call_count + 1,
+            success_count=totals.success_count + int(record.validation_status == "validated"),
+            exact_calls=totals.exact_calls + int(usage.mode == "exact"),
+            partial_calls=totals.partial_calls + int(usage.mode == "partial"),
+            estimated_calls=totals.estimated_calls + int(usage.mode == "estimated"),
+            input_tokens=_add_optional(totals.input_tokens, usage.input_tokens),
+            cached_input_tokens=_add_optional(
+                totals.cached_input_tokens, usage.cached_input_tokens
+            ),
+            output_tokens=_add_optional(totals.output_tokens, usage.output_tokens),
+            reasoning_tokens=_add_optional(totals.reasoning_tokens, usage.reasoning_tokens),
+            total_tokens=_add_optional(totals.total_tokens, usage.total_tokens),
+            input_chars=_add_optional(totals.input_chars, usage.input_chars),
+            output_chars=_add_optional(totals.output_chars, usage.output_chars),
+            input_bytes=_add_optional(totals.input_bytes, usage.input_bytes),
+            output_bytes=_add_optional(totals.output_bytes, usage.output_bytes),
+        )
+    return totals
+
+
+def estimate_usage(prompt: str, response: str) -> UsageMetadata:
+    input_tokens = estimate_token_count(prompt)
+    output_tokens = estimate_token_count(response)
+    return UsageMetadata(
+        mode="estimated",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+    ).with_io_sizes(prompt=prompt, response=response)
+
+
+@dataclass
+class RunUsageContext:
+    run_id: str
+    summary_path: Path
+    records: list[UsageCallRecord] = field(default_factory=list)
+    _next_call_id: int = 1
+
+    def add_record(
+        self,
+        *,
+        agent: AgentName,
+        session_id: str | None,
+        returncode: int,
+        usage: UsageMetadata,
+        raw_backend_usage: object | None = None,
+    ) -> UsageCallRecord:
+        record = UsageCallRecord(
+            call_id=self._next_call_id,
+            agent=agent,
+            session_id=session_id,
+            returncode=returncode,
+            usage=usage,
+            raw_backend_usage=raw_backend_usage,
+        )
+        self._next_call_id += 1
+        self.records.append(record)
+        return record
+
+    def totals(self) -> UsageTotals:
+        return accumulate_usage_totals(self.records)
+
+    def per_agent_totals(self) -> dict[str, UsageTotals]:
+        agent_records: dict[str, list[UsageCallRecord]] = {}
+        for record in self.records:
+            agent_records.setdefault(record.agent, []).append(record)
+        return {
+            agent: accumulate_usage_totals(records)
+            for agent, records in sorted(agent_records.items())
+        }
+
+    def summary_payload(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "summary_path": str(self.summary_path),
+            "totals": self.totals().to_dict(),
+            "per_agent": {
+                agent: totals.to_dict() for agent, totals in self.per_agent_totals().items()
+            },
+            "calls": [record.to_dict() for record in self.records],
+        }
+
+    def write_summary(self) -> None:
+        self.summary_path.parent.mkdir(parents=True, exist_ok=True)
+        self.summary_path.write_text(
+            json.dumps(self.summary_payload(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -31,6 +31,23 @@ def estimate_token_count(text: str) -> int:
     return max(1, (byte_count + 3) // 4)
 
 
+def coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def first_present(payload: dict[str, object], *keys: str) -> object | None:
+    for key in keys:
+        if key in payload:
+            return payload[key]
+    return None
+
+
 @dataclass(frozen=True)
 class UsageMetadata:
     mode: UsageMode

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from coding_review_agent_loop.agents.claude import _parse_claude_output
+from coding_review_agent_loop.agents.codex import _extract_codex_usage
 from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER, _parse_gemini_output
 from coding_review_agent_loop.cli import (
     AgentLoopConfig,
@@ -101,6 +102,8 @@ class FakeRunner(Runner):
 
     def _next_agent_output(self, outputs):
         output = outputs.pop(0)
+        if isinstance(output, dict):
+            return output
         if isinstance(output, tuple):
             return output
         return output, 0
@@ -145,12 +148,19 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
-            output, returncode = self._next_agent_output(self.codex_outputs)
+            output = self._next_agent_output(self.codex_outputs)
+            if isinstance(output, dict):
+                public_response = output.get("public_response", "")
+                stdout = output.get("stdout", "")
+                returncode = output.get("returncode", 0)
+            else:
+                public_response, returncode = output
+                stdout = public_response
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
-                out_path.write_text(output, encoding="utf-8")
+                out_path.write_text(public_response, encoding="utf-8")
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
-            return CommandResult(cmd, cwd_path, "codex completed", "", returncode)
+            return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
         if cmd[:1] == ["gemini"]:
             output, returncode = self._next_agent_output(self.gemini_outputs)
@@ -168,11 +178,18 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
-            output, returncode = self._next_agent_output(self.codex_outputs)
+            output = self._next_agent_output(self.codex_outputs)
+            if isinstance(output, dict):
+                public_response = output.get("public_response", "")
+                stdout = output.get("stdout", "")
+                returncode = output.get("returncode", 0)
+            else:
+                public_response, returncode = output
+                stdout = public_response
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
-                out_path.write_text(output, encoding="utf-8")
-            return CommandResult(cmd, cwd_path, "", "", returncode)
+                out_path.write_text(public_response, encoding="utf-8")
+            return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
         if cmd[:3] == ["gh", "pr", "comment"]:
             if "--body-file" in cmd:
@@ -275,6 +292,12 @@ def command_index(commands, prefix, *, start=0):
     raise AssertionError(f"Command with prefix {prefix!r} not found.")
 
 
+def read_usage_summary(log_dir: Path) -> dict:
+    summary_paths = list(log_dir.glob("*-usage-summary.json"))
+    assert len(summary_paths) == 1
+    return json.loads(summary_paths[0].read_text(encoding="utf-8"))
+
+
 def make_config(tmp_path, *, create_dirs=True, **overrides):
     config = {
         "repo": "OWNER/REPO",
@@ -319,23 +342,29 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
 
 def test_parse_claude_output_extracts_text_and_session_id():
     raw = json.dumps({"result": "Hello.", "session_id": "abc123"})
-    text, sid = _parse_claude_output(raw)
+    text, sid, usage, raw_usage = _parse_claude_output(raw)
     assert text == "Hello."
     assert sid == "abc123"
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_claude_output_falls_back_on_plain_text():
     raw = "plain response"
-    text, sid = _parse_claude_output(raw)
+    text, sid, usage, raw_usage = _parse_claude_output(raw)
     assert text == "plain response"
     assert sid is None
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_claude_output_falls_back_on_non_string_result():
     raw = json.dumps({"result": 42, "session_id": "abc"})
-    text, sid = _parse_claude_output(raw)
+    text, sid, usage, raw_usage = _parse_claude_output(raw)
     assert text == raw  # non-string result → fall back to raw
     assert sid == "abc"
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_extracts_json_response():
@@ -476,6 +505,43 @@ I need to ask a question.
     assert "True color" not in text
     assert "<!-- AGENT_CLARIFY -->" in text
     assert sid is None
+
+
+def test_extract_codex_usage_reads_turn_completed_jsonl():
+    usage, raw_usage = _extract_codex_usage(
+        "\n".join(
+            [
+                json.dumps({"type": "turn.started"}),
+                json.dumps(
+                    {
+                        "type": "turn.completed",
+                        "usage": {
+                            "input_tokens": 120,
+                            "cached_input_tokens": 30,
+                            "output_tokens": 45,
+                            "reasoning_tokens": 11,
+                            "total_tokens": 206,
+                        },
+                    }
+                ),
+            ]
+        )
+    )
+
+    assert usage is not None
+    assert usage.mode == "exact"
+    assert usage.input_tokens == 120
+    assert usage.cached_input_tokens == 30
+    assert usage.output_tokens == 45
+    assert usage.reasoning_tokens == 11
+    assert usage.total_tokens == 206
+    assert raw_usage == {
+        "input_tokens": 120,
+        "cached_input_tokens": 30,
+        "output_tokens": 45,
+        "reasoning_tokens": 11,
+        "total_tokens": 206,
+    }
 
 
 def test_parse_agent_state_accepts_html_marker():
@@ -963,6 +1029,108 @@ def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
     ]
     assert len(runner.comments) == 4
     assert runner.comments[-1].startswith("LGTM.")
+
+
+def test_codex_usage_summary_records_exact_tokens_from_jsonl_and_public_response(tmp_path):
+    public_response = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": public_response,
+                "stdout": "\n".join(
+                    [
+                        json.dumps({"type": "turn.started"}),
+                        json.dumps(
+                            {
+                                "type": "turn.completed",
+                                "usage": {
+                                    "input_tokens": 200,
+                                    "cached_input_tokens": 40,
+                                    "output_tokens": 50,
+                                    "reasoning_tokens": 10,
+                                    "total_tokens": 300,
+                                },
+                            }
+                        ),
+                    ]
+                ),
+            }
+        ]
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments == [public_response]
+    summary = read_usage_summary(tmp_path / "logs")
+    assert summary["totals"]["exact_calls"] == 1
+    assert summary["totals"]["estimated_calls"] == 0
+    assert summary["totals"]["input_tokens"] == 200
+    assert summary["totals"]["cached_input_tokens"] == 40
+    assert summary["totals"]["output_tokens"] == 50
+    assert summary["totals"]["reasoning_tokens"] == 10
+    assert summary["totals"]["total_tokens"] == 300
+    assert summary["calls"][0]["raw_backend_usage"]["cached_input_tokens"] == 40
+    assert summary["calls"][0]["validation_status"] == "validated"
+
+
+def test_usage_summary_estimates_tokens_when_backend_exposes_none(tmp_path):
+    public_response = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(gemini_outputs=[public_response])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    summary = read_usage_summary(tmp_path / "logs")
+    call = summary["calls"][0]
+    assert call["usage"]["mode"] == "estimated"
+    assert call["usage"]["input_tokens"] == max(1, (call["usage"]["input_bytes"] + 3) // 4)
+    assert call["usage"]["output_tokens"] == max(1, (call["usage"]["output_bytes"] + 3) // 4)
+    assert call["usage"]["output_chars"] == len(public_response)
+
+
+def test_usage_summary_keeps_retry_attempts_and_marks_only_validated_call_successful(tmp_path):
+    near_miss = "LGTM.\nAGENT_STATE: approved.\n-- Google Gemini"
+    valid = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    runner = FakeRunner(gemini_outputs=[near_miss, valid])
+    config = make_config(tmp_path, reviewer="gemini")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    summary = read_usage_summary(tmp_path / "logs")
+    assert len(summary["calls"]) == 2
+    assert summary["totals"]["call_count"] == 2
+    assert summary["totals"]["success_count"] == 1
+    assert summary["calls"][0]["validation_status"] == "invalid"
+    assert summary["calls"][1]["validation_status"] == "validated"
+
+
+def test_plan_first_issue_run_writes_one_summary_for_planning_implementation_and_review(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Implement usage logging.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude",
+            "Opened PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Plan reviewed.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(
+        runner,
+        issue_number=56,
+        config=config,
+        plan_first=True,
+        implement_after_approval=True,
+    ) == 0
+
+    summary = read_usage_summary(tmp_path / "logs")
+    assert len(list((tmp_path / "logs").glob("*-usage-summary.json"))) == 1
+    assert summary["totals"]["call_count"] == 4
+    assert set(summary["per_agent"]) == {"claude", "codex"}
+    assert [call["agent"] for call in summary["calls"]] == ["claude", "codex", "claude", "codex"]
 
 
 def test_ensure_log_dir_ignored_does_not_overwrite_existing_file(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,9 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from coding_review_agent_loop.agents.claude import _parse_claude_output
-from coding_review_agent_loop.agents.codex import _extract_codex_usage
-from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER, _parse_gemini_output
+from coding_review_agent_loop.agents.claude import _normalize_claude_usage, _parse_claude_output
+from coding_review_agent_loop.agents.codex import _extract_codex_usage, _normalize_codex_usage
+from coding_review_agent_loop.agents.gemini import (
+    PUBLIC_RESPONSE_MARKER,
+    _normalize_gemini_usage,
+    _parse_gemini_payload,
+)
 from coding_review_agent_loop.cli import (
     AgentLoopConfig,
     AgentLoopError,
@@ -372,22 +376,28 @@ def test_parse_gemini_output_extracts_json_response():
         "response": "Reviewed.\n<!-- AGENT_STATE: approved -->",
         "session_id": "gemini-session-1",
     })
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text == "Reviewed.\n<!-- AGENT_STATE: approved -->"
     assert sid == "gemini-session-1"
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_falls_back_on_plain_text():
-    text, sid = _parse_gemini_output("plain response")
+    text, sid, usage, raw_usage = _parse_gemini_payload("plain response")
     assert text == "plain response"
     assert sid is None
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_falls_back_on_non_string_response():
     raw = json.dumps({"response": 42, "session_id": "gemini-session-1"})
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text == raw
     assert sid == "gemini-session-1"
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_prefers_public_response_marker():
@@ -404,7 +414,7 @@ No blocking findings.
 
 -- Google Gemini
 """
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text.startswith("## Review")
     assert "True color" not in text
     assert "YOLO mode" not in text
@@ -412,6 +422,8 @@ No blocking findings.
     assert "Error executing tool" not in text
     assert "<!-- AGENT_STATE: approved -->" in text
     assert sid is None
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_uses_last_public_response_marker():
@@ -422,8 +434,10 @@ intermediate draft
 Final answer.
 <!-- AGENT_STATE: approved -->
 """
-    text, _sid = _parse_gemini_output(raw)
+    text, _sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text == "Final answer.\n<!-- AGENT_STATE: approved -->\n"
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_json_response_strips_public_response_marker():
@@ -431,9 +445,11 @@ def test_parse_gemini_json_response_strips_public_response_marker():
         "response": f"diagnostic\n{PUBLIC_RESPONSE_MARKER}\nReviewed.\n<!-- AGENT_STATE: approved -->",
         "session_id": "gemini-session-1",
     })
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text == "Reviewed.\n<!-- AGENT_STATE: approved -->"
     assert sid == "gemini-session-1"
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_strips_cli_preamble_before_final_response():
@@ -457,12 +473,14 @@ Looks good.
 
 -- Google Gemini
 """
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text.startswith("## Code Review")
     assert "_GaxiosError" not in text
     assert "YOLO mode" not in text
     assert "<!-- AGENT_STATE: approved -->" in text
     assert sid is None
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_preserves_markdown_rules_after_preamble():
@@ -483,12 +501,14 @@ Still looks good.
 
 <!-- AGENT_STATE: approved -->
 """
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text.startswith("## Summary")
     assert "YOLO mode" not in text
     assert "## Details" in text
     assert "\n---\n\n## Details" in text
     assert sid is None
+    assert usage is None
+    assert raw_usage is None
 
 
 def test_parse_gemini_output_strips_preamble_before_clarification_marker():
@@ -500,11 +520,60 @@ I need to ask a question.
     Which endpoint should I update?
 <!-- AGENT_CLARIFY -->
 """
-    text, sid = _parse_gemini_output(raw)
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
     assert text.startswith("    Which endpoint")
     assert "True color" not in text
     assert "<!-- AGENT_CLARIFY -->" in text
     assert sid is None
+    assert usage is None
+    assert raw_usage is None
+
+
+def test_normalize_claude_usage_keeps_zero_cached_tokens_exact():
+    usage = _normalize_claude_usage(
+        {
+            "input_tokens": 12,
+            "cached_input_tokens": 0,
+            "output_tokens": 8,
+            "total_tokens": 20,
+        }
+    )
+
+    assert usage is not None
+    assert usage.mode == "exact"
+    assert usage.cached_input_tokens == 0
+
+
+def test_normalize_codex_usage_keeps_zero_reasoning_tokens():
+    usage = _normalize_codex_usage(
+        {
+            "input_tokens": 12,
+            "cached_input_tokens": 0,
+            "output_tokens": 8,
+            "reasoning_tokens": 0,
+            "total_tokens": 20,
+        }
+    )
+
+    assert usage is not None
+    assert usage.mode == "exact"
+    assert usage.reasoning_tokens == 0
+
+
+def test_normalize_gemini_usage_keeps_zero_token_values_exact():
+    usage = _normalize_gemini_usage(
+        {
+            "inputTokenCount": 0,
+            "cachedInputTokenCount": 0,
+            "outputTokenCount": 4,
+            "totalTokenCount": 4,
+        }
+    )
+
+    assert usage is not None
+    assert usage.mode == "exact"
+    assert usage.input_tokens == 0
+    assert usage.cached_input_tokens == 0
 
 
 def test_extract_codex_usage_reads_turn_completed_jsonl():


### PR DESCRIPTION
## Summary
- add normalized per-call usage metadata plus a run-level usage accumulator and summary file
- parse exact/partial usage from Codex, Claude, and Gemini where available and fall back to estimated prompt/response usage in the orchestrator
- document the new usage summary output and cover exact, estimated, retry, and plan-first aggregation paths in tests

## Testing
- python3 -m pytest

Closes #105