### PR TITLE
Add structured protocol schema validators

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -74,6 +74,7 @@ from .protocol import (
     parse_plan_review,
     parse_plan_state,
     parse_pr_number,
+    review_freeform_summary_text,
     validate_human_requirements_acknowledgement,
 )
 from .protocol import ApprovedFollowup, parse_review
@@ -569,34 +570,7 @@ def _validate_plan_review_response(
 
 
 def _review_freeform_summary_text(text: str) -> str:
-    lines: list[str] = []
-    skip_structured_section = False
-    structured_heading_res = (
-        SAME_PR_FOLLOWUP_HEADING_RE,
-        FUTURE_FOLLOWUP_HEADING_RE,
-        LEGACY_FOLLOWUP_HEADING_RE,
-        HUMAN_REQUIREMENTS_HEADING_RE,
-        PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
-        PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
-    )
-    for line in text.splitlines():
-        stripped = line.strip()
-        if any(pattern.match(line) for pattern in structured_heading_res):
-            skip_structured_section = True
-            continue
-        if skip_structured_section and stripped.startswith("### "):
-            skip_structured_section = False
-        if skip_structured_section:
-            continue
-        if not stripped:
-            lines.append("")
-            continue
-        if stripped.startswith("<!--") and stripped.endswith("-->"):
-            continue
-        if stripped.startswith("-- "):
-            continue
-        lines.append(line.rstrip())
-    return "\n".join(lines).strip()
+    return review_freeform_summary_text(text)
 
 
 def _normalize_item_summary(text: str, *, limit: int = ITEM_SUMMARY_LIMIT) -> str:
@@ -1520,6 +1494,7 @@ def _run_plan_first_loop(
                 review_output = resumed_record.body
                 parsed_review = ParsedPlanReview(
                     state=resumed_record.metadata.state or parse_plan_state(review_output),
+                    summary=review_freeform_summary_text(review_output),
                     items=parse_plan_review(review_output, reviewer=reviewer_name).items,
                     dispositions=resumed_record.metadata.dispositions,
                 )
@@ -2061,6 +2036,7 @@ def run_pr_loop(
                     review_output = resumed_record.body
                     parsed_review = ParsedReview(
                         state=resumed_record.metadata.state or parse_agent_state(review_output),
+                        summary=review_freeform_summary_text(review_output),
                         followups=parse_review(review_output, reviewer=reviewer_name).followups,
                         dispositions=resumed_record.metadata.dispositions,
                     )

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -820,6 +820,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
         if state != "blocking":
             raise AgentLoopError("plan_revision.state must be `blocking`.")
+        summary = _expect_non_empty_string(payload["summary"], context="plan_revision.summary")
         plan_steps = _expect_string_list(
             payload["plan_steps"],
             context="plan_revision.plan_steps",
@@ -831,7 +832,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         schema_version=1,
         kind="plan_revision",
         state="blocking",
-        summary=_expect_non_empty_string(payload["summary"], context="plan_revision.summary"),
+        summary=summary,
         plan_steps=plan_steps,
     )
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -59,6 +60,7 @@ SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
 BULLET_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)(?P<text>.+?)\s*$")
 HEADING_LEVEL_RE = re.compile(r"^\s*(#{1,6})\s+\S")
 THEMATIC_BREAK_RE = re.compile(r"^\s*(?:([-*_])\s*){3,}\s*$")
+ITEM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _empty_placeholder_re(*phrases: str) -> re.Pattern[str]:
@@ -112,6 +114,7 @@ class UnresolvedReviewItem:
 @dataclass(frozen=True)
 class ParsedReview:
     state: str
+    summary: str
     followups: ApprovedFollowups
     dispositions: tuple[ReviewItemDisposition, ...]
 
@@ -126,8 +129,60 @@ class PlanReviewItems:
 @dataclass(frozen=True)
 class ParsedPlanReview:
     state: str
+    summary: str
     items: PlanReviewItems
     dispositions: tuple[ReviewItemDisposition, ...]
+
+
+@dataclass(frozen=True)
+class StructuredPrReview:
+    schema_version: int
+    kind: str
+    state: str
+    summary: str
+    blocking_items: tuple[str, ...]
+    same_pr_followups: tuple[str, ...]
+    future_followups: tuple[str, ...]
+    prior_item_dispositions: tuple[ReviewItemDisposition, ...]
+
+
+@dataclass(frozen=True)
+class StructuredPlanReview:
+    schema_version: int
+    kind: str
+    state: str
+    summary: str
+    blocking_plan_issues: tuple[str, ...]
+    same_plan_followups: tuple[str, ...]
+    future_followups: tuple[str, ...]
+    prior_plan_item_dispositions: tuple[ReviewItemDisposition, ...]
+
+
+@dataclass(frozen=True)
+class StructuredHumanRequirementsPayload:
+    addressed_ids: tuple[str, ...]
+    checked_discussion_directly: bool
+
+
+@dataclass(frozen=True)
+class StructuredCoderFollowup:
+    schema_version: int
+    kind: str
+    state: str
+    summary: str
+    addressed_items: tuple[str, ...]
+    remaining_items: tuple[str, ...]
+    human_requirements: StructuredHumanRequirementsPayload
+    tests_run: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class StructuredPlanRevision:
+    schema_version: int
+    kind: str
+    state: str
+    summary: str
+    plan_steps: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -271,6 +326,514 @@ def validate_human_requirements_acknowledgement(
             "Coder response must acknowledge that the prompt omitted the detailed signed human requirements "
             f"and that it {HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK}."
         )
+
+
+def review_freeform_summary_text(text: str) -> str:
+    lines: list[str] = []
+    skip_structured_section = False
+    structured_heading_res = (
+        BLOCKING_PLAN_ISSUES_HEADING_RE,
+        SAME_PLAN_FOLLOWUP_HEADING_RE,
+        SAME_PR_FOLLOWUP_HEADING_RE,
+        FUTURE_FOLLOWUP_HEADING_RE,
+        LEGACY_FOLLOWUP_HEADING_RE,
+        HUMAN_REQUIREMENTS_HEADING_RE,
+        PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
+        PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
+    )
+    for line in text.splitlines():
+        stripped = line.strip()
+        if any(pattern.match(line) for pattern in structured_heading_res):
+            skip_structured_section = True
+            continue
+        if skip_structured_section and stripped.startswith("### "):
+            skip_structured_section = False
+        if skip_structured_section:
+            continue
+        if not stripped:
+            lines.append("")
+            continue
+        if stripped.startswith("<!--") and stripped.endswith("-->"):
+            continue
+        if stripped.startswith("-- "):
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines).strip()
+
+
+def _expect_object(value: object, *, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise AgentLoopError(f"{context} must be a JSON object.")
+    return value
+
+
+def _expect_exact_keys(
+    value: dict[str, object],
+    *,
+    context: str,
+    required: set[str],
+    optional: set[str] = frozenset(),
+) -> None:
+    keys = set(value)
+    missing = sorted(required - keys)
+    if missing:
+        raise AgentLoopError(f"{context} is missing required field(s): {', '.join(missing)}")
+    unknown = sorted(keys - required - optional)
+    if unknown:
+        raise AgentLoopError(f"{context} has unknown field(s): {', '.join(unknown)}")
+
+
+def _expect_int(value: object, *, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AgentLoopError(f"{context} must be an integer.")
+    return value
+
+
+def _expect_bool(value: object, *, context: str) -> bool:
+    if not isinstance(value, bool):
+        raise AgentLoopError(f"{context} must be a boolean.")
+    return value
+
+
+def _expect_non_empty_string(value: object, *, context: str) -> str:
+    if not isinstance(value, str):
+        raise AgentLoopError(f"{context} must be a string.")
+    normalized = value.strip()
+    if not normalized:
+        raise AgentLoopError(f"{context} must be a non-empty string.")
+    return normalized
+
+
+def _expect_string_list(
+    value: object,
+    *,
+    context: str,
+    item_context: str,
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    return tuple(
+        _expect_non_empty_string(item, context=f"{item_context} at index {index}")
+        for index, item in enumerate(value)
+    )
+
+
+def _expect_state(value: object, *, context: str) -> str:
+    state = _expect_non_empty_string(value, context=context)
+    if state not in {"approved", "blocking"}:
+        raise AgentLoopError(f"{context} must be `approved` or `blocking`.")
+    return state
+
+
+def _expect_item_id(value: object, *, context: str) -> str:
+    item_id = _expect_non_empty_string(value, context=context)
+    if not ITEM_ID_RE.fullmatch(item_id):
+        raise AgentLoopError(
+            f"{context} must match `[A-Za-z0-9][A-Za-z0-9._-]*`."
+        )
+    return item_id
+
+
+def _expect_item_id_list(value: object, *, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    return tuple(
+        _expect_item_id(item, context=f"{context} item at index {index}")
+        for index, item in enumerate(value)
+    )
+
+
+def _expect_requirement_id_list(value: object, *, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    rendered: list[str] = []
+    for index, item in enumerate(value):
+        label = _expect_non_empty_string(item, context=f"{context} item at index {index}")
+        rendered.append(_normalize_requirement_label(label))
+    return tuple(rendered)
+
+
+def _extract_structured_response_object(text: str) -> dict[str, object] | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    decoder = json.JSONDecoder()
+    try:
+        payload, end = decoder.raw_decode(stripped)
+    except json.JSONDecodeError:
+        return None
+    if stripped[end:].strip():
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _require_supported_schema_version(payload: dict[str, object]) -> None:
+    if "schema_version" not in payload:
+        raise AgentLoopError("Structured response is missing required field: schema_version")
+    version = _expect_int(payload["schema_version"], context="schema_version")
+    if version != 1:
+        raise AgentLoopError(f"Unsupported structured response schema_version: {version}")
+
+
+def _parse_review_item_disposition_payload(
+    value: object,
+    *,
+    field_name: str,
+    reviewer: str,
+    allowed_same_status: str,
+    is_plan_review: bool,
+) -> ReviewItemDisposition:
+    payload = _expect_object(value, context=field_name)
+    _expect_exact_keys(
+        payload,
+        context=field_name,
+        required={"item_id", "disposition"},
+        optional={"note"},
+    )
+    item_id = _expect_item_id(payload["item_id"], context=f"{field_name}.item_id")
+    disposition = _expect_non_empty_string(payload["disposition"], context=f"{field_name}.disposition")
+    allowed_statuses = {"resolved", "blocking", allowed_same_status, "future"}
+    if disposition not in allowed_statuses:
+        rendered = ", ".join(sorted(allowed_statuses))
+        raise AgentLoopError(f"{field_name}.disposition must be one of: {rendered}")
+    note_value = payload.get("note")
+    note = None
+    if note_value is not None:
+        note = _expect_non_empty_string(note_value, context=f"{field_name}.note")
+    if _active_disposition_has_empty_note(
+        disposition,
+        note,
+        same_status=allowed_same_status,
+        is_plan_review=is_plan_review,
+    ):
+        raise AgentLoopError(
+            f"{field_name}.note cannot be an empty placeholder for active disposition `{disposition}`."
+        )
+    return ReviewItemDisposition(
+        item_id=item_id,
+        reviewer=reviewer,
+        disposition=disposition,
+        note=note,
+    )
+
+
+def _expect_disposition_list(
+    value: object,
+    *,
+    context: str,
+    reviewer: str,
+    allowed_same_status: str,
+    is_plan_review: bool,
+) -> tuple[ReviewItemDisposition, ...]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    return tuple(
+        _parse_review_item_disposition_payload(
+            item,
+            field_name=f"{context}[{index}]",
+            reviewer=reviewer,
+            allowed_same_status=allowed_same_status,
+            is_plan_review=is_plan_review,
+        )
+        for index, item in enumerate(value)
+    )
+
+
+def _finalize_parsed_review(
+    *,
+    state: str,
+    summary: str,
+    followups: ApprovedFollowups,
+    dispositions: tuple[ReviewItemDisposition, ...],
+) -> ParsedReview:
+    if state == "blocking" and followups.future:
+        followups = ApprovedFollowups(same_pr=followups.same_pr, future=())
+    if state == "blocking" and any(item.disposition == "future" for item in dispositions):
+        raise AgentLoopError(
+            "Blocking reviews may not downgrade prior unresolved items to Future follow-ups."
+        )
+    if state == "approved":
+        active_dispositions = [
+            item.disposition for item in dispositions if item.disposition in {"blocking", "same-pr"}
+        ]
+        if followups.same_pr or active_dispositions:
+            raise AgentLoopError(
+                "Approved reviews must be fully complete for this round. Do not use "
+                "`approved` when Same-PR follow-ups remain or when any prior unresolved "
+                "item stays `still blocking` or `same-pr`."
+            )
+    return ParsedReview(
+        state=state,
+        summary=summary,
+        followups=followups,
+        dispositions=dispositions,
+    )
+
+
+def _finalize_parsed_plan_review(
+    *,
+    state: str,
+    summary: str,
+    items: PlanReviewItems,
+    dispositions: tuple[ReviewItemDisposition, ...],
+) -> ParsedPlanReview:
+    if state == "blocking" and items.future:
+        items = PlanReviewItems(blocking=items.blocking, same_plan=items.same_plan, future=())
+    if state == "blocking" and any(item.disposition == "future" for item in dispositions):
+        raise AgentLoopError(
+            "Blocking plan reviews may not downgrade prior unresolved plan items to Future follow-ups."
+        )
+    if state == "approved":
+        active_dispositions = [
+            item.disposition for item in dispositions if item.disposition in {"blocking", "same-plan"}
+        ]
+        if items.blocking or items.same_plan or active_dispositions:
+            raise AgentLoopError(
+                "Approved plan reviews must be fully complete for this planning round. "
+                "Do not use `approved` when blocking plan issues, Same-plan follow-ups, "
+                "or carried-forward plan items remain active."
+            )
+    return ParsedPlanReview(
+        state=state,
+        summary=summary,
+        items=items,
+        dispositions=dispositions,
+    )
+
+
+def _structured_followups(items: tuple[str, ...], *, reviewer: str) -> tuple[ApprovedFollowup, ...]:
+    return tuple(ApprovedFollowup(reviewer=reviewer, text=item) for item in items)
+
+
+def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | None:
+    payload = _extract_structured_response_object(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "pr_review":
+        raise AgentLoopError("Structured response kind mismatch: expected `pr_review`.")
+    try:
+        _expect_exact_keys(
+            payload,
+            context="pr_review",
+            required={
+                "schema_version",
+                "kind",
+                "state",
+                "summary",
+                "blocking_items",
+                "same_pr_followups",
+                "future_followups",
+                "prior_item_dispositions",
+            },
+        )
+        state = _expect_state(payload["state"], context="pr_review.state")
+        summary = _expect_non_empty_string(payload["summary"], context="pr_review.summary")
+        blocking_items = _expect_string_list(
+            payload["blocking_items"],
+            context="pr_review.blocking_items",
+            item_context="pr_review.blocking_items",
+        )
+        same_pr_followups = _expect_string_list(
+            payload["same_pr_followups"],
+            context="pr_review.same_pr_followups",
+            item_context="pr_review.same_pr_followups",
+        )
+        future_followups = _expect_string_list(
+            payload["future_followups"],
+            context="pr_review.future_followups",
+            item_context="pr_review.future_followups",
+        )
+        dispositions = _expect_disposition_list(
+            payload["prior_item_dispositions"],
+            context="pr_review.prior_item_dispositions",
+            reviewer=reviewer,
+            allowed_same_status="same-pr",
+            is_plan_review=False,
+        )
+    except AgentLoopError:
+        return None
+    if state == "blocking" and future_followups:
+        raise AgentLoopError("Blocking structured reviews may not include future follow-ups.")
+    return _finalize_parsed_review(
+        state=state,
+        summary=summary,
+        followups=ApprovedFollowups(
+            same_pr=_structured_followups(same_pr_followups, reviewer=reviewer),
+            future=_structured_followups(future_followups, reviewer=reviewer),
+        ),
+        dispositions=dispositions,
+    )
+
+
+def parse_structured_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview | None:
+    payload = _extract_structured_response_object(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "plan_review":
+        raise AgentLoopError("Structured response kind mismatch: expected `plan_review`.")
+    try:
+        _expect_exact_keys(
+            payload,
+            context="plan_review",
+            required={
+                "schema_version",
+                "kind",
+                "state",
+                "summary",
+                "blocking_plan_issues",
+                "same_plan_followups",
+                "future_followups",
+                "prior_plan_item_dispositions",
+            },
+        )
+        state = _expect_state(payload["state"], context="plan_review.state")
+        summary = _expect_non_empty_string(payload["summary"], context="plan_review.summary")
+        blocking_items = _expect_string_list(
+            payload["blocking_plan_issues"],
+            context="plan_review.blocking_plan_issues",
+            item_context="plan_review.blocking_plan_issues",
+        )
+        same_plan_followups = _expect_string_list(
+            payload["same_plan_followups"],
+            context="plan_review.same_plan_followups",
+            item_context="plan_review.same_plan_followups",
+        )
+        future_followups = _expect_string_list(
+            payload["future_followups"],
+            context="plan_review.future_followups",
+            item_context="plan_review.future_followups",
+        )
+        dispositions = _expect_disposition_list(
+            payload["prior_plan_item_dispositions"],
+            context="plan_review.prior_plan_item_dispositions",
+            reviewer=reviewer,
+            allowed_same_status="same-plan",
+            is_plan_review=True,
+        )
+    except AgentLoopError:
+        return None
+    if state == "blocking" and future_followups:
+        raise AgentLoopError("Blocking structured plan reviews may not include future follow-ups.")
+    return _finalize_parsed_plan_review(
+        state=state,
+        summary=summary,
+        items=PlanReviewItems(
+            blocking=_structured_followups(blocking_items, reviewer=reviewer),
+            same_plan=_structured_followups(same_plan_followups, reviewer=reviewer),
+            future=_structured_followups(future_followups, reviewer=reviewer),
+        ),
+        dispositions=dispositions,
+    )
+
+
+def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | None:
+    payload = _extract_structured_response_object(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "coder_followup":
+        raise AgentLoopError("Structured response kind mismatch: expected `coder_followup`.")
+    try:
+        _expect_exact_keys(
+            payload,
+            context="coder_followup",
+            required={
+                "schema_version",
+                "kind",
+                "state",
+                "summary",
+                "addressed_items",
+                "remaining_items",
+                "human_requirements",
+            },
+            optional={"tests_run"},
+        )
+        human_requirements_payload = _expect_object(
+            payload["human_requirements"],
+            context="coder_followup.human_requirements",
+        )
+        _expect_exact_keys(
+            human_requirements_payload,
+            context="coder_followup.human_requirements",
+            required={"addressed_ids", "checked_discussion_directly"},
+        )
+        tests_run_value = payload.get("tests_run")
+        tests_run = (
+            _expect_string_list(
+                tests_run_value,
+                context="coder_followup.tests_run",
+                item_context="coder_followup.tests_run",
+            )
+            if tests_run_value is not None
+            else None
+        )
+        return StructuredCoderFollowup(
+            schema_version=1,
+            kind="coder_followup",
+            state=_expect_state(payload["state"], context="coder_followup.state"),
+            summary=_expect_non_empty_string(payload["summary"], context="coder_followup.summary"),
+            addressed_items=_expect_item_id_list(
+                payload["addressed_items"],
+                context="coder_followup.addressed_items",
+            ),
+            remaining_items=_expect_item_id_list(
+                payload["remaining_items"],
+                context="coder_followup.remaining_items",
+            ),
+            human_requirements=StructuredHumanRequirementsPayload(
+                addressed_ids=_expect_requirement_id_list(
+                    human_requirements_payload["addressed_ids"],
+                    context="coder_followup.human_requirements.addressed_ids",
+                ),
+                checked_discussion_directly=_expect_bool(
+                    human_requirements_payload["checked_discussion_directly"],
+                    context="coder_followup.human_requirements.checked_discussion_directly",
+                ),
+            ),
+            tests_run=tests_run,
+        )
+    except AgentLoopError:
+        return None
+
+
+def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | None:
+    payload = _extract_structured_response_object(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "plan_revision":
+        raise AgentLoopError("Structured response kind mismatch: expected `plan_revision`.")
+    try:
+        _expect_exact_keys(
+            payload,
+            context="plan_revision",
+            required={"schema_version", "kind", "state", "summary", "plan_steps"},
+        )
+        state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
+        if state != "blocking":
+            raise AgentLoopError("plan_revision.state must be `blocking`.")
+        plan_steps = _expect_string_list(
+            payload["plan_steps"],
+            context="plan_revision.plan_steps",
+            item_context="plan_revision.plan_steps",
+        )
+    except AgentLoopError:
+        return None
+    return StructuredPlanRevision(
+        schema_version=1,
+        kind="plan_revision",
+        state="blocking",
+        summary=_expect_non_empty_string(payload["summary"], context="plan_revision.summary"),
+        plan_steps=plan_steps,
+    )
 
 
 def _collect_section_items(
@@ -604,55 +1167,29 @@ def parse_plan_item_dispositions(text: str, *, reviewer: str) -> tuple[ReviewIte
 def parse_review(text: str, *, reviewer: str) -> ParsedReview:
     """Parse a review, including state, follow-ups, and prior-item dispositions."""
     state = parse_agent_state(text)
+    summary = review_freeform_summary_text(text)
     followups = parse_approved_followups(text, reviewer=reviewer)
     dispositions = parse_unresolved_item_dispositions(text, reviewer=reviewer)
-    if state == "blocking" and followups.future:
-        # Some agents still append speculative future work to otherwise valid
-        # blocking reviews. Preserve the blocking findings and ignore that
-        # lower-priority section rather than aborting the whole round.
-        followups = ApprovedFollowups(same_pr=followups.same_pr, future=())
-    if state == "blocking" and any(item.disposition == "future" for item in dispositions):
-        raise AgentLoopError(
-            "Blocking reviews may not downgrade prior unresolved items to Future follow-ups."
-        )
-    if state == "approved":
-        active_dispositions = [
-            item.disposition for item in dispositions if item.disposition in {"blocking", "same-pr"}
-        ]
-        if followups.same_pr or active_dispositions:
-            raise AgentLoopError(
-                "Approved reviews must be fully complete for this round. Do not use "
-                "`approved` when Same-PR follow-ups remain or when any prior unresolved "
-                "item stays `still blocking` or `same-pr`."
-            )
-    return ParsedReview(state=state, followups=followups, dispositions=dispositions)
+    return _finalize_parsed_review(
+        state=state,
+        summary=summary,
+        followups=followups,
+        dispositions=dispositions,
+    )
 
 
 def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
     """Parse a plan review, including state, structured plan items, and dispositions."""
     state = parse_plan_state(text)
+    summary = review_freeform_summary_text(text)
     items = parse_plan_review_items(text, reviewer=reviewer)
     dispositions = parse_plan_item_dispositions(text, reviewer=reviewer)
-    if state == "blocking" and items.future:
-        # Some agents still append speculative future work to otherwise valid
-        # blocking plan reviews. Preserve the blocking findings and ignore that
-        # lower-priority section rather than aborting the whole planning round.
-        items = PlanReviewItems(blocking=items.blocking, same_plan=items.same_plan, future=())
-    if state == "blocking" and any(item.disposition == "future" for item in dispositions):
-        raise AgentLoopError(
-            "Blocking plan reviews may not downgrade prior unresolved plan items to Future follow-ups."
-        )
-    if state == "approved":
-        active_dispositions = [
-            item.disposition for item in dispositions if item.disposition in {"blocking", "same-plan"}
-        ]
-        if items.blocking or items.same_plan or active_dispositions:
-            raise AgentLoopError(
-                "Approved plan reviews must be fully complete for this planning round. "
-                "Do not use `approved` when blocking plan issues, Same-plan follow-ups, "
-                "or carried-forward plan items remain active."
-            )
-    return ParsedPlanReview(state=state, items=items, dispositions=dispositions)
+    return _finalize_parsed_plan_review(
+        state=state,
+        summary=summary,
+        items=items,
+        dispositions=dispositions,
+    )
 
 
 def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -84,12 +84,16 @@ from coding_review_agent_loop.protocol import (
     parse_plan_review,
     parse_plan_review_items,
     parse_plan_state,
+    parse_structured_plan_review,
+    parse_structured_pr_review,
     parse_review,
     parse_non_blocking_followups,
     parse_signed_human_requirement_body,
     parse_unresolved_item_dispositions,
     UnresolvedReviewItem,
     validate_human_requirements_acknowledgement,
+    validate_structured_coder_followup,
+    validate_structured_plan_revision,
 )
 
 
@@ -1983,6 +1987,337 @@ def test_parse_review_rejects_approved_state_with_active_prior_disposition(line)
 
     with pytest.raises(AgentLoopError, match="Approved reviews must be fully complete"):
         parse_review(review, reviewer="OpenAI Codex")
+
+
+def test_parse_review_populates_summary_from_legacy_markdown():
+    review = """
+    Blocking issue summary.
+
+    ### Same-PR follow-ups
+    - Rename the helper.
+
+    <!-- AGENT_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    parsed = parse_review(review, reviewer="OpenAI Codex")
+
+    assert parsed.summary == "Blocking issue summary."
+
+
+def test_parse_plan_review_populates_summary_from_legacy_markdown():
+    review = """
+    Plan needs one more regression test.
+
+    ### Same-plan follow-ups
+    - Add a regression test matrix.
+
+    <!-- AGENT_PLAN_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    parsed = parse_plan_review(review, reviewer="OpenAI Codex")
+
+    assert parsed.summary == "Plan needs one more regression test."
+
+
+def test_parse_structured_pr_review_normalizes_v1_payload():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "Looks good after the latest fix.",
+            "blocking_items": [],
+            "same_pr_followups": [],
+            "future_followups": ["Document cleanup for a later PR."],
+            "prior_item_dispositions": [
+                {"item_id": "item-1", "disposition": "resolved"},
+                {
+                    "item_id": "item-2",
+                    "disposition": "future",
+                    "note": "okay to split into follow-up work",
+                },
+            ],
+        }
+    )
+
+    parsed = parse_structured_pr_review(payload, reviewer="OpenAI Codex")
+
+    assert parsed is not None
+    assert parsed.state == "approved"
+    assert parsed.summary == "Looks good after the latest fix."
+    assert [item.text for item in parsed.followups.future] == ["Document cleanup for a later PR."]
+    assert [(item.item_id, item.disposition, item.note) for item in parsed.dispositions] == [
+        ("item-1", "resolved", None),
+        ("item-2", "future", "okay to split into follow-up work"),
+    ]
+
+
+def test_parse_structured_pr_review_rejects_kind_mismatch():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "approved",
+            "summary": "Wrong kind.",
+            "blocking_plan_issues": [],
+            "same_plan_followups": [],
+            "future_followups": [],
+            "prior_plan_item_dispositions": [],
+        }
+    )
+
+    with pytest.raises(AgentLoopError, match="kind mismatch"):
+        parse_structured_pr_review(payload, reviewer="OpenAI Codex")
+
+
+def test_parse_structured_pr_review_hard_fails_on_unsupported_schema_version():
+    payload = json.dumps(
+        {
+            "schema_version": 2,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "Wrong version.",
+            "blocking_items": [],
+            "same_pr_followups": [],
+            "future_followups": [],
+            "prior_item_dispositions": [],
+        }
+    )
+
+    with pytest.raises(AgentLoopError, match="Unsupported structured response schema_version: 2"):
+        parse_structured_pr_review(payload, reviewer="OpenAI Codex")
+
+
+def test_parse_structured_pr_review_falls_back_on_malformed_json():
+    assert parse_structured_pr_review('{"schema_version": 1,', reviewer="OpenAI Codex") is None
+
+
+def test_parse_structured_pr_review_falls_back_on_invalid_fields():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "Missing required arrays.",
+            "blocking_items": [],
+            "same_pr_followups": [],
+            "future_followups": [],
+        }
+    )
+
+    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+
+
+def test_parse_structured_pr_review_rejects_future_followups_in_blocking_reviews():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "blocking",
+            "summary": "Still blocked.",
+            "blocking_items": ["Needs one more test."],
+            "same_pr_followups": [],
+            "future_followups": ["Clean this up later."],
+            "prior_item_dispositions": [],
+        }
+    )
+
+    with pytest.raises(AgentLoopError, match="Blocking structured reviews may not include future"):
+        parse_structured_pr_review(payload, reviewer="OpenAI Codex")
+
+
+def test_parse_structured_pr_review_rejects_unknown_nested_keys_via_fallback():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "LGTM.",
+            "blocking_items": [],
+            "same_pr_followups": [],
+            "future_followups": [],
+            "prior_item_dispositions": [
+                {"item_id": "item-1", "disposition": "resolved", "extra": "nope"},
+            ],
+        }
+    )
+
+    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+
+
+def test_parse_structured_pr_review_rejects_invalid_item_id_via_fallback():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "LGTM.",
+            "blocking_items": [],
+            "same_pr_followups": [],
+            "future_followups": [],
+            "prior_item_dispositions": [
+                {"item_id": "item 1", "disposition": "resolved"},
+            ],
+        }
+    )
+
+    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+
+
+def test_parse_structured_pr_review_requires_strict_disposition_enums():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "LGTM.",
+            "blocking_items": [],
+            "same_pr_followups": [],
+            "future_followups": [],
+            "prior_item_dispositions": [
+                {"item_id": "item-1", "disposition": "still blocking"},
+            ],
+        }
+    )
+
+    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+
+
+def test_parse_structured_pr_review_falls_back_when_json_is_embedded_in_markdown():
+    review = """
+    Here is an example:
+
+    ```json
+    {"schema_version": 1, "kind": "pr_review"}
+    ```
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    assert parse_structured_pr_review(review, reviewer="OpenAI Codex") is None
+    assert parse_review(review, reviewer="OpenAI Codex").state == "approved"
+
+
+def test_parse_structured_plan_review_normalizes_v1_payload():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "approved",
+            "summary": "Plan looks good.",
+            "blocking_plan_issues": [],
+            "same_plan_followups": [],
+            "future_followups": ["Consider a later cleanup pass."],
+            "prior_plan_item_dispositions": [{"item_id": "item-1", "disposition": "resolved"}],
+        }
+    )
+
+    parsed = parse_structured_plan_review(payload, reviewer="OpenAI Codex")
+
+    assert parsed is not None
+    assert parsed.summary == "Plan looks good."
+    assert [item.text for item in parsed.items.future] == ["Consider a later cleanup pass."]
+    assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
+        ("item-1", "resolved")
+    ]
+
+
+def test_parse_structured_plan_review_rejects_blocking_future_followups():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "blocking",
+            "summary": "Still blocked.",
+            "blocking_plan_issues": ["Need clearer rollback coverage."],
+            "same_plan_followups": [],
+            "future_followups": ["Refactor the prompt later."],
+            "prior_plan_item_dispositions": [],
+        }
+    )
+
+    with pytest.raises(AgentLoopError, match="Blocking structured plan reviews may not include future"):
+        parse_structured_plan_review(payload, reviewer="OpenAI Codex")
+
+
+def test_validate_structured_coder_followup_accepts_v1_payload():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "coder_followup",
+            "state": "blocking",
+            "summary": "Addressed the first item; one remains.",
+            "addressed_items": ["item-1"],
+            "remaining_items": ["item-2"],
+            "human_requirements": {
+                "addressed_ids": ["Requirement 1"],
+                "checked_discussion_directly": False,
+            },
+            "tests_run": ["python -m pytest tests/test_agent_loop.py -k structured"],
+        }
+    )
+
+    parsed = validate_structured_coder_followup(payload)
+
+    assert parsed is not None
+    assert parsed.addressed_items == ("item-1",)
+    assert parsed.remaining_items == ("item-2",)
+    assert parsed.human_requirements.addressed_ids == ("Requirement 1",)
+
+
+def test_validate_structured_coder_followup_rejects_unknown_keys_via_fallback():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "coder_followup",
+            "state": "approved",
+            "summary": "Done.",
+            "addressed_items": [],
+            "remaining_items": [],
+            "human_requirements": {
+                "addressed_ids": [],
+                "checked_discussion_directly": True,
+                "extra": "nope",
+            },
+        }
+    )
+
+    assert validate_structured_coder_followup(payload) is None
+
+
+def test_validate_structured_plan_revision_accepts_v1_payload():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "Revised the plan to cover rollback testing.",
+            "plan_steps": ["Update protocol.py.", "Add regression tests."],
+        }
+    )
+
+    parsed = validate_structured_plan_revision(payload)
+
+    assert parsed is not None
+    assert parsed.state == "blocking"
+    assert parsed.plan_steps == ("Update protocol.py.", "Add regression tests.")
+
+
+def test_validate_structured_plan_revision_rejects_non_blocking_state_via_fallback():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "approved",
+            "summary": "Wrong state.",
+            "plan_steps": ["Update protocol.py."],
+        }
+    )
+
+    assert validate_structured_plan_revision(payload) is None
 
 
 def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2320,6 +2320,20 @@ def test_validate_structured_plan_revision_rejects_non_blocking_state_via_fallba
     assert validate_structured_plan_revision(payload) is None
 
 
+def test_validate_structured_plan_revision_falls_back_on_empty_summary():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "",
+            "plan_steps": ["Update protocol.py."],
+        }
+    )
+
+    assert validate_structured_plan_revision(payload) is None
+
+
 def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions(tmp_path):
     config = make_config(tmp_path, approved_followups="fix-and-summarize")
     prompt = build_review_prompt(


### PR DESCRIPTION
Fixes #152

## Summary
- add strict versioned structured response parsing helpers in `protocol.py` for v1 PR reviews, plan reviews, coder follow-ups, and plan revisions
- normalize PR/plan structured payloads back into existing parsed review dataclasses and add `summary` parity for legacy markdown parsing
- cover valid/invalid structured payloads, strict enums and item IDs, unknown-key rejection, and migration fallback behavior in unit tests

## Testing
- `python3 -m pytest tests/test_agent_loop.py`
- `python3 -m compileall src tests/test_agent_loop.py`