### PR TITLE
Validate Alembic migration topology before PR approval

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -280,6 +280,50 @@ def sync_reviewer_pr_before_review(
     option_name = _agent_dir_option(reviewer)
     default_owned = reviewer in set(config.auto_agent_dirs)
     label = f"Default {reviewer} workdir" if default_owned else option_name
+    sync_checkout_to_pr(
+        config,
+        runner,
+        path=path,
+        label=label,
+        default_owned=default_owned,
+        pr_number=pr_number,
+        pr_metadata=pr_metadata,
+    )
+
+
+def sync_coder_pr_before_validation(
+    config: AgentLoopConfig,
+    runner: Runner,
+    pr_number: int,
+    pr_metadata: PullRequestMetadata,
+) -> None:
+    """Refresh the active coder checkout to the current PR head before local validation."""
+    path = active_workdir(config)
+    option_name = _agent_dir_option(config.coder)
+    default_owned = config.coder in set(config.auto_agent_dirs)
+    label = f"Default {config.coder} workdir" if default_owned else option_name
+    sync_checkout_to_pr(
+        config,
+        runner,
+        path=path,
+        label=label,
+        default_owned=default_owned,
+        pr_number=pr_number,
+        pr_metadata=pr_metadata,
+    )
+
+
+def sync_checkout_to_pr(
+    config: AgentLoopConfig,
+    runner: Runner,
+    *,
+    path: Path,
+    label: str,
+    default_owned: bool,
+    pr_number: int,
+    pr_metadata: PullRequestMetadata,
+) -> None:
+    """Refresh a checkout to the current PR head."""
     pr_ref = f"refs/remotes/origin/pr/{pr_number}"
     pr_fetch_refspec = f"+pull/{pr_number}/head:{pr_ref}"
 

--- a/src/coding_review_agent_loop/migrations.py
+++ b/src/coding_review_agent_loop/migrations.py
@@ -1,0 +1,267 @@
+"""Alembic migration topology validation helpers."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import AgentLoopConfig, _run_git
+from .errors import AgentLoopError
+from .github import PullRequestMetadata
+from .runner import Runner
+
+ALEMBIC_VERSIONS_PREFIX = "alembic/versions/"
+
+
+@dataclass(frozen=True)
+class RevisionMetadata:
+    path: str
+    revision: str
+    down_revisions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RevisionIndex:
+    by_revision: dict[str, RevisionMetadata]
+    by_path: dict[str, RevisionMetadata]
+
+
+@dataclass(frozen=True)
+class MigrationValidationResult:
+    ok: bool
+    message: str | None = None
+
+
+def validate_pr_migration_topology(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    checkout: Path,
+    pr_metadata: PullRequestMetadata,
+) -> MigrationValidationResult:
+    base_branch = (pr_metadata.base_branch or config.base).strip() or config.base
+    base_ref = f"origin/{base_branch}"
+    changed_files = _changed_files_against_base(runner, checkout=checkout, base_ref=base_ref)
+    changed_migrations = [path for path in changed_files if is_alembic_version_path(path)]
+    if not changed_migrations:
+        return MigrationValidationResult(ok=True)
+
+    try:
+        base_index = _build_revision_index(
+            _load_git_revision_sources(runner, checkout=checkout, ref=base_ref)
+        )
+        pr_index = _build_revision_index(_load_worktree_revision_sources(checkout))
+    except AgentLoopError as exc:
+        return MigrationValidationResult(ok=False, message=str(exc))
+
+    base_heads = _head_revisions(base_index)
+    if len(base_heads) != 1:
+        return MigrationValidationResult(ok=True)
+
+    pr_heads = _head_revisions(pr_index)
+    if len(pr_heads) == 1:
+        return MigrationValidationResult(ok=True)
+
+    expected_head = base_heads[0]
+    offending = _find_offending_revision(
+        changed_paths=changed_migrations,
+        pr_index=pr_index,
+        expected_head=expected_head,
+        pr_heads=set(pr_heads),
+    )
+    if offending is None:
+        return MigrationValidationResult(
+            ok=False,
+            message=(
+                "PR changes Alembic revisions under `alembic/versions/`, but the resulting "
+                f"migration graph has multiple heads: {', '.join(f'`{head}`' for head in pr_heads)}. "
+                f"Base branch `{base_branch}` currently has single head `{expected_head}`. "
+                "Update the new revision chain to descend from the current head or add an intentional "
+                "merge migration."
+            ),
+        )
+
+    declared_parent = _format_down_revisions(offending.down_revisions)
+    return MigrationValidationResult(
+        ok=False,
+        message=(
+            "PR changes Alembic revisions under `alembic/versions/`, but the resulting migration "
+            f"graph branches unexpectedly. `{offending.path}` declares `down_revision = {declared_parent}`, "
+            f"while base branch `{base_branch}` currently has single head `{expected_head}`. "
+            f"Resulting PR heads: {', '.join(f'`{head}`' for head in pr_heads)}. "
+            f"Update `{offending.path}` to descend from `{expected_head}` or add an intentional merge migration."
+        ),
+    )
+
+
+def is_alembic_version_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return normalized.startswith(ALEMBIC_VERSIONS_PREFIX) and normalized.endswith(".py")
+
+
+def _changed_files_against_base(runner: Runner, *, checkout: Path, base_ref: str) -> tuple[str, ...]:
+    result = _run_git(runner, checkout, ("diff", "--name-only", f"{base_ref}...HEAD"))
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _load_git_revision_sources(
+    runner: Runner,
+    *,
+    checkout: Path,
+    ref: str,
+) -> dict[str, str]:
+    listing = _run_git(
+        runner,
+        checkout,
+        ("ls-tree", "-r", "--name-only", ref, "--", "alembic/versions"),
+    ).stdout
+    paths = [line.strip() for line in listing.splitlines() if is_alembic_version_path(line.strip())]
+    sources: dict[str, str] = {}
+    for rel_path in paths:
+        show = _run_git(runner, checkout, ("show", f"{ref}:{rel_path}"))
+        sources[rel_path] = show.stdout
+    return sources
+
+
+def _load_worktree_revision_sources(checkout: Path) -> dict[str, str]:
+    versions_dir = checkout / "alembic" / "versions"
+    if not versions_dir.is_dir():
+        return {}
+
+    sources: dict[str, str] = {}
+    for path in sorted(versions_dir.rglob("*.py")):
+        rel_path = path.relative_to(checkout).as_posix()
+        sources[rel_path] = path.read_text(encoding="utf-8")
+    return sources
+
+
+def _build_revision_index(sources: dict[str, str]) -> RevisionIndex:
+    by_revision: dict[str, RevisionMetadata] = {}
+    by_path: dict[str, RevisionMetadata] = {}
+    for rel_path, source in sorted(sources.items()):
+        metadata = parse_revision_metadata(source, path=rel_path)
+        other = by_revision.get(metadata.revision)
+        if other is not None:
+            raise AgentLoopError(
+                f"Could not validate Alembic revision metadata: duplicate revision "
+                f"`{metadata.revision}` in `{other.path}` and `{metadata.path}`."
+            )
+        by_revision[metadata.revision] = metadata
+        by_path[metadata.path] = metadata
+    return RevisionIndex(by_revision=by_revision, by_path=by_path)
+
+
+def parse_revision_metadata(source: str, *, path: str) -> RevisionMetadata:
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError as exc:
+        raise AgentLoopError(
+            f"Could not validate Alembic revision metadata in `{path}`: {exc.msg}."
+        ) from exc
+
+    revision_value: str | None = None
+    down_revision_value: tuple[str, ...] | None = None
+    for node in tree.body:
+        target_name, value_node = _assignment_target(node)
+        if target_name == "revision":
+            revision_value = _parse_string_literal(value_node, field="revision", path=path)
+        elif target_name == "down_revision":
+            down_revision_value = _parse_down_revision_literal(value_node, path=path)
+
+    if not revision_value:
+        raise AgentLoopError(f"Could not validate Alembic revision metadata in `{path}`: missing `revision`.")
+    if down_revision_value is None:
+        raise AgentLoopError(
+            f"Could not validate Alembic revision metadata in `{path}`: missing `down_revision`."
+        )
+    return RevisionMetadata(path=path, revision=revision_value, down_revisions=down_revision_value)
+
+
+def _assignment_target(node: ast.stmt) -> tuple[str | None, ast.AST | None]:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id, node.value
+        return None, None
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id, node.value
+    return None, None
+
+
+def _parse_string_literal(node: ast.AST | None, *, field: str, path: str) -> str:
+    if node is None:
+        raise AgentLoopError(f"Could not validate Alembic revision metadata in `{path}`: missing `{field}`.")
+    try:
+        value = ast.literal_eval(node)
+    except Exception as exc:
+        raise AgentLoopError(
+            f"Could not validate Alembic revision metadata in `{path}`: `{field}` must be a literal string."
+        ) from exc
+    if not isinstance(value, str) or not value:
+        raise AgentLoopError(
+            f"Could not validate Alembic revision metadata in `{path}`: `{field}` must be a literal string."
+        )
+    return value
+
+
+def _parse_down_revision_literal(node: ast.AST | None, *, path: str) -> tuple[str, ...]:
+    if node is None:
+        return ()
+    try:
+        value = ast.literal_eval(node)
+    except Exception as exc:
+        raise AgentLoopError(
+            f"Could not validate Alembic revision metadata in `{path}`: `down_revision` must be a "
+            "literal string, tuple of strings, list of strings, or None."
+        ) from exc
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)) and all(isinstance(item, str) and item for item in value):
+        return tuple(value)
+    raise AgentLoopError(
+        f"Could not validate Alembic revision metadata in `{path}`: `down_revision` must be a "
+        "literal string, tuple of strings, list of strings, or None."
+    )
+
+
+def _head_revisions(index: RevisionIndex) -> tuple[str, ...]:
+    referenced = {
+        parent
+        for metadata in index.by_revision.values()
+        for parent in metadata.down_revisions
+        if parent in index.by_revision
+    }
+    return tuple(sorted(revision for revision in index.by_revision if revision not in referenced))
+
+
+def _find_offending_revision(
+    *,
+    changed_paths: list[str],
+    pr_index: RevisionIndex,
+    expected_head: str,
+    pr_heads: set[str],
+) -> RevisionMetadata | None:
+    for path in changed_paths:
+        metadata = pr_index.by_path.get(path)
+        if metadata is None:
+            continue
+        if metadata.revision in pr_heads and expected_head not in metadata.down_revisions:
+            return metadata
+    for path in changed_paths:
+        metadata = pr_index.by_path.get(path)
+        if metadata is None:
+            continue
+        if metadata.revision in pr_heads:
+            return metadata
+    return None
+
+
+def _format_down_revisions(down_revisions: tuple[str, ...]) -> str:
+    if not down_revisions:
+        return "None"
+    if len(down_revisions) == 1:
+        return repr(down_revisions[0])
+    return repr(down_revisions)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -14,6 +14,7 @@ from .config import (
     ensure_agent_workdirs,
     reviewers,
     sync_coder_base_before_implementation,
+    sync_coder_pr_before_validation,
     sync_reviewer_pr_before_review,
 )
 from .errors import AgentLoopError
@@ -31,6 +32,7 @@ from .github import (
 )
 from .logging import log, new_run_id, run_usage_summary_path
 from .memory import prepare_agent_memory
+from .migrations import validate_pr_migration_topology
 from .prompts import (
     build_followup_prompt,
     build_issue_implementation_prompt,
@@ -887,31 +889,44 @@ def run_pr_loop(
                             f"{', '.join(missing_acknowledgements)}. "
                             "Human intervention is required."
                         )
-                approved_followups = round_future_followups
-                if (
-                    config.approved_followups in ("summarize", "fix-and-summarize")
-                    and approved_followups
-                ):
-                    body = _format_approved_followup_summary(pr_number, approved_followups)
-                    post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-                elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
-                    issue_urls, skipped_count = _create_approved_followup_issues(
-                        runner,
-                        config=config,
-                        pr_number=pr_number,
-                        followups=approved_followups,
+                sync_coder_pr_before_validation(config, runner, pr_number, pr_metadata)
+                migration_validation = validate_pr_migration_topology(
+                    runner,
+                    config=config,
+                    checkout=active_workdir(config),
+                    pr_metadata=pr_metadata,
+                )
+                if not migration_validation.ok:
+                    log(config, f"Round {round_number}: Alembic migration validation blocked approval")
+                    blocking_reviews.append(
+                        ("Alembic migration validation", migration_validation.message or "")
                     )
-                    if issue_urls:
-                        body = _format_created_followup_issue_summary(
-                            pr_number, issue_urls, skipped_count
-                        )
+                if not blocking_reviews:
+                    approved_followups = round_future_followups
+                    if (
+                        config.approved_followups in ("summarize", "fix-and-summarize")
+                        and approved_followups
+                    ):
+                        body = _format_approved_followup_summary(pr_number, approved_followups)
                         post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-                run_optional_tests(runner, config)
-                if config.auto_merge:
-                    wait_for_ci(runner, config, pr_number)
-                    merge_pr(runner, config, pr_number)
-                print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
-                return 0
+                    elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
+                        issue_urls, skipped_count = _create_approved_followup_issues(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            followups=approved_followups,
+                        )
+                        if issue_urls:
+                            body = _format_created_followup_issue_summary(
+                                pr_number, issue_urls, skipped_count
+                            )
+                            post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+                    run_optional_tests(runner, config)
+                    if config.auto_merge:
+                        wait_for_ci(runner, config, pr_number)
+                        merge_pr(runner, config, pr_number)
+                    print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
+                    return 0
             if round_number == config.max_rounds:
                 raise AgentLoopError(
                     f"One or more reviewers still reported blocking issues after round {round_number}; "

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -606,6 +606,9 @@ commands, or produce a blocking review explaining the limitation.
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this
 review step; report blocking findings if {coder_name} needs to fix anything.
+When the PR changes files under `alembic/versions/`, verify migration topology:
+new revisions should descend from the current head unless the PR intentionally
+adds a merge migration.
 {human_requirements_guidance}
 {followup_guidance}
 Use blocking only for issues that should prevent merge.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,5 +1,6 @@
 import json
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -32,6 +33,8 @@ from coding_review_agent_loop.config import (
     default_cache_root,
 )
 from coding_review_agent_loop.github import HumanReviewRequirement, IssueComment, IssueContext
+from coding_review_agent_loop.github import PullRequestMetadata
+from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
 from coding_review_agent_loop.prompts import format_human_requirements, format_issue_context
 from coding_review_agent_loop.protocol import (
     parse_approved_followups,
@@ -342,6 +345,210 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         config["codex_dir"].mkdir(parents=True, exist_ok=True)
         config["gemini_dir"].mkdir(parents=True, exist_ok=True)
     return AgentLoopConfig(**config)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_migration(revision: str, down_revision: str | tuple[str, ...] | None) -> str:
+    return (
+        f'revision = "{revision}"\n'
+        f"down_revision = {repr(down_revision)}\n"
+        "branch_labels = None\n"
+        "depends_on = None\n"
+    )
+
+
+def _init_git_checkout_with_origin(tmp_path: Path) -> Path:
+    origin = tmp_path / "origin.git"
+    worktree = tmp_path / "repo"
+    _git(tmp_path, "init", "--bare", str(origin))
+    _git(tmp_path, "clone", str(origin), str(worktree))
+    _git(worktree, "config", "user.email", "test@example.com")
+    _git(worktree, "config", "user.name", "Test User")
+    _git(worktree, "switch", "-c", "main")
+    return worktree
+
+
+def _commit_all(worktree: Path, message: str) -> None:
+    _git(worktree, "add", ".")
+    _git(worktree, "commit", "-m", message)
+
+
+def _push_main(worktree: Path) -> None:
+    _git(worktree, "push", "-u", "origin", "main")
+
+
+def test_validate_pr_migration_topology_blocks_wrong_down_revision(tmp_path):
+    worktree = _init_git_checkout_with_origin(tmp_path)
+    _write(
+        worktree / "alembic" / "versions" / "5d5f0e1a2b3c_base.py",
+        _make_migration("5d5f0e1a2b3c", None),
+    )
+    _write(
+        worktree / "alembic" / "versions" / "a6b7c8d9e0f1_add_feature.py",
+        _make_migration("a6b7c8d9e0f1", "5d5f0e1a2b3c"),
+    )
+    _write(
+        worktree / "alembic" / "versions" / "402b9e8af79b_latest.py",
+        _make_migration("402b9e8af79b", "a6b7c8d9e0f1"),
+    )
+    _commit_all(worktree, "Base migrations")
+    _push_main(worktree)
+
+    _git(worktree, "switch", "-c", "feature/wrong-parent")
+    _write(
+        worktree / "alembic" / "versions" / "e4f5a6b7c8d9_add_gemini_3_5_flash_pricing.py",
+        _make_migration("e4f5a6b7c8d9", "5d5f0e1a2b3c"),
+    )
+    _commit_all(worktree, "Add migration with stale down_revision")
+
+    result = validate_pr_migration_topology(
+        Runner(),
+        config=make_config(tmp_path / "config"),
+        checkout=worktree,
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Add migration",
+            head_branch="feature/wrong-parent",
+            base_branch="main",
+            head_sha=None,
+            url=None,
+        ),
+    )
+
+    assert result.ok is False
+    assert result.message is not None
+    assert "e4f5a6b7c8d9_add_gemini_3_5_flash_pricing.py" in result.message
+    assert "`down_revision = '5d5f0e1a2b3c'`" in result.message
+    assert "`402b9e8af79b`" in result.message
+    assert "`e4f5a6b7c8d9`" in result.message
+
+
+def test_validate_pr_migration_topology_allows_linear_head_extension(tmp_path):
+    worktree = _init_git_checkout_with_origin(tmp_path)
+    _write(
+        worktree / "alembic" / "versions" / "5d5f0e1a2b3c_base.py",
+        _make_migration("5d5f0e1a2b3c", None),
+    )
+    _write(
+        worktree / "alembic" / "versions" / "402b9e8af79b_latest.py",
+        _make_migration("402b9e8af79b", "5d5f0e1a2b3c"),
+    )
+    _commit_all(worktree, "Base migrations")
+    _push_main(worktree)
+
+    _git(worktree, "switch", "-c", "feature/right-parent")
+    _write(
+        worktree / "alembic" / "versions" / "e4f5a6b7c8d9_add_pricing.py",
+        _make_migration("e4f5a6b7c8d9", "402b9e8af79b"),
+    )
+    _commit_all(worktree, "Add linear migration")
+
+    result = validate_pr_migration_topology(
+        Runner(),
+        config=make_config(tmp_path / "config"),
+        checkout=worktree,
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Add migration",
+            head_branch="feature/right-parent",
+            base_branch="main",
+            head_sha=None,
+            url=None,
+        ),
+    )
+
+    assert result.ok is True
+    assert result.message is None
+
+
+def test_validate_pr_migration_topology_skips_block_when_base_already_has_multiple_heads(tmp_path):
+    worktree = _init_git_checkout_with_origin(tmp_path)
+    _write(
+        worktree / "alembic" / "versions" / "111111111111_first_head.py",
+        _make_migration("111111111111", None),
+    )
+    _write(
+        worktree / "alembic" / "versions" / "222222222222_second_head.py",
+        _make_migration("222222222222", None),
+    )
+    _commit_all(worktree, "Base has multiple heads")
+    _push_main(worktree)
+
+    _git(worktree, "switch", "-c", "feature/merge-heads")
+    _write(
+        worktree / "alembic" / "versions" / "333333333333_merge_heads.py",
+        _make_migration("333333333333", ("111111111111", "222222222222")),
+    )
+    _commit_all(worktree, "Merge existing heads")
+
+    result = validate_pr_migration_topology(
+        Runner(),
+        config=make_config(tmp_path / "config"),
+        checkout=worktree,
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Merge heads",
+            head_branch="feature/merge-heads",
+            base_branch="main",
+            head_sha=None,
+            url=None,
+        ),
+    )
+
+    assert result.ok is True
+    assert result.message is None
+
+
+def test_validate_pr_migration_topology_blocks_non_literal_changed_metadata(tmp_path):
+    worktree = _init_git_checkout_with_origin(tmp_path)
+    _write(
+        worktree / "alembic" / "versions" / "402b9e8af79b_latest.py",
+        _make_migration("402b9e8af79b", None),
+    )
+    _commit_all(worktree, "Base migrations")
+    _push_main(worktree)
+
+    _git(worktree, "switch", "-c", "feature/non-literal-migration")
+    _write(
+        worktree / "alembic" / "versions" / "e4f5a6b7c8d9_non_literal.py",
+        'revision = "e4f5a6b7c8d9"\n'
+        "PREVIOUS = '402b9e8af79b'\n"
+        "down_revision = PREVIOUS\n"
+        "branch_labels = None\n"
+        "depends_on = None\n",
+    )
+    _commit_all(worktree, "Add non-literal migration metadata")
+
+    result = validate_pr_migration_topology(
+        Runner(),
+        config=make_config(tmp_path / "config"),
+        checkout=worktree,
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Bad migration metadata",
+            head_branch="feature/non-literal-migration",
+            base_branch="main",
+            head_sha=None,
+            url=None,
+        ),
+    )
+
+    assert result.ok is False
+    assert result.message is not None
+    assert "Could not validate Alembic revision metadata" in result.message
+    assert "e4f5a6b7c8d9_non_literal.py" in result.message
 
 
 def test_parse_claude_output_extracts_text_and_session_id():
@@ -1455,6 +1662,48 @@ def test_pr_loop_allows_approval_with_human_requirement_resolution_marker(tmp_pa
     assert ["pytest", "tests/test_agent_loop.py"] in commands
 
 
+def test_pr_loop_routes_migration_validation_failure_through_coder_followup(tmp_path, monkeypatch):
+    runner = FakeRunner(
+        claude_outputs=["Fixed migration.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM again.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, test_command=("pytest", "tests/test_agent_loop.py"), max_rounds=2)
+    validations = iter(
+        [
+            MigrationValidationResult(
+                ok=False,
+                message=(
+                    "alembic/versions/e4f5a6b7c8d9_add_pricing.py declares `down_revision = '5d5f0e1a2b3c'`; "
+                    "expected current head `402b9e8af79b`."
+                ),
+            ),
+            MigrationValidationResult(ok=True),
+        ]
+    )
+
+    monkeypatch.setattr(
+        "coding_review_agent_loop.orchestrator.validate_pr_migration_topology",
+        lambda *args, **kwargs: next(validations),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    coder_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(coder_prompts) == 1
+    assert "Alembic migration validation review:" in coder_prompts[0]
+    assert "expected current head `402b9e8af79b`" in coder_prompts[0]
+
+    commands = runner.commands
+    pytest_index = command_index(commands, ["pytest", "tests/test_agent_loop.py"])
+    second_review_index = [
+        index for index, (cmd, _cwd) in enumerate(commands) if cmd[:2] == ["codex", "exec"]
+    ][1]
+    assert second_review_index < pytest_index
+
+
 def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
     config = make_config(tmp_path)
@@ -1484,6 +1733,7 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     assert "ignore approved-review follow-up sections" in prompt
     assert "### Future follow-ups" not in prompt
     assert "legacy heading `### Non-blocking follow-ups`" not in prompt
+    assert "verify migration topology" in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt
 
 
@@ -1685,7 +1935,7 @@ def test_agent_memory_detects_changed_files_since_previous_commit(tmp_path):
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     diff_commands = [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["git", "diff", "--name-only"]]
-    assert diff_commands == [["git", "diff", "--name-only", "abc123..def456"]]
+    assert ["git", "diff", "--name-only", "abc123..def456"] in diff_commands
     prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
     assert "src/coding_review_agent_loop/prompts.py" in prompt
     assert "tests/test_agent_loop.py" in prompt
@@ -2600,7 +2850,7 @@ def test_reviewer_checkout_refreshes_each_round_before_review(tmp_path):
     ]
     review_indices = [index for index, cmd in enumerate(commands) if cmd[:2] == ["codex", "exec"]]
 
-    assert len(pr_fetches) == 2
+    assert len(pr_fetches) == 3
     assert len(review_indices) == 2
     assert pr_fetches[0] < review_indices[0]
     assert pr_fetches[1] < review_indices[1]
@@ -2618,7 +2868,7 @@ def test_dirty_default_reviewer_checkout_is_cleaned_before_review(tmp_path):
         codex_dir=codex_dir,
         coder="claude",
         reviewer="codex",
-        auto_agent_dirs=("codex",),
+        auto_agent_dirs=("claude", "codex"),
         create_dirs=False,
     )
     config.claude_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- add Alembic migration topology validation that runs only when a PR changes \
- refresh the active coder checkout to the PR head before running post-approval validation
- cover stale \, malformed metadata, linear success, merge-head skip, and orchestrator follow-up behavior in tests

Closes #109