### PR TITLE
Link issue-mode PRs back to their source issue

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -152,8 +152,9 @@ def validate_pr_references_issue(
         return
     raise AgentLoopError(
         f"PR #{pr_number} does not reference issue #{issue_number} in its body. "
-        f"Update the PR description to include `Fixes #{issue_number}` or another direct "
-        "issue reference, then rerun the loop."
+        f"Edit the PR description on GitHub to include `Fixes #{issue_number}` or another direct "
+        f"issue reference, then rerun the orchestrator with `--pr {pr_number}` to continue "
+        "the review."
     )
 
 

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -153,7 +153,7 @@ def validate_pr_references_issue(
     raise AgentLoopError(
         f"PR #{pr_number} does not reference issue #{issue_number} in its body. "
         f"Edit the PR description on GitHub to include `Fixes #{issue_number}` or another direct "
-        f"issue reference, then rerun the orchestrator with `--pr {pr_number}` to continue "
+        f"issue reference, then rerun the orchestrator as `agent-loop pr {pr_number}` to continue "
         "the review."
     )
 

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -85,6 +86,7 @@ class PullRequestChecks:
 
 PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url"
 PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
+ISSUE_REFERENCE_RE_TEMPLATE = r"(?:#%d\b|/issues/%d\b)"
 
 
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
@@ -119,6 +121,40 @@ def validate_open_pr(runner: Runner, *, config: AgentLoopConfig, pr_number: int)
         raise AgentLoopError(
             f"PR #{pr_number} is {data.get('state', 'not open')}; provide an open PR number."
         )
+
+
+def validate_pr_references_issue(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    issue_number: int,
+) -> None:
+    if config.dry_run:
+        return
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            "body,url",
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    body = _optional_str(data.get("body")) or ""
+    reference_re = re.compile(ISSUE_REFERENCE_RE_TEMPLATE % (issue_number, issue_number), re.I)
+    if reference_re.search(body):
+        return
+    raise AgentLoopError(
+        f"PR #{pr_number} does not reference issue #{issue_number} in its body. "
+        f"Update the PR description to include `Fixes #{issue_number}` or another direct "
+        "issue reference, then rerun the loop."
+    )
 
 
 def _parse_pr_metadata(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -30,6 +30,7 @@ from .github import (
     post_pr_comment,
     validate_open_issue,
     validate_open_pr,
+    validate_pr_references_issue,
     wait_for_ci,
 )
 from .logging import log, new_run_id, run_usage_summary_path
@@ -1069,6 +1070,12 @@ def _run_plan_first_loop(
             pr_number = int(coder_response.marker_value)
             log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
             validate_open_pr(runner, config=config, pr_number=pr_number)
+            validate_pr_references_issue(
+                runner,
+                config=config,
+                pr_number=pr_number,
+                issue_number=issue_number,
+            )
             post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
             return run_pr_loop(
                 runner,
@@ -1161,6 +1168,12 @@ def run_issue_loop(
         pr_number = int(coder_response.marker_value)
         log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
         validate_open_pr(runner, config=config, pr_number=pr_number)
+        validate_pr_references_issue(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            issue_number=issue_number,
+        )
 
         post_pr_comment(runner, config=config, pr_number=pr_number, body=coder_output)
         return run_pr_loop(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -334,6 +334,13 @@ def _issue_context_block(issue_context: IssueContext | None) -> str:
     )
 
 
+def _issue_pr_reference_guidance(issue_number: int) -> str:
+    return (
+        f"In the pull request body, include `Fixes #{issue_number}` or another direct "
+        f"reference to issue #{issue_number} so GitHub links the PR back to the issue.\n"
+    )
+
+
 def build_issue_prompt(
     issue_number: int,
     config: AgentLoopConfig,
@@ -348,6 +355,7 @@ Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
+{_issue_pr_reference_guidance(issue_number)}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
@@ -547,6 +555,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
+{_issue_pr_reference_guidance(issue_number)}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -116,6 +116,7 @@ class FakeRunner(Runner):
             "state": "OPEN",
             "url": "https://github.com/OWNER/REPO/pull/77",
             "title": "Improve review prompt context",
+            "body": "Fixes #56",
             "headRefName": "feature/review-context",
             "baseRefName": "main",
             "headRefOid": "abc123",
@@ -1816,6 +1817,7 @@ def test_issue_loop_includes_issue_comments_in_coder_and_review_prompts(tmp_path
         )
         assert "Earlier comment refines the request." in prompt
         assert "Later comment should come second." in prompt
+    assert "include `Fixes #56` or another direct reference to issue #56" in claude_prompt
 
 
 def test_format_issue_context_truncates_oversized_newest_comment():
@@ -4799,6 +4801,7 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert len(claude_calls) == 2
     assert "Approved implementation plan" in claude_calls[1][-1]
+    assert "include `Fixes #56` or another direct reference to issue #56" in claude_calls[1][-1]
     first_claude_index = command_index(runner.commands, ["claude", "--print"])
     fetch_index = command_index(runner.commands, ["git", "fetch", "origin"])
     switch_index = command_index(runner.commands, ["git", "switch", "main"])
@@ -4807,6 +4810,52 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     assert len(runner.comments) == 5
     assert runner.comments[3].startswith("Implemented approved plan.")
     assert runner.comments[4].startswith("LGTM.")
+
+
+def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Fixed issue.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "Summary only.",
+        },
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="does not reference issue #56"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+
+def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference_in_body(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "Summary only.",
+        },
+    )
+    config = make_config(tmp_path, reviewer=("codex",))
+
+    with pytest.raises(AgentLoopError, match="does not reference issue #56"):
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
 
 
 def test_is_clarification_request_detects_marker():

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4826,8 +4826,11 @@ def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
     )
     config = make_config(tmp_path)
 
-    with pytest.raises(AgentLoopError, match="does not reference issue #56"):
+    with pytest.raises(AgentLoopError, match="does not reference issue #56") as excinfo:
         run_issue_loop(runner, issue_number=56, config=config)
+
+    assert "Edit the PR description on GitHub" in str(excinfo.value)
+    assert "rerun the orchestrator with `--pr 77` to continue the review" in str(excinfo.value)
 
 
 def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference_in_body(tmp_path):
@@ -4848,7 +4851,7 @@ def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference
     )
     config = make_config(tmp_path, reviewer=("codex",))
 
-    with pytest.raises(AgentLoopError, match="does not reference issue #56"):
+    with pytest.raises(AgentLoopError, match="does not reference issue #56") as excinfo:
         run_issue_loop(
             runner,
             issue_number=56,
@@ -4856,6 +4859,9 @@ def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference
             plan_first=True,
             implement_after_approval=True,
         )
+
+    assert "Edit the PR description on GitHub" in str(excinfo.value)
+    assert "rerun the orchestrator with `--pr 77` to continue the review" in str(excinfo.value)
 
 
 def test_is_clarification_request_detects_marker():

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4830,7 +4830,7 @@ def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
         run_issue_loop(runner, issue_number=56, config=config)
 
     assert "Edit the PR description on GitHub" in str(excinfo.value)
-    assert "rerun the orchestrator with `--pr 77` to continue the review" in str(excinfo.value)
+    assert "rerun the orchestrator as `agent-loop pr 77` to continue the review" in str(excinfo.value)
 
 
 def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference_in_body(tmp_path):
@@ -4861,7 +4861,7 @@ def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference
         )
 
     assert "Edit the PR description on GitHub" in str(excinfo.value)
-    assert "rerun the orchestrator with `--pr 77` to continue the review" in str(excinfo.value)
+    assert "rerun the orchestrator as `agent-loop pr 77` to continue the review" in str(excinfo.value)
 
 
 def test_is_clarification_request_detects_marker():


### PR DESCRIPTION
## Summary
- tell issue-mode coders to include a direct issue reference in the PR body
- validate issue-driven PRs after creation so the loop fails fast when the source issue is missing from the PR description
- add issue-mode and plan-first implementation regressions for missing PR issue references

## Testing
- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest /home/wwind123/openai-codex/coding-review-agent-loop-issue-links/tests/test_agent_loop.py -q
- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile /home/wwind123/openai-codex/coding-review-agent-loop-issue-links/src/coding_review_agent_loop/*.py

-- OpenAI Codex