### PR TITLE
Make unresolved item IDs human-readable in public comments

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 from .agents.base import AgentName, AgentResult
-from .agents.registry import agent_display_name, run_agent_result
+from .agents.registry import agent_display_name, agent_signature, run_agent_result
 from .config import (
     AgentLoopConfig,
     ensure_agent_workdirs,
@@ -51,13 +51,16 @@ from .prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from .protocol import (
+    ANY_HEADING_RE,
     FUTURE_FOLLOWUP_HEADING_RE,
     HUMAN_REQUIREMENTS_HEADING_RE,
     LEGACY_FOLLOWUP_HEADING_RE,
     ParsedPlanReview,
+    HTML_COMMENT_RE,
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
     PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SAME_PR_FOLLOWUP_HEADING_RE,
+    SIGNATURE_RE,
     ParsedReview,
     ReviewItemDisposition,
     UnresolvedReviewItem,
@@ -80,6 +83,10 @@ APPROVED_FOLLOWUP_MARKER_RE = re.compile(
     r"<!--\s*AGENT_APPROVED_FOLLOWUPS:\s*pr=(?P<pr>\d+)\s+head=(?P<head>\S+)\s+mode=(?P<mode>[a-z-]+)\s*-->",
     re.I,
 )
+ITEM_SUMMARY_LIMIT = 100
+PUBLIC_REVIEWER_NAME_BY_DISPLAY = {
+    agent_display_name(agent): agent_signature(agent) for agent in ("claude", "codex", "gemini")
+}
 
 TRANSIENT_AGENT_OUTPUT_RE = re.compile(
     r"Invalid stream|empty response|malformed tool call|"
@@ -324,6 +331,7 @@ def _next_unresolved_item(
         source_round=source_round,
         text=text,
         status=status,
+        source_status=status,
         notes=tuple(notes),
     )
 
@@ -374,6 +382,7 @@ def _upsert_human_requirements_ack_item(
             source_round=source_round,
             text=text,
             status="blocking",
+            source_status="blocking",
         )
     )
     return retained
@@ -448,6 +457,7 @@ def _apply_unresolved_item_dispositions(
                     source_round=item.source_round,
                     text=text,
                     status="blocking",
+                    source_status=item.source_status,
                     notes=tuple(notes),
                 )
             )
@@ -460,6 +470,7 @@ def _apply_unresolved_item_dispositions(
                     source_round=item.source_round,
                     text=text,
                     status=same_status,
+                    source_status=item.source_status,
                     notes=tuple(notes),
                 )
             )
@@ -471,6 +482,7 @@ def _apply_unresolved_item_dispositions(
                 source_round=item.source_round,
                 text=text,
                 status="future",
+                source_status=item.source_status,
                 notes=tuple(notes),
             )
             if retain_future:
@@ -551,6 +563,167 @@ def _review_freeform_summary_text(text: str) -> str:
             continue
         lines.append(line.rstrip())
     return "\n".join(lines).strip()
+
+
+def _normalize_item_summary(text: str, *, limit: int = ITEM_SUMMARY_LIMIT) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        stripped = re.sub(r"^(?:[-*+]\s+|\d+[.)]\s+)+", "", stripped)
+        stripped = " ".join(stripped.split())
+        if len(stripped) <= limit:
+            return stripped
+        if limit <= 3:
+            return stripped[:limit]
+        return stripped[: limit - 3].rstrip() + "..."
+    return "No summary provided."
+
+
+def _item_label_status(item: UnresolvedReviewItem) -> str:
+    return item.source_status or item.status
+
+
+def _public_reviewer_name(name: str) -> str:
+    return PUBLIC_REVIEWER_NAME_BY_DISPLAY.get(name, name)
+
+
+def _format_unresolved_item_label(item: UnresolvedReviewItem) -> str:
+    summary = _normalize_item_summary(item.text)
+    status = _item_label_status(item)
+    if item.item_id == HUMAN_REQUIREMENTS_ACK_ITEM_ID:
+        return f"Human-requirements acknowledgement item, round {item.source_round}: {summary}"
+    phrases = {
+        "blocking": "Blocking issue",
+        "same-pr": "Same-PR follow-up",
+        "same-plan": "Same-plan follow-up",
+        "future": "Future follow-up",
+    }
+    phrase = phrases.get(status, "Unresolved item")
+    reviewer_name = _public_reviewer_name(item.reviewer)
+    return f"{phrase} from {reviewer_name}, round {item.source_round}: {summary}"
+
+
+def _render_disposition_status(disposition: ReviewItemDisposition) -> str:
+    labels = {
+        "resolved": "resolved",
+        "blocking": "still blocking",
+        "same-pr": "same-pr",
+        "same-plan": "same-plan",
+        "future": "future follow-up",
+    }
+    rendered = labels[disposition.disposition]
+    if disposition.note:
+        rendered = f"{rendered}: {disposition.note}"
+    return rendered
+
+
+def _render_prior_dispositions_section(
+    *,
+    heading: str,
+    prior_items: Sequence[UnresolvedReviewItem],
+    dispositions: Sequence[ReviewItemDisposition],
+) -> str:
+    item_by_id = {item.item_id: item for item in prior_items}
+    lines = [heading]
+    for disposition in dispositions:
+        item = item_by_id[disposition.item_id]
+        lines.append(
+            f"- [{disposition.item_id}] {_format_unresolved_item_label(item)}"
+            f" -> {_render_disposition_status(disposition)}"
+        )
+    return "\n".join(lines)
+
+
+def _replace_structured_section(
+    body: str,
+    *,
+    heading_re: re.Pattern[str],
+    replacement: str,
+) -> str:
+    lines = body.splitlines()
+    output: list[str] = []
+    index = 0
+    replaced = False
+    while index < len(lines):
+        line = lines[index]
+        if not replaced and heading_re.match(line):
+            output.extend(replacement.splitlines())
+            replaced = True
+            index += 1
+            while index < len(lines):
+                current = lines[index]
+                if (
+                    PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE.match(current)
+                    or PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE.match(current)
+                    or (
+                        current.strip()
+                        and (
+                            ANY_HEADING_RE.match(current)
+                            or HTML_COMMENT_RE.match(current)
+                            or SIGNATURE_RE.match(current)
+                        )
+                    )
+                ):
+                    break
+                index += 1
+            continue
+        output.append(line)
+        index += 1
+    return "\n".join(output) if replaced else body
+
+
+def _append_before_trailing_metadata(body: str, section: str) -> str:
+    lines = body.splitlines()
+    index = len(lines)
+    while index > 0 and not lines[index - 1].strip():
+        index -= 1
+    metadata_start = index
+    while metadata_start > 0:
+        candidate = lines[metadata_start - 1]
+        if not candidate.strip() or HTML_COMMENT_RE.match(candidate) or SIGNATURE_RE.match(candidate):
+            metadata_start -= 1
+            continue
+        break
+    if metadata_start == index:
+        return body.rstrip() + "\n\n" + section
+    prefix = "\n".join(lines[:metadata_start]).rstrip()
+    suffix = "\n".join(lines[metadata_start:]).lstrip("\n")
+    parts = [prefix, section, suffix]
+    return "\n\n".join(part for part in parts if part)
+
+
+def _render_public_review_comment(
+    body: str,
+    *,
+    review_kind: str,
+    prior_items: Sequence[UnresolvedReviewItem],
+    dispositions: Sequence[ReviewItemDisposition],
+    new_items: Sequence[UnresolvedReviewItem],
+) -> str:
+    rendered = body
+    if prior_items:
+        heading = "### Prior unresolved item dispositions"
+        heading_re = PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE
+        if review_kind == "plan":
+            heading = "### Prior unresolved plan item dispositions"
+            heading_re = PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE
+        rendered = _replace_structured_section(
+            rendered,
+            heading_re=heading_re,
+            replacement=_render_prior_dispositions_section(
+                heading=heading,
+                prior_items=prior_items,
+                dispositions=dispositions,
+            ),
+        )
+    if new_items:
+        section_lines = ["### New tracked unresolved items"]
+        section_lines.extend(
+            f"- [{item.item_id}] {_format_unresolved_item_label(item)}" for item in new_items
+        )
+        rendered = _append_before_trailing_metadata(rendered, "\n".join(section_lines))
+    return rendered
 
 
 def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
@@ -1065,7 +1238,6 @@ def _run_plan_first_loop(
             parsed_review = review_response.marker_value
             assert isinstance(parsed_review, ParsedPlanReview)
             review_state = parsed_review.state
-            post_issue_comment(runner, config=config, issue_number=issue_number, body=review_output)
             log(
                 config,
                 "Planning round "
@@ -1073,33 +1245,56 @@ def _run_plan_first_loop(
             )
             for disposition in parsed_review.dispositions:
                 prior_dispositions[disposition.item_id].append(disposition)
+            reviewer_new_unresolved_items: list[UnresolvedReviewItem] = []
             if review_state == "blocking":
                 all_approved = False
                 blocking_reviews.append((reviewer_name, review_output))
             for item in parsed_review.items.blocking:
-                round_new_unresolved_items.append(
-                    _next_unresolved_item(
-                        item_number=next_unresolved_item_number,
-                        reviewer=item.reviewer,
-                        source_round=round_number,
-                        text=item.text,
-                        status="blocking",
-                    )
+                tracked_item = _next_unresolved_item(
+                    item_number=next_unresolved_item_number,
+                    reviewer=item.reviewer,
+                    source_round=round_number,
+                    text=item.text,
+                    status="blocking",
                 )
+                round_new_unresolved_items.append(tracked_item)
+                reviewer_new_unresolved_items.append(tracked_item)
                 next_unresolved_item_number += 1
             for item in parsed_review.items.same_plan:
-                round_new_unresolved_items.append(
-                    _next_unresolved_item(
-                        item_number=next_unresolved_item_number,
-                        reviewer=item.reviewer,
-                        source_round=round_number,
-                        text=item.text,
-                        status="same-plan",
-                    )
+                tracked_item = _next_unresolved_item(
+                    item_number=next_unresolved_item_number,
+                    reviewer=item.reviewer,
+                    source_round=round_number,
+                    text=item.text,
+                    status="same-plan",
                 )
+                round_new_unresolved_items.append(tracked_item)
+                reviewer_new_unresolved_items.append(tracked_item)
                 next_unresolved_item_number += 1
             for item in parsed_review.items.future:
+                tracked_item = _next_unresolved_item(
+                    item_number=next_unresolved_item_number,
+                    reviewer=item.reviewer,
+                    source_round=round_number,
+                    text=item.text,
+                    status="future",
+                )
+                round_new_unresolved_items.append(tracked_item)
+                reviewer_new_unresolved_items.append(tracked_item)
+                next_unresolved_item_number += 1
                 round_approved_future_followups.append(item)
+            post_issue_comment(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                body=_render_public_review_comment(
+                    review_output,
+                    review_kind="plan",
+                    prior_items=prior_unresolved_items,
+                    dispositions=parsed_review.dispositions,
+                    new_items=reviewer_new_unresolved_items,
+                ),
+            )
 
         unresolved_items, future_from_prior_items = _apply_unresolved_item_dispositions(
             prior_unresolved_items,
@@ -1466,7 +1661,6 @@ def run_pr_loop(
                 assert isinstance(parsed_review, ParsedReview)
                 review_state = parsed_review.state
 
-                post_pr_comment(runner, config=config, pr_number=pr_number, body=review_output)
                 for disposition in parsed_review.dispositions:
                     prior_dispositions[disposition.item_id].append(disposition)
                 blocking_summary = _review_freeform_summary_text(review_output)
@@ -1480,65 +1674,90 @@ def run_pr_loop(
                     f"Round {round_number}: {reviewer_name} outcome is "
                     f"{_describe_pr_review_outcome(parsed_review, has_blocking_summary=has_blocking_summary)}",
                 )
+                reviewer_new_unresolved_items: list[UnresolvedReviewItem] = []
                 if review_state == "blocking":
                     if has_blocking_summary:
-                        round_new_unresolved_items.append(
-                            _next_unresolved_item(
-                                item_number=next_unresolved_item_number,
-                                reviewer=reviewer_name,
-                                source_round=round_number,
-                                text=blocking_summary,
-                                status="blocking",
-                            )
+                        tracked_item = _next_unresolved_item(
+                            item_number=next_unresolved_item_number,
+                            reviewer=reviewer_name,
+                            source_round=round_number,
+                            text=blocking_summary,
+                            status="blocking",
                         )
+                        round_new_unresolved_items.append(tracked_item)
+                        reviewer_new_unresolved_items.append(tracked_item)
                         next_unresolved_item_number += 1
                     if parsed_review.followups.same_pr:
                         if config.approved_followups.startswith("fix-and-"):
                             for followup in parsed_review.followups.same_pr:
-                                round_new_unresolved_items.append(
-                                    _next_unresolved_item(
-                                        item_number=next_unresolved_item_number,
-                                        reviewer=followup.reviewer,
-                                        source_round=round_number,
-                                        text=followup.text,
-                                        status="same-pr",
-                                    )
+                                tracked_item = _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer=followup.reviewer,
+                                    source_round=round_number,
+                                    text=followup.text,
+                                    status="same-pr",
                                 )
+                                round_new_unresolved_items.append(tracked_item)
+                                reviewer_new_unresolved_items.append(tracked_item)
                                 next_unresolved_item_number += 1
                         else:
-                            round_new_unresolved_items.append(
-                                _next_unresolved_item(
-                                    item_number=next_unresolved_item_number,
-                                    reviewer=reviewer_name,
-                                    source_round=round_number,
-                                    text="\n".join(
-                                        [
-                                            "Blocking review included Same-PR follow-ups, "
-                                            f"but --approved-followups={config.approved_followups} "
-                                            "does not enable a same-PR fix path.",
-                                            "",
-                                            _format_same_pr_followups(parsed_review.followups.same_pr),
-                                        ]
-                                    ),
-                                    status="blocking",
-                                )
+                            tracked_item = _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer=reviewer_name,
+                                source_round=round_number,
+                                text="\n".join(
+                                    [
+                                        "Blocking review included Same-PR follow-ups, "
+                                        f"but --approved-followups={config.approved_followups} "
+                                        "does not enable a same-PR fix path.",
+                                        "",
+                                        _format_same_pr_followups(parsed_review.followups.same_pr),
+                                    ]
+                                ),
+                                status="blocking",
                             )
+                            round_new_unresolved_items.append(tracked_item)
+                            reviewer_new_unresolved_items.append(tracked_item)
                             next_unresolved_item_number += 1
+                    post_pr_comment(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        body=_render_public_review_comment(
+                            review_output,
+                            review_kind="pr",
+                            prior_items=prior_unresolved_items,
+                            dispositions=parsed_review.dispositions,
+                            new_items=reviewer_new_unresolved_items,
+                        ),
+                    )
                     continue
 
                 approved_review_outputs.append((reviewer_name, review_output))
                 if config.approved_followups != "ignore":
                     for followup in parsed_review.followups.future:
-                        round_new_unresolved_items.append(
-                            _next_unresolved_item(
-                                item_number=next_unresolved_item_number,
-                                reviewer=followup.reviewer,
-                                source_round=round_number,
-                                text=followup.text,
-                                status="future",
-                            )
+                        tracked_item = _next_unresolved_item(
+                            item_number=next_unresolved_item_number,
+                            reviewer=followup.reviewer,
+                            source_round=round_number,
+                            text=followup.text,
+                            status="future",
                         )
+                        round_new_unresolved_items.append(tracked_item)
+                        reviewer_new_unresolved_items.append(tracked_item)
                         next_unresolved_item_number += 1
+                post_pr_comment(
+                    runner,
+                    config=config,
+                    pr_number=pr_number,
+                    body=_render_public_review_comment(
+                        review_output,
+                        review_kind="pr",
+                        prior_items=prior_unresolved_items,
+                        dispositions=parsed_review.dispositions,
+                        new_items=reviewer_new_unresolved_items,
+                    ),
+                )
 
             unresolved_items, _future_items = _apply_unresolved_item_dispositions(
                 prior_unresolved_items,

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -103,6 +103,7 @@ class UnresolvedReviewItem:
     source_round: int
     text: str
     status: str
+    source_status: str | None = None
     notes: tuple[str, ...] = ()
 
 
@@ -369,15 +370,20 @@ def parse_plan_review_items(text: str, *, reviewer: str) -> PlanReviewItems:
 
 def _disposition_re(*same_statuses: str) -> re.Pattern[str]:
     same_pattern = "|".join(same_statuses)
-    return re.compile(
-        r"^\s*\[?(?P<item_id>[A-Za-z0-9][A-Za-z0-9._-]*)\]?\s*"
-        r"(?:->|:)?\s*"
-        r"(?P<status>"
+    status_pattern = (
         r"resolved|"
         r"(?:still\s+)?blocking|"
         rf"(?:still\s+)?(?:{same_pattern})|"
         r"(?:downgraded\s+to\s+)?future follow[- ]up"
+    )
+    return re.compile(
+        r"^\s*\[?(?P<item_id>[A-Za-z0-9][A-Za-z0-9._-]*)\]?\s*"
+        r"(?:"
+        r"(?:(?P<label>.+?)\s*->\s*)"
+        r"|"
+        r"(?:(?:->|:)?\s*)"
         r")"
+        rf"(?P<status>{status_pattern})"
         r"(?:\s*:\s*(?P<note>.+))?\s*$",
         re.I,
     )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -42,8 +42,11 @@ from coding_review_agent_loop.github import (
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
 from coding_review_agent_loop.orchestrator import (
+    ITEM_SUMMARY_LIMIT,
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     _apply_unresolved_item_dispositions,
+    _format_unresolved_item_label,
+    _render_public_review_comment,
     _review_freeform_summary_text,
     _validate_plan_review_response,
 )
@@ -1348,6 +1351,26 @@ def test_parse_plan_item_dispositions_extracts_same_plan_status():
     ]
 
 
+def test_parse_plan_item_dispositions_accepts_enriched_labels_with_trailing_arrow():
+    review = """
+    Approved after the latest revision.
+
+    ### Prior unresolved plan item dispositions
+    - [item-1] Same-plan follow-up from Google Gemini, round 1: keep the exact wording distinct -> same-plan: still need the mixed-reviewer case
+    - [item-2] Blocking issue from OpenAI Codex, round 1: preserve public labels -> resolved
+
+    <!-- AGENT_PLAN_STATE: blocking -->
+    -- Anthropic Claude
+    """
+
+    dispositions = parse_plan_item_dispositions(review, reviewer="Anthropic Claude")
+
+    assert [(item.item_id, item.disposition, item.note) for item in dispositions] == [
+        ("item-1", "same-plan", "still need the mixed-reviewer case"),
+        ("item-2", "resolved", None),
+    ]
+
+
 @pytest.mark.parametrize(
     "line",
     [
@@ -1550,6 +1573,26 @@ def test_parse_unresolved_item_dispositions_extracts_structured_updates():
         ("item-2", "blocking", None),
         ("item-3", "same-pr", None),
         ("item-4", "future", "split this into a separate PR"),
+    ]
+
+
+def test_parse_unresolved_item_dispositions_accepts_enriched_labels_with_trailing_arrow():
+    review = """
+    LGTM.
+
+    ### Prior unresolved item dispositions
+    - [item-1] Same-PR follow-up from Google Gemini, round 1: require source issue reference in PR body -> same-pr: keep the body reference
+    - [item-2] Blocking issue from OpenAI Codex, round 1: rename the helper -> resolved
+
+    <!-- AGENT_STATE: blocking -->
+    -- Anthropic Claude
+    """
+
+    dispositions = parse_unresolved_item_dispositions(review, reviewer="Anthropic Claude")
+
+    assert [(item.item_id, item.disposition, item.note) for item in dispositions] == [
+        ("item-1", "same-pr", "keep the body reference"),
+        ("item-2", "resolved", None),
     ]
 
 
@@ -1834,6 +1877,109 @@ def test_review_freeform_summary_text_strips_structured_followup_sections():
 """
 
     assert _review_freeform_summary_text(review) == "Blocking issue summary."
+
+
+def test_format_unresolved_item_label_normalizes_multiline_text_and_preserves_origin_status():
+    item = UnresolvedReviewItem(
+        item_id="item-7",
+        reviewer="Google Gemini",
+        source_round=1,
+        text="  - require source issue reference in PR body  \n\nUpdate from Anthropic Claude: keep the wording compact",
+        status="resolved",
+        source_status="same-pr",
+    )
+
+    assert _format_unresolved_item_label(item) == (
+        "Same-PR follow-up from Google Gemini, round 1: require source issue reference in PR body"
+    )
+
+
+def test_format_unresolved_item_label_truncates_at_fixed_limit():
+    summary = "a" * (ITEM_SUMMARY_LIMIT + 20)
+    item = UnresolvedReviewItem(
+        item_id="item-8",
+        reviewer="OpenAI Codex",
+        source_round=2,
+        text=summary,
+        status="blocking",
+    )
+
+    label = _format_unresolved_item_label(item)
+
+    assert label.startswith("Blocking issue from OpenAI Codex, round 2: ")
+    assert label.endswith("...")
+    rendered_summary = label.split(": ", 1)[1]
+    assert len(rendered_summary) == ITEM_SUMMARY_LIMIT
+
+
+def test_format_unresolved_item_label_special_cases_human_requirements_ack_item():
+    item = UnresolvedReviewItem(
+        item_id=HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+        reviewer="Orchestrator",
+        source_round=3,
+        text="Coder response missing required `### Human requirements` section.",
+        status="blocking",
+    )
+
+    assert _format_unresolved_item_label(item) == (
+        "Human-requirements acknowledgement item, round 3: "
+        "Coder response missing required `### Human requirements` section."
+    )
+
+
+def test_render_public_review_comment_replaces_dispositions_and_appends_new_items():
+    body = """Still blocked.
+
+### Same-PR follow-ups
+- Keep the source issue reference in the PR body.
+
+### Prior unresolved item dispositions
+- [item-1] same-pr
+
+<!-- AGENT_STATE: blocking -->
+-- OpenAI Codex
+"""
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="Google Gemini",
+            source_round=1,
+            text="Require source issue reference in PR body.\n\nUpdate from Anthropic Claude: keep the note compact",
+            status="same-pr",
+        ),
+    )
+    dispositions = parse_unresolved_item_dispositions(
+        prior_item_dispositions("[item-1] Same-PR follow-up from Google Gemini, round 1: ignored by parser -> same-pr: keep the body reference"),
+        reviewer="OpenAI Codex",
+    )
+    new_items = (
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="OpenAI Codex",
+            source_round=2,
+            text="Keep the source issue reference in the PR body.",
+            status="same-pr",
+        ),
+    )
+
+    rendered = _render_public_review_comment(
+        body,
+        review_kind="pr",
+        prior_items=prior_items,
+        dispositions=dispositions,
+        new_items=new_items,
+    )
+
+    assert "### Same-PR follow-ups\n- Keep the source issue reference in the PR body." in rendered
+    assert (
+        "### Prior unresolved item dispositions\n"
+        "- [item-1] Same-PR follow-up from Google Gemini, round 1: Require source issue reference in PR body. -> same-pr: keep the body reference"
+    ) in rendered
+    assert (
+        "### New tracked unresolved items\n"
+        "- [item-2] Same-PR follow-up from OpenAI Codex, round 2: Keep the source issue reference in the PR body."
+    ) in rendered
+    assert rendered.rstrip().endswith("-- OpenAI Codex")
 
 
 def test_apply_unresolved_item_dispositions_appends_disposition_notes_to_text():
@@ -3185,7 +3331,9 @@ def test_pr_loop_skips_duplicate_approved_followup_issue_creation_when_marker_ex
 
     assert runner.issues == []
     assert runner.comments == [
-        "Codex approves.\n\n### Future follow-ups\n- Add cleanup docs.\n"
+        "Codex approves.\n\n### Future follow-ups\n- Add cleanup docs.\n\n"
+        "### New tracked unresolved items\n"
+        "- [item-1] Future follow-up from OpenAI Codex, round 1: Add cleanup docs.\n\n"
         "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
     ]
 
@@ -4331,6 +4479,41 @@ def test_pr_loop_carries_prior_item_notes_without_creating_duplicate_blocker_ite
     assert "[item-2]" not in second_coder_prompt
 
 
+def test_pr_loop_posts_human_readable_item_labels_in_new_and_prior_sections(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented the requested PR body change.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "### Same-PR follow-ups\n"
+            "- Require source issue reference in PR body.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Looks good."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", approved_followups="fix-and-summarize", max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.comments[0] == (
+        "### Same-PR follow-ups\n"
+        "- Require source issue reference in PR body.\n\n"
+        "### New tracked unresolved items\n"
+        "- [item-1] Same-PR follow-up from OpenAI Codex, round 1: Require source issue reference in PR body.\n\n"
+        "<!-- AGENT_STATE: blocking -->\n"
+        "-- OpenAI Codex"
+    )
+    assert runner.comments[2] == (
+        "Looks good.\n\n"
+        "### Prior unresolved item dispositions\n"
+        "- [item-1] Same-PR follow-up from OpenAI Codex, round 1: Require source issue reference in PR body. -> resolved\n"
+        "<!-- AGENT_STATE: approved -->\n"
+        "-- OpenAI Codex"
+    )
+
+
 def test_pr_loop_same_pr_items_remain_blocking_until_explicitly_resolved(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
@@ -5342,6 +5525,51 @@ def test_issue_loop_plan_first_carries_same_plan_item_across_reviewers_and_round
     claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert any("item-1" in call[-1] for call in claude_calls[1:])
     assert "Approved plan:" in runner.comments[-1]
+
+
+def test_issue_loop_plan_first_posts_human_readable_item_labels_in_new_and_prior_sections(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "### Blocking plan issues\n"
+            "- Keep plan-review wording distinct from PR wording.\n"
+            "### Same-plan follow-ups\n"
+            "- Add one carry-forward plan test.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Plan looks sound."
+            + prior_plan_item_dispositions(
+                "[item-1] resolved",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, reviewer="codex", max_rounds=2)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.comments[1] == (
+        "### Blocking plan issues\n"
+        "- Keep plan-review wording distinct from PR wording.\n"
+        "### Same-plan follow-ups\n"
+        "- Add one carry-forward plan test.\n\n"
+        "### New tracked unresolved items\n"
+        "- [item-1] Blocking issue from OpenAI Codex, round 1: Keep plan-review wording distinct from PR wording.\n"
+        "- [item-2] Same-plan follow-up from OpenAI Codex, round 1: Add one carry-forward plan test.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n"
+        "-- OpenAI Codex"
+    )
+    assert runner.comments[3] == (
+        "Plan looks sound.\n\n"
+        "### Prior unresolved plan item dispositions\n"
+        "- [item-1] Blocking issue from OpenAI Codex, round 1: Keep plan-review wording distinct from PR wording. -> resolved\n"
+        "- [item-2] Same-plan follow-up from OpenAI Codex, round 1: Add one carry-forward plan test. -> resolved\n"
+        "<!-- AGENT_PLAN_STATE: approved -->\n"
+        "-- OpenAI Codex"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- parse enriched prior-item disposition bullets using the trailing `-> status[: note]` segment as canonical
- render public PR and plan-review comments from structured unresolved-item data with deterministic human-readable labels
- cover parser, formatter, and end-to-end comment rendering paths in tests

## Testing
- python3 -m pytest tests/test_agent_loop.py

Fixes #138