### PR TITLE
Support signed human requirements in issue flows

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -46,6 +46,7 @@ class IssueContext:
     body: str | None
     url: str | None
     comments: tuple[IssueComment, ...]
+    human_requirements: tuple[HumanReviewRequirement, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -555,6 +556,7 @@ def get_issue_context(runner: Runner, *, config: AgentLoopConfig, issue_number: 
             body=None,
             url=None,
             comments=(),
+            human_requirements=(),
         )
 
     result = runner.run(
@@ -567,33 +569,53 @@ def get_issue_context(runner: Runner, *, config: AgentLoopConfig, issue_number: 
             config.repo,
             "--comments",
             "--json",
-            "number,title,body,url,comments",
+            "number,title,body,url,author,createdAt,comments",
         ],
         cwd=active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
-    comments: list[IssueComment] = []
-    for raw_comment in data.get("comments") or []:
-        author = raw_comment.get("author")
-        if isinstance(author, dict):
-            author_name = author.get("login")
-        else:
-            author_name = None
-        comments.append(
-            IssueComment(
-                author=author_name,
-                created_at=raw_comment.get("createdAt") or raw_comment.get("created_at"),
-                body=raw_comment.get("body"),
-            )
-        )
+    comments = _parse_issue_comments(data.get("comments"))
     return IssueContext(
         number=int(data.get("number") or issue_number),
         repo=config.repo,
-        title=data.get("title"),
-        body=data.get("body"),
-        url=data.get("url"),
-        comments=tuple(sorted(comments, key=_comment_sort_key)),
+        title=_optional_str(data.get("title")),
+        body=_optional_str(data.get("body")),
+        url=_optional_str(data.get("url")),
+        comments=comments,
+        human_requirements=_parse_issue_human_requirements(data),
     )
+
+
+def _parse_issue_human_requirements(data: dict[str, object]) -> tuple[HumanReviewRequirement, ...]:
+    requirements: list[HumanReviewRequirement] = []
+    issue_body = parse_signed_human_requirement_body(_optional_str(data.get("body")))
+    if issue_body is not None:
+        requirements.append(
+            HumanReviewRequirement(
+                source_type="Issue body",
+                author=_author_login(data.get("author")),
+                created_at=_optional_str(data.get("createdAt")) or _optional_str(data.get("created_at")),
+                url=_optional_str(data.get("url")),
+                body=issue_body,
+            )
+        )
+    for raw_comment in data.get("comments") or []:
+        if not isinstance(raw_comment, dict):
+            continue
+        body = parse_signed_human_requirement_body(_optional_str(raw_comment.get("body")))
+        if body is None:
+            continue
+        requirements.append(
+            HumanReviewRequirement(
+                source_type="Issue comment",
+                author=_author_login(raw_comment.get("author")),
+                created_at=_optional_str(raw_comment.get("createdAt"))
+                or _optional_str(raw_comment.get("created_at")),
+                url=_optional_str(raw_comment.get("url")),
+                body=body,
+            )
+        )
+    return tuple(sorted(requirements, key=_human_requirement_sort_key))
 
 
 def post_pr_comment(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -455,6 +455,37 @@ def _reconcile_human_requirements_ack_item(
     return _clear_human_requirements_ack_item(unresolved_items)
 
 
+def _validate_response_with_human_requirements(
+    text: str,
+    *,
+    marker_validator: Callable[[str], object],
+    human_requirements,
+    requirement_scope: str,
+    full_omission_fallback: str,
+) -> object:
+    marker_value = marker_validator(text)
+    prompt_context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope=requirement_scope,
+        full_omission_fallback=full_omission_fallback,
+    )
+    validate_human_requirements_acknowledgement(
+        text,
+        surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+        requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+    )
+    return marker_value
+
+
+def _merge_human_requirements(
+    issue_context: IssueContext | None,
+    pr_context: PullRequestReviewContext,
+):
+    combined = list(issue_context.human_requirements if issue_context is not None else ())
+    combined.extend(pr_context.human_requirements)
+    return tuple(sorted(combined, key=lambda requirement: requirement.created_at or ""))
+
+
 def _apply_unresolved_item_dispositions(
     unresolved_items: Sequence[UnresolvedReviewItem],
     dispositions_by_item: dict[str, list[ReviewItemDisposition]],
@@ -1438,7 +1469,13 @@ def _run_plan_first_loop(
             config=config,
             prompt=build_issue_plan_prompt(issue_number, config, memory, issue_context=issue_context),
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking --> or <!-- AGENT_CLARIFY -->",
-            validate=_require_plan_state_or_clarification,
+            validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
+                text,
+                marker_validator=_require_plan_state_or_clarification,
+                human_requirements=human_requirements,
+                requirement_scope="planning requirements",
+                full_omission_fallback="Fetch the issue discussion directly before finalizing the plan.",
+            ),
             usage_context=usage_context,
         )
         plan_output = plan_response.text
@@ -1656,7 +1693,13 @@ def _run_plan_first_loop(
                 ),
                 session_id=coder_session_id,
                 marker_description="<!-- AGENT_PR: <number> --> or PR URL",
-                validate=_require_pr_number,
+                validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
+                    text,
+                    marker_validator=_require_pr_number,
+                    human_requirements=human_requirements,
+                    requirement_scope="implementation requirements",
+                    full_omission_fallback="Fetch the issue discussion directly before implementing.",
+                ),
                 usage_context=usage_context,
             )
             coder_output = coder_response.text
@@ -1721,7 +1764,13 @@ def _run_plan_first_loop(
             ),
             session_id=coder_session_id,
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
-            validate=parse_plan_state,
+            validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
+                text,
+                marker_validator=parse_plan_state,
+                human_requirements=human_requirements,
+                requirement_scope="planning requirements",
+                full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+            ),
             usage_context=usage_context,
         )
         current_plan = plan_response.text
@@ -1786,7 +1835,13 @@ def run_issue_loop(
             config=config,
             prompt=build_issue_prompt(issue_number, config, memory, issue_context=issue_context),
             marker_description="<!-- AGENT_PR: <number> --> or PR URL",
-            validate=_require_pr_number,
+            validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
+                text,
+                marker_validator=_require_pr_number,
+                human_requirements=human_requirements,
+                requirement_scope="implementation requirements",
+                full_omission_fallback="Fetch the issue discussion directly before implementing.",
+            ),
             usage_context=usage_context,
         )
         coder_output = coder_response.text
@@ -2011,7 +2066,7 @@ def run_pr_loop(
             initial_pr_context = pr_context
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
-            human_requirements = pr_context.human_requirements
+            human_requirements = _merge_human_requirements(issue_context, pr_context)
             current_resume = resumed_round if resumed_round is not None and round_number == resumed_round.round_number else None
             unresolved_items = _reconcile_human_requirements_ack_item(
                 current_resume.prior_items if current_resume is not None else unresolved_items,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -157,6 +157,8 @@ def format_human_requirements(
     human_requirements: Sequence[HumanReviewRequirement],
     *,
     max_chars: int = 12_000,
+    requirement_scope: str = "PR requirements",
+    full_omission_fallback: str = "Fetch the PR discussion directly before approving.",
 ) -> str:
     if not human_requirements:
         return ""
@@ -165,7 +167,7 @@ def format_human_requirements(
         [
             "Signed Human Reviewer Requirements",
             "",
-            "Treat these signed human reviewer comments as high-priority PR requirements. "
+            f"Treat these signed human reviewer comments as high-priority {requirement_scope}. "
             "Later human comments may supersede earlier ones; the latest human instruction wins. "
             "If a requirement is unsafe, impossible, or contradicted by a later human instruction, "
             "explain that explicitly instead of ignoring it.",
@@ -236,27 +238,45 @@ def format_human_requirements(
         header
         + "\n\n"
         + f"All {omitted_count} signed human requirement(s) were omitted to keep this prompt bounded. "
-        "Fetch the PR discussion directly before approving."
+        + full_omission_fallback
     )
 
 
 def _human_requirements_block(
     human_requirements: Sequence[HumanReviewRequirement] | None,
+    *,
+    requirement_scope: str = "PR requirements",
+    full_omission_fallback: str = "Fetch the PR discussion directly before approving.",
 ) -> str:
     if not human_requirements:
         return ""
-    return f"{format_human_requirements(human_requirements)}\n"
+    return (
+        f"{format_human_requirements(
+            human_requirements,
+            requirement_scope=requirement_scope,
+            full_omission_fallback=full_omission_fallback,
+        )}\n"
+    )
 
 
 def render_coder_human_requirements_prompt_context(
     human_requirements: Sequence[HumanReviewRequirement] | None,
     *,
     max_chars: int = 12_000,
+    requirement_scope: str = "PR requirements",
+    full_omission_fallback: str = "Fetch the PR discussion directly before approving.",
 ) -> CoderHumanRequirementsPromptContext:
     if not human_requirements:
         block = ""
     else:
-        block = f"{format_human_requirements(human_requirements, max_chars=max_chars)}\n"
+        block = (
+            f"{format_human_requirements(
+                human_requirements,
+                max_chars=max_chars,
+                requirement_scope=requirement_scope,
+                full_omission_fallback=full_omission_fallback,
+            )}\n"
+        )
     if not block:
         return CoderHumanRequirementsPromptContext(
             block="",
@@ -280,11 +300,16 @@ def render_coder_human_requirements_prompt_context(
 
 def _coder_human_requirements_guidance(
     context: CoderHumanRequirementsPromptContext,
+    *,
+    requirement_label: str = "next-revision requirements",
+    surfaced_requirement_instruction: str = (
+        "Each bullet must explain how you addressed that item or why it could not be satisfied safely."
+    ),
 ) -> str:
     if not context.block:
         return ""
     lines = [
-        "The signed human reviewer requirements above are mandatory next-revision requirements, not passive context.",
+        f"The signed human reviewer requirements above are mandatory {requirement_label}, not passive context.",
         "Later signed human comments supersede earlier ones; the latest human instruction wins.",
         "If any signed human requirement cannot be satisfied safely or is impossible, say that explicitly instead of skipping it.",
         "",
@@ -297,7 +322,7 @@ def _coder_human_requirements_guidance(
         surfaced = ", ".join(f"`{item}`" for item in context.surfaced_requirement_ids)
         lines.append(
             "Include one bullet for each surfaced signed human requirement ID shown in this prompt: "
-            f"{surfaced}. Each bullet must explain how you addressed that item or why it could not be satisfied safely."
+            f"{surfaced}. {surfaced_requirement_instruction}"
         )
     elif context.requires_direct_discussion_ack:
         lines.append(
@@ -310,18 +335,20 @@ def _coder_human_requirements_guidance(
 
 def _human_requirements_review_guidance(
     human_requirements: Sequence[HumanReviewRequirement] | None,
+    *,
+    requirement_label: str = "signed human reviewer requirements",
 ) -> str:
     if not human_requirements:
         return ""
-    return """Signed human reviewer requirements override AI reviewer preferences unless they
+    return f"""{requirement_label.capitalize()} override AI reviewer preferences unless they
 are unsafe, impossible, or contradicted by a later signed human instruction.
-Verify every signed human reviewer requirement before approving. If all signed
-human reviewer requirements are addressed or explicitly resolved, an approved
+Verify each requirement in this set before approving. If all surfaced signed
+human requirements are addressed or explicitly resolved, an approved
 review must include exactly:
 
 <!-- HUMAN_REQUIREMENTS_RESOLVED -->
 
-If any signed human reviewer requirement is unresolved, return blocking.
+If any signed human requirement in this set is unresolved, return blocking.
 """
 
 
@@ -407,6 +434,40 @@ def _issue_context_block(issue_context: IssueContext | None) -> str:
     )
 
 
+def _issue_human_requirements_block(
+    issue_context: IssueContext | None,
+    *,
+    requirement_scope: str,
+    full_omission_fallback: str,
+) -> str:
+    if issue_context is None:
+        return ""
+    return _human_requirements_block(
+        issue_context.human_requirements,
+        requirement_scope=requirement_scope,
+        full_omission_fallback=full_omission_fallback,
+    )
+
+
+def _issue_human_requirements_prompt_context(
+    issue_context: IssueContext | None,
+    *,
+    requirement_scope: str,
+    full_omission_fallback: str,
+) -> CoderHumanRequirementsPromptContext:
+    if issue_context is None:
+        return CoderHumanRequirementsPromptContext(
+            block="",
+            surfaced_requirement_ids=(),
+            requires_direct_discussion_ack=False,
+        )
+    return render_coder_human_requirements_prompt_context(
+        issue_context.human_requirements,
+        requirement_scope=requirement_scope,
+        full_omission_fallback=full_omission_fallback,
+    )
+
+
 def _issue_pr_reference_guidance(issue_number: int) -> str:
     return (
         f"In the pull request body, include `Fixes #{issue_number}` or another direct "
@@ -422,6 +483,11 @@ def build_issue_prompt(
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
+    human_requirements_context = _issue_human_requirements_prompt_context(
+        issue_context,
+        requirement_scope="implementation requirements",
+        full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
     return f"""Fix GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the fix,
@@ -429,6 +495,10 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
+{human_requirements_context.block}{_coder_human_requirements_guidance(
+    human_requirements_context,
+    requirement_label="implementation requirements",
+)}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
@@ -455,6 +525,11 @@ def build_issue_plan_prompt(
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
+    human_requirements_context = _issue_human_requirements_prompt_context(
+        issue_context,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before finalizing the plan.",
+    )
     return f"""Plan GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout only to inspect context. Do not edit files, create a
@@ -462,6 +537,13 @@ branch, commit, push, or open a pull request during this planning stage.
 Write a concise implementation plan covering the intended approach, key files or
 areas to change, edge cases, and test strategy.
 {_scratch_file_guidance()}
+{human_requirements_context.block}{_coder_human_requirements_guidance(
+    human_requirements_context,
+    requirement_label="planning requirements",
+    surfaced_requirement_instruction=(
+        "Each bullet must explain how the plan covers that item or what remains risky or blocked."
+    ),
+)}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
@@ -497,6 +579,15 @@ def build_plan_review_prompt(
     reviewer_signature = agent_signature(reviewer)
     reviewer_group = format_agent_list(reviewers(config))
     unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
+    human_requirements_block = _issue_human_requirements_block(
+        issue_context,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before approving the plan.",
+    )
+    human_requirements_guidance = _human_requirements_review_guidance(
+        issue_context.human_requirements if issue_context is not None else (),
+        requirement_label="signed human issue requirements",
+    )
     if unresolved_items:
         unresolved_items_guidance = """Because prior unresolved plan items exist, include this exact section in your review:
 
@@ -518,7 +609,7 @@ Contradictory forms like `same-plan: none`, `still blocking: none`, and `future 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this planning review.
 {_scratch_file_guidance()}
-{_issue_context_block(issue_context)}
+{human_requirements_block}{_issue_context_block(issue_context)}
 {unresolved_items_block}{_memory_block(memory)}
 
 Plan from {coder_name}:
@@ -551,6 +642,9 @@ reviewers appear elsewhere in the issue discussion, treat them as
 informational only and do not disposition them until a later round carries
 them forward explicitly.
 {unresolved_items_guidance}
+Signed human issue requirements are approval-critical issue constraints for this
+plan review.
+{human_requirements_guidance}
 Use blocking only when the current plan still has blocking plan issues or
 same-plan follow-ups. All configured reviewers ({reviewer_group}) must approve
 in the same planning round before implementation can proceed.
@@ -583,11 +677,23 @@ def build_plan_revision_prompt(
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
     unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
+    human_requirements_context = _issue_human_requirements_prompt_context(
+        issue_context,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
     return f"""{reviewer_name} reviewed the implementation plan for GitHub issue #{issue_number} in {config.repo} and found blocking issues.
 
 Revise the plan in this local checkout without editing code. Do not create a
 branch, commit, push, or open a pull request during this planning stage.
 {_scratch_file_guidance()}
+{human_requirements_context.block}{_coder_human_requirements_guidance(
+    human_requirements_context,
+    requirement_label="planning requirements",
+    surfaced_requirement_instruction=(
+        "Each bullet must explain how the revised plan covers that item or what remains risky or blocked."
+    ),
+)}
 {_issue_context_block(issue_context)}
 {unresolved_items_block}{_memory_block(memory)}
 
@@ -632,6 +738,11 @@ def build_issue_implementation_prompt(
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
+    human_requirements_context = _issue_human_requirements_prompt_context(
+        issue_context,
+        requirement_scope="implementation requirements",
+        full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the
@@ -640,6 +751,10 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
+{human_requirements_context.block}{_coder_human_requirements_guidance(
+    human_requirements_context,
+    requirement_label="implementation requirements",
+)}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 from .errors import AgentLoopError
 
 HUMAN_REQUIREMENTS_ADDRESSED_MARKER = "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->"
-HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK = "checked the PR discussion directly before responding"
+HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK = (
+    "checked the relevant GitHub discussion directly before responding"
+)
 
 STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->", re.I)
 PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->", re.I)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -48,6 +48,7 @@ from coding_review_agent_loop.github import (
     IssueContext,
     PullRequestReviewContext,
     PullRequestMetadata,
+    get_issue_context,
     get_pr_checks,
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
@@ -69,6 +70,9 @@ from coding_review_agent_loop.prompts import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
     build_followup_prompt,
+    build_issue_implementation_prompt,
+    build_issue_plan_prompt,
+    build_issue_prompt,
     build_same_pr_followup_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
@@ -339,6 +343,8 @@ class FakeRunner(Runner):
                 "title": self.issue_payload.get("title"),
                 "body": self.issue_payload.get("body"),
                 "url": self.issue_payload.get("url"),
+                "author": self.issue_payload.get("author"),
+                "createdAt": self.issue_payload.get("createdAt"),
                 "comments": self.issue_comments,
             }
             return CommandResult(cmd, cwd_path, json_dumps(payload), "", 0)
@@ -2798,6 +2804,49 @@ def test_format_issue_context_truncates_oversized_newest_comment():
     assert "Older detail should not be kept instead of the newest comment." not in text
 
 
+def test_get_issue_context_parses_signed_issue_body_and_comments(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "number": 56,
+            "title": "Support signed issue requirements",
+            "body": "Use the stable API path.\n\n-- Human Reviewer",
+            "url": "https://github.com/OWNER/REPO/issues/56",
+            "author": {"login": "issue-author"},
+            "createdAt": "2026-05-17T08:00:00Z",
+        },
+        issue_comments=[
+            {
+                "author": {"login": "maintainer"},
+                "createdAt": "2026-05-17T09:00:00Z",
+                "url": "https://github.com/OWNER/REPO/issues/56#issuecomment-1",
+                "body": "Unsigned discussion remains normal context.",
+            },
+            {
+                "author": {"login": "lead"},
+                "createdAt": "2026-05-17T10:00:00Z",
+                "url": "https://github.com/OWNER/REPO/issues/56#issuecomment-2",
+                "body": "Add a regression test.\n\n-- Human Reviewer",
+            },
+        ],
+    )
+    config = make_config(tmp_path)
+
+    issue_context = get_issue_context(runner, config=config, issue_number=56)
+
+    assert [item.source_type for item in issue_context.human_requirements] == [
+        "Issue body",
+        "Issue comment",
+    ]
+    assert [item.author for item in issue_context.human_requirements] == ["issue-author", "lead"]
+    assert [item.created_at for item in issue_context.human_requirements] == [
+        "2026-05-17T08:00:00Z",
+        "2026-05-17T10:00:00Z",
+    ]
+    assert issue_context.human_requirements[0].body == "Use the stable API path."
+    assert issue_context.human_requirements[1].body == "Add a regression test."
+    assert issue_context.comments[0].body == "Unsigned discussion remains normal context."
+
+
 def test_format_human_requirements_uses_distinct_high_priority_section():
     text = format_human_requirements(
         (
@@ -2817,6 +2866,26 @@ def test_format_human_requirements_uses_distinct_high_priority_section():
     assert "- Source: PR comment" in text
     assert "- Author: reviewer" in text
     assert "Please use the absolute URL." in text
+
+
+def test_format_human_requirements_supports_issue_specific_wording_and_fallback():
+    text = format_human_requirements(
+        (
+            HumanReviewRequirement(
+                source_type="Issue body",
+                author="maintainer",
+                created_at="2026-05-18T10:00:00Z",
+                url="https://github.com/OWNER/REPO/issues/56",
+                body="Keep the current CLI flag.",
+            ),
+        ),
+        max_chars=120,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before finalizing the plan.",
+    )
+
+    assert "high-priority planning requirements" in text
+    assert "Fetch the issue discussion directly before finalizing the plan." in text
 
 
 def test_format_human_requirements_preserves_entry_spacing_when_truncated():
@@ -2907,6 +2976,112 @@ def test_render_coder_human_requirements_prompt_context_handles_full_omission_fa
     assert "All 1 signed human requirement(s) were omitted" in context.block
     assert context.surfaced_requirement_ids == ()
     assert context.requires_direct_discussion_ack is True
+
+
+@pytest.mark.parametrize(
+    ("builder_name", "expected_scope", "expected_guidance"),
+    [
+        ("issue", "high-priority implementation requirements", "how you addressed that item"),
+        ("issue_plan", "high-priority planning requirements", "how the plan covers that item"),
+        ("plan_revision", "high-priority planning requirements", "how the revised plan covers that item"),
+        (
+            "issue_implementation",
+            "high-priority implementation requirements",
+            "how you addressed that item",
+        ),
+    ],
+)
+def test_issue_and_plan_prompts_surface_signed_human_requirements_before_issue_context(
+    tmp_path,
+    builder_name,
+    expected_scope,
+    expected_guidance,
+):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="commenter",
+                created_at="2026-05-17T10:00:00Z",
+                body="General issue context.",
+            ),
+        ),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue comment",
+                author="maintainer",
+                created_at="2026-05-17T11:00:00Z",
+                url="https://github.com/OWNER/REPO/issues/56#issuecomment-1",
+                body="Preserve backward compatibility.",
+            ),
+        ),
+    )
+    if builder_name == "issue":
+        prompt = build_issue_prompt(56, config, issue_context=issue_context)
+    elif builder_name == "issue_plan":
+        prompt = build_issue_plan_prompt(56, config, issue_context=issue_context)
+    elif builder_name == "plan_revision":
+        prompt = build_plan_revision_prompt(
+            56,
+            2,
+            "Old plan.",
+            "Blocking review.",
+            config,
+            issue_context=issue_context,
+        )
+    else:
+        prompt = build_issue_implementation_prompt(
+            56,
+            "Approved plan.",
+            config,
+            issue_context=issue_context,
+        )
+
+    assert "Signed Human Reviewer Requirements" in prompt
+    assert expected_scope in prompt
+    assert expected_guidance in prompt
+    assert prompt.index("Signed Human Reviewer Requirements") < prompt.index("Issue context from GitHub")
+
+
+def test_plan_review_prompt_surfaces_signed_issue_requirements_as_approval_critical(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue body",
+                author="maintainer",
+                created_at="2026-05-17T08:00:00Z",
+                url="https://github.com/OWNER/REPO/issues/56",
+                body="Keep the public API unchanged.",
+            ),
+        ),
+    )
+
+    prompt = build_plan_review_prompt(
+        56,
+        1,
+        "Plan:\n- Update the parser.",
+        config,
+        reviewer="codex",
+        issue_context=issue_context,
+    )
+
+    assert "Signed Human Reviewer Requirements" in prompt
+    assert "high-priority planning requirements" in prompt
+    assert "approval-critical issue constraints" in prompt
+    assert "Verify each requirement in this set before approving." in prompt
+    assert prompt.index("Signed Human Reviewer Requirements") < prompt.index("Issue context from GitHub")
 
 
 @pytest.mark.parametrize("builder", [build_followup_prompt, build_same_pr_followup_prompt])
@@ -3786,7 +3961,7 @@ def test_review_prompt_includes_signed_human_requirements(tmp_path):
     assert "Signed Human Reviewer Requirements" in prompt
     assert "Please use the absolute URL." in prompt
     assert "Signed human reviewer requirements override AI reviewer preferences" in prompt
-    assert "Verify every signed human reviewer requirement before approving." in prompt
+    assert "Verify each requirement in this set before approving." in prompt
     assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in prompt
 
 
@@ -4134,6 +4309,52 @@ def test_blocking_followup_prompt_includes_human_requirements_before_ai_feedback
     )
     assert "Please use the absolute URL." in followup_prompt
     assert "Needs a fix." in followup_prompt
+
+
+def test_pr_loop_combines_issue_and_pr_signed_human_requirements(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        pr_payload={
+            "comments": [
+                {
+                    "author": {"login": "maintainer"},
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                    "body": "Use the absolute URL in the PR path.\n\n-- Human Reviewer",
+                }
+            ],
+            "reviews": [],
+        },
+    )
+    config = make_config(tmp_path, reviewer="codex")
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue body",
+                author="issue-author",
+                created_at="2026-05-17T08:00:00Z",
+                url="https://github.com/OWNER/REPO/issues/56",
+                body="Preserve backward compatibility.",
+            ),
+        ),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config, issue_context=issue_context) == 0
+
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Preserve backward compatibility." in prompt
+    assert "Use the absolute URL in the PR path." in prompt
+    assert prompt.index("Preserve backward compatibility.") < prompt.index(
+        "Use the absolute URL in the PR path."
+    )
 
 
 def test_review_prompt_requests_future_followups_when_processed(tmp_path):
@@ -6125,6 +6346,46 @@ def test_issue_loop_requires_claude_to_report_pr_number(tmp_path):
         run_issue_loop(runner, issue_number=56, config=config)
 
 
+def test_issue_loop_rejects_missing_initial_issue_human_requirements_acknowledgement(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Keep the legacy flag.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Created PR.\nTests: python -m pytest passed.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->"
+        ],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="missing required signed human requirements marker"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+
+def test_issue_loop_accepts_initial_issue_human_requirements_acknowledgement(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Keep the legacy flag.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Created PR.\nTests: python3 -m pytest passed.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: kept the legacy flag path.\n"
+            "<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->"
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+
 def test_issue_loop_rejects_pr_number_before_running_claude(tmp_path):
     runner = FakeRunner(issue_payload={
         "number": 62,
@@ -6164,6 +6425,46 @@ def test_issue_loop_plan_first_stops_after_approved_plan(tmp_path):
     assert not any(cmd[:2] == ["git", "switch"] for cmd, _cwd in runner.commands)
 
 
+def test_issue_loop_plan_first_rejects_missing_initial_plan_human_requirements_acknowledgement(
+    tmp_path,
+):
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Keep the public API unchanged.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Plan:\n- Update the parser.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+        ],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="missing required signed human requirements marker"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+
+def test_issue_loop_plan_first_accepts_initial_plan_human_requirements_acknowledgement(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Keep the public API unchanged.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Plan:\n- Update the parser.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan keeps the public API unchanged.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+        ],
+        codex_outputs=["Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+
 def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
@@ -6179,9 +6480,66 @@ def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
 
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
 
+
+def test_issue_loop_plan_revision_rejects_missing_human_requirements_acknowledgement(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Initial plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the revised plan still preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["Missing a regression test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="missing required signed human requirements marker"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+
+def test_issue_loop_plan_revision_accepts_human_requirements_acknowledgement(tmp_path):
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Initial plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Revised plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the revised plan still preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Missing a regression test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
     claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert len(claude_calls) == 2
-    assert "Missing test strategy" in claude_calls[1][-1]
+    assert "Missing a regression test." in claude_calls[1][-1]
     assert len(runner.comments) == 5
     assert runner.comments[2].startswith("Revised plan")
 


### PR DESCRIPTION
## Summary
- parse signed human requirements from issue bodies and issue comments into `IssueContext`
- surface and enforce signed issue requirements in issue-mode and plan-first prompts and validators
- carry issue-sourced signed requirements forward into later PR review rounds and extend tests

## Testing
- python3 -m pytest tests/test_agent_loop.py -q

Fixes #131
