### PR TITLE
Disallow approved state when Same-PR follow-ups remain

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,11 @@ mode, approved reviews may include future work under:
 Reviewers should use that section only for substantial work that is better
 handled in a separate issue or PR. The legacy heading
 `### Non-blocking follow-ups` is still parsed as future work for compatibility.
+Approval means the review is fully complete for that round: no new blocking
+work, and no carried-forward unresolved items left active in the reviewer’s
+disposition section.
 
-When `--approved-followups` uses a `fix-and-*` mode, approved reviews may also
+When `--approved-followups` uses a `fix-and-*` mode, blocking reviews may also
 include small, localized, low-risk current-PR cleanup under:
 
 ```md
@@ -230,13 +233,19 @@ include small, localized, low-risk current-PR cleanup under:
 ```
 
 Same-PR follow-ups are sent back to the coder in the existing PR and require a
-new review round. They should stay narrowly scoped to files already touched by
-the PR or directly adjacent code; larger redesigns and independent work belong
-under Future follow-ups. Approved future follow-ups remain in the round-to-round
+new review round. They may not appear in an approved review. They should stay
+narrowly scoped to files already touched by the PR or directly adjacent code;
+larger redesigns and independent work belong under Future follow-ups. Approved
+future follow-ups remain in the round-to-round
 ledger so later reviewers can explicitly confirm they are still future work,
 resolved, or should be promoted back to same-PR or blocking status. The final
 summary or issue creation uses the remaining future items from that ledger. The
 issue modes create at most three follow-up issues to avoid issue noise.
+
+Plan reviews follow the same rule: approved plan reviews may include Future
+follow-ups only. Blocking plan issues, Same-plan follow-ups, or carried-forward
+plan items left `still blocking` or `same-plan` keep the planning round
+unapproved.
 
 By default, `--approved-followups=ignore` asks reviewers not to include
 approved-review follow-up sections. Reviewers should mark the review blocking

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -856,6 +856,29 @@ def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
     return "\n".join(lines).strip()
 
 
+def _describe_pr_review_outcome(parsed_review: ParsedReview, *, has_blocking_summary: bool) -> str:
+    if parsed_review.state == "approved":
+        return "approved"
+    has_same_pr = bool(parsed_review.followups.same_pr)
+    if has_blocking_summary and has_same_pr:
+        return "blocking with blocking findings and same-PR follow-ups"
+    if has_same_pr:
+        return "blocking with same-PR follow-ups"
+    return "blocking with blocking findings"
+
+
+def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
+    if parsed_review.state == "approved":
+        return "approved"
+    has_blocking = bool(parsed_review.items.blocking)
+    has_same_plan = bool(parsed_review.items.same_plan)
+    if has_blocking and has_same_plan:
+        return "blocking with blocking plan issues and same-plan follow-ups"
+    if has_same_plan:
+        return "blocking with same-plan follow-ups"
+    return "blocking with blocking plan issues"
+
+
 def _format_same_pr_unresolved_items(items: Sequence[UnresolvedReviewItem]) -> str:
     lines: list[str] = []
     for item in items:
@@ -1043,7 +1066,11 @@ def _run_plan_first_loop(
             assert isinstance(parsed_review, ParsedPlanReview)
             review_state = parsed_review.state
             post_issue_comment(runner, config=config, issue_number=issue_number, body=review_output)
-            log(config, f"Planning round {round_number}: {reviewer_name} state is {review_state}")
+            log(
+                config,
+                "Planning round "
+                f"{round_number}: {reviewer_name} outcome is {_describe_plan_review_outcome(parsed_review)}",
+            )
             for disposition in parsed_review.dispositions:
                 prior_dispositions[disposition.item_id].append(disposition)
             if review_state == "blocking":
@@ -1440,16 +1467,21 @@ def run_pr_loop(
                 review_state = parsed_review.state
 
                 post_pr_comment(runner, config=config, pr_number=pr_number, body=review_output)
-                log(config, f"Round {round_number}: {reviewer_name} state is {review_state}")
                 for disposition in parsed_review.dispositions:
                     prior_dispositions[disposition.item_id].append(disposition)
+                blocking_summary = _review_freeform_summary_text(review_output)
+                has_blocking_summary = _should_record_new_blocking_item(
+                    blocking_summary,
+                    had_prior_items=bool(prior_unresolved_items),
+                    had_dispositions=bool(parsed_review.dispositions),
+                )
+                log(
+                    config,
+                    f"Round {round_number}: {reviewer_name} outcome is "
+                    f"{_describe_pr_review_outcome(parsed_review, has_blocking_summary=has_blocking_summary)}",
+                )
                 if review_state == "blocking":
-                    blocking_summary = _review_freeform_summary_text(review_output)
-                    if _should_record_new_blocking_item(
-                        blocking_summary,
-                        had_prior_items=bool(prior_unresolved_items),
-                        had_dispositions=bool(parsed_review.dispositions),
-                    ):
+                    if has_blocking_summary:
                         round_new_unresolved_items.append(
                             _next_unresolved_item(
                                 item_number=next_unresolved_item_number,
@@ -1457,21 +1489,6 @@ def run_pr_loop(
                                 source_round=round_number,
                                 text=blocking_summary,
                                 status="blocking",
-                            )
-                        )
-                        next_unresolved_item_number += 1
-                    continue
-
-                approved_review_outputs.append((reviewer_name, review_output))
-                if config.approved_followups != "ignore":
-                    for followup in parsed_review.followups.future:
-                        round_new_unresolved_items.append(
-                            _next_unresolved_item(
-                                item_number=next_unresolved_item_number,
-                                reviewer=followup.reviewer,
-                                source_round=round_number,
-                                text=followup.text,
-                                status="future",
                             )
                         )
                         next_unresolved_item_number += 1
@@ -1496,7 +1513,7 @@ def run_pr_loop(
                                     source_round=round_number,
                                     text="\n".join(
                                         [
-                                            "Approved review included Same-PR follow-ups, "
+                                            "Blocking review included Same-PR follow-ups, "
                                             f"but --approved-followups={config.approved_followups} "
                                             "does not enable a same-PR fix path.",
                                             "",
@@ -1507,6 +1524,21 @@ def run_pr_loop(
                                 )
                             )
                             next_unresolved_item_number += 1
+                    continue
+
+                approved_review_outputs.append((reviewer_name, review_output))
+                if config.approved_followups != "ignore":
+                    for followup in parsed_review.followups.future:
+                        round_new_unresolved_items.append(
+                            _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer=followup.reviewer,
+                                source_round=round_number,
+                                text=followup.text,
+                                status="future",
+                            )
+                        )
+                        next_unresolved_item_number += 1
 
             unresolved_items, _future_items = _apply_unresolved_item_dispositions(
                 prior_unresolved_items,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -537,11 +537,14 @@ strategy, and ambiguity. Use this exact structured format in your response body:
 ### Future follow-ups
 - Ideas worth tracking separately that are not required for the current implementation plan.
 
-Blocking plan issues and Same-plan follow-ups both prevent approval. Future
-follow-ups are allowed only in approved plan reviews. If you return
-`<!-- AGENT_PLAN_STATE: blocking -->`, do not use structured Future
-follow-ups; keep all required current-round issues in the main blocking
-content so they are not missed during plan revision.
+Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
+follow-ups may appear only in blocking plan reviews. Future follow-ups are
+allowed only in approved plan reviews. Approved means there are no blocking
+plan issues, no Same-plan follow-ups, and no carried-forward plan items left
+active for this planning round. If you return `<!-- AGENT_PLAN_STATE:
+blocking -->`, do not use structured Future follow-ups; keep all required
+current-round issues in the main blocking content so they are not missed
+during plan revision.
 {unresolved_items_guidance}
 Use blocking only when the current plan still has blocking plan issues or
 same-plan follow-ups. All configured reviewers ({reviewer_group}) must approve
@@ -555,7 +558,9 @@ or:
 
 <!-- AGENT_PLAN_STATE: blocking -->
 
-Use approved only if there are no blocking plan issues. Always sign your response:
+Use approved only if there are no blocking plan issues, no Same-plan
+follow-ups, and no carried-forward plan items left active for this planning
+round. Always sign your response:
 -- {reviewer_signature}
 """
 
@@ -784,26 +789,32 @@ ignore approved-review follow-up sections. Mark the review blocking instead
 when cleanup should be fixed before merge.
 """
     elif config.approved_followups.startswith("fix-and-"):
-        followup_guidance = f"""If you approve but notice small, localized, low-risk cleanup worth fixing
-before merge, list those items under this exact heading:
+        followup_guidance = f"""For small, localized, low-risk cleanup that must still be fixed in this PR
+before merge, return `<!-- AGENT_STATE: blocking -->` and list those items
+under this exact heading:
 
 ### Same-PR follow-ups
 
 Use Same-PR follow-ups only for narrow current-PR cleanup in files already
 touched by this PR or directly adjacent code. Do not use this section for
 larger redesigns, broad refactors, or independent future work.
+Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
+follow-up remains, including a carried-forward prior item that stays
+`still blocking` or `same-pr`, the review is not approved yet.
 
-If you approve but notice substantial work that is better handled separately in
-a future issue or PR, list at most three highest-value items under this exact
-heading:
+If the PR is otherwise fully complete for this round but you notice substantial
+work that is better handled separately in a future issue or PR, list at most
+three highest-value items under this exact heading:
 
 ### Future follow-ups
 
+Approved means there are no blocking issues, no Same-PR follow-ups, and no
+carried-forward prior unresolved items left active for this round.
 Same-PR follow-ups will be sent back to {coder_name} and require another review
 round before final approval. Do not put trivial style nits in either follow-up
 section. If you return `<!-- AGENT_STATE: blocking -->`, do not use structured
-follow-up sections; include all findings in the main body of your response so
-they are not missed during revision.
+Future follow-ups; keep all required current-round work in the blocking review
+so it is not missed during revision.
 """
     else:
         followup_guidance = """If you approve but notice substantial work that is better handled separately in
@@ -870,7 +881,9 @@ or:
 
 <!-- AGENT_STATE: blocking -->
 
-Use approved only if there are no blocking issues. Always sign your response:
+Use approved only if there are no blocking issues, no Same-PR follow-ups, and
+no carried-forward unresolved items left active for this round. Always sign
+your response:
 -- {reviewer_signature}
 """
 
@@ -931,14 +944,15 @@ def build_same_pr_followup_prompt(
     coder_signature = agent_signature(config.coder)
     if human_requirements_context is None:
         human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
-    return f"""{reviewer_name} approved pull request #{pr_number} in {config.repo} with same-PR follow-ups.
+    return f"""{reviewer_name} requested same-PR follow-ups on pull request #{pr_number} in {config.repo}.
 
 Address the follow-up items below in this local checkout. Pull/sync the PR
 branch if needed, implement fixes, run relevant tests, commit, and push to the
 same PR. Do not create a new PR.
 These same-PR follow-ups are intended to be small, localized cleanup for the
 current PR. Keep the change narrowly scoped to the listed items. Do not take on
-larger redesigns or unrelated future work; call that out instead.
+larger redesigns or unrelated future work; call that out instead. The PR
+remains blocked pending another review round after this cleanup.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -532,6 +532,16 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
         raise AgentLoopError(
             "Blocking reviews may not downgrade prior unresolved items to Future follow-ups."
         )
+    if state == "approved":
+        active_dispositions = [
+            item.disposition for item in dispositions if item.disposition in {"blocking", "same-pr"}
+        ]
+        if followups.same_pr or active_dispositions:
+            raise AgentLoopError(
+                "Approved reviews must be fully complete for this round. Do not use "
+                "`approved` when Same-PR follow-ups remain or when any prior unresolved "
+                "item stays `still blocking` or `same-pr`."
+            )
     return ParsedReview(state=state, followups=followups, dispositions=dispositions)
 
 
@@ -549,6 +559,16 @@ def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
         raise AgentLoopError(
             "Blocking plan reviews may not downgrade prior unresolved plan items to Future follow-ups."
         )
+    if state == "approved":
+        active_dispositions = [
+            item.disposition for item in dispositions if item.disposition in {"blocking", "same-plan"}
+        ]
+        if items.blocking or items.same_plan or active_dispositions:
+            raise AgentLoopError(
+                "Approved plan reviews must be fully complete for this planning round. "
+                "Do not use `approved` when blocking plan issues, Same-plan follow-ups, "
+                "or carried-forward plan items remain active."
+            )
     return ParsedPlanReview(state=state, items=items, dispositions=dispositions)
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1442,7 +1442,7 @@ def test_parse_plan_review_rejects_contradictory_prior_plan_item_disposition():
         parse_plan_review(review, reviewer="OpenAI Codex")
 
 
-def test_parse_plan_review_uses_plan_marker_while_pr_review_remains_pr_only():
+def test_parse_plan_review_rejects_approved_state_with_active_items():
     plan_review = """
     ### Same-plan follow-ups
     - Add one more orchestration test.
@@ -1451,12 +1451,33 @@ def test_parse_plan_review_uses_plan_marker_while_pr_review_remains_pr_only():
     -- OpenAI Codex
     """
 
-    parsed = parse_plan_review(plan_review, reviewer="OpenAI Codex")
+    with pytest.raises(AgentLoopError, match="Approved plan reviews must be fully complete"):
+        parse_plan_review(plan_review, reviewer="OpenAI Codex")
 
-    assert parsed.state == "approved"
-    assert [item.text for item in parsed.items.same_plan] == ["Add one more orchestration test."]
     with pytest.raises(AgentLoopError, match="AGENT_STATE"):
         parse_review(plan_review, reviewer="OpenAI Codex")
+
+
+def test_parse_plan_review_rejects_approved_state_with_blocking_items():
+    review = """
+    ### Blocking plan issues
+    - Add one more orchestration test.
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    with pytest.raises(AgentLoopError, match="Approved plan reviews must be fully complete"):
+        parse_plan_review(review, reviewer="OpenAI Codex")
+
+
+@pytest.mark.parametrize("line", ["[item-1] still blocking", "[item-1] same-plan"])
+def test_parse_plan_review_rejects_approved_state_with_active_prior_disposition(line):
+    review = "Looks good now." + prior_plan_item_dispositions(line)
+    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match="Approved plan reviews must be fully complete"):
+        parse_plan_review(review, reviewer="OpenAI Codex")
 
 
 def test_validate_plan_review_response_rejects_duplicate_item_ids():
@@ -1467,7 +1488,7 @@ def test_validate_plan_review_response_rejects_duplicate_item_ids():
         "[item-1] same-plan: keep the extra regression coverage",
         "[item-1] resolved",
     )
-    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    review += "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
 
     with pytest.raises(AgentLoopError, match="more than once: item-1"):
         _validate_plan_review_response(
@@ -1628,6 +1649,30 @@ def test_parse_review_rejects_contradictory_prior_item_disposition():
         parse_review(review, reviewer="OpenAI Codex")
 
 
+def test_parse_review_rejects_approved_state_with_same_pr_followups():
+    review = """
+    LGTM.
+
+    ### Same-PR follow-ups
+    - Tighten the helper in this file.
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    with pytest.raises(AgentLoopError, match="Approved reviews must be fully complete"):
+        parse_review(review, reviewer="OpenAI Codex")
+
+
+@pytest.mark.parametrize("line", ["[item-1] still blocking", "[item-1] same-pr"])
+def test_parse_review_rejects_approved_state_with_active_prior_disposition(line):
+    review = "LGTM." + prior_item_dispositions(line)
+    review += "\n\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match="Approved reviews must be fully complete"):
+        parse_review(review, reviewer="OpenAI Codex")
+
+
 def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions(tmp_path):
     config = make_config(tmp_path, approved_followups="fix-and-summarize")
     prompt = build_review_prompt(
@@ -1669,6 +1714,8 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "- [item-id] resolved" in prompt
     assert "Only use `future follow-up` when returning `approved`." in prompt
     assert "Contradictory forms like `same-pr: none`, `still blocking: none`, and `future follow-up: none` are invalid" in prompt
+    assert "Same-PR follow-ups may appear only in blocking reviews." in prompt
+    assert "no blocking issues, no Same-PR follow-ups, and no" in prompt
 
 
 def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
@@ -1736,8 +1783,9 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
     assert "[item-2] same-plan from Google Gemini in round 1" in prompt
     assert "Only use `future follow-up` when returning `approved`." in prompt
     assert "Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid" in prompt
-    assert "do not use structured Future\nfollow-ups" in prompt
-    assert "keep all required current-round issues in the main blocking\ncontent" in prompt
+    assert "Same-plan\nfollow-ups may appear only in blocking plan reviews" in prompt
+    assert "do not use structured Future follow-ups" in prompt
+    assert "no blocking plan issues, no Same-plan\nfollow-ups, and no carried-forward plan items left active" in prompt
 
 
 def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositions(tmp_path):
@@ -3345,9 +3393,20 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     assert "### Future follow-ups" in prompt
     assert "small, localized, low-risk cleanup" in prompt
     assert "narrow current-PR cleanup in files already\ntouched by this PR or directly adjacent code" in prompt
+    assert "Same-PR follow-ups may appear only in blocking reviews." in prompt
     assert "will be sent back to Claude and require another review" in prompt
-    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not use structured\nfollow-up sections" in prompt
-    assert "include all findings in the main body of your response so\nthey are not missed during revision" in prompt
+    assert "Approved means there are no blocking issues, no Same-PR follow-ups, and no\ncarried-forward prior unresolved items left active" in prompt
+    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not use structured\nFuture follow-ups" in prompt
+
+
+def test_same_pr_followup_prompt_no_longer_claims_pr_was_approved(tmp_path):
+    config = make_config(tmp_path)
+
+    prompt = build_same_pr_followup_prompt(77, 2, "Rename the helper.", config)
+
+    assert "requested same-PR follow-ups" in prompt
+    assert "approved pull request" not in prompt
+    assert "remains blocked pending another review round" in prompt
 
 
 def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(tmp_path):
@@ -3361,13 +3420,13 @@ def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(t
             "<!-- AGENT_STATE: blocking -->\n"
             "-- Google Gemini",
             "LGTM."
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions("[item-1] resolved", "[item-2] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini",
         ],
         codex_outputs=[
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
             "LGTM."
-            + prior_item_dispositions("[item-1] resolved")
+            + prior_item_dispositions("[item-1] resolved", "[item-2] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -3723,10 +3782,10 @@ def test_pr_loop_logs_created_followup_issue_url(tmp_path, capsys):
 def test_pr_loop_treats_same_pr_followups_as_blocking_without_fix_mode(tmp_path, mode):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
+            "Codex found cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "- Rename the helper before merge.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
         ],
     )
     config = make_config(tmp_path, approved_followups=mode, max_rounds=1)
@@ -3743,11 +3802,11 @@ def test_pr_loop_treats_same_pr_followups_as_blocking_without_fix_mode(tmp_path,
 def test_pr_loop_treats_same_pr_prose_followups_as_blocking_without_fix_mode(tmp_path, mode):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
+            "Codex found cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "Rename the helper before merge.\n"
             "Keep the behavior unchanged.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
         ],
     )
     config = make_config(tmp_path, approved_followups=mode, max_rounds=1)
@@ -3790,17 +3849,13 @@ def test_pr_loop_caps_approved_followup_issues(tmp_path):
 def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rereviews(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
             "### Same-PR follow-ups\n"
-            "- Rename the helper before merge.\n\n"
+            "- Rename the helper before merge.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add broader integration coverage later.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "Codex approves final pass."
-            + prior_item_dispositions(
-                "[item-1] future follow-up: still future work",
-                "[item-2] resolved",
-            )
+            + prior_item_dispositions("[item-1] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Renamed helper.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -3826,11 +3881,11 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
     agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"])]
     assert agent_commands == [["codex", "exec"], ["claude", "--print"], ["codex", "exec"]]
     assert len(runner.comments) == 4
-    followup_prompt = next(
-        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Same-PR follow-ups" in cmd[-1]
-    )
+    followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "requested same-PR follow-ups" in followup_prompt
+    assert "remains blocked pending another review round" in followup_prompt
     assert "Rename the helper before merge." in followup_prompt
-    assert "[item-2]" in followup_prompt
+    assert "[item-1]" in followup_prompt
     assert "Issue context from GitHub" in followup_prompt
     assert "Title:\nSupport issue comments" in followup_prompt
     assert "Clarifying issue comment." in followup_prompt
@@ -3840,20 +3895,18 @@ def test_pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rerevie
     assert "Add broader integration coverage later." in runner.comments[-1]
 
 
-def test_pr_loop_fix_and_issue_persists_future_followups_from_pre_fix_round(tmp_path):
+def test_pr_loop_fix_and_issue_uses_final_round_future_followups_after_same_pr_cleanup(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "- Tighten the validation message.\n\n"
             "### Future follow-ups\n"
+            "- Stale future item from the blocking round.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Codex approves final pass.\n\n"
+            "### Future follow-ups\n"
             "- Add a separate migration dry-run command.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-            "Codex approves final pass."
-            + prior_item_dispositions(
-                "[item-1] future follow-up: still separate work",
-                "[item-2] resolved",
-            )
+            + prior_item_dispositions("[item-1] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -3863,23 +3916,45 @@ def test_pr_loop_fix_and_issue_persists_future_followups_from_pre_fix_round(tmp_
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert len(runner.issues) == 1
-    assert runner.issues[0]["title"] == (
-        "Follow up future review note: Add a separate migration dry-run command. "
-        "Update from Codex: still separate work"
-    )
+    assert runner.issues[0]["title"] == "Follow up future review note: Add a separate migration dry-run command."
+    assert "Stale future item from the blocking round." not in runner.issues[0]["body"]
     commands = [cmd[:3] for cmd, _cwd in runner.commands]
     assert commands.count(["gh", "issue", "create"]) == 1
+
+
+def test_pr_loop_fix_and_issue_drops_blocking_round_future_followups(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "### Same-PR follow-ups\n"
+            "- Tighten the validation message.\n\n"
+            "### Future follow-ups\n"
+            "- Stale future item from the blocking round.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Codex approves final pass.\n\n"
+            "### Future follow-ups\n"
+            "- Add a separate migration dry-run command.\n"
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Tightened message.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+    )
+    config = make_config(tmp_path, approved_followups="fix-and-issue")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.issues) == 1
+    assert "Stale future item from the blocking round." not in runner.issues[0]["body"]
 
 
 def test_pr_loop_fix_and_issue_uses_only_final_round_future_followups(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
+            "Codex found cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "- Tighten the validation message.\n\n"
             "### Future follow-ups\n"
             "- Stale item fixed by the same-PR pass.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add a separate migration dry-run command.\n"
@@ -3906,12 +3981,12 @@ def test_pr_loop_fix_and_issue_uses_only_final_round_future_followups(tmp_path):
 def test_pr_loop_fix_and_summarize_uses_only_final_round_future_followups(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
+            "Codex found cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "- Add a small assertion before merge.\n\n"
             "### Future follow-ups\n"
             "- Add Codex's larger follow-up later.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Add Codex's final follow-up later.\n"
@@ -3966,12 +4041,12 @@ def test_pr_loop_fix_and_summarize_uses_only_final_round_future_followups(tmp_pa
 def test_pr_loop_fix_and_issue_extracts_final_round_bullet_and_prose_future_followups(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
+            "Codex found cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "- Tighten the validation message.\n\n"
             "### Future follow-ups\n"
             "- Stale Codex item fixed by the same-PR pass.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
             "Codex approves final pass.\n\n"
             "### Future follow-ups\n"
             "- Refine token estimation for large review prompts.\n"
@@ -4259,13 +4334,12 @@ def test_pr_loop_carries_prior_item_notes_without_creating_duplicate_blocker_ite
 def test_pr_loop_same_pr_items_remain_blocking_until_explicitly_resolved(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
-            "Codex approves with cleanup.\n\n"
             "### Same-PR follow-ups\n"
             "- Rename the helper before merge.\n"
-            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
             "Codex still wants the rename."
             + prior_item_dispositions("[item-1] same-pr")
-            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Tried a partial fix.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
     )
@@ -5244,9 +5318,9 @@ def test_issue_loop_plan_first_carries_same_plan_item_across_reviewers_and_round
         ],
         codex_outputs=[
             "### Same-plan follow-ups\n- Add the carry-forward orchestration test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
-            "Looks mostly good."
+            "Still needs one plan refinement."
             + prior_plan_item_dispositions("[item-1] same-plan: still need the mixed-reviewer case")
-            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
             "Plan looks sound."
             + prior_plan_item_dispositions("[item-1] resolved")
             + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",


### PR DESCRIPTION
## Summary
- tighten review and plan parsers so `approved` is invalid when Same-PR/Same-plan work or active carried-forward items remain
- rework PR-loop handling so blocking reviews preserve Same-PR follow-ups without polluting final approved consensus
- update prompts, README guidance, and follow-up mode tests to reflect the stricter protocol

## Testing
- python3 -m pytest tests/test_agent_loop.py

Fixes #135