### PR TITLE
Verify GitHub PR checks before approval summaries

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -260,13 +260,13 @@ def _fetch_branch_protection_required_checks(
     stderr = (result.stderr or "").lower()
     stdout = (result.stdout or "").lower()
     combined = f"{stdout}\n{stderr}"
-    if result.returncode == 404 or "404" in combined:
+    if "404" in combined:
         return (
             "not_found",
             (),
             "Required status checks are not configured on the PR base branch.",
         )
-    if result.returncode == 403 or "403" in combined or "forbidden" in combined:
+    if "403" in combined or "forbidden" in combined:
         return (
             "forbidden",
             (),
@@ -287,7 +287,7 @@ def get_pr_checks(
 ) -> PullRequestChecks:
     if config.dry_run:
         return PullRequestChecks(
-            state="unavailable",
+            state="no_checks",
             required_checks=(),
             passing=(),
             pending=(),

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from .errors import AgentLoopError
 from .logging import log
@@ -60,6 +60,26 @@ class HumanReviewRequirement:
 class PullRequestReviewContext:
     metadata: PullRequestMetadata
     human_requirements: tuple[HumanReviewRequirement, ...]
+
+
+@dataclass(frozen=True)
+class PullRequestCheck:
+    name: str
+    kind: Literal["check_run", "status_context"]
+    status: str
+    url: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestChecks:
+    state: Literal["passing", "failing", "pending", "no_checks", "unavailable"]
+    required_checks: tuple[str, ...]
+    passing: tuple[PullRequestCheck, ...]
+    pending: tuple[PullRequestCheck, ...]
+    failing: tuple[PullRequestCheck, ...]
+    missing_required: tuple[str, ...]
+    branch_protection_status: Literal["configured", "not_found", "forbidden", "unavailable"]
+    branch_protection_note: str | None = None
 
 
 PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url"
@@ -166,6 +186,239 @@ def get_pr_review_context(
     return PullRequestReviewContext(
         metadata=_parse_pr_metadata(data, config=config, pr_number=pr_number),
         human_requirements=_parse_pr_human_requirements(data),
+    )
+
+
+def _normalize_check_run_status(raw_run: object) -> str:
+    if not isinstance(raw_run, dict):
+        return "unknown"
+    status = _optional_str(raw_run.get("status"))
+    conclusion = _optional_str(raw_run.get("conclusion"))
+    if status != "completed":
+        return status or "pending"
+    return conclusion or "completed"
+
+
+def _classify_check_status(status: str) -> Literal["passing", "pending", "failing"]:
+    normalized = status.strip().lower()
+    if normalized in {"success", "neutral", "skipped"}:
+        return "passing"
+    if normalized in {
+        "failure",
+        "cancelled",
+        "timed_out",
+        "action_required",
+        "startup_failure",
+        "stale",
+        "error",
+    }:
+        return "failing"
+    return "pending"
+
+
+def _dedupe_checks(checks: list[PullRequestCheck]) -> tuple[PullRequestCheck, ...]:
+    deduped: dict[tuple[str, str], PullRequestCheck] = {}
+    for check in checks:
+        deduped.setdefault((check.kind, check.name), check)
+    return tuple(deduped.values())
+
+
+def _fetch_branch_protection_required_checks(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    base_branch: str | None,
+) -> tuple[Literal["configured", "not_found", "forbidden", "unavailable"], tuple[str, ...], str | None]:
+    if not base_branch:
+        return ("unavailable", (), "PR base branch is unavailable, so branch protection could not be checked.")
+
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/branches/{base_branch}/protection/required_status_checks",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode == 0:
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            return ("unavailable", (), "Branch protection response was not valid JSON.")
+        required_checks: list[str] = []
+        for context in payload.get("contexts") or []:
+            if isinstance(context, str) and context:
+                required_checks.append(context)
+        for check in payload.get("checks") or []:
+            if isinstance(check, dict):
+                context = _optional_str(check.get("context"))
+                if context:
+                    required_checks.append(context)
+        return ("configured", tuple(dict.fromkeys(required_checks)), None)
+
+    stderr = (result.stderr or "").lower()
+    stdout = (result.stdout or "").lower()
+    combined = f"{stdout}\n{stderr}"
+    if result.returncode == 404 or "404" in combined:
+        return (
+            "not_found",
+            (),
+            "Required status checks are not configured on the PR base branch.",
+        )
+    if result.returncode == 403 or "403" in combined or "forbidden" in combined:
+        return (
+            "forbidden",
+            (),
+            "Current GitHub token cannot inspect branch protection on the PR base branch.",
+        )
+    return (
+        "unavailable",
+        (),
+        "GitHub branch protection could not be inspected due to an unexpected API failure.",
+    )
+
+
+def get_pr_checks(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    metadata: PullRequestMetadata,
+) -> PullRequestChecks:
+    if config.dry_run:
+        return PullRequestChecks(
+            state="unavailable",
+            required_checks=(),
+            passing=(),
+            pending=(),
+            failing=(),
+            missing_required=(),
+            branch_protection_status="unavailable",
+            branch_protection_note="Dry run mode does not query live GitHub PR checks.",
+        )
+
+    if not metadata.head_sha:
+        return PullRequestChecks(
+            state="unavailable",
+            required_checks=(),
+            passing=(),
+            pending=(),
+            failing=(),
+            missing_required=(),
+            branch_protection_status="unavailable",
+            branch_protection_note="PR head SHA is unavailable, so GitHub PR checks could not be queried.",
+        )
+
+    branch_protection_status, required_checks, branch_protection_note = (
+        _fetch_branch_protection_required_checks(
+            runner,
+            config=config,
+            base_branch=metadata.base_branch,
+        )
+    )
+    check_runs_result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/commits/{metadata.head_sha}/check-runs",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    statuses_result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/commits/{metadata.head_sha}/status",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+
+    check_errors: list[str] = []
+    checks: list[PullRequestCheck] = []
+
+    if check_runs_result.returncode == 0:
+        try:
+            payload = json.loads(check_runs_result.stdout or "{}")
+        except json.JSONDecodeError:
+            check_errors.append("check-runs response was not valid JSON")
+        else:
+            for raw_check in payload.get("check_runs") or []:
+                if not isinstance(raw_check, dict):
+                    continue
+                name = _optional_str(raw_check.get("name"))
+                if not name:
+                    continue
+                checks.append(
+                    PullRequestCheck(
+                        name=name,
+                        kind="check_run",
+                        status=_normalize_check_run_status(raw_check),
+                        url=_optional_str(raw_check.get("html_url") or raw_check.get("details_url")),
+                    )
+                )
+    else:
+        check_errors.append("check-runs query failed")
+
+    if statuses_result.returncode == 0:
+        try:
+            payload = json.loads(statuses_result.stdout or "{}")
+        except json.JSONDecodeError:
+            check_errors.append("commit-status response was not valid JSON")
+        else:
+            for raw_status in payload.get("statuses") or []:
+                if not isinstance(raw_status, dict):
+                    continue
+                name = _optional_str(raw_status.get("context"))
+                if not name:
+                    continue
+                checks.append(
+                    PullRequestCheck(
+                        name=name,
+                        kind="status_context",
+                        status=_optional_str(raw_status.get("state")) or "pending",
+                        url=_optional_str(raw_status.get("target_url")),
+                    )
+                )
+    else:
+        check_errors.append("commit-status query failed")
+
+    deduped_checks = _dedupe_checks(checks)
+    passing = tuple(check for check in deduped_checks if _classify_check_status(check.status) == "passing")
+    pending = tuple(check for check in deduped_checks if _classify_check_status(check.status) == "pending")
+    failing = tuple(check for check in deduped_checks if _classify_check_status(check.status) == "failing")
+    observed_names = {check.name for check in deduped_checks}
+    missing_required = tuple(name for name in required_checks if name not in observed_names)
+
+    state: Literal["passing", "failing", "pending", "no_checks", "unavailable"]
+    if failing:
+        state = "failing"
+    elif pending or missing_required:
+        state = "pending"
+    elif passing:
+        state = "passing"
+    elif branch_protection_status == "configured" and required_checks:
+        state = "pending"
+    elif branch_protection_status in {"configured", "not_found", "forbidden"}:
+        state = "no_checks"
+    elif check_errors:
+        state = "unavailable"
+    else:
+        state = "no_checks"
+
+    if state == "unavailable" and not branch_protection_note and check_errors:
+        branch_protection_note = "; ".join(check_errors)
+
+    return PullRequestChecks(
+        state=state,
+        required_checks=required_checks,
+        passing=passing,
+        pending=pending,
+        failing=failing,
+        missing_required=missing_required,
+        branch_protection_status=branch_protection_status,
+        branch_protection_note=branch_protection_note,
     )
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -22,6 +22,7 @@ from .github import (
     IssueContext,
     create_issue,
     get_issue_context,
+    get_pr_checks,
     get_pr_review_context,
     merge_pr,
     post_issue_comment,
@@ -472,6 +473,65 @@ def _format_plan_approval_summary(issue_number: int, approved_plan: str) -> str:
     )
 
 
+def _format_pr_checks_comment(pr_number: int, state: str, details: list[str]) -> str:
+    headline = {
+        "failing": f"GitHub PR checks are failing for PR #{pr_number}.",
+        "pending": f"GitHub PR checks are still pending for PR #{pr_number}.",
+        "unavailable": f"GitHub PR check status is unavailable for PR #{pr_number}.",
+    }[state]
+    lines = [
+        headline,
+        "",
+        "Reviewer approvals do not make this PR merge-ready until GitHub PR checks are green, or the PR explicitly states that only a local subset passed.",
+        "",
+    ]
+    lines.extend(f"- {detail}" for detail in details)
+    lines.extend(["", "-- coding-review-agent-loop"])
+    return "\n".join(lines)
+
+
+def _pr_check_blocking_review(pr_number: int, state: str, details: list[str]) -> str:
+    headline = {
+        "failing": "GitHub PR checks are failing and must be resolved before approval.",
+        "pending": "GitHub PR checks are still pending, so this PR cannot be treated as merge-ready yet.",
+        "unavailable": "GitHub PR check status is unavailable, so merge readiness cannot be confirmed yet.",
+    }[state]
+    lines = [headline, ""]
+    lines.extend(f"- {detail}" for detail in details)
+    lines.extend(
+        [
+            "",
+            "Do not claim global test success unless GitHub PR checks are green. If only local tests passed, say that explicitly.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _pr_check_details(pr_checks) -> list[str]:
+    details: list[str] = []
+    if pr_checks.required_checks:
+        details.append(f"Required checks: {', '.join(pr_checks.required_checks)}")
+    if pr_checks.failing:
+        details.append(
+            "Failing checks: "
+            + ", ".join(f"{check.name} ({check.status})" for check in pr_checks.failing)
+        )
+    if pr_checks.pending:
+        details.append(
+            "Pending checks: "
+            + ", ".join(f"{check.name} ({check.status})" for check in pr_checks.pending)
+        )
+    if pr_checks.missing_required:
+        details.append(
+            "Required checks not yet reporting: " + ", ".join(pr_checks.missing_required)
+        )
+    if pr_checks.branch_protection_note:
+        details.append(pr_checks.branch_protection_note)
+    if not details:
+        details.append("No individual check names were available from the GitHub API.")
+    return details
+
+
 def _run_plan_first_loop(
     runner: Runner,
     *,
@@ -819,6 +879,7 @@ def run_pr_loop(
             pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
             pr_metadata = pr_context.metadata
             human_requirements = pr_context.human_requirements
+            pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
             for reviewer in configured_reviewers:
                 reviewer_name = agent_display_name(reviewer)
                 log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
@@ -833,6 +894,7 @@ def run_pr_loop(
                         config,
                         reviewer=reviewer,
                         pr_metadata=pr_metadata,
+                        pr_checks=pr_checks,
                         memory=memory,
                         issue_context=issue_context,
                         human_requirements=human_requirements,
@@ -901,6 +963,31 @@ def run_pr_loop(
                     blocking_reviews.append(
                         ("Alembic migration validation", migration_validation.message or "")
                     )
+                if not blocking_reviews:
+                    if pr_checks.state in {"failing", "pending", "unavailable"}:
+                        details = _pr_check_details(pr_checks)
+                        post_pr_comment(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            body=_format_pr_checks_comment(pr_number, pr_checks.state, details),
+                        )
+                        if pr_checks.state == "failing":
+                            log(
+                                config,
+                                f"Round {round_number}: GitHub PR checks blocked approval ({pr_checks.state})",
+                            )
+                            blocking_reviews.append(
+                                (
+                                    "GitHub PR checks",
+                                    _pr_check_blocking_review(pr_number, pr_checks.state, details),
+                                )
+                            )
+                        else:
+                            raise AgentLoopError(
+                                f"GitHub PR checks for PR #{pr_number} are {pr_checks.state}; "
+                                "wait for CI or investigate GitHub API access before treating the PR as approved."
+                            )
                 if not blocking_reviews:
                     approved_followups = round_future_followups
                     if (

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -20,6 +20,7 @@ from .config import (
 from .errors import AgentLoopError
 from .github import (
     IssueContext,
+    PullRequestChecks,
     create_issue,
     get_issue_context,
     get_pr_checks,
@@ -507,7 +508,7 @@ def _pr_check_blocking_review(pr_number: int, state: str, details: list[str]) ->
     return "\n".join(lines)
 
 
-def _pr_check_details(pr_checks) -> list[str]:
+def _pr_check_details(pr_checks: PullRequestChecks) -> list[str]:
     details: list[str] = []
     if pr_checks.required_checks:
         details.append(f"Required checks: {', '.join(pr_checks.required_checks)}")

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -7,7 +7,7 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
-from .github import HumanReviewRequirement, IssueContext, PullRequestMetadata
+from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
 
 
@@ -239,6 +239,30 @@ review must include exactly:
 
 If any signed human reviewer requirement is unresolved, return blocking.
 """
+
+
+def format_pr_checks(checks: PullRequestChecks) -> str:
+    lines = [
+        "GitHub PR checks:",
+        f"- Overall state: {checks.state}",
+    ]
+    if checks.required_checks:
+        lines.append(f"- Required checks: {', '.join(checks.required_checks)}")
+    if checks.failing:
+        lines.append(
+            "- Failing checks: "
+            + ", ".join(f"{check.name} ({check.status})" for check in checks.failing)
+        )
+    if checks.pending:
+        lines.append(
+            "- Pending checks: "
+            + ", ".join(f"{check.name} ({check.status})" for check in checks.pending)
+        )
+    if checks.missing_required:
+        lines.append(f"- Required checks not yet reporting: {', '.join(checks.missing_required)}")
+    if checks.branch_protection_note:
+        lines.append(f"- Branch protection: {checks.branch_protection_note}")
+    return "\n".join(lines)
 
 
 def _issue_context_block(issue_context: IssueContext | None) -> str:
@@ -515,6 +539,7 @@ def build_review_prompt(
     *,
     reviewer: AgentName,
     pr_metadata: PullRequestMetadata | None = None,
+    pr_checks: PullRequestChecks | None = None,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     human_requirements: Sequence[HumanReviewRequirement] | None = None,
@@ -536,6 +561,7 @@ def build_review_prompt(
     base_branch = metadata.base_branch or "(unknown)"
     head_sha = metadata.head_sha or "(unknown)"
     url_line = f"- URL: {metadata.url}\n" if metadata.url else ""
+    checks_block = f"{format_pr_checks(pr_checks)}\n" if pr_checks is not None else ""
     human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
     if config.approved_followups == "ignore":
         followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
@@ -591,7 +617,7 @@ checkout before reviewing. Do not spend time discovering the PR
 branch. Do not report findings based on untracked files unless those files are
 present in the PR diff.
 {_scratch_file_guidance()}
-{_issue_context_block(issue_context)}
+{checks_block}{_issue_context_block(issue_context)}
 {_human_requirements_block(human_requirements)}
 {_memory_block(memory)}
 
@@ -606,6 +632,10 @@ commands, or produce a blocking review explaining the limitation.
 Focus on correctness, security, test coverage, and maintainability. Review the
 full diff and any existing PR discussion. Do not make code changes in this
 review step; report blocking findings if {coder_name} needs to fix anything.
+Treat the GitHub PR checks block above as authoritative for current CI state.
+Do not say or imply that tests passed globally unless the GitHub PR checks
+state is `passing` or `no_checks`. If only a local subset passed while GitHub
+checks are `failing`, `pending`, or `unavailable`, say that explicitly.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -32,8 +32,13 @@ from coding_review_agent_loop.config import (
     default_agent_workdir,
     default_cache_root,
 )
-from coding_review_agent_loop.github import HumanReviewRequirement, IssueComment, IssueContext
-from coding_review_agent_loop.github import PullRequestMetadata
+from coding_review_agent_loop.github import (
+    HumanReviewRequirement,
+    IssueComment,
+    IssueContext,
+    PullRequestMetadata,
+    get_pr_checks,
+)
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
 from coding_review_agent_loop.prompts import format_human_requirements, format_issue_context
 from coding_review_agent_loop.protocol import (
@@ -1909,7 +1914,7 @@ def test_pr_loop_allows_repos_without_github_checks_when_branch_protection_404(t
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
         pr_check_runs_payload={"check_runs": []},
         pr_status_payload={"state": "pending", "statuses": []},
-        pr_branch_protection_returncode=404,
+        pr_branch_protection_returncode=1,
         pr_branch_protection_stderr="404 Not Found",
     )
     config = make_config(tmp_path)
@@ -1923,7 +1928,7 @@ def test_pr_loop_allows_repos_without_github_checks_when_branch_protection_403(t
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
         pr_check_runs_payload={"check_runs": []},
         pr_status_payload={"state": "pending", "statuses": []},
-        pr_branch_protection_returncode=403,
+        pr_branch_protection_returncode=1,
         pr_branch_protection_stderr="403 Forbidden",
     )
     config = make_config(tmp_path)
@@ -1959,7 +1964,7 @@ def test_review_prompt_mentions_branch_protection_forbidden_when_checks_exist(tm
         pr_check_runs_payload={
             "check_runs": [{"name": "test", "status": "completed", "conclusion": "success"}]
         },
-        pr_branch_protection_returncode=403,
+        pr_branch_protection_returncode=1,
         pr_branch_protection_stderr="403 Forbidden",
     )
     config = make_config(tmp_path)
@@ -1968,6 +1973,29 @@ def test_review_prompt_mentions_branch_protection_forbidden_when_checks_exist(tm
 
     prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
     assert "Current GitHub token cannot inspect branch protection on the PR base branch." in prompt
+
+
+def test_get_pr_checks_returns_no_checks_in_dry_run(tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, dry_run=True)
+
+    pr_checks = get_pr_checks(
+        runner,
+        config=config,
+        metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Improve review prompt context",
+            head_branch="feature/review-context",
+            base_branch="main",
+            head_sha="abc123",
+            url="https://github.com/OWNER/REPO/pull/77",
+        ),
+    )
+
+    assert pr_checks.state == "no_checks"
+    assert pr_checks.branch_protection_status == "unavailable"
+    assert pr_checks.branch_protection_note == "Dry run mode does not query live GitHub PR checks."
 
 
 def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -53,6 +53,15 @@ class FakeRunner(Runner):
         issue_payload=None,
         issue_comments=None,
         pr_payload=None,
+        pr_check_runs_payload=None,
+        pr_status_payload=None,
+        pr_branch_protection_payload=None,
+        pr_branch_protection_returncode=0,
+        pr_branch_protection_stderr="",
+        pr_check_runs_returncode=0,
+        pr_check_runs_stderr="",
+        pr_status_returncode=0,
+        pr_status_stderr="",
         git_status="",
         git_remote="git@github.com:OWNER/REPO.git",
         git_inside=True,
@@ -68,7 +77,7 @@ class FakeRunner(Runner):
         self.claude_outputs = list(claude_outputs or [])
         self.codex_outputs = list(codex_outputs or [])
         self.gemini_outputs = list(gemini_outputs or [])
-        self.issue_payload = issue_payload or {
+        self.issue_payload = {
             "number": 56,
             "state": "open",
             "is_pr": False,
@@ -76,8 +85,10 @@ class FakeRunner(Runner):
             "title": "Fix issue-mode context",
             "body": "Original issue body.",
         }
+        if issue_payload:
+            self.issue_payload.update(issue_payload)
         self.issue_comments = list(issue_comments or [])
-        self.pr_payload = pr_payload or {
+        self.pr_payload = {
             "number": 77,
             "state": "OPEN",
             "url": "https://github.com/OWNER/REPO/pull/77",
@@ -88,6 +99,19 @@ class FakeRunner(Runner):
             "comments": [],
             "reviews": [],
         }
+        if pr_payload:
+            self.pr_payload.update(pr_payload)
+        self.pr_check_runs_payload = pr_check_runs_payload or {
+            "check_runs": [{"name": "test", "status": "completed", "conclusion": "success"}]
+        }
+        self.pr_status_payload = pr_status_payload or {"state": "success", "statuses": []}
+        self.pr_branch_protection_payload = pr_branch_protection_payload or {"contexts": ["test"]}
+        self.pr_branch_protection_returncode = pr_branch_protection_returncode
+        self.pr_branch_protection_stderr = pr_branch_protection_stderr
+        self.pr_check_runs_returncode = pr_check_runs_returncode
+        self.pr_check_runs_stderr = pr_check_runs_stderr
+        self.pr_status_returncode = pr_status_returncode
+        self.pr_status_stderr = pr_status_stderr
         self.commands = []
         self.comments = []
         self.issues = []
@@ -247,7 +271,42 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, json_dumps(self.issue_payload), "", 0)
 
         if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs"):
-            return CommandResult(cmd, cwd_path, "success\n", "", 0)
+            if "--jq" in cmd:
+                return CommandResult(cmd, cwd_path, "success\n", "", 0)
+            stdout = (
+                json_dumps(self.pr_check_runs_payload) if self.pr_check_runs_returncode == 0 else ""
+            )
+            return CommandResult(
+                cmd,
+                cwd_path,
+                stdout,
+                self.pr_check_runs_stderr,
+                self.pr_check_runs_returncode,
+            )
+
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/status"):
+            stdout = json_dumps(self.pr_status_payload) if self.pr_status_returncode == 0 else ""
+            return CommandResult(
+                cmd,
+                cwd_path,
+                stdout,
+                self.pr_status_stderr,
+                self.pr_status_returncode,
+            )
+
+        if cmd[:2] == ["gh", "api"] and "/protection/required_status_checks" in cmd[2]:
+            stdout = (
+                json_dumps(self.pr_branch_protection_payload)
+                if self.pr_branch_protection_returncode == 0
+                else ""
+            )
+            return CommandResult(
+                cmd,
+                cwd_path,
+                stdout,
+                self.pr_branch_protection_stderr,
+                self.pr_branch_protection_returncode,
+            )
 
         if cmd[:1] == ["sleep"]:
             return CommandResult(cmd, cwd_path, "", "", 0)
@@ -1436,8 +1495,16 @@ def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
         "gh",
         "api",
         "repos/OWNER/REPO/commits/abc123/check-runs",
-        "--jq",
-        '[.check_runs[] | select(.name == "test")] | if length == 0 then "pending" else .[0].conclusion // .[0].status end',
+    ] in commands
+    assert [
+        "gh",
+        "api",
+        "repos/OWNER/REPO/commits/abc123/status",
+    ] in commands
+    assert [
+        "gh",
+        "api",
+        "repos/OWNER/REPO/branches/main/protection/required_status_checks",
     ] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
 
@@ -1730,6 +1797,10 @@ def test_review_prompt_includes_pr_metadata_and_suggested_commands(tmp_path):
     assert "requires confirmation in non-interactive mode" in prompt
     assert "write them outside the repository checkout" in prompt
     assert "/tmp/coding-review-agent-loop/scratch/" in prompt
+    assert "GitHub PR checks:" in prompt
+    assert "- Overall state: passing" in prompt
+    assert "- Required checks: test" in prompt
+    assert "Do not say or imply that tests passed globally unless the GitHub PR checks" in prompt
     assert "ignore approved-review follow-up sections" in prompt
     assert "### Future follow-ups" not in prompt
     assert "legacy heading `### Non-blocking follow-ups`" not in prompt
@@ -1771,6 +1842,132 @@ def test_review_prompt_includes_signed_human_requirements(tmp_path):
     assert "Signed human reviewer requirements override AI reviewer preferences" in prompt
     assert "Verify every signed human reviewer requirement before approving." in prompt
     assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in prompt
+
+
+def test_pr_loop_routes_failing_github_checks_through_coder_followup(tmp_path, monkeypatch):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Still failing upstream.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Investigated CI.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(tmp_path, max_rounds=2)
+    check_states = iter(
+        [
+            {
+                "check_runs": [
+                    {"name": "tests/test_server.py", "status": "completed", "conclusion": "success"},
+                    {"name": "tests/test_security.py", "status": "completed", "conclusion": "failure"},
+                ]
+            },
+            {"check_runs": [{"name": "test", "status": "completed", "conclusion": "success"}]},
+        ]
+    )
+
+    def advance_checks(*_args, **_kwargs):
+        runner.pr_check_runs_payload = next(check_states)
+        return original_get_pr_checks(*_args, **_kwargs)
+
+    from coding_review_agent_loop import orchestrator as orchestrator_module
+
+    original_get_pr_checks = orchestrator_module.get_pr_checks
+    monkeypatch.setattr(orchestrator_module, "get_pr_checks", advance_checks)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert any(
+        comment.startswith("GitHub PR checks are failing for PR #77.") for comment in runner.comments
+    )
+    followup_prompt = next(
+        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "GitHub PR checks review:" in cmd[-1]
+    )
+    assert "Failing checks: tests/test_security.py (failure)" in followup_prompt
+    assert "Do not claim global test success unless GitHub PR checks are green." in followup_prompt
+
+
+def test_pr_loop_blocks_final_approval_when_github_checks_pending(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["Looks good locally.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="GitHub PR checks for PR #77 are pending"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert any(
+        comment.startswith("GitHub PR checks are still pending for PR #77.")
+        for comment in runner.comments
+    )
+
+
+def test_pr_loop_allows_repos_without_github_checks_when_branch_protection_404(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_returncode=404,
+        pr_branch_protection_stderr="404 Not Found",
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert not any(comment.startswith("GitHub PR checks are") for comment in runner.comments)
+
+
+def test_pr_loop_allows_repos_without_github_checks_when_branch_protection_403(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_returncode=403,
+        pr_branch_protection_stderr="403 Forbidden",
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert not any(comment.startswith("GitHub PR checks are") for comment in runner.comments)
+
+
+def test_review_prompt_includes_failing_github_check_status(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["Blocking.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"],
+        pr_check_runs_payload={
+            "check_runs": [
+                {"name": "tests/test_security.py", "status": "completed", "conclusion": "failure"}
+            ]
+        },
+        pr_branch_protection_payload={"contexts": ["tests/test_security.py"]},
+    )
+    config = make_config(tmp_path, max_rounds=1)
+
+    with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "GitHub PR checks:" in prompt
+    assert "- Overall state: failing" in prompt
+    assert "- Failing checks: tests/test_security.py (failure)" in prompt
+
+
+def test_review_prompt_mentions_branch_protection_forbidden_when_checks_exist(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_check_runs_payload={
+            "check_runs": [{"name": "test", "status": "completed", "conclusion": "success"}]
+        },
+        pr_branch_protection_returncode=403,
+        pr_branch_protection_stderr="403 Forbidden",
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Current GitHub token cannot inspect branch protection on the PR base branch." in prompt
 
 
 def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):


### PR DESCRIPTION
Closes #113

## Summary
- add structured GitHub PR check/status inspection, including branch protection fallback handling for 403 and 404
- feed current PR check state into reviewer prompts and block merge-ready outcomes when CI is failing, pending, or unavailable
- add regression coverage for failing, pending, no-checks, and branch-protection fallback scenarios

## Testing
- python3 -m pytest -q