### PR TITLE
Track unresolved review items across review rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,11 @@ include small, localized, low-risk current-PR cleanup under:
 Same-PR follow-ups are sent back to the coder in the existing PR and require a
 new review round. They should stay narrowly scoped to files already touched by
 the PR or directly adjacent code; larger redesigns and independent work belong
-under Future follow-ups. After same-PR follow-ups trigger another round, only
-future follow-ups restated in the final approval round are summarized or turned
-into issues. The issue modes create at most three follow-up issues to avoid
-issue noise.
+under Future follow-ups. Approved future follow-ups remain in the round-to-round
+ledger so later reviewers can explicitly confirm they are still future work,
+resolved, or should be promoted back to same-PR or blocking status. The final
+summary or issue creation uses the remaining future items from that ledger. The
+issue modes create at most three follow-up issues to avoid issue noise.
 
 By default, `--approved-followups=ignore` asks reviewers not to include
 approved-review follow-up sections. Reviewers should mark the review blocking

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -427,10 +427,12 @@ under:
 Same-PR follow-ups are sent back to the coder in the existing PR and require a
 new review round. They should stay narrowly scoped to files already touched by
 the PR or directly adjacent code; larger redesigns and independent work belong
-under Future follow-ups. After same-PR follow-ups trigger another round, only
-future follow-ups restated in the final approval round are summarized or turned
-into issues. Without a `fix-and-*` mode, reviewers should mark same-PR cleanup
-blocking instead.
+under Future follow-ups. Approved future follow-ups remain in the round-to-round
+ledger so later reviewers can explicitly confirm they are still future work,
+resolved, or should be promoted back to same-PR or blocking status. The final
+summary or issue creation uses the remaining future items from that ledger.
+Without a `fix-and-*` mode, reviewers should mark same-PR cleanup blocking
+instead.
 
 By default, `--approved-followups=ignore` asks reviewers not to include these
 sections. Reviewers should mark the review blocking instead when cleanup should

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -690,6 +690,17 @@ def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
     return "\n".join(lines).strip()
 
 
+def _format_same_pr_unresolved_items(items: Sequence[UnresolvedReviewItem]) -> str:
+    lines: list[str] = []
+    for item in items:
+        lines.append(
+            f"{item.reviewer} same-PR follow-up [{item.item_id}] from round {item.source_round}:"
+        )
+        lines.append(f"- {item.text}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
 def _format_unresolved_items_for_coder(items: Sequence[UnresolvedReviewItem]) -> str:
     lines: list[str] = []
     for item in items:
@@ -1115,6 +1126,7 @@ def run_pr_loop(
         reviewer_session_ids: dict[AgentName, str | None] = {}
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
+        carried_future_followups: list[ApprovedFollowup] = []
         next_unresolved_item_number = 1
         if reviewer_session_id is not None and configured_reviewers:
             # Backward-compatible single-reviewer resume support: older callers
@@ -1230,7 +1242,8 @@ def run_pr_loop(
                 prior_dispositions,
             )
             unresolved_items = [*carried_unresolved_items, *round_new_unresolved_items]
-            round_future_followups.extend(downgraded_future_followups)
+            carried_future_followups.extend(downgraded_future_followups)
+            all_future_followups = [*carried_future_followups, *round_future_followups]
 
             if not unresolved_items:
                 if human_requirements:
@@ -1273,7 +1286,7 @@ def run_pr_loop(
                             pr_number=pr_number,
                             head_sha=pr_metadata.head_sha,
                             pr_comments=pr_comments,
-                            followups=round_future_followups,
+                            followups=all_future_followups,
                         )
                     if pr_checks.state in {"failing", "pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)
@@ -1310,7 +1323,7 @@ def run_pr_loop(
                         pr_number=pr_number,
                         head_sha=pr_metadata.head_sha,
                         pr_comments=pr_comments,
-                        followups=round_future_followups,
+                        followups=all_future_followups,
                     )
                     run_optional_tests(runner, config)
                     if config.auto_merge:
@@ -1324,14 +1337,10 @@ def run_pr_loop(
                     "human review required."
                 )
 
-            same_pr_followups = [
-                ApprovedFollowup(reviewer=item.reviewer, text=item.text)
-                for item in unresolved_items
-                if item.status == "same-pr"
-            ]
+            same_pr_items = [item for item in unresolved_items if item.status == "same-pr"]
             blocking_items = [item for item in unresolved_items if item.status == "blocking"]
-            if same_pr_followups and not blocking_items:
-                combined_review = _format_same_pr_followups(same_pr_followups)
+            if same_pr_items and not blocking_items:
+                combined_review = _format_same_pr_unresolved_items(same_pr_items)
                 followup_prompt = build_same_pr_followup_prompt(
                     pr_number,
                     round_number,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -360,20 +360,26 @@ def _apply_unresolved_item_dispositions(
         if not dispositions:
             next_unresolved.append(item)
             continue
+        text = item.text
         notes = list(item.notes)
+        outcomes = {disposition.disposition for disposition in dispositions}
+        preserve_note_in_text = bool({"blocking", "same-pr"} & outcomes)
         for disposition in dispositions:
             if disposition.note:
                 note_text = f"{disposition.reviewer}: {disposition.note}"
+                if preserve_note_in_text:
+                    update_line = f"Update from {note_text}"
+                    if update_line not in text:
+                        text = f"{text.rstrip()}\n\n{update_line}"
                 if note_text not in notes:
                     notes.append(note_text)
-        outcomes = {disposition.disposition for disposition in dispositions}
         if "blocking" in outcomes:
             next_unresolved.append(
                 UnresolvedReviewItem(
                     item_id=item.item_id,
                     reviewer=item.reviewer,
                     source_round=item.source_round,
-                    text=item.text,
+                    text=text,
                     status="blocking",
                     notes=tuple(notes),
                 )
@@ -385,7 +391,7 @@ def _apply_unresolved_item_dispositions(
                     item_id=item.item_id,
                     reviewer=item.reviewer,
                     source_round=item.source_round,
-                    text=item.text,
+                    text=text,
                     status="same-pr",
                     notes=tuple(notes),
                 )
@@ -397,7 +403,7 @@ def _apply_unresolved_item_dispositions(
                     item_id=item.item_id,
                     reviewer=item.reviewer,
                     source_round=item.source_round,
-                    text=item.text,
+                    text=text,
                     status="future",
                     notes=tuple(notes),
                 )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -49,6 +49,10 @@ from .prompts import (
     format_agent_list,
 )
 from .protocol import (
+    FUTURE_FOLLOWUP_HEADING_RE,
+    LEGACY_FOLLOWUP_HEADING_RE,
+    PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
+    SAME_PR_FOLLOWUP_HEADING_RE,
     ParsedReview,
     ReviewItemDisposition,
     UnresolvedReviewItem,
@@ -297,21 +301,6 @@ class GroupedApprovedFollowup:
         return tuple(reviewers)
 
 
-def _review_summary_text(review: str) -> str:
-    lines: list[str] = []
-    for line in review.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            lines.append("")
-            continue
-        if stripped.startswith("<!--") and stripped.endswith("-->"):
-            continue
-        if stripped.startswith("-- "):
-            continue
-        lines.append(line.rstrip())
-    return "\n".join(lines).strip()
-
-
 def _next_unresolved_item(
     *,
     item_number: int,
@@ -319,6 +308,7 @@ def _next_unresolved_item(
     source_round: int,
     text: str,
     status: str,
+    notes: Sequence[str] = (),
 ) -> UnresolvedReviewItem:
     return UnresolvedReviewItem(
         item_id=f"item-{item_number}",
@@ -326,6 +316,7 @@ def _next_unresolved_item(
         source_round=source_round,
         text=text,
         status=status,
+        notes=tuple(notes),
     )
 
 
@@ -362,14 +353,19 @@ def _validate_review_response(
 def _apply_unresolved_item_dispositions(
     unresolved_items: Sequence[UnresolvedReviewItem],
     dispositions_by_item: dict[str, list[ReviewItemDisposition]],
-) -> tuple[list[UnresolvedReviewItem], list[ApprovedFollowup]]:
+) -> list[UnresolvedReviewItem]:
     next_unresolved: list[UnresolvedReviewItem] = []
-    downgraded_future: list[ApprovedFollowup] = []
     for item in unresolved_items:
         dispositions = dispositions_by_item.get(item.item_id, [])
         if not dispositions:
             next_unresolved.append(item)
             continue
+        notes = list(item.notes)
+        for disposition in dispositions:
+            if disposition.note:
+                note_text = f"{disposition.reviewer}: {disposition.note}"
+                if note_text not in notes:
+                    notes.append(note_text)
         outcomes = {disposition.disposition for disposition in dispositions}
         if "blocking" in outcomes:
             next_unresolved.append(
@@ -379,6 +375,7 @@ def _apply_unresolved_item_dispositions(
                     source_round=item.source_round,
                     text=item.text,
                     status="blocking",
+                    notes=tuple(notes),
                 )
             )
             continue
@@ -390,12 +387,62 @@ def _apply_unresolved_item_dispositions(
                     source_round=item.source_round,
                     text=item.text,
                     status="same-pr",
+                    notes=tuple(notes),
                 )
             )
             continue
         if "future" in outcomes:
-            downgraded_future.append(ApprovedFollowup(reviewer=item.reviewer, text=item.text))
-    return next_unresolved, downgraded_future
+            next_unresolved.append(
+                UnresolvedReviewItem(
+                    item_id=item.item_id,
+                    reviewer=item.reviewer,
+                    source_round=item.source_round,
+                    text=item.text,
+                    status="future",
+                    notes=tuple(notes),
+                )
+            )
+    return next_unresolved
+
+
+def _review_freeform_summary_text(text: str) -> str:
+    lines: list[str] = []
+    skip_structured_section = False
+    structured_heading_res = (
+        SAME_PR_FOLLOWUP_HEADING_RE,
+        FUTURE_FOLLOWUP_HEADING_RE,
+        LEGACY_FOLLOWUP_HEADING_RE,
+        PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
+    )
+    for line in text.splitlines():
+        stripped = line.strip()
+        if any(pattern.match(line) for pattern in structured_heading_res):
+            skip_structured_section = True
+            continue
+        if skip_structured_section and stripped.startswith("### "):
+            skip_structured_section = False
+        if skip_structured_section:
+            continue
+        if not stripped:
+            lines.append("")
+            continue
+        if stripped.startswith("<!--") and stripped.endswith("-->"):
+            continue
+        if stripped.startswith("-- "):
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines).strip()
+
+
+def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
+    if not summary:
+        return False
+    if not had_prior_items or not had_dispositions:
+        return True
+    non_empty_lines = [line.strip() for line in summary.splitlines() if line.strip()]
+    if len(non_empty_lines) > 1:
+        return True
+    return len(non_empty_lines[0]) >= 80
 
 
 def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
@@ -697,6 +744,9 @@ def _format_same_pr_unresolved_items(items: Sequence[UnresolvedReviewItem]) -> s
             f"{item.reviewer} same-PR follow-up [{item.item_id}] from round {item.source_round}:"
         )
         lines.append(f"- {item.text}")
+        if item.notes:
+            lines.append("Latest reviewer updates:")
+            lines.extend(f"- {note}" for note in item.notes)
         lines.append("")
     return "\n".join(lines).strip()
 
@@ -708,6 +758,9 @@ def _format_unresolved_items_for_coder(items: Sequence[UnresolvedReviewItem]) ->
             f"{item.reviewer} unresolved {item.status} item [{item.item_id}] from round {item.source_round}:"
         )
         lines.append(f"- {item.text}")
+        if item.notes:
+            lines.append("Latest reviewer updates:")
+            lines.extend(f"- {note}" for note in item.notes)
         lines.append("")
     return "\n".join(lines).strip()
 
@@ -1126,7 +1179,6 @@ def run_pr_loop(
         reviewer_session_ids: dict[AgentName, str | None] = {}
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
-        carried_future_followups: list[ApprovedFollowup] = []
         next_unresolved_item_number = 1
         if reviewer_session_id is not None and configured_reviewers:
             # Backward-compatible single-reviewer resume support: older callers
@@ -1139,7 +1191,6 @@ def run_pr_loop(
                 item.item_id: [] for item in prior_unresolved_items
             }
             round_new_unresolved_items: list[UnresolvedReviewItem] = []
-            round_future_followups: list[ApprovedFollowup] = []
             approved_review_outputs: list[tuple[str, str]] = []
             if pre_review_test_pending:
                 run_pre_review_tests(runner, config)
@@ -1189,21 +1240,37 @@ def run_pr_loop(
                 for disposition in parsed_review.dispositions:
                     prior_dispositions[disposition.item_id].append(disposition)
                 if review_state == "blocking":
-                    round_new_unresolved_items.append(
-                        _next_unresolved_item(
-                            item_number=next_unresolved_item_number,
-                            reviewer=reviewer_name,
-                            source_round=round_number,
-                            text=_review_summary_text(review_output) or "Blocking review requires follow-up.",
-                            status="blocking",
+                    blocking_summary = _review_freeform_summary_text(review_output)
+                    if _should_record_new_blocking_item(
+                        blocking_summary,
+                        had_prior_items=bool(prior_unresolved_items),
+                        had_dispositions=bool(parsed_review.dispositions),
+                    ):
+                        round_new_unresolved_items.append(
+                            _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer=reviewer_name,
+                                source_round=round_number,
+                                text=blocking_summary,
+                                status="blocking",
+                            )
                         )
-                    )
-                    next_unresolved_item_number += 1
+                        next_unresolved_item_number += 1
                     continue
 
                 approved_review_outputs.append((reviewer_name, review_output))
                 if config.approved_followups != "ignore":
-                    round_future_followups.extend(parsed_review.followups.future)
+                    for followup in parsed_review.followups.future:
+                        round_new_unresolved_items.append(
+                            _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer=followup.reviewer,
+                                source_round=round_number,
+                                text=followup.text,
+                                status="future",
+                            )
+                        )
+                        next_unresolved_item_number += 1
                     if parsed_review.followups.same_pr:
                         if config.approved_followups.startswith("fix-and-"):
                             for followup in parsed_review.followups.same_pr:
@@ -1237,15 +1304,19 @@ def run_pr_loop(
                             )
                             next_unresolved_item_number += 1
 
-            carried_unresolved_items, downgraded_future_followups = _apply_unresolved_item_dispositions(
+            unresolved_items = _apply_unresolved_item_dispositions(
                 prior_unresolved_items,
                 prior_dispositions,
             )
-            unresolved_items = [*carried_unresolved_items, *round_new_unresolved_items]
-            carried_future_followups.extend(downgraded_future_followups)
-            all_future_followups = [*carried_future_followups, *round_future_followups]
+            unresolved_items = [*unresolved_items, *round_new_unresolved_items]
+            future_followups = [
+                ApprovedFollowup(reviewer=item.reviewer, text=item.text)
+                for item in unresolved_items
+                if item.status == "future"
+            ]
+            must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
 
-            if not unresolved_items:
+            if not must_fix_items:
                 if human_requirements:
                     missing_acknowledgements = [
                         reviewer_name
@@ -1278,7 +1349,8 @@ def run_pr_loop(
                         )
                     )
                     next_unresolved_item_number += 1
-                if not unresolved_items:
+                    must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
+                if not must_fix_items:
                     if pr_checks.state in {"pending", "unavailable"}:
                         _publish_approved_followups(
                             runner,
@@ -1286,7 +1358,7 @@ def run_pr_loop(
                             pr_number=pr_number,
                             head_sha=pr_metadata.head_sha,
                             pr_comments=pr_comments,
-                            followups=all_future_followups,
+                            followups=future_followups,
                         )
                     if pr_checks.state in {"failing", "pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)
@@ -1311,19 +1383,22 @@ def run_pr_loop(
                                 )
                             )
                             next_unresolved_item_number += 1
+                            must_fix_items = [
+                                item for item in unresolved_items if item.status in {"blocking", "same-pr"}
+                            ]
                         else:
                             raise AgentLoopError(
                                 f"GitHub PR checks for PR #{pr_number} are {pr_checks.state}; "
                                 "wait for CI or investigate GitHub API access before treating the PR as approved."
                             )
-                if not unresolved_items:
+                if not must_fix_items:
                     _publish_approved_followups(
                         runner,
                         config=config,
                         pr_number=pr_number,
                         head_sha=pr_metadata.head_sha,
                         pr_comments=pr_comments,
-                        followups=all_future_followups,
+                        followups=future_followups,
                     )
                     run_optional_tests(runner, config)
                     if config.auto_merge:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -49,13 +49,16 @@ from .prompts import (
     format_agent_list,
 )
 from .protocol import (
+    ParsedReview,
+    ReviewItemDisposition,
+    UnresolvedReviewItem,
     human_requirements_resolved,
     is_clarification_request,
     parse_agent_state,
     parse_plan_state,
     parse_pr_number,
 )
-from .protocol import ApprovedFollowup, parse_approved_followups
+from .protocol import ApprovedFollowup, parse_review
 from .runner import Runner
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
@@ -292,6 +295,107 @@ class GroupedApprovedFollowup:
             if item.reviewer not in reviewers:
                 reviewers.append(item.reviewer)
         return tuple(reviewers)
+
+
+def _review_summary_text(review: str) -> str:
+    lines: list[str] = []
+    for line in review.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            lines.append("")
+            continue
+        if stripped.startswith("<!--") and stripped.endswith("-->"):
+            continue
+        if stripped.startswith("-- "):
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines).strip()
+
+
+def _next_unresolved_item(
+    *,
+    item_number: int,
+    reviewer: str,
+    source_round: int,
+    text: str,
+    status: str,
+) -> UnresolvedReviewItem:
+    return UnresolvedReviewItem(
+        item_id=f"item-{item_number}",
+        reviewer=reviewer,
+        source_round=source_round,
+        text=text,
+        status=status,
+    )
+
+
+def _validate_review_response(
+    text: str,
+    *,
+    reviewer: str,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+) -> ParsedReview:
+    parsed = parse_review(text, reviewer=reviewer)
+    if not unresolved_items:
+        return parsed
+
+    unresolved_by_id = {item.item_id: item for item in unresolved_items}
+    disposition_ids = [item.item_id for item in parsed.dispositions]
+    duplicates = sorted({item_id for item_id in disposition_ids if disposition_ids.count(item_id) > 1})
+    if duplicates:
+        raise AgentLoopError(
+            "Review listed prior unresolved items more than once: " + ", ".join(duplicates)
+        )
+    unknown = sorted(set(disposition_ids) - set(unresolved_by_id))
+    if unknown:
+        raise AgentLoopError(
+            "Review referenced unknown prior unresolved item IDs: " + ", ".join(unknown)
+        )
+    missing = sorted(set(unresolved_by_id) - set(disposition_ids))
+    if missing:
+        raise AgentLoopError(
+            "Review did not evaluate all prior unresolved items: " + ", ".join(missing)
+        )
+    return parsed
+
+
+def _apply_unresolved_item_dispositions(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    dispositions_by_item: dict[str, list[ReviewItemDisposition]],
+) -> tuple[list[UnresolvedReviewItem], list[ApprovedFollowup]]:
+    next_unresolved: list[UnresolvedReviewItem] = []
+    downgraded_future: list[ApprovedFollowup] = []
+    for item in unresolved_items:
+        dispositions = dispositions_by_item.get(item.item_id, [])
+        if not dispositions:
+            next_unresolved.append(item)
+            continue
+        outcomes = {disposition.disposition for disposition in dispositions}
+        if "blocking" in outcomes:
+            next_unresolved.append(
+                UnresolvedReviewItem(
+                    item_id=item.item_id,
+                    reviewer=item.reviewer,
+                    source_round=item.source_round,
+                    text=item.text,
+                    status="blocking",
+                )
+            )
+            continue
+        if "same-pr" in outcomes:
+            next_unresolved.append(
+                UnresolvedReviewItem(
+                    item_id=item.item_id,
+                    reviewer=item.reviewer,
+                    source_round=item.source_round,
+                    text=item.text,
+                    status="same-pr",
+                )
+            )
+            continue
+        if "future" in outcomes:
+            downgraded_future.append(ApprovedFollowup(reviewer=item.reviewer, text=item.text))
+    return next_unresolved, downgraded_future
 
 
 def run_optional_tests(runner: Runner, config: AgentLoopConfig) -> None:
@@ -582,6 +686,17 @@ def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
     for followup in followups:
         lines.append(f"{followup.reviewer} same-PR follow-up:")
         lines.append(f"- {followup.text}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def _format_unresolved_items_for_coder(items: Sequence[UnresolvedReviewItem]) -> str:
+    lines: list[str] = []
+    for item in items:
+        lines.append(
+            f"{item.reviewer} unresolved {item.status} item [{item.item_id}] from round {item.source_round}:"
+        )
+        lines.append(f"- {item.text}")
         lines.append("")
     return "\n".join(lines).strip()
 
@@ -999,14 +1114,19 @@ def run_pr_loop(
         memory = prepare_agent_memory(runner, config)
         reviewer_session_ids: dict[AgentName, str | None] = {}
         configured_reviewers = reviewers(config)
+        unresolved_items: list[UnresolvedReviewItem] = []
+        next_unresolved_item_number = 1
         if reviewer_session_id is not None and configured_reviewers:
             # Backward-compatible single-reviewer resume support: older callers
             # pass one reviewer session, so attach it to the first configured reviewer.
             reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
         for round_number in range(1, config.max_rounds + 1):
             coder_name = agent_display_name(config.coder)
-            blocking_reviews: list[tuple[str, str]] = []
-            same_pr_followups: list[ApprovedFollowup] = []
+            prior_unresolved_items = tuple(unresolved_items)
+            prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
+                item.item_id: [] for item in prior_unresolved_items
+            }
+            round_new_unresolved_items: list[UnresolvedReviewItem] = []
             round_future_followups: list[ApprovedFollowup] = []
             approved_review_outputs: list[tuple[str, str]] = []
             if pre_review_test_pending:
@@ -1035,46 +1155,84 @@ def run_pr_loop(
                         memory=memory,
                         issue_context=issue_context,
                         human_requirements=human_requirements,
+                        unresolved_items=prior_unresolved_items,
                     ),
                     session_id=reviewer_session_ids.get(reviewer),
                     marker_description="<!-- AGENT_STATE: approved|blocking -->",
-                    validate=parse_agent_state,
+                    validate=lambda text, reviewer_name=reviewer_name, items=prior_unresolved_items: _validate_review_response(
+                        text,
+                        reviewer=reviewer_name,
+                        unresolved_items=items,
+                    ),
                     usage_context=usage_context,
                 )
                 review_output = review_response.text
                 reviewer_session_ids[reviewer] = review_response.session_id
-                review_state = str(review_response.marker_value)
+                parsed_review = review_response.marker_value
+                assert isinstance(parsed_review, ParsedReview)
+                review_state = parsed_review.state
 
                 post_pr_comment(runner, config=config, pr_number=pr_number, body=review_output)
                 log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
+                for disposition in parsed_review.dispositions:
+                    prior_dispositions[disposition.item_id].append(disposition)
                 if review_state == "blocking":
-                    blocking_reviews.append((reviewer_name, review_output))
+                    round_new_unresolved_items.append(
+                        _next_unresolved_item(
+                            item_number=next_unresolved_item_number,
+                            reviewer=reviewer_name,
+                            source_round=round_number,
+                            text=_review_summary_text(review_output) or "Blocking review requires follow-up.",
+                            status="blocking",
+                        )
+                    )
+                    next_unresolved_item_number += 1
                     continue
 
                 approved_review_outputs.append((reviewer_name, review_output))
                 if config.approved_followups != "ignore":
-                    followups = parse_approved_followups(review_output, reviewer=reviewer_name)
-                    round_future_followups.extend(followups.future)
-                    if followups.same_pr:
+                    round_future_followups.extend(parsed_review.followups.future)
+                    if parsed_review.followups.same_pr:
                         if config.approved_followups.startswith("fix-and-"):
-                            same_pr_followups.extend(followups.same_pr)
+                            for followup in parsed_review.followups.same_pr:
+                                round_new_unresolved_items.append(
+                                    _next_unresolved_item(
+                                        item_number=next_unresolved_item_number,
+                                        reviewer=followup.reviewer,
+                                        source_round=round_number,
+                                        text=followup.text,
+                                        status="same-pr",
+                                    )
+                                )
+                                next_unresolved_item_number += 1
                         else:
-                            blocking_reviews.append(
-                                (
-                                    reviewer_name,
-                                    "\n".join(
+                            round_new_unresolved_items.append(
+                                _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer=reviewer_name,
+                                    source_round=round_number,
+                                    text="\n".join(
                                         [
                                             "Approved review included Same-PR follow-ups, "
                                             f"but --approved-followups={config.approved_followups} "
                                             "does not enable a same-PR fix path.",
                                             "",
-                                            _format_same_pr_followups(followups.same_pr),
+                                            _format_same_pr_followups(parsed_review.followups.same_pr),
                                         ]
                                     ),
+                                    status="blocking",
                                 )
                             )
+                            next_unresolved_item_number += 1
 
-            if not blocking_reviews and not same_pr_followups:
+            carried_unresolved_items, downgraded_future_followups = _apply_unresolved_item_dispositions(
+                prior_unresolved_items,
+                prior_dispositions,
+            )
+            unresolved_items = [*carried_unresolved_items, *round_new_unresolved_items]
+            round_future_followups.extend(downgraded_future_followups)
+
+            if not unresolved_items:
                 if human_requirements:
                     missing_acknowledgements = [
                         reviewer_name
@@ -1097,10 +1255,17 @@ def run_pr_loop(
                 )
                 if not migration_validation.ok:
                     log(config, f"Round {round_number}: Alembic migration validation blocked approval")
-                    blocking_reviews.append(
-                        ("Alembic migration validation", migration_validation.message or "")
+                    unresolved_items.append(
+                        _next_unresolved_item(
+                            item_number=next_unresolved_item_number,
+                            reviewer="Alembic migration validation",
+                            source_round=round_number,
+                            text=migration_validation.message or "Migration validation failed.",
+                            status="blocking",
+                        )
                     )
-                if not blocking_reviews:
+                    next_unresolved_item_number += 1
+                if not unresolved_items:
                     if pr_checks.state in {"pending", "unavailable"}:
                         _publish_approved_followups(
                             runner,
@@ -1123,18 +1288,22 @@ def run_pr_loop(
                                 config,
                                 f"Round {round_number}: GitHub PR checks blocked approval ({pr_checks.state})",
                             )
-                            blocking_reviews.append(
-                                (
-                                    "GitHub PR checks",
-                                    _pr_check_blocking_review(pr_number, pr_checks.state, details),
+                            unresolved_items.append(
+                                _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer="GitHub PR checks",
+                                    source_round=round_number,
+                                    text=_pr_check_blocking_review(pr_number, pr_checks.state, details),
+                                    status="blocking",
                                 )
                             )
+                            next_unresolved_item_number += 1
                         else:
                             raise AgentLoopError(
                                 f"GitHub PR checks for PR #{pr_number} are {pr_checks.state}; "
                                 "wait for CI or investigate GitHub API access before treating the PR as approved."
                             )
-                if not blocking_reviews:
+                if not unresolved_items:
                     _publish_approved_followups(
                         runner,
                         config=config,
@@ -1155,7 +1324,13 @@ def run_pr_loop(
                     "human review required."
                 )
 
-            if same_pr_followups and not blocking_reviews:
+            same_pr_followups = [
+                ApprovedFollowup(reviewer=item.reviewer, text=item.text)
+                for item in unresolved_items
+                if item.status == "same-pr"
+            ]
+            blocking_items = [item for item in unresolved_items if item.status == "blocking"]
+            if same_pr_followups and not blocking_items:
                 combined_review = _format_same_pr_followups(same_pr_followups)
                 followup_prompt = build_same_pr_followup_prompt(
                     pr_number,
@@ -1167,18 +1342,7 @@ def run_pr_loop(
                     human_requirements=human_requirements,
                 )
             else:
-                # Discard future-work suggestions from non-final rounds so reviewers
-                # can restate still-relevant items after the PR has been updated.
-                if same_pr_followups:
-                    blocking_reviews.append(
-                        (
-                            "Approved same-PR follow-ups",
-                            _format_same_pr_followups(same_pr_followups),
-                        )
-                    )
-                combined_review = "\n\n".join(
-                    f"{name} review:\n\n{review}" for name, review in blocking_reviews
-                )
+                combined_review = _format_unresolved_items_for_coder(unresolved_items)
                 followup_prompt = build_followup_prompt(
                     pr_number,
                     round_number,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -262,10 +262,14 @@ def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewI
         "",
     ]
     for item in unresolved_items:
+        details = [indent(item.text, "  ")]
+        if item.notes:
+            details.append("  Latest reviewer updates:")
+            details.extend(f"  - {note}" for note in item.notes)
         lines.extend(
             [
                 f"- [{item.item_id}] {item.status} from {item.reviewer} in round {item.source_round}",
-                indent(item.text, "  "),
+                *details,
             ]
         )
     lines.append("")

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from textwrap import indent
 from typing import Sequence
 
 from .agents.base import AgentName
@@ -264,7 +265,7 @@ def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewI
         lines.extend(
             [
                 f"- [{item.item_id}] {item.status} from {item.reviewer} in round {item.source_round}",
-                f"  {item.text}",
+                indent(item.text, "  "),
             ]
         )
     lines.append("")

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -9,6 +9,7 @@ from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
+from .protocol import UnresolvedReviewItem
 
 
 def format_agent_list(agents: Sequence[AgentName]) -> str:
@@ -248,6 +249,26 @@ review must include exactly:
 
 If any signed human reviewer requirement is unresolved, return blocking.
 """
+
+
+def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewItem] | None) -> str:
+    if not unresolved_items:
+        return ""
+    lines = [
+        "Prior unresolved review items from earlier rounds",
+        "",
+        "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
+        "",
+    ]
+    for item in unresolved_items:
+        lines.extend(
+            [
+                f"- [{item.item_id}] {item.status} from {item.reviewer} in round {item.source_round}",
+                f"  {item.text}",
+            ]
+        )
+    lines.append("")
+    return "\n".join(lines)
 
 
 def format_pr_checks(checks: PullRequestChecks) -> str:
@@ -556,6 +577,7 @@ def build_review_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     human_requirements: Sequence[HumanReviewRequirement] | None = None,
+    unresolved_items: Sequence[UnresolvedReviewItem] | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
@@ -576,6 +598,22 @@ def build_review_prompt(
     url_line = f"- URL: {metadata.url}\n" if metadata.url else ""
     checks_block = f"{format_pr_checks(pr_checks)}\n" if pr_checks is not None else ""
     human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
+    unresolved_items_block = _format_unresolved_review_items(unresolved_items)
+    if unresolved_items:
+        unresolved_items_guidance = """Because prior unresolved items exist, include this exact section in your review:
+
+### Prior unresolved item dispositions
+
+Use one bullet per listed item and cover every item exactly once. Allowed forms:
+- [item-id] resolved
+- [item-id] still blocking
+- [item-id] same-pr
+- [item-id] future follow-up: brief reason
+
+Only use `future follow-up` when returning `approved`. If an item should still be fixed before merge, keep it as `still blocking` or `same-pr` instead of downgrading it.
+"""
+    else:
+        unresolved_items_guidance = ""
     if config.approved_followups == "ignore":
         followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
 Non-blocking follow-ups sections in approved reviews; this run is configured to
@@ -632,7 +670,7 @@ present in the PR diff.
 {_scratch_file_guidance()}
 {checks_block}{_issue_context_block(issue_context)}
 {_human_requirements_block(human_requirements)}
-{_memory_block(memory)}
+{unresolved_items_block}{_memory_block(memory)}
 
 Suggested commands:
 - {config.gh_cmd} pr view {metadata.number} --repo {metadata.repo} --json title,body,headRefName,baseRefName,headRefOid,comments,reviews
@@ -653,6 +691,7 @@ When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
 {human_requirements_guidance}
+{unresolved_items_guidance}
 {followup_guidance}
 Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -32,12 +32,27 @@ def _followup_heading_re(title: str) -> re.Pattern[str]:
 SAME_PR_FOLLOWUP_HEADING_RE = _followup_heading_re(r"same[- ]pr follow[- ]ups")
 FUTURE_FOLLOWUP_HEADING_RE = _followup_heading_re(r"future follow[- ]ups")
 LEGACY_FOLLOWUP_HEADING_RE = _followup_heading_re(r"non[- ]blocking follow[- ]ups")
+PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
+    r"prior unresolved item dispositions"
+)
 ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
 BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
 EMPTY_FOLLOWUP_RE = re.compile(
     r"^(?:none|n/a|no follow[- ]?ups?|no same[- ]pr follow[- ]?ups?|no future follow[- ]?ups?)\.?$",
+    re.I,
+)
+DISPOSITION_RE = re.compile(
+    r"^\s*\[?(?P<item_id>[A-Za-z0-9][A-Za-z0-9._-]*)\]?\s*"
+    r"(?:->|:)?\s*"
+    r"(?P<status>"
+    r"resolved|"
+    r"(?:still\s+)?blocking|"
+    r"(?:still\s+)?same[- ]pr|"
+    r"(?:downgraded\s+to\s+)?future follow[- ]up"
+    r")"
+    r"(?:\s*:\s*(?P<note>.+))?\s*$",
     re.I,
 )
 
@@ -52,6 +67,30 @@ class ApprovedFollowup:
 class ApprovedFollowups:
     same_pr: tuple[ApprovedFollowup, ...]
     future: tuple[ApprovedFollowup, ...]
+
+
+@dataclass(frozen=True)
+class ReviewItemDisposition:
+    item_id: str
+    reviewer: str
+    disposition: str
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class UnresolvedReviewItem:
+    item_id: str
+    reviewer: str
+    source_round: int
+    text: str
+    status: str
+
+
+@dataclass(frozen=True)
+class ParsedReview:
+    state: str
+    followups: ApprovedFollowups
+    dispositions: tuple[ReviewItemDisposition, ...]
 
 
 def parse_agent_state(text: str) -> str:
@@ -155,6 +194,78 @@ def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
 
     flush_current()
     return ApprovedFollowups(same_pr=tuple(same_pr), future=tuple(future))
+
+
+def _normalize_disposition(status: str) -> str:
+    normalized = " ".join(status.lower().split()).replace("same pr", "same-pr")
+    if normalized == "resolved":
+        return "resolved"
+    if normalized.endswith("blocking"):
+        return "blocking"
+    if normalized.endswith("same-pr"):
+        return "same-pr"
+    if normalized.endswith("future follow-up"):
+        return "future"
+    raise AgentLoopError(f"Unsupported unresolved item disposition: {status}")
+
+
+def parse_unresolved_item_dispositions(text: str, *, reviewer: str) -> tuple[ReviewItemDisposition, ...]:
+    """Extract structured prior-item dispositions from a review."""
+    dispositions: list[ReviewItemDisposition] = []
+    active = False
+
+    for line in text.splitlines():
+        if PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE.match(line):
+            active = True
+            continue
+        if not active:
+            continue
+        if ANY_HEADING_RE.match(line) or HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
+            active = False
+            continue
+        if not line.strip():
+            continue
+        bullet = BULLET_RE.match(line)
+        if not bullet:
+            raise AgentLoopError(
+                "Prior unresolved item dispositions must use one bullet per item, for example "
+                "`- [item-1] resolved`."
+            )
+        entry = bullet.group("text")
+        if EMPTY_FOLLOWUP_RE.match(entry):
+            continue
+        match = DISPOSITION_RE.match(entry)
+        if not match:
+            raise AgentLoopError(
+                "Invalid prior unresolved item disposition. Use bullets like "
+                "`- [item-1] resolved`, `- [item-2] still blocking`, "
+                "`- [item-3] same-pr`, or `- [item-4] future follow-up: reason`."
+            )
+        note = match.group("note")
+        dispositions.append(
+            ReviewItemDisposition(
+                item_id=match.group("item_id"),
+                reviewer=reviewer,
+                disposition=_normalize_disposition(match.group("status")),
+                note=note.strip() if note else None,
+            )
+        )
+
+    return tuple(dispositions)
+
+
+def parse_review(text: str, *, reviewer: str) -> ParsedReview:
+    """Parse a review, including state, follow-ups, and prior-item dispositions."""
+    state = parse_agent_state(text)
+    followups = parse_approved_followups(text, reviewer=reviewer)
+    dispositions = parse_unresolved_item_dispositions(text, reviewer=reviewer)
+    if state == "blocking" and followups.future:
+        raise AgentLoopError("Blocking reviews may not include Future follow-ups.")
+    if state == "blocking" and any(item.disposition == "future" for item in dispositions):
+        raise AgentLoopError(
+            "Blocking reviews may not downgrade prior unresolved items to Future follow-ups."
+        )
+    return ParsedReview(state=state, followups=followups, dispositions=dispositions)
 
 
 def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -227,10 +227,7 @@ def parse_unresolved_item_dispositions(text: str, *, reviewer: str) -> tuple[Rev
             continue
         bullet = BULLET_RE.match(line)
         if not bullet:
-            raise AgentLoopError(
-                "Prior unresolved item dispositions must use one bullet per item, for example "
-                "`- [item-1] resolved`."
-            )
+            continue
         entry = bullet.group("text")
         if EMPTY_FOLLOWUP_RE.match(entry):
             continue

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -84,6 +84,7 @@ class UnresolvedReviewItem:
     source_round: int
     text: str
     status: str
+    notes: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2888,7 +2888,10 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
             "- Add broader integration coverage later.\n"
             "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
             "Codex approves final pass."
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] future follow-up: still future work",
+                "[item-2] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Renamed helper.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -2913,22 +2916,22 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
 
     agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"])]
     assert agent_commands == [["codex", "exec"], ["claude", "--print"], ["codex", "exec"]]
-    assert len(runner.comments) == 3
+    assert len(runner.comments) == 4
     followup_prompt = next(
         cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Same-PR follow-ups" in cmd[-1]
     )
     assert "Rename the helper before merge." in followup_prompt
-    assert "[item-1]" in followup_prompt
+    assert "[item-2]" in followup_prompt
     assert "Issue context from GitHub" in followup_prompt
     assert "Title:\nSupport issue comments" in followup_prompt
     assert "Clarifying issue comment." in followup_prompt
     assert "small, localized cleanup for the\ncurrent PR" in followup_prompt
     assert "Keep the change narrowly scoped to the listed items" in followup_prompt
     assert "Do not take on\nlarger redesigns or unrelated future work" in followup_prompt
-    assert "Add broader integration coverage later." not in runner.comments[-1]
+    assert "Add broader integration coverage later." in runner.comments[-1]
 
 
-def test_pr_loop_fix_and_issue_ignores_future_followups_from_pre_fix_round(tmp_path):
+def test_pr_loop_fix_and_issue_persists_future_followups_from_pre_fix_round(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
             "Codex approves with cleanup.\n\n"
@@ -2938,7 +2941,10 @@ def test_pr_loop_fix_and_issue_ignores_future_followups_from_pre_fix_round(tmp_p
             "- Add a separate migration dry-run command.\n"
             "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
             "Codex approves final pass."
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] future follow-up: still separate work",
+                "[item-2] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -2947,9 +2953,10 @@ def test_pr_loop_fix_and_issue_ignores_future_followups_from_pre_fix_round(tmp_p
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    assert runner.issues == []
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "Follow up future review note: Add a separate migration dry-run command."
     commands = [cmd[:3] for cmd, _cwd in runner.commands]
-    assert commands.count(["gh", "issue", "create"]) == 0
+    assert commands.count(["gh", "issue", "create"]) == 1
 
 
 def test_pr_loop_fix_and_issue_uses_only_final_round_future_followups(tmp_path):
@@ -2964,7 +2971,10 @@ def test_pr_loop_fix_and_issue_uses_only_final_round_future_followups(tmp_path):
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add a separate migration dry-run command.\n"
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                "[item-2] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -2993,7 +3003,11 @@ def test_pr_loop_fix_and_summarize_uses_only_final_round_future_followups(tmp_pa
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add Codex's final follow-up later.\n"
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                "[item-2] resolved",
+                "[item-3] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=[
@@ -3004,7 +3018,11 @@ def test_pr_loop_fix_and_summarize_uses_only_final_round_future_followups(tmp_pa
             "Claude approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add Claude's final follow-up later.\n"
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                "[item-2] resolved",
+                "[item-3] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
         gemini_outputs=["Added assertion.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
@@ -3045,7 +3063,11 @@ def test_pr_loop_fix_and_issue_extracts_final_round_bullet_and_prose_future_foll
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Refine token estimation for large review prompts.\n"
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                "[item-2] resolved",
+                "[item-3] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=[
@@ -3059,7 +3081,11 @@ def test_pr_loop_fix_and_issue_extracts_final_round_bullet_and_prose_future_foll
             "in a future cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "No same-PR follow-ups.\n"
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                "[item-2] resolved",
+                "[item-3] resolved",
+            )
             + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
         gemini_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
@@ -3206,6 +3232,79 @@ def test_pr_loop_persists_downgraded_future_followup_across_later_blocking_round
     summary = runner.comments[-1]
     assert summary.startswith("Approved-review future follow-ups for PR #77:")
     assert "Missing docs cleanup." in summary
+
+
+def test_pr_loop_carries_new_future_followups_into_later_reviewer_prompts(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with future work.\n\n"
+            "### Future follow-ups\n"
+            "- Document cache cleanup behavior.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass."
+            + prior_item_dispositions(
+                "[item-1] future follow-up: still future work",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Claude still blocks.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Claude approves final pass."
+            + prior_item_dispositions(
+                "[item-1] future follow-up: still future work",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        gemini_outputs=["Implemented blocker.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        approved_followups="summarize",
+        max_rounds=2,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    second_claude_prompt = [
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "round 2" in cmd[-1]
+    ][0]
+    assert "Document cache cleanup behavior." in second_claude_prompt
+    assert "[item-1] future" in second_claude_prompt
+    summary = runner.comments[-1]
+    assert summary.startswith("Approved-review future follow-ups for PR #77:")
+    assert "Document cache cleanup behavior." in summary
+
+
+def test_pr_loop_carries_prior_item_notes_without_creating_duplicate_blocker_items(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Needs regression coverage.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Still blocked."
+            + prior_item_dispositions("[item-1] still blocking: include API error path too")
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Looks good."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Added coverage.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Expanded coverage.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=3)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    second_coder_prompt = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]][1]
+    assert "Latest reviewer updates:" in second_coder_prompt
+    assert "Codex: include API error path too" in second_coder_prompt
+    assert "[item-2]" not in second_coder_prompt
 
 
 def test_pr_loop_same_pr_items_remain_blocking_until_explicitly_resolved(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1292,6 +1292,37 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "Only use `future follow-up` when returning `approved`." in prompt
 
 
+def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    prompt = build_review_prompt(
+        77,
+        2,
+        config,
+        reviewer="codex",
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Improve review prompt context",
+            head_branch="feature/review-context",
+            base_branch="main",
+            head_sha="abc123",
+            url="https://github.com/OWNER/REPO/pull/77",
+        ),
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Needs a regression test before merge.\n\nInclude the mixed-reviewer approval case.",
+                status="blocking",
+            ),
+        ),
+    )
+
+    assert "  Needs a regression test before merge." in prompt
+    assert "\n\n  Include the mixed-reviewer approval case." in prompt
+
+
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])
 def test_parse_non_blocking_followups_stops_at_final_markers(terminator):
     review = f"""

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1235,6 +1235,26 @@ def test_parse_unresolved_item_dispositions_extracts_structured_updates():
     ]
 
 
+def test_parse_unresolved_item_dispositions_ignores_non_bullet_prose():
+    review = """
+    LGTM.
+
+    ### Prior unresolved item dispositions
+    These are the remaining status calls.
+    - [item-1] resolved
+    Closing thought after the bullets.
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    dispositions = parse_unresolved_item_dispositions(review, reviewer="OpenAI Codex")
+
+    assert [(item.item_id, item.disposition, item.note) for item in dispositions] == [
+        ("item-1", "resolved", None),
+    ]
+
+
 def test_parse_review_rejects_future_followups_in_blocking_reviews():
     review = """
     Still blocked.
@@ -2898,6 +2918,7 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
         cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Same-PR follow-ups" in cmd[-1]
     )
     assert "Rename the helper before merge." in followup_prompt
+    assert "[item-1]" in followup_prompt
     assert "Issue context from GitHub" in followup_prompt
     assert "Title:\nSupport issue comments" in followup_prompt
     assert "Clarifying issue comment." in followup_prompt
@@ -3148,6 +3169,37 @@ def test_pr_loop_can_downgrade_prior_blocker_to_future_followup_only_in_approved
         ],
     )
     config = make_config(tmp_path, approved_followups="summarize", max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    summary = runner.comments[-1]
+    assert summary.startswith("Approved-review future follow-ups for PR #77:")
+    assert "Missing docs cleanup." in summary
+
+
+def test_pr_loop_persists_downgraded_future_followup_across_later_blocking_rounds(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Still blocked.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "LGTM."
+            + prior_item_dispositions("[item-1] future follow-up: cleanup can wait", "[item-2] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Missing docs cleanup.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Implemented fix for Claude.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Looks good."
+            + prior_item_dispositions("[item-1] future follow-up: cleanup can wait", "[item-2] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        coder="codex",
+        approved_followups="summarize",
+        max_rounds=2,
+    )
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -40,11 +40,18 @@ from coding_review_agent_loop.github import (
     get_pr_checks,
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
-from coding_review_agent_loop.prompts import format_human_requirements, format_issue_context
+from coding_review_agent_loop.prompts import (
+    build_review_prompt,
+    format_human_requirements,
+    format_issue_context,
+)
 from coding_review_agent_loop.protocol import (
     parse_approved_followups,
+    parse_review,
     parse_non_blocking_followups,
     parse_signed_human_requirement_body,
+    parse_unresolved_item_dispositions,
+    UnresolvedReviewItem,
 )
 
 
@@ -367,6 +374,12 @@ def read_usage_summary(log_dir: Path) -> dict:
     summary_paths = list(log_dir.glob("*-usage-summary.json"))
     assert len(summary_paths) == 1
     return json.loads(summary_paths[0].read_text(encoding="utf-8"))
+
+
+def prior_item_dispositions(*lines: str) -> str:
+    if not lines:
+        return ""
+    return "\n\n### Prior unresolved item dispositions\n" + "\n".join(f"- {line}" for line in lines)
 
 
 def make_config(tmp_path, *, create_dirs=True, **overrides):
@@ -1198,6 +1211,87 @@ def test_parse_approved_followups_ignores_prose_empty_placeholders():
     assert followups.future == ()
 
 
+def test_parse_unresolved_item_dispositions_extracts_structured_updates():
+    review = """
+    LGTM.
+
+    ### Prior unresolved item dispositions
+    - [item-1] resolved
+    - [item-2] still blocking
+    - [item-3] same-pr
+    - [item-4] future follow-up: split this into a separate PR
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    dispositions = parse_unresolved_item_dispositions(review, reviewer="OpenAI Codex")
+
+    assert [(item.item_id, item.disposition, item.note) for item in dispositions] == [
+        ("item-1", "resolved", None),
+        ("item-2", "blocking", None),
+        ("item-3", "same-pr", None),
+        ("item-4", "future", "split this into a separate PR"),
+    ]
+
+
+def test_parse_review_rejects_future_followups_in_blocking_reviews():
+    review = """
+    Still blocked.
+
+    ### Future follow-ups
+    - Do this later.
+
+    <!-- AGENT_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    with pytest.raises(AgentLoopError, match="Future follow-ups"):
+        parse_review(review, reviewer="OpenAI Codex")
+
+
+def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions(tmp_path):
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    prompt = build_review_prompt(
+        77,
+        2,
+        config,
+        reviewer="codex",
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Improve review prompt context",
+            head_branch="feature/review-context",
+            base_branch="main",
+            head_sha="abc123",
+            url="https://github.com/OWNER/REPO/pull/77",
+        ),
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Needs a regression test before merge.",
+                status="blocking",
+            ),
+            UnresolvedReviewItem(
+                item_id="item-2",
+                reviewer="OpenAI Codex",
+                source_round=1,
+                text="Rename the helper before merge.",
+                status="same-pr",
+            ),
+        ),
+    )
+
+    assert "Prior unresolved review items from earlier rounds" in prompt
+    assert "[item-1] blocking from Anthropic Claude in round 1" in prompt
+    assert "[item-2] same-pr from OpenAI Codex in round 1" in prompt
+    assert "### Prior unresolved item dispositions" in prompt
+    assert "- [item-id] resolved" in prompt
+    assert "Only use `future follow-up` when returning `approved`." in prompt
+
+
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])
 def test_parse_non_blocking_followups_stops_at_final_markers(terminator):
     review = f"""
@@ -1236,7 +1330,9 @@ def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
         ],
         codex_outputs=[
             "Finding: bug remains.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
     )
     config = make_config(tmp_path)
@@ -1422,7 +1518,9 @@ def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
         ],
         claude_outputs=[
             "Finding: bug remains.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
     )
     config = make_config(tmp_path, coder="codex", reviewer="claude")
@@ -1448,7 +1546,9 @@ def test_issue_loop_runs_pre_review_tests_after_coder_changes(tmp_path):
         ],
         codex_outputs=[
             "Finding: bug remains.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
     )
     config = make_config(tmp_path, test_command=("pytest", "tests/test_agent_loop.py"))
@@ -1853,7 +1953,9 @@ def test_pr_loop_routes_migration_validation_failure_through_coder_followup(tmp_
         claude_outputs=["Fixed migration.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
         codex_outputs=[
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "LGTM again.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM again."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
     )
     config = make_config(tmp_path, test_command=("pytest", "tests/test_agent_loop.py"), max_rounds=2)
@@ -1879,7 +1981,7 @@ def test_pr_loop_routes_migration_validation_failure_through_coder_followup(tmp_
 
     coder_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert len(coder_prompts) == 1
-    assert "Alembic migration validation review:" in coder_prompts[0]
+    assert "Alembic migration validation unresolved blocking item [item-1]" in coder_prompts[0]
     assert "expected current head `402b9e8af79b`" in coder_prompts[0]
 
     commands = runner.commands
@@ -1970,7 +2072,9 @@ def test_pr_loop_routes_failing_github_checks_through_coder_followup(tmp_path, m
     runner = FakeRunner(
         codex_outputs=[
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "Still failing upstream.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Still failing upstream."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Investigated CI.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
@@ -2002,7 +2106,10 @@ def test_pr_loop_routes_failing_github_checks_through_coder_followup(tmp_path, m
         comment.startswith("GitHub PR checks are failing for PR #77.") for comment in runner.comments
     )
     followup_prompt = next(
-        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "GitHub PR checks review:" in cmd[-1]
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"]
+        and "GitHub PR checks unresolved blocking item [item-1] from round 1:" in cmd[-1]
     )
     assert "Failing checks: tests/test_security.py (failure)" in followup_prompt
     assert "Do not claim global test success unless GitHub PR checks are green." in followup_prompt
@@ -2220,7 +2327,9 @@ def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
             "Needs a fix.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
@@ -2255,7 +2364,9 @@ def test_blocking_followup_prompt_includes_human_requirements_before_ai_feedback
     runner = FakeRunner(
         codex_outputs=[
             "Needs a fix.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
         pr_payload={
@@ -2285,7 +2396,7 @@ def test_blocking_followup_prompt_includes_human_requirements_before_ai_feedback
         cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Address the review below" in cmd[-1]
     )
     assert followup_prompt.index("Signed Human Reviewer Requirements") < followup_prompt.index(
-        "Codex review:"
+        "Codex unresolved blocking item [item-1] from round 1:"
     )
     assert "Please use the absolute URL." in followup_prompt
     assert "Needs a fix." in followup_prompt
@@ -2725,7 +2836,9 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
             "### Future follow-ups\n"
             "- Add broader integration coverage later.\n"
             "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "Codex approves final pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Renamed helper.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
@@ -2772,7 +2885,9 @@ def test_pr_loop_fix_and_issue_ignores_future_followups_from_pre_fix_round(tmp_p
             "### Future follow-ups\n"
             "- Add a separate migration dry-run command.\n"
             "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "Codex approves final pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
@@ -2797,7 +2912,8 @@ def test_pr_loop_fix_and_issue_uses_only_final_round_future_followups(tmp_path):
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add a separate migration dry-run command.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
@@ -2825,7 +2941,8 @@ def test_pr_loop_fix_and_summarize_uses_only_final_round_future_followups(tmp_pa
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add Codex's final follow-up later.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=[
             "Claude approves.\n\n"
@@ -2835,7 +2952,8 @@ def test_pr_loop_fix_and_summarize_uses_only_final_round_future_followups(tmp_pa
             "Claude approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add Claude's final follow-up later.\n"
-            "<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
         gemini_outputs=["Added assertion.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
     )
@@ -2875,7 +2993,8 @@ def test_pr_loop_fix_and_issue_extracts_final_round_bullet_and_prose_future_foll
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Refine token estimation for large review prompts.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=[
             "Claude approves with cleanup.\n\n"
@@ -2888,7 +3007,8 @@ def test_pr_loop_fix_and_issue_extracts_final_round_bullet_and_prose_future_foll
             "in a future cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "No same-PR follow-ups.\n"
-            "<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
         gemini_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
         issue_urls=[
@@ -2925,11 +3045,15 @@ def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
         claude_outputs=[
             "Needs a regression test.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
             "Addressed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
-            "Claude approves.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+            "Claude approves."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
         codex_outputs=[
             "Codex approves first pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "Codex approves second pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves second pass."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
     )
     config = make_config(tmp_path, coder="claude", reviewer=("claude", "codex"))
@@ -2952,6 +3076,72 @@ def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
         == "number,title,headRefName,baseRefName,headRefOid,url,comments,reviews"
     ]
     assert len(metadata_fetches) == 2
+
+
+def test_pr_loop_rejects_cross_reviewer_approval_without_prior_item_disposition(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Needs a regression test.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Claude resolves it."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Codex approves first pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves second pass.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        gemini_outputs=["Implemented fix.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini"],
+    )
+    config = make_config(tmp_path, coder="gemini", reviewer=("claude", "codex"), max_rounds=2)
+
+    with pytest.raises(AgentLoopError, match="did not evaluate all prior unresolved items: item-1"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    second_codex_prompt = [
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:2] == ["codex", "exec"] and "round 2" in cmd[-1]
+    ][0]
+    assert "Prior unresolved review items from earlier rounds" in second_codex_prompt
+    assert "[item-1] blocking from Claude in round 1" in second_codex_prompt
+
+
+def test_pr_loop_can_downgrade_prior_blocker_to_future_followup_only_in_approved_review(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Addressed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=[
+            "Missing docs cleanup.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM now."
+            + prior_item_dispositions("[item-1] future follow-up: cleanup can wait")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, approved_followups="summarize", max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    summary = runner.comments[-1]
+    assert summary.startswith("Approved-review future follow-ups for PR #77:")
+    assert "Missing docs cleanup." in summary
+
+
+def test_pr_loop_same_pr_items_remain_blocking_until_explicitly_resolved(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with cleanup.\n\n"
+            "### Same-PR follow-ups\n"
+            "- Rename the helper before merge.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex still wants the rename."
+            + prior_item_dispositions("[item-1] same-pr")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Tried a partial fix.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(tmp_path, approved_followups="fix-and-summarize", max_rounds=2)
+
+    with pytest.raises(AgentLoopError, match="still reported blocking issues after round 2"):
+        run_pr_loop(runner, pr_number=77, config=config)
 
 
 def test_pr_loop_does_not_run_claude_after_final_blocking_round(tmp_path):
@@ -3386,7 +3576,9 @@ def test_reviewer_checkout_refreshes_each_round_before_review(tmp_path):
         claude_outputs=["Fixed.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
         codex_outputs=[
             "Please fix it.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex")
@@ -3918,7 +4110,9 @@ def test_task_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
         ],
         codex_outputs=[
             "One nit.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         pr_payload={
             "number": 91,
@@ -4148,7 +4342,9 @@ def test_codex_issue_loop_alternates_until_claude_approval(tmp_path):
         ],
         claude_outputs=[
             "Missing test.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
-            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
         ],
     )
     config = make_config(tmp_path, coder="codex", reviewer="claude")
@@ -4237,7 +4433,9 @@ def test_gemini_issue_loop_resumes_session_for_followup(tmp_path):
         ],
         codex_outputs=[
             "Needs a regression test.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Looks good."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
     )
     config = make_config(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -40,6 +40,10 @@ from coding_review_agent_loop.github import (
     get_pr_checks,
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
+from coding_review_agent_loop.orchestrator import (
+    _apply_unresolved_item_dispositions,
+    _review_freeform_summary_text,
+)
 from coding_review_agent_loop.prompts import (
     build_review_prompt,
     format_human_requirements,
@@ -1341,6 +1345,54 @@ def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
 
     assert "  Needs a regression test before merge." in prompt
     assert "\n\n  Include the mixed-reviewer approval case." in prompt
+
+
+def test_review_freeform_summary_text_strips_structured_followup_sections():
+    review = """Blocking issue summary.
+
+### Prior unresolved item dispositions
+- [item-1] still blocking: needs one more assertion
+
+### Same-PR follow-ups
+- Rename helper
+
+### Future follow-ups
+- Document cleanup later
+
+<!-- AGENT_STATE: blocking -->
+-- OpenAI Codex
+"""
+
+    assert _review_freeform_summary_text(review) == "Blocking issue summary."
+
+
+def test_apply_unresolved_item_dispositions_appends_disposition_notes_to_text():
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Needs regression coverage before merge.",
+            status="blocking",
+        ),
+    )
+    dispositions_by_item = {
+        "item-1": [
+            parse_unresolved_item_dispositions(
+                prior_item_dispositions("[item-1] still blocking: include API error path too"),
+                reviewer="Anthropic Claude",
+            )[0]
+        ]
+    }
+
+    updated_items = _apply_unresolved_item_dispositions(unresolved_items, dispositions_by_item)
+
+    assert len(updated_items) == 1
+    assert updated_items[0].text == (
+        "Needs regression coverage before merge.\n\n"
+        "Update from Anthropic Claude: include API error path too"
+    )
+    assert updated_items[0].notes == ("Anthropic Claude: include API error path too",)
 
 
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])


### PR DESCRIPTION
Closes #119

## Summary
- track unresolved blocking and same-PR review items across rounds in the orchestrator
- require later reviewer prompts and responses to explicitly classify prior unresolved items
- reject future follow-ups from blocking reviews and add regression coverage for cross-reviewer and downgrade flows

## Testing
- python3 -m pytest tests/test_agent_loop.py -q