### PR TITLE
Harden coder handling of signed human reviewer requirements

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1338,8 +1338,6 @@ def run_pr_loop(
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
         next_unresolved_item_number = 1
-        last_coder_output: str | None = None
-        last_coder_human_requirements_context = None
         if reviewer_session_id is not None and configured_reviewers:
             # Backward-compatible single-reviewer resume support: older callers
             # pass one reviewer session, so attach it to the first configured reviewer.
@@ -1353,20 +1351,6 @@ def run_pr_loop(
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
             human_requirements = pr_context.human_requirements
-            if any(item.item_id == HUMAN_REQUIREMENTS_ACK_ITEM_ID for item in unresolved_items):
-                if last_coder_output is not None and last_coder_human_requirements_context is not None:
-                    try:
-                        validate_human_requirements_acknowledgement(
-                            last_coder_output,
-                            surfaced_requirement_ids=last_coder_human_requirements_context.surfaced_requirement_ids,
-                            requires_direct_discussion_ack=(
-                                last_coder_human_requirements_context.requires_direct_discussion_ack
-                            ),
-                        )
-                    except AgentLoopError:
-                        pass
-                    else:
-                        unresolved_items = _clear_human_requirements_ack_item(unresolved_items)
             prior_unresolved_items = tuple(unresolved_items)
             prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
                 item.item_id: [] for item in prior_unresolved_items
@@ -1601,6 +1585,7 @@ def run_pr_loop(
                     memory,
                     issue_context=issue_context,
                     human_requirements=human_requirements,
+                    human_requirements_context=coder_human_requirements_context,
                 )
             else:
                 combined_review = _format_unresolved_items_for_coder(unresolved_items)
@@ -1615,6 +1600,7 @@ def run_pr_loop(
                     memory,
                     issue_context=issue_context,
                     human_requirements=human_requirements,
+                    human_requirements_context=coder_human_requirements_context,
                 )
             log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
             coder_response = _run_validated_agent(
@@ -1629,8 +1615,6 @@ def run_pr_loop(
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id
-            last_coder_output = coder_output
-            last_coder_human_requirements_context = coder_human_requirements_context
 
             try:
                 validate_human_requirements_acknowledgement(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -384,6 +384,32 @@ def _clear_human_requirements_ack_item(
     return [item for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID]
 
 
+def _reconcile_human_requirements_ack_item(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    *,
+    coder_output: str | None,
+    human_requirements,
+    source_round: int,
+) -> list[UnresolvedReviewItem]:
+    if coder_output is None:
+        return list(unresolved_items)
+
+    prompt_context = render_coder_human_requirements_prompt_context(human_requirements)
+    try:
+        validate_human_requirements_acknowledgement(
+            coder_output,
+            surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+            requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+        )
+    except AgentLoopError as exc:
+        return _upsert_human_requirements_ack_item(
+            unresolved_items,
+            source_round=source_round,
+            text=str(exc),
+        )
+    return _clear_human_requirements_ack_item(unresolved_items)
+
+
 def _apply_unresolved_item_dispositions(
     unresolved_items: Sequence[UnresolvedReviewItem],
     dispositions_by_item: dict[str, list[ReviewItemDisposition]],
@@ -1337,6 +1363,7 @@ def run_pr_loop(
         reviewer_session_ids: dict[AgentName, str | None] = {}
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
+        latest_coder_output: str | None = None
         next_unresolved_item_number = 1
         if reviewer_session_id is not None and configured_reviewers:
             # Backward-compatible single-reviewer resume support: older callers
@@ -1351,6 +1378,12 @@ def run_pr_loop(
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
             human_requirements = pr_context.human_requirements
+            unresolved_items = _reconcile_human_requirements_ack_item(
+                unresolved_items,
+                coder_output=latest_coder_output,
+                human_requirements=human_requirements,
+                source_round=round_number,
+            )
             prior_unresolved_items = tuple(unresolved_items)
             prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
                 item.item_id: [] for item in prior_unresolved_items
@@ -1615,23 +1648,14 @@ def run_pr_loop(
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id
+            latest_coder_output = coder_output
 
-            try:
-                validate_human_requirements_acknowledgement(
-                    coder_output,
-                    surfaced_requirement_ids=coder_human_requirements_context.surfaced_requirement_ids,
-                    requires_direct_discussion_ack=(
-                        coder_human_requirements_context.requires_direct_discussion_ack
-                    ),
-                )
-            except AgentLoopError as exc:
-                unresolved_items = _upsert_human_requirements_ack_item(
-                    unresolved_items,
-                    source_round=round_number,
-                    text=str(exc),
-                )
-            else:
-                unresolved_items = _clear_human_requirements_ack_item(unresolved_items)
+            unresolved_items = _reconcile_human_requirements_ack_item(
+                unresolved_items,
+                coder_output=coder_output,
+                human_requirements=human_requirements,
+                source_round=round_number,
+            )
 
             post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
             log(config, f"Round {round_number}: {coder_name} pushed updates for re-review")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -47,9 +47,11 @@ from .prompts import (
     build_task_clarification_prompt,
     build_task_prompt,
     format_agent_list,
+    render_coder_human_requirements_prompt_context,
 )
 from .protocol import (
     FUTURE_FOLLOWUP_HEADING_RE,
+    HUMAN_REQUIREMENTS_HEADING_RE,
     LEGACY_FOLLOWUP_HEADING_RE,
     ParsedPlanReview,
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
@@ -64,6 +66,7 @@ from .protocol import (
     parse_plan_review,
     parse_plan_state,
     parse_pr_number,
+    validate_human_requirements_acknowledgement,
 )
 from .protocol import ApprovedFollowup, parse_review
 from .runner import Runner
@@ -71,6 +74,7 @@ from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
 
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
+HUMAN_REQUIREMENTS_ACK_ITEM_ID = "item-human-requirements-acknowledgement"
 APPROVED_FOLLOWUP_MARKER_RE = re.compile(
     r"<!--\s*AGENT_APPROVED_FOLLOWUPS:\s*pr=(?P<pr>\d+)\s+head=(?P<head>\S+)\s+mode=(?P<mode>[a-z-]+)\s*-->",
     re.I,
@@ -353,6 +357,33 @@ def _validate_review_response(
     return parsed
 
 
+def _upsert_human_requirements_ack_item(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    *,
+    source_round: int,
+    text: str,
+) -> list[UnresolvedReviewItem]:
+    retained = [
+        item for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+    ]
+    retained.append(
+        UnresolvedReviewItem(
+            item_id=HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=source_round,
+            text=text,
+            status="blocking",
+        )
+    )
+    return retained
+
+
+def _clear_human_requirements_ack_item(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+) -> list[UnresolvedReviewItem]:
+    return [item for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID]
+
+
 def _apply_unresolved_item_dispositions(
     unresolved_items: Sequence[UnresolvedReviewItem],
     dispositions_by_item: dict[str, list[ReviewItemDisposition]],
@@ -471,6 +502,7 @@ def _review_freeform_summary_text(text: str) -> str:
         SAME_PR_FOLLOWUP_HEADING_RE,
         FUTURE_FOLLOWUP_HEADING_RE,
         LEGACY_FOLLOWUP_HEADING_RE,
+        HUMAN_REQUIREMENTS_HEADING_RE,
         PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
         PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     )
@@ -1306,18 +1338,14 @@ def run_pr_loop(
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
         next_unresolved_item_number = 1
+        last_coder_output: str | None = None
+        last_coder_human_requirements_context = None
         if reviewer_session_id is not None and configured_reviewers:
             # Backward-compatible single-reviewer resume support: older callers
             # pass one reviewer session, so attach it to the first configured reviewer.
             reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
         for round_number in range(1, config.max_rounds + 1):
             coder_name = agent_display_name(config.coder)
-            prior_unresolved_items = tuple(unresolved_items)
-            prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
-                item.item_id: [] for item in prior_unresolved_items
-            }
-            round_new_unresolved_items: list[UnresolvedReviewItem] = []
-            approved_review_outputs: list[tuple[str, str]] = []
             if pre_review_test_pending:
                 run_pre_review_tests(runner, config)
                 pre_review_test_pending = False
@@ -1325,6 +1353,26 @@ def run_pr_loop(
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
             human_requirements = pr_context.human_requirements
+            if any(item.item_id == HUMAN_REQUIREMENTS_ACK_ITEM_ID for item in unresolved_items):
+                if last_coder_output is not None and last_coder_human_requirements_context is not None:
+                    try:
+                        validate_human_requirements_acknowledgement(
+                            last_coder_output,
+                            surfaced_requirement_ids=last_coder_human_requirements_context.surfaced_requirement_ids,
+                            requires_direct_discussion_ack=(
+                                last_coder_human_requirements_context.requires_direct_discussion_ack
+                            ),
+                        )
+                    except AgentLoopError:
+                        pass
+                    else:
+                        unresolved_items = _clear_human_requirements_ack_item(unresolved_items)
+            prior_unresolved_items = tuple(unresolved_items)
+            prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
+                item.item_id: [] for item in prior_unresolved_items
+            }
+            round_new_unresolved_items: list[UnresolvedReviewItem] = []
+            approved_review_outputs: list[tuple[str, str]] = []
             pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
             for reviewer in configured_reviewers:
                 reviewer_name = agent_display_name(reviewer)
@@ -1542,6 +1590,9 @@ def run_pr_loop(
             blocking_items = [item for item in unresolved_items if item.status == "blocking"]
             if same_pr_items and not blocking_items:
                 combined_review = _format_same_pr_unresolved_items(same_pr_items)
+                coder_human_requirements_context = render_coder_human_requirements_prompt_context(
+                    human_requirements
+                )
                 followup_prompt = build_same_pr_followup_prompt(
                     pr_number,
                     round_number,
@@ -1553,6 +1604,9 @@ def run_pr_loop(
                 )
             else:
                 combined_review = _format_unresolved_items_for_coder(unresolved_items)
+                coder_human_requirements_context = render_coder_human_requirements_prompt_context(
+                    human_requirements
+                )
                 followup_prompt = build_followup_prompt(
                     pr_number,
                     round_number,
@@ -1575,6 +1629,25 @@ def run_pr_loop(
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id
+            last_coder_output = coder_output
+            last_coder_human_requirements_context = coder_human_requirements_context
+
+            try:
+                validate_human_requirements_acknowledgement(
+                    coder_output,
+                    surfaced_requirement_ids=coder_human_requirements_context.surfaced_requirement_ids,
+                    requires_direct_discussion_ack=(
+                        coder_human_requirements_context.requires_direct_discussion_ack
+                    ),
+                )
+            except AgentLoopError as exc:
+                unresolved_items = _upsert_human_requirements_ack_item(
+                    unresolved_items,
+                    source_round=round_number,
+                    text=str(exc),
+                )
+            else:
+                unresolved_items = _clear_human_requirements_ack_item(unresolved_items)
 
             post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
             log(config, f"Round {round_number}: {coder_name} pushed updates for re-review")

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -872,10 +872,13 @@ def build_followup_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     human_requirements: Sequence[HumanReviewRequirement] | None = None,
+    *,
+    human_requirements_context: CoderHumanRequirementsPromptContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
-    human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
+    if human_requirements_context is None:
+        human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
     return f"""{reviewer_name} reviewed pull request #{pr_number} in {config.repo} and found blocking issues.
 
 Address the review below in this local checkout. Pull/sync the PR branch if
@@ -910,10 +913,13 @@ def build_same_pr_followup_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     human_requirements: Sequence[HumanReviewRequirement] | None = None,
+    *,
+    human_requirements_context: CoderHumanRequirementsPromptContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
-    human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
+    if human_requirements_context is None:
+        human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
     return f"""{reviewer_name} approved pull request #{pr_number} in {config.repo} with same-PR follow-ups.
 
 Address the follow-up items below in this local checkout. Pull/sync the PR

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from textwrap import indent
 from typing import Sequence
 
@@ -10,7 +12,18 @@ from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
-from .protocol import UnresolvedReviewItem
+from .protocol import (
+    HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+    HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
+    UnresolvedReviewItem,
+)
+
+
+@dataclass(frozen=True)
+class CoderHumanRequirementsPromptContext:
+    block: str
+    surfaced_requirement_ids: tuple[str, ...]
+    requires_direct_discussion_ack: bool
 
 
 def format_agent_list(agents: Sequence[AgentName]) -> str:
@@ -233,6 +246,66 @@ def _human_requirements_block(
     if not human_requirements:
         return ""
     return f"{format_human_requirements(human_requirements)}\n"
+
+
+def render_coder_human_requirements_prompt_context(
+    human_requirements: Sequence[HumanReviewRequirement] | None,
+    *,
+    max_chars: int = 12_000,
+) -> CoderHumanRequirementsPromptContext:
+    if not human_requirements:
+        block = ""
+    else:
+        block = f"{format_human_requirements(human_requirements, max_chars=max_chars)}\n"
+    if not block:
+        return CoderHumanRequirementsPromptContext(
+            block="",
+            surfaced_requirement_ids=(),
+            requires_direct_discussion_ack=False,
+        )
+    surfaced_requirement_ids = tuple(
+        f"Requirement {match.group(1)}"
+        for match in re.finditer(r"(?m)^Requirement (\d+):$", block)
+    )
+    requires_direct_discussion_ack = (
+        not surfaced_requirement_ids
+        and "signed human requirement(s) were omitted to keep this prompt bounded" in block
+    )
+    return CoderHumanRequirementsPromptContext(
+        block=block,
+        surfaced_requirement_ids=surfaced_requirement_ids,
+        requires_direct_discussion_ack=requires_direct_discussion_ack,
+    )
+
+
+def _coder_human_requirements_guidance(
+    context: CoderHumanRequirementsPromptContext,
+) -> str:
+    if not context.block:
+        return ""
+    lines = [
+        "The signed human reviewer requirements above are mandatory next-revision requirements, not passive context.",
+        "Later signed human comments supersede earlier ones; the latest human instruction wins.",
+        "If any signed human requirement cannot be satisfied safely or is impossible, say that explicitly instead of skipping it.",
+        "",
+        "When signed human reviewer requirements are present, your response must include exactly:",
+        HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+        "",
+        "Then add a `### Human requirements` section.",
+    ]
+    if context.surfaced_requirement_ids:
+        surfaced = ", ".join(f"`{item}`" for item in context.surfaced_requirement_ids)
+        lines.append(
+            "Include one bullet for each surfaced signed human requirement ID shown in this prompt: "
+            f"{surfaced}. Each bullet must explain how you addressed that item or why it could not be satisfied safely."
+        )
+    elif context.requires_direct_discussion_ack:
+        lines.append(
+            "The detailed requirement entries were omitted from this prompt to stay bounded. "
+            "In the `### Human requirements` section, state that the prompt omitted the detailed items and that you "
+            f"`{HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK}` before responding."
+        )
+    return "\n".join(lines) + "\n"
 
 
 def _human_requirements_review_guidance(
@@ -802,6 +875,7 @@ def build_followup_prompt(
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
+    human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
     return f"""{reviewer_name} reviewed pull request #{pr_number} in {config.repo} and found blocking issues.
 
 Address the review below in this local checkout. Pull/sync the PR branch if
@@ -810,7 +884,7 @@ Do not create a new PR.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
-{_human_requirements_block(human_requirements)}
+{human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}
 
 {reviewer_name} review:
@@ -839,6 +913,7 @@ def build_same_pr_followup_prompt(
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
+    human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
     return f"""{reviewer_name} approved pull request #{pr_number} in {config.repo} with same-PR follow-ups.
 
 Address the follow-up items below in this local checkout. Pull/sync the PR
@@ -850,7 +925,7 @@ larger redesigns or unrelated future work; call that out instead.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
-{_human_requirements_block(human_requirements)}
+{human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}
 
 Same-PR follow-ups:

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 
 from .errors import AgentLoopError
 
+HUMAN_REQUIREMENTS_ADDRESSED_MARKER = "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->"
+HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK = "checked the PR discussion directly before responding"
+
 STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->", re.I)
 PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->", re.I)
 PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
@@ -16,6 +19,14 @@ CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
 HUMAN_REVIEWER_SIGNATURE_RE = re.compile(r"^\s*--\s*Human Reviewer\s*$", re.I | re.M)
 HUMAN_REQUIREMENTS_RESOLVED_RE = re.compile(
     r"<!--\s*HUMAN_REQUIREMENTS_RESOLVED\s*-->",
+    re.I,
+)
+HUMAN_REQUIREMENTS_ADDRESSED_RE = re.compile(
+    re.escape(HUMAN_REQUIREMENTS_ADDRESSED_MARKER),
+    re.I,
+)
+HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK_RE = re.compile(
+    re.escape(HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK),
     re.I,
 )
 
@@ -38,6 +49,7 @@ PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
 )
 BLOCKING_PLAN_ISSUES_HEADING_RE = _followup_heading_re(r"blocking plan issues")
 SAME_PLAN_FOLLOWUP_HEADING_RE = _followup_heading_re(r"same[- ]plan follow[- ]ups")
+HUMAN_REQUIREMENTS_HEADING_RE = _followup_heading_re(r"human requirements")
 PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
     r"prior unresolved plan item dispositions"
 )
@@ -115,6 +127,14 @@ class ParsedPlanReview:
     dispositions: tuple[ReviewItemDisposition, ...]
 
 
+@dataclass(frozen=True)
+class ParsedHumanRequirementsAcknowledgement:
+    marker_present: bool
+    section_present: bool
+    addressed_ids: tuple[str, ...]
+    section_text: str
+
+
 def parse_agent_state(text: str) -> str:
     matches = STATE_RE.findall(text)
     if not matches:
@@ -159,6 +179,95 @@ def parse_signed_human_requirement_body(text: str | None) -> str | None:
 
 def human_requirements_resolved(text: str) -> bool:
     return bool(HUMAN_REQUIREMENTS_RESOLVED_RE.search(text))
+
+
+def _normalize_requirement_label(text: str) -> str:
+    match = re.fullmatch(r"\s*Requirement\s+(\d+)\s*", text, re.I)
+    if not match:
+        raise AgentLoopError(f"Invalid human requirement label: {text}")
+    return f"Requirement {match.group(1)}"
+
+
+def parse_human_requirements_acknowledgement(text: str) -> ParsedHumanRequirementsAcknowledgement:
+    marker_present = bool(HUMAN_REQUIREMENTS_ADDRESSED_RE.search(text))
+    section_present = False
+    section_lines: list[str] = []
+    addressed_ids: list[str] = []
+    active = False
+
+    for line in text.splitlines():
+        if HUMAN_REQUIREMENTS_HEADING_RE.match(line):
+            section_present = True
+            active = True
+            continue
+        if not active:
+            continue
+        if ANY_HEADING_RE.match(line) or HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
+            active = False
+            continue
+        section_lines.append(line)
+        bullet = BULLET_RE.match(line)
+        if not bullet:
+            continue
+        for match in re.finditer(r"\bRequirement\s+\d+\b", bullet.group("text"), re.I):
+            addressed_ids.append(_normalize_requirement_label(match.group(0)))
+
+    return ParsedHumanRequirementsAcknowledgement(
+        marker_present=marker_present,
+        section_present=section_present,
+        addressed_ids=tuple(addressed_ids),
+        section_text="\n".join(section_lines).strip(),
+    )
+
+
+def validate_human_requirements_acknowledgement(
+    text: str,
+    *,
+    surfaced_requirement_ids: Sequence[str],
+    requires_direct_discussion_ack: bool,
+) -> None:
+    if not surfaced_requirement_ids and not requires_direct_discussion_ack:
+        return
+
+    parsed = parse_human_requirements_acknowledgement(text)
+    if not parsed.marker_present:
+        raise AgentLoopError(
+            "Coder response missing required signed human requirements marker "
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}."
+        )
+    if not parsed.section_present:
+        raise AgentLoopError("Coder response missing required `### Human requirements` section.")
+
+    addressed_ids = list(parsed.addressed_ids)
+    duplicates = sorted({item_id for item_id in addressed_ids if addressed_ids.count(item_id) > 1})
+    if duplicates:
+        raise AgentLoopError(
+            "Coder response listed signed human requirement IDs more than once: "
+            + ", ".join(duplicates)
+        )
+
+    expected_ids = tuple(_normalize_requirement_label(item_id) for item_id in surfaced_requirement_ids)
+    unknown = sorted(set(addressed_ids) - set(expected_ids))
+    if unknown:
+        raise AgentLoopError(
+            "Coder response referenced unknown signed human requirement IDs: "
+            + ", ".join(unknown)
+        )
+
+    if expected_ids:
+        missing = sorted(set(expected_ids) - set(addressed_ids))
+        if missing:
+            raise AgentLoopError(
+                "Coder response did not address all surfaced signed human requirement IDs: "
+                + ", ".join(missing)
+            )
+        return
+
+    if not HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK_RE.search(parsed.section_text):
+        raise AgentLoopError(
+            "Coder response must acknowledge that the prompt omitted the detailed signed human requirements "
+            f"and that it {HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK}."
+        )
 
 
 def _collect_section_items(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -41,19 +41,26 @@ from coding_review_agent_loop.github import (
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
 from coding_review_agent_loop.orchestrator import (
+    HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     _apply_unresolved_item_dispositions,
     _review_freeform_summary_text,
     _validate_plan_review_response,
 )
 from coding_review_agent_loop.prompts import (
+    HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+    HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
+    build_followup_prompt,
+    build_same_pr_followup_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
     build_review_prompt,
     format_human_requirements,
     format_issue_context,
+    render_coder_human_requirements_prompt_context,
 )
 from coding_review_agent_loop.protocol import (
     parse_approved_followups,
+    parse_human_requirements_acknowledgement,
     parse_plan_item_dispositions,
     parse_plan_review,
     parse_plan_review_items,
@@ -63,6 +70,7 @@ from coding_review_agent_loop.protocol import (
     parse_signed_human_requirement_body,
     parse_unresolved_item_dispositions,
     UnresolvedReviewItem,
+    validate_human_requirements_acknowledgement,
 )
 
 
@@ -1641,6 +1649,9 @@ def test_review_freeform_summary_text_strips_structured_followup_sections():
 ### Prior unresolved item dispositions
 - [item-1] still blocking: needs one more assertion
 
+### Human requirements
+- Requirement 1: addressed in the latest patch
+
 ### Same-PR follow-ups
 - Rename helper
 
@@ -1902,6 +1913,181 @@ def test_format_human_requirements_preserves_entry_spacing_when_truncated():
     assert "Oldest requirement." not in text
     assert "Middle requirement.\n\nRequirement 3:" in text
     assert "Newest requirement." in text
+
+
+def test_render_coder_human_requirements_prompt_context_tracks_surfaced_ids_after_truncation():
+    requirements = (
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+            body="Oldest requirement.",
+        ),
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T11:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-2",
+            body="Middle requirement.",
+        ),
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T12:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-3",
+            body="Newest requirement.",
+        ),
+    )
+    full_text = format_human_requirements(requirements)
+
+    context = render_coder_human_requirements_prompt_context(
+        requirements,
+        max_chars=len(full_text) - 1,
+    )
+
+    assert context.block.endswith("\n")
+    assert "Older signed human requirement(s) omitted: 1." in context.block
+    assert context.surfaced_requirement_ids == ("Requirement 2", "Requirement 3")
+    assert context.requires_direct_discussion_ack is False
+
+
+def test_render_coder_human_requirements_prompt_context_handles_full_omission_fallback():
+    context = render_coder_human_requirements_prompt_context(
+        (
+            HumanReviewRequirement(
+                source_type="PR comment",
+                author="reviewer",
+                created_at="2026-05-18T10:00:00Z",
+                url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                body="Please use the absolute URL.",
+            ),
+        ),
+        max_chars=120,
+    )
+
+    assert "All 1 signed human requirement(s) were omitted" in context.block
+    assert context.surfaced_requirement_ids == ()
+    assert context.requires_direct_discussion_ack is True
+
+
+@pytest.mark.parametrize("builder", [build_followup_prompt, build_same_pr_followup_prompt])
+def test_coder_followup_prompts_require_human_requirements_acknowledgement_only_when_present(
+    tmp_path, builder
+):
+    config = make_config(tmp_path)
+    with_requirements = builder(
+        77,
+        2,
+        "Fix the bug.",
+        config,
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="PR comment",
+                author="reviewer",
+                created_at="2026-05-18T10:00:00Z",
+                url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                body="Please use the absolute URL.",
+            ),
+        ),
+    )
+    without_requirements = builder(77, 2, "Fix the bug.", config)
+
+    assert "mandatory next-revision requirements" in with_requirements
+    assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER in with_requirements
+    assert "### Human requirements" in with_requirements
+    assert "`Requirement 1`" in with_requirements
+    assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER not in without_requirements
+    assert "### Human requirements" not in without_requirements
+
+
+def test_validate_human_requirements_acknowledgement_accepts_multiple_bullet_styles():
+    response = f"""Implemented the fix.
+{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}
+### Human requirements
+1. Requirement 1: updated the URL handling.
+* Requirement 2: could not satisfy safely without widening scope, so I documented the limit.
+<!-- AGENT_STATE: blocking -->
+"""
+
+    validate_human_requirements_acknowledgement(
+        response,
+        surfaced_requirement_ids=("Requirement 1", "Requirement 2"),
+        requires_direct_discussion_ack=False,
+    )
+
+    parsed = parse_human_requirements_acknowledgement(response)
+    assert parsed.addressed_ids == ("Requirement 1", "Requirement 2")
+
+
+@pytest.mark.parametrize(
+    ("response", "surfaced_ids", "requires_direct_discussion_ack", "message"),
+    [
+        (
+            "Implemented.\n### Human requirements\n- Requirement 1: handled.\n<!-- AGENT_STATE: blocking -->",
+            ("Requirement 1",),
+            False,
+            "missing required signed human requirements marker",
+        ),
+        (
+            f"Implemented.\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n<!-- AGENT_STATE: blocking -->",
+            ("Requirement 1",),
+            False,
+            "missing required `### Human requirements` section",
+        ),
+        (
+            f"Implemented.\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n### Human requirements\n- Requirement 1: handled.\n<!-- AGENT_STATE: blocking -->",
+            ("Requirement 1", "Requirement 2"),
+            False,
+            "did not address all surfaced signed human requirement IDs",
+        ),
+        (
+            f"Implemented.\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n### Human requirements\n- Requirement 1: handled.\n- Requirement 1: repeated.\n<!-- AGENT_STATE: blocking -->",
+            ("Requirement 1",),
+            False,
+            "listed signed human requirement IDs more than once",
+        ),
+        (
+            f"Implemented.\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n### Human requirements\n- Requirement 99: handled.\n<!-- AGENT_STATE: blocking -->",
+            ("Requirement 1",),
+            False,
+            "referenced unknown signed human requirement IDs",
+        ),
+        (
+            f"Implemented.\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n### Human requirements\n- Prompt omitted details.\n<!-- AGENT_STATE: blocking -->",
+            (),
+            True,
+            "must acknowledge that the prompt omitted the detailed signed human requirements",
+        ),
+    ],
+)
+def test_validate_human_requirements_acknowledgement_rejects_structural_failures(
+    response,
+    surfaced_ids,
+    requires_direct_discussion_ack,
+    message,
+):
+    with pytest.raises(AgentLoopError, match=message):
+        validate_human_requirements_acknowledgement(
+            response,
+            surfaced_requirement_ids=surfaced_ids,
+            requires_direct_discussion_ack=requires_direct_discussion_ack,
+        )
+
+
+def test_validate_human_requirements_acknowledgement_accepts_full_truncation_fallback():
+    response = f"""Implemented the fix.
+{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}
+### Human requirements
+- The prompt omitted the detailed signed human requirements, so I {HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK}.
+<!-- AGENT_STATE: blocking -->
+"""
+
+    validate_human_requirements_acknowledgement(
+        response,
+        surfaced_requirement_ids=(),
+        requires_direct_discussion_ack=True,
+    )
 
 
 def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
@@ -2342,6 +2528,105 @@ def test_pr_loop_allows_approval_with_human_requirement_resolution_marker(tmp_pa
     assert ["pytest", "tests/test_agent_loop.py"] in commands
 
 
+def test_pr_loop_surfaces_coder_human_requirements_acknowledgement_blocker_next_round(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Blocking issue."
+            "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Still blocked."
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                f"[{HUMAN_REQUIREMENTS_ACK_ITEM_ID}] still blocking",
+            )
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
+
+    with pytest.raises(
+        AgentLoopError,
+        match="One or more reviewers still reported blocking issues after round 2",
+    ):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    review_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(review_prompts) == 2
+    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID in review_prompts[1]
+    assert "Coder response missing required signed human requirements marker" in review_prompts[1]
+    assert "Orchestrator" in review_prompts[1]
+
+
+def test_pr_loop_clears_human_requirements_acknowledgement_blocker_before_next_review(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Implemented follow-up.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: updated the URL handling.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Blocking issue."
+            "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Need coder acknowledgement."
+            + prior_item_dispositions(
+                "[item-1] resolved",
+                f"[{HUMAN_REQUIREMENTS_ACK_ITEM_ID}] still blocking",
+            )
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    review_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(review_prompts) == 3
+    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID in review_prompts[1]
+    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID not in review_prompts[2]
+
+
 def test_pr_loop_routes_migration_validation_failure_through_coder_followup(tmp_path, monkeypatch):
     runner = FakeRunner(
         claude_outputs=["Fixed migration.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -2725,7 +3010,13 @@ def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):
             + prior_item_dispositions("[item-1] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
-        claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        claude_outputs=[
+            "Fixed review.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: used the absolute URL.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+        ],
     )
     config = make_config(tmp_path)
     issue_context = IssueContext(
@@ -2762,7 +3053,13 @@ def test_blocking_followup_prompt_includes_human_requirements_before_ai_feedback
             + prior_item_dispositions("[item-1] resolved")
             + "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
-        claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        claude_outputs=[
+            "Fixed review.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: used the absolute URL.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+        ],
         pr_payload={
             "number": 77,
             "state": "OPEN",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -36,6 +36,7 @@ from coding_review_agent_loop.github import (
     HumanReviewRequirement,
     IssueComment,
     IssueContext,
+    PullRequestReviewContext,
     PullRequestMetadata,
     get_pr_checks,
 )
@@ -2653,6 +2654,83 @@ def test_pr_loop_clears_human_requirements_acknowledgement_blocker_before_next_r
     assert len(review_prompts) == 3
     assert HUMAN_REQUIREMENTS_ACK_ITEM_ID in review_prompts[1]
     assert HUMAN_REQUIREMENTS_ACK_ITEM_ID not in review_prompts[2]
+
+
+def test_pr_loop_revalidates_latest_coder_output_against_refreshed_human_requirements(
+    tmp_path, monkeypatch
+):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Blocking issue.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "title": "Improve review prompt context",
+            "headRefName": "feature/review-context",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
+    metadata = PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Improve review prompt context",
+        head_branch="feature/review-context",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/77",
+    )
+    contexts = iter(
+        [
+            PullRequestReviewContext(
+                metadata=metadata,
+                comments=(),
+                human_requirements=(
+                    HumanReviewRequirement(
+                        source_type="PR comment",
+                        author="maintainer",
+                        created_at="2026-05-18T10:00:00Z",
+                        url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                        body="Please use the absolute URL.",
+                    ),
+                ),
+            ),
+            PullRequestReviewContext(
+                metadata=metadata,
+                comments=(),
+                human_requirements=(),
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(
+        "coding_review_agent_loop.orchestrator.get_pr_review_context",
+        lambda *args, **kwargs: next(contexts),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    review_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(review_prompts) == 2
+    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID not in review_prompts[1]
 
 
 def test_pr_loop_routes_migration_validation_failure_through_coder_followup(tmp_path, monkeypatch):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2001,6 +2001,34 @@ def test_coder_followup_prompts_require_human_requirements_acknowledgement_only_
     assert "### Human requirements" not in without_requirements
 
 
+@pytest.mark.parametrize("builder", [build_followup_prompt, build_same_pr_followup_prompt])
+def test_coder_followup_prompts_accept_precomputed_human_requirements_context(tmp_path, builder):
+    config = make_config(tmp_path)
+    requirements = (
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+            body="Please use the absolute URL.",
+        ),
+    )
+    context = render_coder_human_requirements_prompt_context(requirements)
+
+    prompt = builder(
+        77,
+        2,
+        "Fix the bug.",
+        config,
+        human_requirements=requirements,
+        human_requirements_context=context,
+    )
+
+    assert context.block in prompt
+    assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER in prompt
+    assert "`Requirement 1`" in prompt
+
+
 def test_validate_human_requirements_acknowledgement_accepts_multiple_bullet_styles():
     response = f"""Implemented the fix.
 {HUMAN_REQUIREMENTS_ADDRESSED_MARKER}


### PR DESCRIPTION
Fixes #117

## Summary
- strengthen coder follow-up prompts with an explicit signed-human-requirements acknowledgement contract tied to the surfaced Requirement IDs
- validate coder acknowledgement structure in the protocol/orchestrator flow and surface a stable Orchestrator blocker when the contract is missed
- auto-clear the synthetic blocker before the next reviewer snapshot once the latest coder response satisfies the contract, and add regression coverage for truncation and stale-blocker removal

## Testing
- python3 -m pytest tests/test_agent_loop.py

-- OpenAI Codex