### PR TITLE
Preserve approved follow-ups when CI is still pending

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -59,6 +59,7 @@ class HumanReviewRequirement:
 @dataclass(frozen=True)
 class PullRequestReviewContext:
     metadata: PullRequestMetadata
+    comments: tuple[IssueComment, ...]
     human_requirements: tuple[HumanReviewRequirement, ...]
 
 
@@ -166,6 +167,7 @@ def get_pr_review_context(
                 head_sha=None,
                 url=None,
             ),
+            comments=(),
             human_requirements=(),
         )
 
@@ -183,10 +185,29 @@ def get_pr_review_context(
         cwd=active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
+    comments = _parse_issue_comments(data.get("comments"))
     return PullRequestReviewContext(
         metadata=_parse_pr_metadata(data, config=config, pr_number=pr_number),
+        comments=comments,
         human_requirements=_parse_pr_human_requirements(data),
     )
+
+
+def _parse_issue_comments(raw_comments: object) -> tuple[IssueComment, ...]:
+    comments: list[IssueComment] = []
+    if not isinstance(raw_comments, list):
+        return ()
+    for raw_comment in raw_comments:
+        if not isinstance(raw_comment, dict):
+            continue
+        comments.append(
+            IssueComment(
+                author=_author_login(raw_comment.get("author")),
+                created_at=raw_comment.get("createdAt") or raw_comment.get("created_at"),
+                body=_optional_str(raw_comment.get("body")),
+            )
+        )
+    return tuple(sorted(comments, key=_comment_sort_key))
 
 
 def _normalize_check_run_status(raw_run: object) -> str:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -344,6 +344,7 @@ def _append_approved_followups_marker(
     prefix, found, _suffix = body.rpartition(footer)
     if not found:
         return body
+    prefix = prefix.rstrip()
     return "\n".join(
         [
             prefix,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -61,6 +61,10 @@ from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
 
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
+APPROVED_FOLLOWUP_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_APPROVED_FOLLOWUPS:\s*pr=(?P<pr>\d+)\s+head=(?P<head>\S+)\s+mode=(?P<mode>[a-z-]+)\s*-->",
+    re.I,
+)
 
 TRANSIENT_AGENT_OUTPUT_RE = re.compile(
     r"Invalid stream|empty response|malformed tool call|"
@@ -324,6 +328,54 @@ def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFo
     return "\n".join(lines)
 
 
+def _approved_followups_marker(pr_number: int, head_sha: str | None, mode: str) -> str:
+    head = head_sha or "unknown"
+    return f"<!-- AGENT_APPROVED_FOLLOWUPS: pr={pr_number} head={head} mode={mode} -->"
+
+
+def _append_approved_followups_marker(
+    body: str,
+    *,
+    pr_number: int,
+    head_sha: str | None,
+    mode: str,
+) -> str:
+    footer = "\n-- coding-review-agent-loop"
+    prefix, found, _suffix = body.rpartition(footer)
+    if not found:
+        return body
+    return "\n".join(
+        [
+            prefix,
+            "",
+            _approved_followups_marker(pr_number, head_sha, mode),
+            "-- coding-review-agent-loop",
+        ]
+    )
+
+
+def _has_approved_followups_marker(
+    comments: Sequence[object],
+    *,
+    pr_number: int,
+    head_sha: str | None,
+    mode: str,
+) -> bool:
+    target_head = head_sha or "unknown"
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in APPROVED_FOLLOWUP_MARKER_RE.finditer(body):
+            if (
+                int(match.group("pr")) == pr_number
+                and match.group("head") == target_head
+                and match.group("mode").lower() == mode.lower()
+            ):
+                return True
+    return False
+
+
 def _followup_issue_title(followup: ApprovedFollowup) -> str:
     text = " ".join(followup.text.split())
     title = f"Follow up future review note: {text}"
@@ -455,6 +507,73 @@ def _format_created_followup_issue_summary(
         )
     lines.extend(["", "-- coding-review-agent-loop"])
     return "\n".join(lines)
+
+
+def _publish_approved_followups(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    head_sha: str | None,
+    pr_comments: Sequence[object],
+    followups: list[ApprovedFollowup],
+) -> bool:
+    if not followups or config.approved_followups == "ignore":
+        return False
+
+    if config.approved_followups in ("summarize", "fix-and-summarize"):
+        mode = "summarize"
+        if _has_approved_followups_marker(
+            pr_comments,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            mode=mode,
+        ):
+            log(
+                config,
+                f"Approved-review future follow-ups already recorded for PR #{pr_number} at {head_sha or 'unknown'} ({mode})",
+            )
+            return False
+        body = _format_approved_followup_summary(pr_number, followups)
+        body = _append_approved_followups_marker(
+            body,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            mode=mode,
+        )
+        post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+        return True
+
+    if config.approved_followups in ("issue", "fix-and-issue"):
+        mode = "issue"
+        if _has_approved_followups_marker(
+            pr_comments,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            mode=mode,
+        ):
+            log(
+                config,
+                f"Approved-review future follow-ups already recorded for PR #{pr_number} at {head_sha or 'unknown'} ({mode})",
+            )
+            return False
+        issue_urls, skipped_count = _create_approved_followup_issues(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            followups=followups,
+        )
+        if issue_urls:
+            body = _format_created_followup_issue_summary(pr_number, issue_urls, skipped_count)
+            body = _append_approved_followups_marker(
+                body,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                mode=mode,
+            )
+            post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+            return True
+    return False
 
 
 def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
@@ -894,6 +1013,7 @@ def run_pr_loop(
                 pre_review_test_pending = False
             pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
             pr_metadata = pr_context.metadata
+            pr_comments = pr_context.comments
             human_requirements = pr_context.human_requirements
             pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
             for reviewer in configured_reviewers:
@@ -980,6 +1100,15 @@ def run_pr_loop(
                         ("Alembic migration validation", migration_validation.message or "")
                     )
                 if not blocking_reviews:
+                    if pr_checks.state in {"pending", "unavailable"}:
+                        _publish_approved_followups(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=round_future_followups,
+                        )
                     if pr_checks.state in {"failing", "pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)
                         post_pr_comment(
@@ -1005,25 +1134,14 @@ def run_pr_loop(
                                 "wait for CI or investigate GitHub API access before treating the PR as approved."
                             )
                 if not blocking_reviews:
-                    approved_followups = round_future_followups
-                    if (
-                        config.approved_followups in ("summarize", "fix-and-summarize")
-                        and approved_followups
-                    ):
-                        body = _format_approved_followup_summary(pr_number, approved_followups)
-                        post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-                    elif config.approved_followups in ("issue", "fix-and-issue") and approved_followups:
-                        issue_urls, skipped_count = _create_approved_followup_issues(
-                            runner,
-                            config=config,
-                            pr_number=pr_number,
-                            followups=approved_followups,
-                        )
-                        if issue_urls:
-                            body = _format_created_followup_issue_summary(
-                                pr_number, issue_urls, skipped_count
-                            )
-                            post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+                    _publish_approved_followups(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        head_sha=pr_metadata.head_sha,
+                        pr_comments=pr_comments,
+                        followups=round_future_followups,
+                    )
                     run_optional_tests(runner, config)
                     if config.auto_merge:
                         wait_for_ci(runner, config, pr_number)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2048,6 +2048,25 @@ def test_pr_loop_summarizes_approved_followups_before_pending_check_exit(tmp_pat
     assert runner.comments[2].startswith("GitHub PR checks are still pending for PR #77.")
 
 
+def test_pr_loop_summary_marker_has_single_blank_line_before_footer_marker(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Looks good locally.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+    )
+    config = make_config(tmp_path, approved_followups="summarize")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    summary = runner.comments[-1]
+    assert (
+        "These were mentioned in approved reviews as future work and did not block merge readiness.\n\n"
+        "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=summarize -->\n"
+        "-- coding-review-agent-loop"
+    ) in summary
+
+
 def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_exit(tmp_path):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2026,6 +2026,88 @@ def test_pr_loop_blocks_final_approval_when_github_checks_pending(tmp_path):
     )
 
 
+def test_pr_loop_summarizes_approved_followups_before_pending_check_exit(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Looks good locally.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, approved_followups="summarize")
+
+    with pytest.raises(AgentLoopError, match="GitHub PR checks for PR #77 are pending"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(runner.comments) == 3
+    assert runner.comments[1].startswith("Approved-review future follow-ups for PR #77:")
+    assert "- Add cleanup docs. (Codex)" in runner.comments[1]
+    assert "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=summarize -->" in runner.comments[1]
+    assert runner.comments[2].startswith("GitHub PR checks are still pending for PR #77.")
+
+
+def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_exit(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Looks good locally.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        pr_check_runs_payload={"check_runs": []},
+        pr_branch_protection_returncode=1,
+        pr_branch_protection_stderr="500 Internal Server Error",
+        pr_check_runs_returncode=1,
+        pr_check_runs_stderr="500 Internal Server Error",
+        pr_status_returncode=1,
+        pr_status_stderr="500 Internal Server Error",
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    with pytest.raises(AgentLoopError, match="GitHub PR checks for PR #77 are unavailable"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "Follow up future review note: Add cleanup docs."
+    assert len(runner.comments) == 3
+    assert runner.comments[1].startswith("Created approved-review future follow-up issues for PR #77:")
+    assert "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=issue -->" in runner.comments[1]
+    assert runner.comments[2].startswith("GitHub PR check status is unavailable for PR #77.")
+
+
+def test_pr_loop_skips_duplicate_approved_followup_issue_creation_when_marker_exists(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        pr_payload={
+            "comments": [
+                {
+                    "author": {"login": "coding-review-agent-loop"},
+                    "createdAt": "2026-05-22T10:00:00Z",
+                    "body": (
+                        "Created approved-review future follow-up issues for PR #77:\n\n"
+                        "- https://github.com/OWNER/REPO/issues/99\n\n"
+                        "These were mentioned in approved reviews as future work and did not block merge readiness.\n\n"
+                        "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=issue -->\n"
+                        "-- coding-review-agent-loop"
+                    ),
+                }
+            ]
+        },
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.issues == []
+    assert runner.comments == [
+        "Codex approves.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+        "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    ]
+
+
 def test_pr_loop_allows_repos_without_github_checks_when_branch_protection_404(tmp_path):
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],


### PR DESCRIPTION
## Summary
- preserve approved-review future follow-ups before the pending/unavailable PR-check gate exits the run
- add a hidden PR-comment marker keyed by PR/head SHA/mode so reruns do not duplicate summaries or follow-up issues
- expose PR comments in review context and add regression coverage for pending, unavailable, and rerun idempotency

Closes #116
