### PR TITLE
Tolerate stray future followups in blocking reviews

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -643,7 +643,9 @@ heading:
 
 Same-PR follow-ups will be sent back to {coder_name} and require another review
 round before final approval. Do not put trivial style nits in either follow-up
-section.
+section. If you return `<!-- AGENT_STATE: blocking -->`, do not include a
+Future follow-ups section at all; keep only blocking findings and any Same-PR
+follow-ups that should be fixed before approval.
 """
     else:
         followup_guidance = """If you approve but notice substantial work that is better handled separately in

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -643,9 +643,9 @@ heading:
 
 Same-PR follow-ups will be sent back to {coder_name} and require another review
 round before final approval. Do not put trivial style nits in either follow-up
-section. If you return `<!-- AGENT_STATE: blocking -->`, do not include a
-Future follow-ups section at all; keep only blocking findings and any Same-PR
-follow-ups that should be fixed before approval.
+section. If you return `<!-- AGENT_STATE: blocking -->`, do not use structured
+follow-up sections; include all findings in the main body of your response so
+they are not missed during revision.
 """
     else:
         followup_guidance = """If you approve but notice substantial work that is better handled separately in

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -258,7 +258,10 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
     followups = parse_approved_followups(text, reviewer=reviewer)
     dispositions = parse_unresolved_item_dispositions(text, reviewer=reviewer)
     if state == "blocking" and followups.future:
-        raise AgentLoopError("Blocking reviews may not include Future follow-ups.")
+        # Some agents still append speculative future work to otherwise valid
+        # blocking reviews. Preserve the blocking findings and ignore that
+        # lower-priority section rather than aborting the whole round.
+        followups = ApprovedFollowups(same_pr=followups.same_pr, future=())
     if state == "blocking" and any(item.disposition == "future" for item in dispositions):
         raise AgentLoopError(
             "Blocking reviews may not downgrade prior unresolved items to Future follow-ups."

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2535,7 +2535,8 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     assert "small, localized, low-risk cleanup" in prompt
     assert "narrow current-PR cleanup in files already\ntouched by this PR or directly adjacent code" in prompt
     assert "will be sent back to Claude and require another review" in prompt
-    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not include a\nFuture follow-ups section at all" in prompt
+    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not use structured\nfollow-up sections" in prompt
+    assert "include all findings in the main body of your response so\nthey are not missed during revision" in prompt
 
 
 def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1259,9 +1259,12 @@ def test_parse_unresolved_item_dispositions_ignores_non_bullet_prose():
     ]
 
 
-def test_parse_review_rejects_future_followups_in_blocking_reviews():
+def test_parse_review_drops_future_followups_in_blocking_reviews():
     review = """
     Still blocked.
+
+    ### Same-PR follow-ups
+    - Tighten the helper in this file.
 
     ### Future follow-ups
     - Do this later.
@@ -1270,8 +1273,11 @@ def test_parse_review_rejects_future_followups_in_blocking_reviews():
     -- OpenAI Codex
     """
 
-    with pytest.raises(AgentLoopError, match="Future follow-ups"):
-        parse_review(review, reviewer="OpenAI Codex")
+    parsed = parse_review(review, reviewer="OpenAI Codex")
+
+    assert parsed.state == "blocking"
+    assert [item.text for item in parsed.followups.same_pr] == ["Tighten the helper in this file."]
+    assert parsed.followups.future == ()
 
 
 def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions(tmp_path):
@@ -2529,6 +2535,45 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     assert "small, localized, low-risk cleanup" in prompt
     assert "narrow current-PR cleanup in files already\ntouched by this PR or directly adjacent code" in prompt
     assert "will be sent back to Claude and require another review" in prompt
+    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not include a\nFuture follow-ups section at all" in prompt
+
+
+def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=[
+            "Still blocked.\n\n"
+            "### Same-PR follow-ups\n"
+            "- Tighten the reset helper.\n\n"
+            "### Future follow-ups\n"
+            "- Consider a broader cleanup later.\n\n"
+            "<!-- AGENT_STATE: blocking -->\n"
+            "-- Google Gemini",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("gemini", "codex"),
+        approved_followups="fix-and-issue",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments[0].startswith("Still blocked.")
+    assert "Consider a broader cleanup later." in runner.comments[0]
+    followup_prompt = next(
+        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Address the review below" in cmd[-1]
+    )
+    assert "Still blocked." in followup_prompt
 
 
 def test_agent_memory_is_created_and_added_to_review_prompt(tmp_path):


### PR DESCRIPTION
## Summary
- ignore stray Future follow-ups sections when a review is otherwise blocking
- tighten the reviewer prompt so blocking reviews explicitly omit future follow-ups
- add parser and PR-loop regressions for the Gemini failure mode

## Testing
- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest /home/wwind123/openai-codex/coding-review-agent-loop-pre-review-tests/tests/test_agent_loop.py -q
- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile /home/wwind123/openai-codex/coding-review-agent-loop-pre-review-tests/src/coding_review_agent_loop/*.py

-- OpenAI Codex