### PR TITLE
Phase 2: split machine-response transport from human-message transport

### DIFF
--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -20,6 +20,8 @@ AgentName = Literal["claude", "codex", "gemini"]
 @dataclass(frozen=True)
 class AgentResult:
     text: str
+    response_file_text: str | None = None
+    message_text: str | None = None
     session_id: str | None = None
     log_path: Path | None = None
     returncode: int = 0

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -96,9 +96,12 @@ class ClaudeBackend:
             check=False,
         )
         log(config, f"Claude finished; log: {log_path}")
-        text, new_session_id, usage, raw_usage = _parse_claude_output(result.stdout)
+        message_text, new_session_id, usage, raw_usage = _parse_claude_output(result.stdout)
+        response_file_text = read_public_response_file(response_path)
         return AgentResult(
-            text=read_public_response_file(response_path) or text,
+            text=response_file_text or message_text,
+            response_file_text=response_file_text,
+            message_text=message_text,
             session_id=new_session_id,
             log_path=log_path,
             returncode=result.returncode,

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -8,7 +8,13 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .base import AgentName, AgentResult
+from .base import (
+    AgentName,
+    AgentResult,
+    public_response_path,
+    read_public_response_file,
+    with_public_response_file_instruction,
+)
 from ..logging import agent_log_path, log
 from ..runner import Runner
 from ..usage import UsageMetadata, coerce_int, first_present
@@ -76,6 +82,15 @@ def _extract_codex_usage(raw: str) -> tuple[UsageMetadata | None, object | None]
     return None, last_usage
 
 
+def _read_codex_message_file(output_path: Path) -> str | None:
+    try:
+        text = output_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    text = text.strip()
+    return text or None
+
+
 class CodexBackend:
     name: AgentName = "codex"
     display_name = "Codex"
@@ -96,7 +111,12 @@ class CodexBackend:
         run_id: str | None = None,
     ) -> AgentResult:
         log_path = agent_log_path(config, "codex", run_id=run_id)
-        log(config, f"Starting Codex in {config.codex_dir}; log: {log_path}")
+        response_path = public_response_path(config, "codex")
+        prompt_with_response_file = with_public_response_file_instruction(prompt, response_path)
+        log(
+            config,
+            f"Starting Codex in {config.codex_dir}; log: {log_path}; response: {response_path}",
+        )
         if config.dry_run:
             result = runner.run(
                 [
@@ -110,7 +130,12 @@ class CodexBackend:
                 cwd=config.codex_dir,
             )
             log(config, f"Codex finished; log: {log_path}")
-            return AgentResult(text=result.stdout, log_path=log_path, returncode=result.returncode)
+            return AgentResult(
+                text=result.stdout,
+                message_text=result.stdout,
+                log_path=log_path,
+                returncode=result.returncode,
+            )
 
         with tempfile.NamedTemporaryFile("r", encoding="utf-8", delete=False) as handle:
             output_path = handle.name
@@ -125,7 +150,7 @@ class CodexBackend:
                     "--output-last-message",
                     output_path,
                     *config.codex_args,
-                    prompt,
+                    prompt_with_response_file,
                 ],
                 cwd=config.codex_dir,
                 log_path=log_path,
@@ -133,13 +158,14 @@ class CodexBackend:
                 progress_interval_seconds=config.progress_interval_seconds,
                 check=False,
             )
-            output = Path(output_path).read_text(encoding="utf-8") if Path(output_path).exists() else ""
-            if not output:
-                output = result.stdout
+            response_file_text = read_public_response_file(response_path)
+            message_text = _read_codex_message_file(Path(output_path)) or result.stdout
             usage, raw_usage = _extract_codex_usage(result.stdout)
             log(config, f"Codex finished; log: {log_path}")
             return AgentResult(
-                text=output,
+                text=response_file_text or message_text,
+                response_file_text=response_file_text,
+                message_text=message_text,
                 log_path=log_path,
                 returncode=result.returncode,
                 usage=usage,

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -187,9 +187,12 @@ class GeminiBackend:
             check=False,
         )
         log(config, f"Gemini finished; log: {log_path}")
-        text, new_session_id, usage, raw_usage = _parse_gemini_payload(result.stdout)
+        message_text, new_session_id, usage, raw_usage = _parse_gemini_payload(result.stdout)
+        response_file_text = read_public_response_file(response_path)
         return AgentResult(
-            text=read_public_response_file(response_path) or text,
+            text=response_file_text or message_text,
+            response_file_text=response_file_text,
+            message_text=message_text,
             session_id=new_session_id,
             log_path=log_path,
             returncode=result.returncode,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -6,9 +6,18 @@ from pathlib import Path
 
 import pytest
 
-from coding_review_agent_loop.agents.claude import _normalize_claude_usage, _parse_claude_output
-from coding_review_agent_loop.agents.codex import _extract_codex_usage, _normalize_codex_usage
+from coding_review_agent_loop.agents.claude import (
+    BACKEND as CLAUDE_BACKEND,
+    _normalize_claude_usage,
+    _parse_claude_output,
+)
+from coding_review_agent_loop.agents.codex import (
+    BACKEND as CODEX_BACKEND,
+    _extract_codex_usage,
+    _normalize_codex_usage,
+)
 from coding_review_agent_loop.agents.gemini import (
+    BACKEND as GEMINI_BACKEND,
     PUBLIC_RESPONSE_MARKER,
     _normalize_gemini_usage,
     _parse_gemini_payload,
@@ -229,6 +238,7 @@ class FakeRunner(Runner):
             else:
                 public_response, returncode = output
                 stdout = public_response
+            self._maybe_write_public_response_file(cmd)
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
@@ -954,6 +964,134 @@ def test_extract_codex_usage_reads_turn_completed_jsonl():
         "reasoning_tokens": 11,
         "total_tokens": 206,
     }
+
+
+def test_claude_backend_prefers_response_file_over_message_text(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            json.dumps(
+                {
+                    "result": "stdout message text",
+                    "session_id": "claude-session-1",
+                }
+            )
+        ],
+        public_response_outputs=["response file text"],
+    )
+    config = make_config(tmp_path)
+
+    result = CLAUDE_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.response_file_text == "response file text"
+    assert result.message_text == "stdout message text"
+    assert result.text == "response file text"
+    assert result.session_id == "claude-session-1"
+
+
+def test_gemini_backend_prefers_response_file_over_message_text(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=[
+            json.dumps(
+                {
+                    "response": f"diagnostic\n{PUBLIC_RESPONSE_MARKER}\nstdout message text",
+                    "session_id": "gemini-session-1",
+                }
+            )
+        ],
+        public_response_outputs=["response file text"],
+    )
+    config = make_config(tmp_path)
+
+    result = GEMINI_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.response_file_text == "response file text"
+    assert result.message_text == "stdout message text"
+    assert result.text == "response file text"
+    assert result.session_id == "gemini-session-1"
+
+
+def test_codex_backend_prefers_response_file_over_last_message_and_stdout(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": "last message text",
+                "stdout": "\n".join(
+                    [
+                        "noisy stdout chatter",
+                        json.dumps(
+                            {
+                                "type": "turn.completed",
+                                "usage": {
+                                    "input_tokens": 12,
+                                    "cached_input_tokens": 3,
+                                    "output_tokens": 4,
+                                    "reasoning_tokens": 1,
+                                    "total_tokens": 20,
+                                },
+                            }
+                        ),
+                    ]
+                ),
+            }
+        ],
+        public_response_outputs=["response file text"],
+    )
+    config = make_config(tmp_path)
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.response_file_text == "response file text"
+    assert result.message_text == "last message text"
+    assert result.text == "response file text"
+    assert result.usage is not None
+    assert result.usage.total_tokens == 20
+
+
+def test_codex_backend_prefers_last_message_over_stdout_without_response_file(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": "last message text",
+                "stdout": "raw stdout fallback",
+            }
+        ]
+    )
+    config = make_config(tmp_path)
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.response_file_text is None
+    assert result.message_text == "last message text"
+    assert result.text == "last message text"
+
+
+def test_codex_backend_uses_stdout_when_files_are_absent_or_empty(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": "",
+                "stdout": "raw stdout fallback",
+            }
+        ]
+    )
+    config = make_config(tmp_path)
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.response_file_text is None
+    assert result.message_text == "raw stdout fallback"
+    assert result.text == "raw stdout fallback"
+
+
+def test_codex_backend_dry_run_sets_message_text_without_response_file(tmp_path):
+    runner = FakeRunner(codex_outputs=[{"stdout": "dry run stdout"}])
+    config = make_config(tmp_path, dry_run=True)
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.response_file_text is None
+    assert result.message_text == "dry run stdout"
+    assert result.text == "dry run stdout"
 
 
 def test_parse_agent_state_accepts_html_marker():


### PR DESCRIPTION
## Summary
- add additive `response_file_text` and `message_text` channels to `AgentResult` while keeping `text` as the effective response
- keep Claude and Gemini on file-first transport, and add the same machine-response-file contract plus explicit fallback priority to Codex
- extend backend tests to prove noisy stdout is ignored when a valid response file is present and that legacy fallbacks still work

## Testing
- `python3 -m pytest tests/test_agent_loop.py`

Fixes #153
