### PR TITLE
Preserve multiline review findings as single tracked items

### DIFF
--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -57,6 +57,8 @@ ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
 BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
+HEADING_LEVEL_RE = re.compile(r"^\s*(#{1,6})\s+\S")
+THEMATIC_BREAK_RE = re.compile(r"^\s*(?:([-*_])\s*){3,}\s*$")
 
 
 def _empty_placeholder_re(*phrases: str) -> re.Pattern[str]:
@@ -278,54 +280,129 @@ def _collect_section_items(
     empty_item_re: re.Pattern[str],
     reviewer: str,
 ) -> None:
+    def heading_level(line: str) -> int | None:
+        match = HEADING_LEVEL_RE.match(line)
+        if not match:
+            return None
+        return len(match.group(1))
+
+    def normalize_item_text(lines: list[str]) -> str:
+        trimmed = list(lines)
+        while trimmed and not trimmed[0].strip():
+            trimmed.pop(0)
+        while trimmed and not trimmed[-1].strip():
+            trimmed.pop()
+        if not trimmed:
+            return ""
+        common_indent = min(
+            len(line) - len(line.lstrip(" "))
+            for line in trimmed
+            if line.strip()
+        )
+        if common_indent:
+            trimmed = [line[common_indent:] if line.strip() else "" for line in trimmed]
+
+        rendered: list[str] = []
+        paragraph: list[str] = []
+        fence_marker: str | None = None
+
+        def flush_paragraph() -> None:
+            if paragraph:
+                rendered.append(" ".join(part.strip() for part in paragraph))
+                paragraph.clear()
+
+        for raw_line in trimmed:
+            line = raw_line.rstrip()
+            stripped = line.strip()
+            if not stripped:
+                flush_paragraph()
+                if rendered and rendered[-1] != "":
+                    rendered.append("")
+                continue
+
+            fence_match = re.match(r"^\s*(```+|~~~+)", line)
+            if fence_match:
+                flush_paragraph()
+                rendered.append(line)
+                marker = fence_match.group(1)
+                if fence_marker == marker:
+                    fence_marker = None
+                elif fence_marker is None:
+                    fence_marker = marker
+                continue
+            if fence_marker is not None:
+                rendered.append(line)
+                continue
+
+            if HEADING_LEVEL_RE.match(line):
+                flush_paragraph()
+                rendered.append(line)
+                continue
+
+            if re.match(r"^\s{2,}(?:[-*+]\s+|\d+[.)]\s+)", line) or stripped.startswith(">"):
+                flush_paragraph()
+                rendered.append(line)
+                continue
+
+            paragraph.append(stripped)
+
+        flush_paragraph()
+        while rendered and rendered[-1] == "":
+            rendered.pop()
+        return "\n".join(rendered).strip()
+
+    def section_bucket(line: str) -> list[ApprovedFollowup] | None:
+        for pattern, bucket in sections:
+            if pattern.match(line):
+                return bucket
+        return None
+
     active: list[ApprovedFollowup] | None = None
     current: list[str] = []
-    current_is_prose = False
+    active_heading_level: int | None = None
 
     def flush_current() -> None:
-        nonlocal current_is_prose
         if active is not None and current:
-            item = " ".join(part.strip() for part in current if part.strip()).strip()
+            item = normalize_item_text(current)
             if item and not empty_item_re.match(item):
                 active.append(ApprovedFollowup(reviewer=reviewer, text=item))
             current.clear()
-        current_is_prose = False
 
     for line in text.splitlines():
-        next_active = None
-        for pattern, bucket in sections:
-            if pattern.match(line):
-                next_active = bucket
-                break
+        next_active = section_bucket(line)
         if next_active is not None:
             flush_current()
             active = next_active
+            active_heading_level = heading_level(line)
             continue
         if active is None:
             continue
-        if ANY_HEADING_RE.match(line):
+
+        next_heading_level = heading_level(line)
+        if next_heading_level is not None and active_heading_level is not None and next_heading_level <= active_heading_level:
             flush_current()
             active = None
+            active_heading_level = None
             continue
         if HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
             flush_current()
             active = None
+            active_heading_level = None
             continue
-        if not line.strip():
-            if current_is_prose:
-                flush_current()
+        if THEMATIC_BREAK_RE.match(line):
+            flush_current()
             continue
         bullet = BULLET_RE.match(line)
         if bullet:
             flush_current()
             current.append(bullet.group("text"))
-            current_is_prose = False
             continue
-        if current and line.strip():
-            current.append(line)
+        if next_heading_level is not None:
+            flush_current()
+            current.append(line.rstrip())
             continue
-        current.append(line)
-        current_is_prose = True
+        if current or line.strip():
+            current.append(line.rstrip())
 
     flush_current()
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1230,6 +1230,68 @@ def test_parse_approved_followups_extracts_bullets_and_prose_paragraphs():
     ]
 
 
+def test_parse_approved_followups_keeps_multiline_markdown_finding_as_one_item():
+    review = """
+    Still blocked.
+
+    ### Same-PR follow-ups
+    #### Normalize `_plan_subject` whitespace handling
+
+    Keep the helper from creating distinct round subjects for leading/trailing
+    whitespace-only differences.
+
+    ```python
+    assert _plan_subject("x") == _plan_subject(" x ")
+    ```
+
+    The implementation should preserve the current hash format.
+
+    ---
+
+    #### Harden `_decode_round_metadata` exception handling
+
+    Invalid base64 and invalid JSON should still become `AgentLoopError`
+    consistently.
+
+    ### Notes
+    CI note outside the section.
+
+    <!-- AGENT_STATE: blocking -->
+    -- Anthropic Claude
+    """
+
+    followups = parse_approved_followups(review, reviewer="Anthropic Claude")
+
+    assert [(item.reviewer, item.text) for item in followups.same_pr] == [
+        (
+            "Anthropic Claude",
+            "\n".join(
+                [
+                    "#### Normalize `_plan_subject` whitespace handling",
+                    "",
+                    "Keep the helper from creating distinct round subjects for leading/trailing whitespace-only differences.",
+                    "",
+                    "```python",
+                    'assert _plan_subject("x") == _plan_subject(" x ")',
+                    "```",
+                    "",
+                    "The implementation should preserve the current hash format.",
+                ]
+            ),
+        ),
+        (
+            "Anthropic Claude",
+            "\n".join(
+                [
+                    "#### Harden `_decode_round_metadata` exception handling",
+                    "",
+                    "Invalid base64 and invalid JSON should still become `AgentLoopError` consistently.",
+                ]
+            ),
+        ),
+    ]
+
+
 @pytest.mark.parametrize(
     "placeholder",
     [
@@ -1316,6 +1378,49 @@ def test_parse_plan_review_items_extracts_structured_sections():
         (
             "OpenAI Codex",
             "Consider a later helper to unify plan and PR disposition rendering.",
+        )
+    ]
+
+
+def test_parse_plan_review_items_keeps_multiline_markdown_blocking_item_as_one_entry():
+    review = """
+    Plan needs one revision.
+
+    ### Blocking plan issues
+    #### Preserve multiline review items during tracking
+
+    Do not split one reviewer-authored finding into separate ledger entries for
+    paragraphs or code blocks.
+
+    ```text
+    item-2: heading
+    item-3: paragraph
+    ```
+
+    ### Same-plan follow-ups
+    - Mention the regression shape in the implementation plan.
+
+    <!-- AGENT_PLAN_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    items = parse_plan_review_items(review, reviewer="OpenAI Codex")
+
+    assert [(item.reviewer, item.text) for item in items.blocking] == [
+        (
+            "OpenAI Codex",
+            "\n".join(
+                [
+                    "#### Preserve multiline review items during tracking",
+                    "",
+                    "Do not split one reviewer-authored finding into separate ledger entries for paragraphs or code blocks.",
+                    "",
+                    "```text",
+                    "item-2: heading",
+                    "item-3: paragraph",
+                    "```",
+                ]
+            ),
         )
     ]
 


### PR DESCRIPTION
## Summary
- preserve multiline markdown inside structured review items instead of splitting on paragraphs or code fences
- treat new bullets and in-section subheadings as explicit item boundaries while ignoring separator-only lines
- add regression coverage for multiline Same-PR and blocking plan findings

## Testing
- python3 -m pytest tests/test_agent_loop.py -k "approved_followups or plan_review_items"
- python3 -m pytest tests/test_agent_loop.py
- python3 -m pytest

Fixes #148