### PR TITLE
Add structured plan review protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,21 @@ agent-loop issue 123 --repo OWNER/REPO
 For larger or ambiguous issues, add `--plan-first` to run a plan review on the
 issue before code is written. The coder may inspect the checkout but must not
 edit files, push, or open a PR during planning. Reviewers approve or block with
-`AGENT_PLAN_STATE` markers. By default the loop posts the approved plan summary
-and stops; add `--implement-after-approval` to continue into the normal PR flow:
+`AGENT_PLAN_STATE` markers using explicit plan-review sections:
+
+```md
+### Blocking plan issues
+### Same-plan follow-ups
+### Future follow-ups
+```
+
+When earlier plan issues remain open, reviewers must also include
+`### Prior unresolved plan item dispositions` and disposition every carried item
+exactly once with `resolved`, `still blocking`, `same-plan`, or `future
+follow-up`. `Future follow-ups` are accepted only in approved plan reviews and
+are summarized with the final approved plan instead of reopening planning. By
+default the loop posts the approved plan summary and stops; add
+`--implement-after-approval` to continue into the normal PR flow:
 
 ```bash
 agent-loop issue 123 --repo OWNER/REPO --plan-first --implement-after-approval

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -151,7 +151,20 @@ agent-loop issue 56 --repo OWNER/REPO --plan-first
 With `--plan-first`, the coder writes an implementation plan without editing
 code, pushing a branch, or opening a PR. Reviewers critique that plan on the
 issue using `AGENT_PLAN_STATE` markers until every reviewer approves in the
-same planning round. By default the loop posts an approved consensus summary to
+same planning round. Plan reviews use explicit sections:
+
+```md
+### Blocking plan issues
+### Same-plan follow-ups
+### Future follow-ups
+```
+
+If earlier blocking or same-plan items are still open, reviewers must also add
+`### Prior unresolved plan item dispositions` and disposition every carried
+item exactly once. Use `same-plan` for required current-plan refinements,
+reserve `future follow-up` for approved plan reviews only, and expect approved
+future follow-ups to be summarized with the final approved plan instead of
+reopening planning. By default the loop posts an approved consensus summary to
 the issue and stops. Add `--implement-after-approval` to continue into the
 normal implementation and PR review loop using the approved plan:
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -51,7 +51,9 @@ from .prompts import (
 from .protocol import (
     FUTURE_FOLLOWUP_HEADING_RE,
     LEGACY_FOLLOWUP_HEADING_RE,
+    ParsedPlanReview,
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
+    PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SAME_PR_FOLLOWUP_HEADING_RE,
     ParsedReview,
     ReviewItemDisposition,
@@ -59,6 +61,7 @@ from .protocol import (
     human_requirements_resolved,
     is_clarification_request,
     parse_agent_state,
+    parse_plan_review,
     parse_plan_state,
     parse_pr_number,
 )
@@ -353,8 +356,12 @@ def _validate_review_response(
 def _apply_unresolved_item_dispositions(
     unresolved_items: Sequence[UnresolvedReviewItem],
     dispositions_by_item: dict[str, list[ReviewItemDisposition]],
-) -> list[UnresolvedReviewItem]:
+    *,
+    same_status: str = "same-pr",
+    retain_future: bool = True,
+) -> tuple[list[UnresolvedReviewItem], list[UnresolvedReviewItem]]:
     next_unresolved: list[UnresolvedReviewItem] = []
+    future_items: list[UnresolvedReviewItem] = []
     for item in unresolved_items:
         dispositions = dispositions_by_item.get(item.item_id, [])
         if not dispositions:
@@ -363,7 +370,9 @@ def _apply_unresolved_item_dispositions(
         text = item.text
         notes = list(item.notes)
         outcomes = {disposition.disposition for disposition in dispositions}
-        preserve_note_in_text = bool({"blocking", "same-pr"} & outcomes)
+        preserve_note_in_text = bool({"blocking", same_status} & outcomes) or (
+            "future" in outcomes and not retain_future
+        )
         for disposition in dispositions:
             if disposition.note:
                 note_text = f"{disposition.reviewer}: {disposition.note}"
@@ -385,30 +394,65 @@ def _apply_unresolved_item_dispositions(
                 )
             )
             continue
-        if "same-pr" in outcomes:
+        if same_status in outcomes:
             next_unresolved.append(
                 UnresolvedReviewItem(
                     item_id=item.item_id,
                     reviewer=item.reviewer,
                     source_round=item.source_round,
                     text=text,
-                    status="same-pr",
+                    status=same_status,
                     notes=tuple(notes),
                 )
             )
             continue
         if "future" in outcomes:
-            next_unresolved.append(
-                UnresolvedReviewItem(
-                    item_id=item.item_id,
-                    reviewer=item.reviewer,
-                    source_round=item.source_round,
-                    text=text,
-                    status="future",
-                    notes=tuple(notes),
-                )
+            future_item = UnresolvedReviewItem(
+                item_id=item.item_id,
+                reviewer=item.reviewer,
+                source_round=item.source_round,
+                text=text,
+                status="future",
+                notes=tuple(notes),
             )
-    return next_unresolved
+            if retain_future:
+                next_unresolved.append(future_item)
+            else:
+                future_items.append(future_item)
+    return next_unresolved, future_items
+
+
+def _validate_plan_review_response(
+    text: str,
+    *,
+    reviewer: str,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+) -> ParsedPlanReview:
+    parsed = parse_plan_review(text, reviewer=reviewer)
+    if not unresolved_items:
+        return parsed
+
+    unresolved_by_id = {item.item_id: item for item in unresolved_items}
+    disposition_ids = [item.item_id for item in parsed.dispositions]
+    duplicates = sorted({item_id for item_id in disposition_ids if disposition_ids.count(item_id) > 1})
+    if duplicates:
+        raise AgentLoopError(
+            "Plan review listed prior unresolved plan items more than once: "
+            + ", ".join(duplicates)
+        )
+    unknown = sorted(set(disposition_ids) - set(unresolved_by_id))
+    if unknown:
+        raise AgentLoopError(
+            "Plan review referenced unknown prior unresolved plan item IDs: "
+            + ", ".join(unknown)
+        )
+    missing = sorted(set(unresolved_by_id) - set(disposition_ids))
+    if missing:
+        raise AgentLoopError(
+            "Plan review did not evaluate all prior unresolved plan items: "
+            + ", ".join(missing)
+        )
+    return parsed
 
 
 def _review_freeform_summary_text(text: str) -> str:
@@ -419,6 +463,7 @@ def _review_freeform_summary_text(text: str) -> str:
         FUTURE_FOLLOWUP_HEADING_RE,
         LEGACY_FOLLOWUP_HEADING_RE,
         PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
+        PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     )
     for line in text.splitlines():
         stripped = line.strip()
@@ -787,6 +832,27 @@ def _format_plan_approval_summary(issue_number: int, approved_plan: str) -> str:
     )
 
 
+def _format_plan_approval_summary_with_followups(
+    issue_number: int,
+    approved_plan: str,
+    future_followups: Sequence[ApprovedFollowup],
+) -> str:
+    lines = [
+        f"Planning complete for issue #{issue_number}.",
+        "",
+        "Outcome: implement",
+        "",
+        "Approved plan:",
+        "",
+        approved_plan,
+    ]
+    if future_followups:
+        lines.extend(["", "Approved plan future follow-ups:", ""])
+        lines.extend(f"- {followup.text} ({followup.reviewer})" for followup in future_followups)
+    lines.extend(["", "-- coding-review-agent-loop"])
+    return "\n".join(lines)
+
+
 def _format_pr_checks_comment(pr_number: int, state: str, details: list[str]) -> str:
     headline = {
         "failing": f"GitHub PR checks are failing for PR #{pr_number}.",
@@ -860,6 +926,9 @@ def _run_plan_first_loop(
     configured_reviewers = reviewers(config)
     coder_session_id: str | None = None
     reviewer_session_ids: dict[AgentName, str | None] = {}
+    unresolved_items: list[UnresolvedReviewItem] = []
+    approved_future_followups: list[ApprovedFollowup] = []
+    next_unresolved_item_number = 1
 
     log(config, f"Planning issue #{issue_number}: invoking {coder_name}")
     plan_response = _run_validated_agent(
@@ -882,7 +951,14 @@ def _run_plan_first_loop(
     current_plan = plan_output
 
     for round_number in range(1, config.max_rounds + 1):
+        prior_unresolved_items = tuple(unresolved_items)
+        prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
+            item.item_id: [] for item in prior_unresolved_items
+        }
+        round_new_unresolved_items: list[UnresolvedReviewItem] = []
+        round_approved_future_followups: list[ApprovedFollowup] = []
         blocking_reviews: list[tuple[str, str]] = []
+        all_approved = True
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             log(config, f"Planning round {round_number}: {reviewer_name} reviewing issue #{issue_number}")
@@ -898,26 +974,78 @@ def _run_plan_first_loop(
                     reviewer=reviewer,
                     memory=memory,
                     issue_context=issue_context,
+                    unresolved_items=prior_unresolved_items,
                 ),
                 session_id=reviewer_session_ids.get(reviewer),
                 marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
-                validate=parse_plan_state,
+                validate=lambda text, reviewer_name=reviewer_name, items=prior_unresolved_items: _validate_plan_review_response(
+                    text,
+                    reviewer=reviewer_name,
+                    unresolved_items=items,
+                ),
                 usage_context=usage_context,
             )
             review_output = review_response.text
             reviewer_session_ids[reviewer] = review_response.session_id
-            review_state = str(review_response.marker_value)
+            parsed_review = review_response.marker_value
+            assert isinstance(parsed_review, ParsedPlanReview)
+            review_state = parsed_review.state
             post_issue_comment(runner, config=config, issue_number=issue_number, body=review_output)
             log(config, f"Planning round {round_number}: {reviewer_name} state is {review_state}")
+            for disposition in parsed_review.dispositions:
+                prior_dispositions[disposition.item_id].append(disposition)
             if review_state == "blocking":
+                all_approved = False
                 blocking_reviews.append((reviewer_name, review_output))
+            for item in parsed_review.items.blocking:
+                round_new_unresolved_items.append(
+                    _next_unresolved_item(
+                        item_number=next_unresolved_item_number,
+                        reviewer=item.reviewer,
+                        source_round=round_number,
+                        text=item.text,
+                        status="blocking",
+                    )
+                )
+                next_unresolved_item_number += 1
+            for item in parsed_review.items.same_plan:
+                round_new_unresolved_items.append(
+                    _next_unresolved_item(
+                        item_number=next_unresolved_item_number,
+                        reviewer=item.reviewer,
+                        source_round=round_number,
+                        text=item.text,
+                        status="same-plan",
+                    )
+                )
+                next_unresolved_item_number += 1
+            for item in parsed_review.items.future:
+                round_approved_future_followups.append(item)
 
-        if not blocking_reviews:
+        unresolved_items, future_from_prior_items = _apply_unresolved_item_dispositions(
+            prior_unresolved_items,
+            prior_dispositions,
+            same_status="same-plan",
+            retain_future=False,
+        )
+        unresolved_items = [*unresolved_items, *round_new_unresolved_items]
+        must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-plan"}]
+        approved_future_followups.extend(
+            ApprovedFollowup(reviewer=item.reviewer, text=item.text) for item in future_from_prior_items
+        )
+        if all_approved:
+            approved_future_followups.extend(round_approved_future_followups)
+
+        if all_approved and not must_fix_items:
             post_issue_comment(
                 runner,
                 config=config,
                 issue_number=issue_number,
-                body=_format_plan_approval_summary(issue_number, current_plan),
+                body=_format_plan_approval_summary_with_followups(
+                    issue_number,
+                    current_plan,
+                    approved_future_followups,
+                ),
             )
             if not implement_after_approval:
                 print(
@@ -966,9 +1094,7 @@ def _run_plan_first_loop(
                 f"round {round_number}; human review required."
             )
 
-        combined_review = "\n\n".join(
-            f"{name} plan review:\n\n{review}" for name, review in blocking_reviews
-        )
+        combined_review = "\n\n".join(f"{name} plan review:\n\n{review}" for name, review in blocking_reviews)
         log(config, f"Planning round {round_number}: {coder_name} revising the plan")
         plan_response = _run_validated_agent(
             runner,
@@ -982,6 +1108,7 @@ def _run_plan_first_loop(
                 config,
                 memory,
                 issue_context=issue_context,
+                unresolved_items=must_fix_items,
             ),
             session_id=coder_session_id,
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
@@ -1310,7 +1437,7 @@ def run_pr_loop(
                             )
                             next_unresolved_item_number += 1
 
-            unresolved_items = _apply_unresolved_item_dispositions(
+            unresolved_items, _future_items = _apply_unresolved_item_dispositions(
                 prior_unresolved_items,
                 prior_dispositions,
             )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -816,22 +816,6 @@ def _format_unresolved_items_for_coder(items: Sequence[UnresolvedReviewItem]) ->
     return "\n".join(lines).strip()
 
 
-def _format_plan_approval_summary(issue_number: int, approved_plan: str) -> str:
-    return "\n".join(
-        [
-            f"Planning complete for issue #{issue_number}.",
-            "",
-            "Outcome: implement",
-            "",
-            "Approved plan:",
-            "",
-            approved_plan,
-            "",
-            "-- coding-review-agent-loop",
-        ]
-    )
-
-
 def _format_plan_approval_summary_with_followups(
     issue_number: int,
     approved_plan: str,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -422,6 +422,15 @@ def _apply_unresolved_item_dispositions(
     return next_unresolved, future_items
 
 
+def _approved_followup_from_unresolved_item(item: UnresolvedReviewItem) -> ApprovedFollowup:
+    text = item.text
+    for note in item.notes:
+        update_line = f"Update from {note}"
+        if update_line not in text:
+            text = f"{text.rstrip()}\n\n{update_line}"
+    return ApprovedFollowup(reviewer=item.reviewer, text=text)
+
+
 def _validate_plan_review_response(
     text: str,
     *,
@@ -1015,7 +1024,7 @@ def _run_plan_first_loop(
         unresolved_items = [*unresolved_items, *round_new_unresolved_items]
         must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-plan"}]
         approved_future_followups.extend(
-            ApprovedFollowup(reviewer=item.reviewer, text=item.text) for item in future_from_prior_items
+            _approved_followup_from_unresolved_item(item) for item in future_from_prior_items
         )
         if all_approved:
             approved_future_followups.extend(round_approved_future_followups)
@@ -1427,7 +1436,7 @@ def run_pr_loop(
             )
             unresolved_items = [*unresolved_items, *round_new_unresolved_items]
             future_followups = [
-                ApprovedFollowup(reviewer=item.reviewer, text=item.text)
+                _approved_followup_from_unresolved_item(item)
                 for item in unresolved_items
                 if item.status == "future"
             ]

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -276,6 +276,30 @@ def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewI
     return "\n".join(lines)
 
 
+def _format_unresolved_plan_items(unresolved_items: Sequence[UnresolvedReviewItem] | None) -> str:
+    if not unresolved_items:
+        return ""
+    lines = [
+        "Prior unresolved plan items from earlier rounds",
+        "",
+        "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
+        "",
+    ]
+    for item in unresolved_items:
+        details = [indent(item.text, "  ")]
+        if item.notes:
+            details.append("  Latest reviewer updates:")
+            details.extend(f"  - {note}" for note in item.notes)
+        lines.extend(
+            [
+                f"- [{item.item_id}] {item.status} from {item.reviewer} in round {item.source_round}",
+                *details,
+            ]
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
 def format_pr_checks(checks: PullRequestChecks) -> str:
     lines = [
         "GitHub PR checks:",
@@ -386,26 +410,57 @@ def build_plan_review_prompt(
     reviewer: AgentName,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    unresolved_items: Sequence[UnresolvedReviewItem] = (),
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
     reviewer_group = format_agent_list(reviewers(config))
+    unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
+    if unresolved_items:
+        unresolved_items_guidance = """Because prior unresolved plan items exist, include this exact section in your review:
+
+### Prior unresolved plan item dispositions
+
+Use one bullet per listed item and cover every item exactly once. Allowed forms:
+- [item-id] resolved
+- [item-id] still blocking
+- [item-id] same-plan
+- [item-id] future follow-up: brief reason
+
+Only use `future follow-up` when returning `approved`. If a current-plan item still needs to be fixed before implementation starts, keep it as `still blocking` or `same-plan` instead of downgrading it.
+"""
+    else:
+        unresolved_items_guidance = ""
     return f"""Review the implementation plan for GitHub issue #{issue_number} in {config.repo} (planning round {round_number}).
 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this planning review.
 {_scratch_file_guidance()}
 {_issue_context_block(issue_context)}
-{_memory_block(memory)}
+{unresolved_items_block}{_memory_block(memory)}
 
 Plan from {coder_name}:
 
 {plan}
 
 Review the plan for correctness, architecture fit, missing edge cases, test
-strategy, and ambiguity. Use blocking only for issues that should be resolved
-before implementation starts. All configured reviewers ({reviewer_group}) must
-approve in the same planning round before implementation can proceed.
+strategy, and ambiguity. Use this exact structured format in your response body:
+
+### Blocking plan issues
+- Required corrections that must be resolved before the plan can be approved.
+
+### Same-plan follow-ups
+- Required current-plan refinements that should be folded into the next plan revision before approval.
+
+### Future follow-ups
+- Ideas worth tracking separately that are not required for the current implementation plan.
+
+Blocking plan issues and Same-plan follow-ups both prevent approval. Future
+follow-ups are allowed only in approved plan reviews.
+{unresolved_items_guidance}
+Use blocking only when the current plan still has blocking plan issues or
+same-plan follow-ups. All configured reviewers ({reviewer_group}) must approve
+in the same planning round before implementation can proceed.
 
 End your final response with exactly one planning marker:
 
@@ -428,16 +483,18 @@ def build_plan_revision_prompt(
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    unresolved_items: Sequence[UnresolvedReviewItem] = (),
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
+    unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
     return f"""{reviewer_name} reviewed the implementation plan for GitHub issue #{issue_number} in {config.repo} and found blocking issues.
 
 Revise the plan in this local checkout without editing code. Do not create a
 branch, commit, push, or open a pull request during this planning stage.
 {_scratch_file_guidance()}
 {_issue_context_block(issue_context)}
-{_memory_block(memory)}
+{unresolved_items_block}{_memory_block(memory)}
 
 Previous plan:
 
@@ -446,6 +503,20 @@ Previous plan:
 {reviewer_name} plan review:
 
 {review}
+
+Revise the plan item by item instead of replying only with free-form prose. If
+prior unresolved plan items are listed above, include this exact section in
+your response and address each item ID exactly once:
+
+### Prior plan review item dispositions
+- [item-id] resolved: brief explanation of how the revised plan addresses it
+- [item-id] still blocking: brief explanation if you cannot resolve it yet
+- [item-id] same-plan: brief explanation of the remaining current-plan refinement
+- [item-id] future: brief explanation only if a reviewer explicitly asked to move it to future work
+
+Then provide the revised implementation plan with concrete file areas, edge
+cases, and tests. Use `same-plan`, never `same-pr`, when describing plan-only
+current-round refinements.
 
 This is planning round {round_number}. End your final response with exactly one
 planning marker:

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .errors import AgentLoopError

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -35,25 +35,31 @@ LEGACY_FOLLOWUP_HEADING_RE = _followup_heading_re(r"non[- ]blocking follow[- ]up
 PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
     r"prior unresolved item dispositions"
 )
+BLOCKING_PLAN_ISSUES_HEADING_RE = _followup_heading_re(r"blocking plan issues")
+SAME_PLAN_FOLLOWUP_HEADING_RE = _followup_heading_re(r"same[- ]plan follow[- ]ups")
+PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
+    r"prior unresolved plan item dispositions"
+)
 ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
 BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
-EMPTY_FOLLOWUP_RE = re.compile(
-    r"^(?:none|n/a|no follow[- ]?ups?|no same[- ]pr follow[- ]?ups?|no future follow[- ]?ups?)\.?$",
-    re.I,
+
+
+def _empty_placeholder_re(*phrases: str) -> re.Pattern[str]:
+    joined = "|".join(phrases)
+    return re.compile(rf"^(?:none|n/a|{joined})\.?$", re.I)
+
+
+EMPTY_FOLLOWUP_RE = _empty_placeholder_re(
+    r"no follow[- ]?ups?",
+    r"no same[- ]pr follow[- ]?ups?",
+    r"no future follow[- ]?ups?",
 )
-DISPOSITION_RE = re.compile(
-    r"^\s*\[?(?P<item_id>[A-Za-z0-9][A-Za-z0-9._-]*)\]?\s*"
-    r"(?:->|:)?\s*"
-    r"(?P<status>"
-    r"resolved|"
-    r"(?:still\s+)?blocking|"
-    r"(?:still\s+)?same[- ]pr|"
-    r"(?:downgraded\s+to\s+)?future follow[- ]up"
-    r")"
-    r"(?:\s*:\s*(?P<note>.+))?\s*$",
-    re.I,
+EMPTY_PLAN_SECTION_RE = _empty_placeholder_re(
+    r"no blocking plan issues?",
+    r"no same[- ]plan follow[- ]?ups?",
+    r"no future follow[- ]?ups?",
 )
 
 
@@ -91,6 +97,20 @@ class UnresolvedReviewItem:
 class ParsedReview:
     state: str
     followups: ApprovedFollowups
+    dispositions: tuple[ReviewItemDisposition, ...]
+
+
+@dataclass(frozen=True)
+class PlanReviewItems:
+    blocking: tuple[ApprovedFollowup, ...]
+    same_plan: tuple[ApprovedFollowup, ...]
+    future: tuple[ApprovedFollowup, ...]
+
+
+@dataclass(frozen=True)
+class ParsedPlanReview:
+    state: str
+    items: PlanReviewItems
     dispositions: tuple[ReviewItemDisposition, ...]
 
 
@@ -140,10 +160,13 @@ def human_requirements_resolved(text: str) -> bool:
     return bool(HUMAN_REQUIREMENTS_RESOLVED_RE.search(text))
 
 
-def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
-    """Extract same-PR and future follow-ups from an approved review."""
-    same_pr: list[ApprovedFollowup] = []
-    future: list[ApprovedFollowup] = []
+def _collect_section_items(
+    text: str,
+    *,
+    sections: Sequence[tuple[re.Pattern[str], list[ApprovedFollowup]]],
+    empty_item_re: re.Pattern[str],
+    reviewer: str,
+) -> None:
     active: list[ApprovedFollowup] | None = None
     current: list[str] = []
     current_is_prose = False
@@ -152,19 +175,20 @@ def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
         nonlocal current_is_prose
         if active is not None and current:
             item = " ".join(part.strip() for part in current if part.strip()).strip()
-            if item and not EMPTY_FOLLOWUP_RE.match(item):
+            if item and not empty_item_re.match(item):
                 active.append(ApprovedFollowup(reviewer=reviewer, text=item))
             current.clear()
         current_is_prose = False
 
     for line in text.splitlines():
-        if SAME_PR_FOLLOWUP_HEADING_RE.match(line):
+        next_active = None
+        for pattern, bucket in sections:
+            if pattern.match(line):
+                next_active = bucket
+                break
+        if next_active is not None:
             flush_current()
-            active = same_pr
-            continue
-        if FUTURE_FOLLOWUP_HEADING_RE.match(line) or LEGACY_FOLLOWUP_HEADING_RE.match(line):
-            flush_current()
-            active = future
+            active = next_active
             continue
         if active is None:
             continue
@@ -189,34 +213,95 @@ def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
         if current and line.strip():
             current.append(line)
             continue
-        if line.strip():
-            current.append(line)
-            current_is_prose = True
+        current.append(line)
+        current_is_prose = True
 
     flush_current()
+
+
+def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
+    """Extract same-PR and future follow-ups from an approved review."""
+    same_pr: list[ApprovedFollowup] = []
+    future: list[ApprovedFollowup] = []
+    _collect_section_items(
+        text,
+        sections=(
+            (SAME_PR_FOLLOWUP_HEADING_RE, same_pr),
+            (FUTURE_FOLLOWUP_HEADING_RE, future),
+            (LEGACY_FOLLOWUP_HEADING_RE, future),
+        ),
+        empty_item_re=EMPTY_FOLLOWUP_RE,
+        reviewer=reviewer,
+    )
     return ApprovedFollowups(same_pr=tuple(same_pr), future=tuple(future))
 
 
-def _normalize_disposition(status: str) -> str:
-    normalized = " ".join(status.lower().split()).replace("same pr", "same-pr")
+def parse_plan_review_items(text: str, *, reviewer: str) -> PlanReviewItems:
+    blocking: list[ApprovedFollowup] = []
+    same_plan: list[ApprovedFollowup] = []
+    future: list[ApprovedFollowup] = []
+    _collect_section_items(
+        text,
+        sections=(
+            (BLOCKING_PLAN_ISSUES_HEADING_RE, blocking),
+            (SAME_PLAN_FOLLOWUP_HEADING_RE, same_plan),
+            (FUTURE_FOLLOWUP_HEADING_RE, future),
+        ),
+        empty_item_re=EMPTY_PLAN_SECTION_RE,
+        reviewer=reviewer,
+    )
+    return PlanReviewItems(
+        blocking=tuple(blocking),
+        same_plan=tuple(same_plan),
+        future=tuple(future),
+    )
+
+
+def _disposition_re(*same_statuses: str) -> re.Pattern[str]:
+    same_pattern = "|".join(same_statuses)
+    return re.compile(
+        r"^\s*\[?(?P<item_id>[A-Za-z0-9][A-Za-z0-9._-]*)\]?\s*"
+        r"(?:->|:)?\s*"
+        r"(?P<status>"
+        r"resolved|"
+        r"(?:still\s+)?blocking|"
+        rf"(?:still\s+)?(?:{same_pattern})|"
+        r"(?:downgraded\s+to\s+)?future follow[- ]up"
+        r")"
+        r"(?:\s*:\s*(?P<note>.+))?\s*$",
+        re.I,
+    )
+
+
+def _normalize_disposition(status: str, *, same_status: str) -> str:
+    normalized = " ".join(status.lower().split())
+    normalized = normalized.replace("same pr", "same-pr").replace("same plan", "same-plan")
     if normalized == "resolved":
         return "resolved"
     if normalized.endswith("blocking"):
         return "blocking"
-    if normalized.endswith("same-pr"):
-        return "same-pr"
+    if normalized.endswith(same_status):
+        return same_status
     if normalized.endswith("future follow-up"):
         return "future"
     raise AgentLoopError(f"Unsupported unresolved item disposition: {status}")
 
 
-def parse_unresolved_item_dispositions(text: str, *, reviewer: str) -> tuple[ReviewItemDisposition, ...]:
-    """Extract structured prior-item dispositions from a review."""
+def _parse_unresolved_item_dispositions(
+    text: str,
+    *,
+    reviewer: str,
+    heading_re: re.Pattern[str],
+    empty_item_re: re.Pattern[str],
+    disposition_re: re.Pattern[str],
+    same_status: str,
+    error_message: str,
+) -> tuple[ReviewItemDisposition, ...]:
     dispositions: list[ReviewItemDisposition] = []
     active = False
 
     for line in text.splitlines():
-        if PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE.match(line):
+        if heading_re.match(line):
             active = True
             continue
         if not active:
@@ -230,26 +315,56 @@ def parse_unresolved_item_dispositions(text: str, *, reviewer: str) -> tuple[Rev
         if not bullet:
             continue
         entry = bullet.group("text")
-        if EMPTY_FOLLOWUP_RE.match(entry):
+        if empty_item_re.match(entry):
             continue
-        match = DISPOSITION_RE.match(entry)
+        match = disposition_re.match(entry)
         if not match:
-            raise AgentLoopError(
-                "Invalid prior unresolved item disposition. Use bullets like "
-                "`- [item-1] resolved`, `- [item-2] still blocking`, "
-                "`- [item-3] same-pr`, or `- [item-4] future follow-up: reason`."
-            )
+            raise AgentLoopError(error_message)
         note = match.group("note")
         dispositions.append(
             ReviewItemDisposition(
                 item_id=match.group("item_id"),
                 reviewer=reviewer,
-                disposition=_normalize_disposition(match.group("status")),
+                disposition=_normalize_disposition(match.group("status"), same_status=same_status),
                 note=note.strip() if note else None,
             )
         )
 
     return tuple(dispositions)
+
+
+def parse_unresolved_item_dispositions(text: str, *, reviewer: str) -> tuple[ReviewItemDisposition, ...]:
+    """Extract structured prior-item dispositions from a review."""
+    return _parse_unresolved_item_dispositions(
+        text,
+        reviewer=reviewer,
+        heading_re=PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
+        empty_item_re=EMPTY_FOLLOWUP_RE,
+        disposition_re=_disposition_re(r"same[- ]pr"),
+        same_status="same-pr",
+        error_message=(
+            "Invalid prior unresolved item disposition. Use bullets like "
+            "`- [item-1] resolved`, `- [item-2] still blocking`, "
+            "`- [item-3] same-pr`, or `- [item-4] future follow-up: reason`."
+        ),
+    )
+
+
+def parse_plan_item_dispositions(text: str, *, reviewer: str) -> tuple[ReviewItemDisposition, ...]:
+    """Extract structured prior plan-item dispositions from a plan review."""
+    return _parse_unresolved_item_dispositions(
+        text,
+        reviewer=reviewer,
+        heading_re=PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
+        empty_item_re=EMPTY_PLAN_SECTION_RE,
+        disposition_re=_disposition_re(r"same[- ]plan"),
+        same_status="same-plan",
+        error_message=(
+            "Invalid prior unresolved plan item disposition. Use bullets like "
+            "`- [item-1] resolved`, `- [item-2] still blocking`, "
+            "`- [item-3] same-plan`, or `- [item-4] future follow-up: reason`."
+        ),
+    )
 
 
 def parse_review(text: str, *, reviewer: str) -> ParsedReview:
@@ -264,6 +379,20 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
             "Blocking reviews may not downgrade prior unresolved items to Future follow-ups."
         )
     return ParsedReview(state=state, followups=followups, dispositions=dispositions)
+
+
+def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
+    """Parse a plan review, including state, structured plan items, and dispositions."""
+    state = parse_plan_state(text)
+    items = parse_plan_review_items(text, reviewer=reviewer)
+    dispositions = parse_plan_item_dispositions(text, reviewer=reviewer)
+    if state == "blocking" and items.future:
+        raise AgentLoopError("Blocking plan reviews may not include Future follow-ups.")
+    if state == "blocking" and any(item.disposition == "future" for item in dispositions):
+        raise AgentLoopError(
+            "Blocking plan reviews may not downgrade prior unresolved plan items to Future follow-ups."
+        )
+    return ParsedPlanReview(state=state, items=items, dispositions=dispositions)
 
 
 def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3285,7 +3285,10 @@ def test_pr_loop_fix_and_issue_persists_future_followups_from_pre_fix_round(tmp_
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert len(runner.issues) == 1
-    assert runner.issues[0]["title"] == "Follow up future review note: Add a separate migration dry-run command."
+    assert runner.issues[0]["title"] == (
+        "Follow up future review note: Add a separate migration dry-run command. "
+        "Update from Codex: still separate work"
+    )
     commands = [cmd[:3] for cmd, _cwd in runner.commands]
     assert commands.count(["gh", "issue", "create"]) == 1
 
@@ -3563,6 +3566,43 @@ def test_pr_loop_persists_downgraded_future_followup_across_later_blocking_round
     summary = runner.comments[-1]
     assert summary.startswith("Approved-review future follow-ups for PR #77:")
     assert "Missing docs cleanup." in summary
+
+
+def test_pr_loop_finalized_future_followup_summary_preserves_disposition_notes(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Still blocked.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Claude approves final pass."
+            + prior_item_dispositions(
+                "[item-1] future follow-up: cleanup can wait until after rollout",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Missing docs cleanup.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Implemented blocker.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Codex approves final pass."
+            + prior_item_dispositions(
+                "[item-1] future follow-up: cleanup can wait until after rollout",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        coder="codex",
+        approved_followups="summarize",
+        max_rounds=2,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    summary = runner.comments[-1]
+    assert "Missing docs cleanup." in summary
+    assert "Update from Codex: cleanup can wait until after rollout" in summary
 
 
 def test_pr_loop_carries_new_future_followups_into_later_reviewer_prompts(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -43,14 +43,21 @@ from coding_review_agent_loop.migrations import MigrationValidationResult, valid
 from coding_review_agent_loop.orchestrator import (
     _apply_unresolved_item_dispositions,
     _review_freeform_summary_text,
+    _validate_plan_review_response,
 )
 from coding_review_agent_loop.prompts import (
+    build_plan_review_prompt,
+    build_plan_revision_prompt,
     build_review_prompt,
     format_human_requirements,
     format_issue_context,
 )
 from coding_review_agent_loop.protocol import (
     parse_approved_followups,
+    parse_plan_item_dispositions,
+    parse_plan_review,
+    parse_plan_review_items,
+    parse_plan_state,
     parse_review,
     parse_non_blocking_followups,
     parse_signed_human_requirement_body,
@@ -384,6 +391,14 @@ def prior_item_dispositions(*lines: str) -> str:
     if not lines:
         return ""
     return "\n\n### Prior unresolved item dispositions\n" + "\n".join(f"- {line}" for line in lines)
+
+
+def prior_plan_item_dispositions(*lines: str) -> str:
+    if not lines:
+        return ""
+    return "\n\n### Prior unresolved plan item dispositions\n" + "\n".join(
+        f"- {line}" for line in lines
+    )
 
 
 def make_config(tmp_path, *, create_dirs=True, **overrides):
@@ -922,6 +937,21 @@ def test_parse_agent_state_requires_marker():
         parse_agent_state("LGTM")
 
 
+def test_parse_plan_state_uses_last_marker_as_authoritative():
+    text = """
+    Quoting earlier plan review: <!-- AGENT_PLAN_STATE: blocking -->
+
+    Final decision:
+    <!-- AGENT_PLAN_STATE: approved -->
+    """
+    assert parse_plan_state(text) == "approved"
+
+
+def test_parse_plan_state_requires_plan_marker():
+    with pytest.raises(AgentLoopError):
+        parse_plan_state("<!-- AGENT_STATE: approved -->")
+
+
 def test_parse_signed_human_requirement_body_extracts_text_before_signature():
     body = parse_signed_human_requirement_body(
         "Please use the absolute URL.\n\n-- Human Reviewer\n\nExtra text ignored."
@@ -1215,6 +1245,191 @@ def test_parse_approved_followups_ignores_prose_empty_placeholders():
     assert followups.future == ()
 
 
+def test_parse_plan_review_items_extracts_structured_sections():
+    review = """
+    Plan looks sound with one required revision.
+
+    ### Blocking plan issues
+    - Cover how the plan avoids mixing `AGENT_STATE` and `AGENT_PLAN_STATE`.
+
+    ### Same-plan follow-ups
+    - Mention the exact docs pages to update.
+
+    ### Future follow-ups
+    - Consider a later helper to unify plan and PR disposition rendering.
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    items = parse_plan_review_items(review, reviewer="OpenAI Codex")
+
+    assert [(item.reviewer, item.text) for item in items.blocking] == [
+        (
+            "OpenAI Codex",
+            "Cover how the plan avoids mixing `AGENT_STATE` and `AGENT_PLAN_STATE`.",
+        )
+    ]
+    assert [(item.reviewer, item.text) for item in items.same_plan] == [
+        ("OpenAI Codex", "Mention the exact docs pages to update.")
+    ]
+    assert [(item.reviewer, item.text) for item in items.future] == [
+        (
+            "OpenAI Codex",
+            "Consider a later helper to unify plan and PR disposition rendering.",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "None",
+        "No blocking plan issues.",
+        "No same-plan follow-ups",
+        "No future follow-ups.",
+    ],
+)
+def test_parse_plan_review_items_ignores_empty_placeholders(placeholder):
+    review = f"""
+    Looks good.
+
+    ### Blocking plan issues
+    - {placeholder}
+
+    ### Same-plan follow-ups
+    {placeholder}
+
+    ### Future follow-ups
+    - {placeholder}
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- Google Gemini
+    """
+
+    items = parse_plan_review_items(review, reviewer="Gemini")
+
+    assert items.blocking == ()
+    assert items.same_plan == ()
+    assert items.future == ()
+
+
+def test_parse_plan_item_dispositions_extracts_same_plan_status():
+    review = """
+    Approved after the latest revision.
+
+    ### Prior unresolved plan item dispositions
+    - [item-1] resolved
+    - [item-2] still blocking
+    - [item-3] same-plan
+    - [item-4] future follow-up: okay to track separately now
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    dispositions = parse_plan_item_dispositions(review, reviewer="OpenAI Codex")
+
+    assert [(item.item_id, item.disposition, item.note) for item in dispositions] == [
+        ("item-1", "resolved", None),
+        ("item-2", "blocking", None),
+        ("item-3", "same-plan", None),
+        ("item-4", "future", "okay to track separately now"),
+    ]
+
+
+def test_parse_plan_review_rejects_future_followups_in_blocking_reviews():
+    review = """
+    Still blocked.
+
+    ### Future follow-ups
+    - Do this later.
+
+    <!-- AGENT_PLAN_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    with pytest.raises(AgentLoopError, match="Blocking plan reviews may not include Future follow-ups"):
+        parse_plan_review(review, reviewer="OpenAI Codex")
+
+
+def test_parse_plan_review_rejects_future_disposition_in_blocking_reviews():
+    review = """
+    Still blocked.
+    """
+    review += prior_plan_item_dispositions("[item-1] future follow-up: maybe later")
+    review += "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match="Blocking plan reviews may not downgrade"):
+        parse_plan_review(review, reviewer="OpenAI Codex")
+
+
+def test_parse_plan_review_uses_plan_marker_while_pr_review_remains_pr_only():
+    plan_review = """
+    ### Same-plan follow-ups
+    - Add one more orchestration test.
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    parsed = parse_plan_review(plan_review, reviewer="OpenAI Codex")
+
+    assert parsed.state == "approved"
+    assert [item.text for item in parsed.items.same_plan] == ["Add one more orchestration test."]
+    with pytest.raises(AgentLoopError, match="AGENT_STATE"):
+        parse_review(plan_review, reviewer="OpenAI Codex")
+
+
+def test_validate_plan_review_response_rejects_duplicate_item_ids():
+    review = """
+    Still refining the plan.
+    """
+    review += prior_plan_item_dispositions(
+        "[item-1] same-plan: keep the extra regression coverage",
+        "[item-1] resolved",
+    )
+    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match="more than once: item-1"):
+        _validate_plan_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Keep the extra regression coverage.",
+                    status="same-plan",
+                ),
+            ),
+        )
+
+
+def test_validate_plan_review_response_rejects_unknown_item_ids():
+    review = """
+    Looks good now.
+    """
+    review += prior_plan_item_dispositions("[item-9] resolved")
+    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match="unknown prior unresolved plan item IDs: item-9"):
+        _validate_plan_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Keep the extra regression coverage.",
+                    status="same-plan",
+                ),
+            ),
+        )
+
+
 def test_parse_unresolved_item_dispositions_extracts_structured_updates():
     review = """
     LGTM.
@@ -1347,6 +1562,67 @@ def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
     assert "\n\n  Include the mixed-reviewer approval case." in prompt
 
 
+def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_plan_review_prompt(
+        56,
+        2,
+        "Revise protocol parsing and add tests.",
+        config,
+        reviewer="codex",
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Define exact plan-review headings.",
+                status="blocking",
+            ),
+            UnresolvedReviewItem(
+                item_id="item-2",
+                reviewer="Google Gemini",
+                source_round=1,
+                text="Add an orchestration carry-forward test.",
+                status="same-plan",
+            ),
+        ),
+    )
+
+    assert "### Blocking plan issues" in prompt
+    assert "### Same-plan follow-ups" in prompt
+    assert "### Future follow-ups" in prompt
+    assert "### Prior unresolved plan item dispositions" in prompt
+    assert "[item-1] blocking from Anthropic Claude in round 1" in prompt
+    assert "[item-2] same-plan from Google Gemini in round 1" in prompt
+    assert "Only use `future follow-up` when returning `approved`." in prompt
+
+
+def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositions(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_plan_revision_prompt(
+        56,
+        2,
+        "Previous plan text.",
+        "OpenAI Codex plan review:\n\nNeeds a carry-forward ledger.",
+        config,
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-3",
+                reviewer="OpenAI Codex",
+                source_round=1,
+                text="Track unresolved plan items across rounds.",
+                status="blocking",
+            ),
+        ),
+    )
+
+    assert "Prior unresolved plan items from earlier rounds" in prompt
+    assert "[item-3] blocking from OpenAI Codex in round 1" in prompt
+    assert "### Prior plan review item dispositions" in prompt
+    assert "- [item-id] same-plan:" in prompt
+    assert "Use `same-plan`, never `same-pr`" in prompt
+
+
 def test_review_freeform_summary_text_strips_structured_followup_sections():
     review = """Blocking issue summary.
 
@@ -1385,9 +1661,12 @@ def test_apply_unresolved_item_dispositions_appends_disposition_notes_to_text():
         ]
     }
 
-    updated_items = _apply_unresolved_item_dispositions(unresolved_items, dispositions_by_item)
+    updated_items, future_items = _apply_unresolved_item_dispositions(
+        unresolved_items, dispositions_by_item
+    )
 
     assert len(updated_items) == 1
+    assert future_items == []
     assert updated_items[0].text == (
         "Needs regression coverage before merge.\n\n"
         "Update from Anthropic Claude: include API error path too"
@@ -4291,6 +4570,82 @@ def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     assert "Missing test strategy" in claude_calls[1][-1]
     assert len(runner.comments) == 5
     assert runner.comments[2].startswith("Revised plan")
+
+
+def test_issue_loop_plan_first_requires_reviewers_to_disposition_prior_items(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Second revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "### Blocking plan issues\n- Add parser validation tests.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Still needs the test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    with pytest.raises(AgentLoopError, match="did not evaluate all prior unresolved plan items"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+
+def test_issue_loop_plan_first_carries_same_plan_item_across_reviewers_and_rounds(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Second revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "### Same-plan follow-ups\n- Add the carry-forward orchestration test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Looks mostly good."
+            + prior_plan_item_dispositions("[item-1] same-plan: still need the mixed-reviewer case")
+            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            "Plan looks sound."
+            + prior_plan_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        gemini_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini",
+            "Plan looks sound now."
+            + prior_plan_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini",
+            "Final pass."
+            + prior_plan_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini",
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), max_rounds=3)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert any("item-1" in call[-1] for call in claude_calls[1:])
+    assert "Approved plan:" in runner.comments[-1]
+
+
+def test_issue_loop_plan_first_approved_future_followups_are_summarized_without_reopening(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "### Same-plan follow-ups\n- Tighten the prompt wording.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Looks good."
+            + prior_plan_item_dispositions("[item-1] future follow-up: document parser helper reuse separately")
+            + "\n### Future follow-ups\n- Add a later cleanup to dedupe shared prompt rendering.\n"
+            + "<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert "Approved plan future follow-ups:" in runner.comments[-1]
+    assert "document parser helper reuse separately" in runner.comments[-1]
+    assert "Add a later cleanup to dedupe shared prompt rendering." in runner.comments[-1]
 
 
 def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):


### PR DESCRIPTION
Closes #121

## Summary
- add plan-specific structured review parsing, validation, and prior-item disposition handling
- carry blocking and same-plan issues across plan-first rounds while summarizing approved future follow-ups at plan approval
- update plan prompts, docs, and tests for the new structured plan review flow