### PR TITLE
Migrate PR reviews to structured rendering

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -71,6 +71,7 @@ from .protocol import (
     human_requirements_resolved,
     is_clarification_request,
     parse_agent_state,
+    parse_pr_review,
     parse_plan_review,
     parse_plan_state,
     parse_pr_number,
@@ -377,7 +378,7 @@ def _validate_review_response(
     reviewer: str,
     unresolved_items: Sequence[UnresolvedReviewItem],
 ) -> ParsedReview:
-    parsed = parse_review(text, reviewer=reviewer)
+    parsed = parse_pr_review(text, reviewer=reviewer)
     if not unresolved_items:
         return parsed
 
@@ -1007,6 +1008,62 @@ def _render_public_review_comment(
             ),
         )
     return rendered
+
+
+def _render_public_pr_review_comment(
+    parsed_review: ParsedReview,
+    *,
+    reviewer: str,
+    human_requirements_resolved_flag: bool,
+    prior_items: Sequence[UnresolvedReviewItem],
+    dispositions: Sequence[ReviewItemDisposition],
+) -> str:
+    sections: list[str] = []
+    if parsed_review.summary:
+        sections.append(parsed_review.summary.strip())
+    if parsed_review.blocking_items:
+        sections.append(
+            "\n".join(
+                [
+                    "### Blocking issues",
+                    *[f"- {item.text}" for item in parsed_review.blocking_items],
+                ]
+            )
+        )
+    if parsed_review.followups.same_pr:
+        sections.append(
+            "\n".join(
+                [
+                    "### Same-PR follow-ups",
+                    *[f"- {item.text}" for item in parsed_review.followups.same_pr],
+                ]
+            )
+        )
+    if parsed_review.followups.future:
+        sections.append(
+            "\n".join(
+                [
+                    "### Future follow-ups",
+                    *[f"- {item.text}" for item in parsed_review.followups.future],
+                ]
+            )
+        )
+    if prior_items:
+        sections.append(
+            _render_prior_dispositions_section(
+                heading="### Prior unresolved item dispositions",
+                prior_items=prior_items,
+                dispositions=dispositions,
+            )
+        )
+    footer: list[str] = []
+    if human_requirements_resolved_flag:
+        footer.append("<!-- HUMAN_REQUIREMENTS_RESOLVED -->")
+    footer.append(f"<!-- AGENT_STATE: {parsed_review.state} -->")
+    footer.append(f"-- {_public_reviewer_name(reviewer)}")
+    return "\n\n".join(section for section in sections if section) + (
+        ("\n\n" if sections else "") + "\n".join(footer)
+    )
 
 
 def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
@@ -2089,10 +2146,12 @@ def run_pr_loop(
                 resumed_record = resumed_by_name.get(reviewer_name)
                 if resumed_record is not None:
                     review_output = resumed_record.body
+                    reparsed_review = parse_review(review_output, reviewer=reviewer_name)
                     parsed_review = ParsedReview(
                         state=resumed_record.metadata.state or parse_agent_state(review_output),
                         summary=review_freeform_summary_text(review_output),
-                        followups=parse_review(review_output, reviewer=reviewer_name).followups,
+                        blocking_items=reparsed_review.blocking_items,
+                        followups=reparsed_review.followups,
                         dispositions=resumed_record.metadata.dispositions,
                     )
                     review_state = parsed_review.state
@@ -2135,7 +2194,7 @@ def run_pr_loop(
 
                 for disposition in parsed_review.dispositions:
                     prior_dispositions[disposition.item_id].append(disposition)
-                blocking_summary = _review_freeform_summary_text(review_output)
+                blocking_summary = parsed_review.summary
                 has_blocking_summary = _should_record_new_blocking_item(
                     blocking_summary,
                     had_prior_items=bool(prior_unresolved_items),
@@ -2196,12 +2255,14 @@ def run_pr_loop(
                             config=config,
                             pr_number=pr_number,
                             body=_attach_round_metadata(
-                                _render_public_review_comment(
-                                    review_output,
-                                    review_kind="pr",
+                                _render_public_pr_review_comment(
+                                    parsed_review,
+                                    reviewer=reviewer_name,
+                                    human_requirements_resolved_flag=human_requirements_resolved(
+                                        review_output
+                                    ),
                                     prior_items=prior_unresolved_items,
                                     dispositions=parsed_review.dispositions,
-                                    new_items=reviewer_new_unresolved_items,
                                 ),
                                 PostedRoundMetadata(
                                     flow="pr",
@@ -2239,12 +2300,14 @@ def run_pr_loop(
                         config=config,
                         pr_number=pr_number,
                         body=_attach_round_metadata(
-                            _render_public_review_comment(
-                                review_output,
-                                review_kind="pr",
+                            _render_public_pr_review_comment(
+                                parsed_review,
+                                reviewer=reviewer_name,
+                                human_requirements_resolved_flag=human_requirements_resolved(
+                                    review_output
+                                ),
                                 prior_items=prior_unresolved_items,
                                 dispositions=parsed_review.dispositions,
-                                new_items=reviewer_new_unresolved_items,
                             ),
                             PostedRoundMetadata(
                                 flow="pr",

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -948,6 +948,12 @@ instead when small or local cleanup should be fixed before merge.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
+    markdown_fallback_sections = ["- summary paragraph", "- `### Blocking issues`"]
+    if config.approved_followups.startswith("fix-and-"):
+        markdown_fallback_sections.append("- `### Same-PR follow-ups`")
+    if config.approved_followups != "ignore":
+        markdown_fallback_sections.append("- `### Future follow-ups`")
+    markdown_fallback_sections.append("- `### Prior unresolved item dispositions`")
     return f"""Review pull request #{pr_number} in {config.repo} (round {round_number}).
 
 PR metadata:
@@ -997,6 +1003,38 @@ them forward explicitly.
 Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.
+
+Prefer this structured PR review format. Start your response with exactly one
+top-level JSON object and no prose before it:
+
+```json
+{{
+  "schema_version": 1,
+  "kind": "pr_review",
+  "state": "approved" | "blocking",
+  "summary": "short reviewer summary",
+  "blocking_items": ["render-only blocking bullet", "..."],
+  "same_pr_followups": ["same-PR fix still required", "..."],
+  "future_followups": ["future work after approval", "..."],
+  "prior_item_dispositions": [
+    {{"item_id": "item-1", "disposition": "resolved"}},
+    {{"item_id": "item-2", "disposition": "future", "note": "brief reason"}}
+  ]
+}}
+```
+
+After the JSON object, include only:
+1. optional `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`
+2. required `<!-- AGENT_STATE: approved -->` or `<!-- AGENT_STATE: blocking -->`
+3. your standalone signature line `-- {reviewer_signature}`
+
+Do not include any extra prose, headings, bullets, or fenced blocks before or
+after that structured response. The footer AGENT_STATE must match the JSON
+`state`.
+
+Markdown fallback remains available for compatibility when you do not use the
+structured format. In markdown reviews, use this section order:
+{chr(10).join(markdown_fallback_sections)}
 
 End your final response with exactly one marker:
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -50,6 +50,7 @@ LEGACY_FOLLOWUP_HEADING_RE = _followup_heading_re(r"non[- ]blocking follow[- ]up
 PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
     r"prior unresolved item dispositions"
 )
+BLOCKING_ISSUES_HEADING_RE = _followup_heading_re(r"blocking issues")
 BLOCKING_PLAN_ISSUES_HEADING_RE = _followup_heading_re(r"blocking plan issues")
 SAME_PLAN_FOLLOWUP_HEADING_RE = _followup_heading_re(r"same[- ]plan follow[- ]ups")
 HUMAN_REQUIREMENTS_HEADING_RE = _followup_heading_re(r"human requirements")
@@ -117,6 +118,7 @@ class UnresolvedReviewItem:
 class ParsedReview:
     state: str
     summary: str
+    blocking_items: tuple[ApprovedFollowup, ...]
     followups: ApprovedFollowups
     dispositions: tuple[ReviewItemDisposition, ...]
 
@@ -334,6 +336,7 @@ def review_freeform_summary_text(text: str) -> str:
     lines: list[str] = []
     skip_structured_section = False
     structured_heading_res = (
+        BLOCKING_ISSUES_HEADING_RE,
         BLOCKING_PLAN_ISSUES_HEADING_RE,
         SAME_PLAN_FOLLOWUP_HEADING_RE,
         SAME_PR_FOLLOWUP_HEADING_RE,
@@ -471,6 +474,49 @@ def _extract_structured_response_object(text: str) -> dict[str, object] | None:
     return payload
 
 
+def _extract_json_object_prefix(text: str) -> tuple[dict[str, object], str] | None:
+    stripped = text.lstrip()
+    if not stripped.startswith("{"):
+        return None
+    decoder = json.JSONDecoder()
+    try:
+        payload, end = decoder.raw_decode(stripped)
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError("Structured PR review must begin with one top-level JSON object.") from exc
+    if not isinstance(payload, dict):
+        raise AgentLoopError("Structured PR review must begin with a JSON object.")
+    return payload, stripped[end:]
+
+
+def _extract_structured_pr_review_payload(text: str) -> dict[str, object] | None:
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    trailing = trailing.lstrip()
+    if HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing):
+        marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing)
+        assert marker_match is not None
+        trailing = trailing[marker_match.end() :].lstrip()
+    state_match = STATE_RE.match(trailing)
+    if state_match is None:
+        raise AgentLoopError(
+            "Structured PR review must place <!-- AGENT_STATE: approved|blocking --> after the JSON object."
+        )
+    trailing = trailing[state_match.end() :].lstrip()
+    signature_match = re.match(r"^--\s+\S[^\n]*(?:\n)?$", trailing)
+    if signature_match is None or trailing[signature_match.end() :].strip():
+        raise AgentLoopError(
+            "Structured PR review may not include trailing prose after the JSON footer and signature."
+        )
+    footer_state = state_match.group(1).lower()
+    payload_state = payload.get("state")
+    if isinstance(payload_state, str) and payload_state.strip():
+        if payload_state.strip() != footer_state:
+            raise AgentLoopError("Structured PR review footer AGENT_STATE must match the payload state.")
+    return payload
+
+
 def _require_supported_schema_version(payload: dict[str, object]) -> None:
     if "schema_version" not in payload:
         raise AgentLoopError("Structured response is missing required field: schema_version")
@@ -547,6 +593,7 @@ def _finalize_parsed_review(
     *,
     state: str,
     summary: str,
+    blocking_items: tuple[ApprovedFollowup, ...],
     followups: ApprovedFollowups,
     dispositions: tuple[ReviewItemDisposition, ...],
 ) -> ParsedReview:
@@ -560,15 +607,16 @@ def _finalize_parsed_review(
         active_dispositions = [
             item.disposition for item in dispositions if item.disposition in {"blocking", "same-pr"}
         ]
-        if followups.same_pr or active_dispositions:
+        if blocking_items or followups.same_pr or active_dispositions:
             raise AgentLoopError(
                 "Approved reviews must be fully complete for this round. Do not use "
-                "`approved` when Same-PR follow-ups remain or when any prior unresolved "
+                "`approved` when blocking issues, Same-PR follow-ups, or any prior unresolved "
                 "item stays `still blocking` or `same-pr`."
             )
     return ParsedReview(
         state=state,
         summary=summary,
+        blocking_items=blocking_items,
         followups=followups,
         dispositions=dispositions,
     )
@@ -610,59 +658,57 @@ def _structured_followups(items: tuple[str, ...], *, reviewer: str) -> tuple[App
 
 
 def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | None:
-    payload = _extract_structured_response_object(text)
+    payload = _extract_structured_pr_review_payload(text)
     if payload is None:
         return None
     _require_supported_schema_version(payload)
     kind = payload.get("kind")
     if isinstance(kind, str) and kind != "pr_review":
         raise AgentLoopError("Structured response kind mismatch: expected `pr_review`.")
-    try:
-        _expect_exact_keys(
-            payload,
-            context="pr_review",
-            required={
-                "schema_version",
-                "kind",
-                "state",
-                "summary",
-                "blocking_items",
-                "same_pr_followups",
-                "future_followups",
-                "prior_item_dispositions",
-            },
-        )
-        state = _expect_state(payload["state"], context="pr_review.state")
-        summary = _expect_non_empty_string(payload["summary"], context="pr_review.summary")
-        blocking_items = _expect_string_list(
-            payload["blocking_items"],
-            context="pr_review.blocking_items",
-            item_context="pr_review.blocking_items",
-        )
-        same_pr_followups = _expect_string_list(
-            payload["same_pr_followups"],
-            context="pr_review.same_pr_followups",
-            item_context="pr_review.same_pr_followups",
-        )
-        future_followups = _expect_string_list(
-            payload["future_followups"],
-            context="pr_review.future_followups",
-            item_context="pr_review.future_followups",
-        )
-        dispositions = _expect_disposition_list(
-            payload["prior_item_dispositions"],
-            context="pr_review.prior_item_dispositions",
-            reviewer=reviewer,
-            allowed_same_status="same-pr",
-            is_plan_review=False,
-        )
-    except AgentLoopError:
-        return None
+    _expect_exact_keys(
+        payload,
+        context="pr_review",
+        required={
+            "schema_version",
+            "kind",
+            "state",
+            "summary",
+            "blocking_items",
+            "same_pr_followups",
+            "future_followups",
+            "prior_item_dispositions",
+        },
+    )
+    state = _expect_state(payload["state"], context="pr_review.state")
+    summary = _expect_non_empty_string(payload["summary"], context="pr_review.summary")
+    blocking_items = _expect_string_list(
+        payload["blocking_items"],
+        context="pr_review.blocking_items",
+        item_context="pr_review.blocking_items",
+    )
+    same_pr_followups = _expect_string_list(
+        payload["same_pr_followups"],
+        context="pr_review.same_pr_followups",
+        item_context="pr_review.same_pr_followups",
+    )
+    future_followups = _expect_string_list(
+        payload["future_followups"],
+        context="pr_review.future_followups",
+        item_context="pr_review.future_followups",
+    )
+    dispositions = _expect_disposition_list(
+        payload["prior_item_dispositions"],
+        context="pr_review.prior_item_dispositions",
+        reviewer=reviewer,
+        allowed_same_status="same-pr",
+        is_plan_review=False,
+    )
     if state == "blocking" and future_followups:
         raise AgentLoopError("Blocking structured reviews may not include future follow-ups.")
     return _finalize_parsed_review(
         state=state,
         summary=summary,
+        blocking_items=_structured_followups(blocking_items, reviewer=reviewer),
         followups=ApprovedFollowups(
             same_pr=_structured_followups(same_pr_followups, reviewer=reviewer),
             future=_structured_followups(future_followups, reviewer=reviewer),
@@ -990,6 +1036,17 @@ def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
     return ApprovedFollowups(same_pr=tuple(same_pr), future=tuple(future))
 
 
+def parse_pr_blocking_items(text: str, *, reviewer: str) -> tuple[ApprovedFollowup, ...]:
+    blocking: list[ApprovedFollowup] = []
+    _collect_section_items(
+        text,
+        sections=((BLOCKING_ISSUES_HEADING_RE, blocking),),
+        empty_item_re=EMPTY_FOLLOWUP_RE,
+        reviewer=reviewer,
+    )
+    return tuple(blocking)
+
+
 def parse_plan_review_items(text: str, *, reviewer: str) -> PlanReviewItems:
     blocking: list[ApprovedFollowup] = []
     same_plan: list[ApprovedFollowup] = []
@@ -1171,14 +1228,23 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
     """Parse a review, including state, follow-ups, and prior-item dispositions."""
     state = parse_agent_state(text)
     summary = review_freeform_summary_text(text)
+    blocking_items = parse_pr_blocking_items(text, reviewer=reviewer)
     followups = parse_approved_followups(text, reviewer=reviewer)
     dispositions = parse_unresolved_item_dispositions(text, reviewer=reviewer)
     return _finalize_parsed_review(
         state=state,
         summary=summary,
+        blocking_items=blocking_items,
         followups=followups,
         dispositions=dispositions,
     )
+
+
+def parse_pr_review(text: str, *, reviewer: str) -> ParsedReview:
+    parsed = parse_structured_pr_review(text, reviewer=reviewer)
+    if parsed is not None:
+        return parsed
+    return parse_review(text, reviewer=reviewer)
 
 
 def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -61,9 +61,12 @@ from coding_review_agent_loop.orchestrator import (
     _decode_round_metadata,
     _format_unresolved_item_label,
     _plan_subject,
+    _render_public_pr_review_comment,
     _render_public_review_comment,
     _review_freeform_summary_text,
+    _resume_pr_round,
     _strip_round_metadata,
+    _validate_review_response,
     _validate_plan_review_response,
 )
 from coding_review_agent_loop.prompts import (
@@ -84,6 +87,7 @@ from coding_review_agent_loop.prompts import (
 from coding_review_agent_loop.protocol import (
     parse_approved_followups,
     parse_human_requirements_acknowledgement,
+    parse_pr_review,
     parse_plan_item_dispositions,
     parse_plan_review,
     parse_plan_review_items,
@@ -451,6 +455,12 @@ def prior_item_dispositions(*lines: str) -> str:
     if not lines:
         return ""
     return "\n\n### Prior unresolved item dispositions\n" + "\n".join(f"- {line}" for line in lines)
+
+
+def blocking_issues(*lines: str) -> str:
+    if not lines:
+        return ""
+    return "\n\n### Blocking issues\n" + "\n".join(f"- {line}" for line in lines)
 
 
 def prior_plan_item_dispositions(*lines: str) -> str:
@@ -2012,6 +2022,25 @@ def test_parse_review_populates_summary_from_legacy_markdown():
     assert parsed.summary == "Blocking issue summary."
 
 
+def test_parse_review_round_trips_blocking_issues_section_without_polluting_summary():
+    review = (
+        "Blocking issue summary."
+        + blocking_issues(
+            "Cover the regression case in the PR test suite.",
+            "Tighten the error assertion wording.",
+        )
+        + "\n\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = parse_review(review, reviewer="OpenAI Codex")
+
+    assert parsed.summary == "Blocking issue summary."
+    assert [item.text for item in parsed.blocking_items] == [
+        "Cover the regression case in the PR test suite.",
+        "Tighten the error assertion wording.",
+    ]
+
+
 def test_parse_plan_review_populates_summary_from_legacy_markdown():
     review = """
     Plan needs one more regression test.
@@ -2028,25 +2057,28 @@ def test_parse_plan_review_populates_summary_from_legacy_markdown():
     assert parsed.summary == "Plan needs one more regression test."
 
 
-def test_parse_structured_pr_review_normalizes_v1_payload():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "pr_review",
-            "state": "approved",
-            "summary": "Looks good after the latest fix.",
-            "blocking_items": [],
-            "same_pr_followups": [],
-            "future_followups": ["Document cleanup for a later PR."],
-            "prior_item_dispositions": [
-                {"item_id": "item-1", "disposition": "resolved"},
-                {
-                    "item_id": "item-2",
-                    "disposition": "future",
-                    "note": "okay to split into follow-up work",
-                },
-            ],
-        }
+def test_parse_structured_pr_review_normalizes_v1_payload_with_footer_contract():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Looks good after the latest fix.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": ["Document cleanup for a later PR."],
+                "prior_item_dispositions": [
+                    {"item_id": "item-1", "disposition": "resolved"},
+                    {
+                        "item_id": "item-2",
+                        "disposition": "future",
+                        "note": "okay to split into follow-up work",
+                    },
+                ],
+            }
+        )
+        + "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex\n"
     )
 
     parsed = parse_structured_pr_review(payload, reviewer="OpenAI Codex")
@@ -2054,6 +2086,7 @@ def test_parse_structured_pr_review_normalizes_v1_payload():
     assert parsed is not None
     assert parsed.state == "approved"
     assert parsed.summary == "Looks good after the latest fix."
+    assert parsed.blocking_items == ()
     assert [item.text for item in parsed.followups.future] == ["Document cleanup for a later PR."]
     assert [(item.item_id, item.disposition, item.note) for item in parsed.dispositions] == [
         ("item-1", "resolved", None),
@@ -2062,17 +2095,20 @@ def test_parse_structured_pr_review_normalizes_v1_payload():
 
 
 def test_parse_structured_pr_review_rejects_kind_mismatch():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "plan_review",
-            "state": "approved",
-            "summary": "Wrong kind.",
-            "blocking_plan_issues": [],
-            "same_plan_followups": [],
-            "future_followups": [],
-            "prior_plan_item_dispositions": [],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "approved",
+                "summary": "Wrong kind.",
+                "blocking_plan_issues": [],
+                "same_plan_followups": [],
+                "future_followups": [],
+                "prior_plan_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
     )
 
     with pytest.raises(AgentLoopError, match="kind mismatch"):
@@ -2080,62 +2116,175 @@ def test_parse_structured_pr_review_rejects_kind_mismatch():
 
 
 def test_parse_structured_pr_review_hard_fails_on_unsupported_schema_version():
-    payload = json.dumps(
-        {
-            "schema_version": 2,
-            "kind": "pr_review",
-            "state": "approved",
-            "summary": "Wrong version.",
-            "blocking_items": [],
-            "same_pr_followups": [],
-            "future_followups": [],
-            "prior_item_dispositions": [],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 2,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Wrong version.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
     )
 
     with pytest.raises(AgentLoopError, match="Unsupported structured response schema_version: 2"):
         parse_structured_pr_review(payload, reviewer="OpenAI Codex")
 
 
-def test_parse_structured_pr_review_falls_back_on_malformed_json():
-    assert parse_structured_pr_review('{"schema_version": 1,', reviewer="OpenAI Codex") is None
+def test_parse_pr_review_falls_back_to_markdown_when_no_structured_candidate_exists():
+    review = "Looks good in markdown.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+
+    parsed = parse_pr_review(review, reviewer="OpenAI Codex")
+
+    assert parsed.state == "approved"
+    assert parsed.summary == "Looks good in markdown."
 
 
-def test_parse_structured_pr_review_falls_back_on_invalid_fields():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "pr_review",
-            "state": "approved",
-            "summary": "Missing required arrays.",
-            "blocking_items": [],
-            "same_pr_followups": [],
-            "future_followups": [],
-        }
+def test_parse_pr_review_rejects_invalid_structured_candidate_instead_of_falling_back_to_markdown():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Missing required arrays.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
     )
 
-    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+    with pytest.raises(AgentLoopError, match="missing required field"):
+        parse_pr_review(payload, reviewer="OpenAI Codex")
 
 
 def test_parse_structured_pr_review_rejects_future_followups_in_blocking_reviews():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "pr_review",
-            "state": "blocking",
-            "summary": "Still blocked.",
-            "blocking_items": ["Needs one more test."],
-            "same_pr_followups": [],
-            "future_followups": ["Clean this up later."],
-            "prior_item_dispositions": [],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "blocking",
+                "summary": "Still blocked.",
+                "blocking_items": ["Needs one more test."],
+                "same_pr_followups": [],
+                "future_followups": ["Clean this up later."],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
     )
 
     with pytest.raises(AgentLoopError, match="Blocking structured reviews may not include future"):
         parse_structured_pr_review(payload, reviewer="OpenAI Codex")
 
 
-def test_parse_structured_pr_review_rejects_unknown_nested_keys_via_fallback():
+def test_parse_pr_review_rejects_structured_candidate_with_unknown_nested_keys():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "LGTM.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [
+                    {"item_id": "item-1", "disposition": "resolved", "extra": "nope"},
+                ],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="unknown field"):
+        parse_pr_review(payload, reviewer="OpenAI Codex")
+
+
+def test_parse_pr_review_rejects_structured_candidate_with_invalid_item_id():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "LGTM.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [
+                    {"item_id": "item 1", "disposition": "resolved"},
+                ],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="must match"):
+        parse_pr_review(payload, reviewer="OpenAI Codex")
+
+
+def test_parse_pr_review_requires_strict_structured_disposition_enums():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "LGTM.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [
+                    {"item_id": "item-1", "disposition": "still blocking"},
+                ],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="must be one of"):
+        parse_pr_review(payload, reviewer="OpenAI Codex")
+
+
+def test_parse_structured_pr_review_rejects_approved_blocking_items():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Almost there.",
+                "blocking_items": ["Still needs a regression test."],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="Approved reviews must be fully complete"):
+        parse_structured_pr_review(payload, reviewer="OpenAI Codex")
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "\nExtra explanation after the payload.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        "\n```text\nextra block\n```\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        "\n- stray bullet\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+    ],
+)
+def test_parse_structured_pr_review_rejects_trailing_content_before_footer(suffix):
     payload = json.dumps(
         {
             "schema_version": 1,
@@ -2145,51 +2294,33 @@ def test_parse_structured_pr_review_rejects_unknown_nested_keys_via_fallback():
             "blocking_items": [],
             "same_pr_followups": [],
             "future_followups": [],
-            "prior_item_dispositions": [
-                {"item_id": "item-1", "disposition": "resolved", "extra": "nope"},
-            ],
+            "prior_item_dispositions": [],
         }
     )
 
-    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+    with pytest.raises(AgentLoopError, match="place <!-- AGENT_STATE|may not include trailing prose"):
+        parse_structured_pr_review(payload + suffix, reviewer="OpenAI Codex")
 
 
-def test_parse_structured_pr_review_rejects_invalid_item_id_via_fallback():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "pr_review",
-            "state": "approved",
-            "summary": "LGTM.",
-            "blocking_items": [],
-            "same_pr_followups": [],
-            "future_followups": [],
-            "prior_item_dispositions": [
-                {"item_id": "item 1", "disposition": "resolved"},
-            ],
-        }
+def test_parse_structured_pr_review_rejects_footer_state_mismatch():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "LGTM.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
     )
 
-    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
-
-
-def test_parse_structured_pr_review_requires_strict_disposition_enums():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "pr_review",
-            "state": "approved",
-            "summary": "LGTM.",
-            "blocking_items": [],
-            "same_pr_followups": [],
-            "future_followups": [],
-            "prior_item_dispositions": [
-                {"item_id": "item-1", "disposition": "still blocking"},
-            ],
-        }
-    )
-
-    assert parse_structured_pr_review(payload, reviewer="OpenAI Codex") is None
+    with pytest.raises(AgentLoopError, match="must match the payload state"):
+        parse_structured_pr_review(payload, reviewer="OpenAI Codex")
 
 
 def test_parse_structured_pr_review_falls_back_when_json_is_embedded_in_markdown():
@@ -2386,6 +2517,9 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "same-round findings from\nother reviewers appear elsewhere in the PR discussion" in prompt
     assert "Same-PR follow-ups may appear only in blocking reviews." in prompt
     assert "no blocking issues, no Same-PR follow-ups, and no" in prompt
+    assert '"kind": "pr_review"' in prompt
+    assert "After the JSON object, include only:" in prompt
+    assert "`### Blocking issues`" in prompt
 
 
 def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
@@ -2489,6 +2623,9 @@ def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositio
 def test_review_freeform_summary_text_strips_structured_followup_sections():
     review = """Blocking issue summary.
 
+### Blocking issues
+- needs one more assertion
+
 ### Prior unresolved item dispositions
 - [item-1] still blocking: needs one more assertion
 
@@ -2506,6 +2643,126 @@ def test_review_freeform_summary_text_strips_structured_followup_sections():
 """
 
     assert _review_freeform_summary_text(review) == "Blocking issue summary."
+
+
+def test_validate_review_response_accepts_structured_pr_review():
+    review = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "blocking",
+                "summary": "Need one more regression test before merge.",
+                "blocking_items": ["Add the mixed-history regression case to the suite."],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = _validate_review_response(review, reviewer="OpenAI Codex", unresolved_items=())
+
+    assert parsed.summary == "Need one more regression test before merge."
+    assert [item.text for item in parsed.blocking_items] == [
+        "Add the mixed-history regression case to the suite."
+    ]
+
+
+def test_render_public_pr_review_comment_uses_normalized_sections_and_footer():
+    parsed = parse_pr_review(
+        (
+            "Need one more regression test."
+            + blocking_issues("Exercise the structured-resume path.")
+            + "\n\n### Same-PR follow-ups\n- Rename the helper for clarity."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+        ),
+        reviewer="OpenAI Codex",
+    )
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="Anthropic Claude",
+            source_round=1,
+            text="Add a regression test before merge.",
+            status="blocking",
+        ),
+    )
+
+    rendered = _render_public_pr_review_comment(
+        parsed,
+        reviewer="Codex",
+        human_requirements_resolved_flag=True,
+        prior_items=prior_items,
+        dispositions=parsed.dispositions,
+    )
+
+    assert rendered == (
+        "Need one more regression test.\n\n"
+        "### Blocking issues\n"
+        "- Exercise the structured-resume path.\n\n"
+        "### Same-PR follow-ups\n"
+        "- Rename the helper for clarity.\n\n"
+        "### Prior unresolved item dispositions\n"
+        "- [item-1] Blocking issue from Anthropic Claude, round 1: Add a regression test before merge. -> resolved\n\n"
+        "<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n"
+        "<!-- AGENT_STATE: blocking -->\n"
+        "-- OpenAI Codex"
+    )
+
+
+def test_render_public_pr_review_comment_normalizes_markdown_and_structured_reviews_the_same():
+    markdown_review = (
+        "Need one more regression test."
+        + blocking_issues("Exercise the structured-resume path.")
+        + "\n\n### Same-PR follow-ups\n- Rename the helper for clarity."
+        + prior_item_dispositions("[item-1] resolved")
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+    structured_review = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "blocking",
+                "summary": "Need one more regression test.",
+                "blocking_items": ["Exercise the structured-resume path."],
+                "same_pr_followups": ["Rename the helper for clarity."],
+                "future_followups": [],
+                "prior_item_dispositions": [{"item_id": "item-1", "disposition": "resolved"}],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="Anthropic Claude",
+            source_round=1,
+            text="Add a regression test before merge.",
+            status="blocking",
+        ),
+    )
+
+    markdown_rendered = _render_public_pr_review_comment(
+        parse_pr_review(markdown_review, reviewer="OpenAI Codex"),
+        reviewer="Codex",
+        human_requirements_resolved_flag=False,
+        prior_items=prior_items,
+        dispositions=parse_pr_review(markdown_review, reviewer="OpenAI Codex").dispositions,
+    )
+    structured_parsed = parse_pr_review(structured_review, reviewer="OpenAI Codex")
+    structured_rendered = _render_public_pr_review_comment(
+        structured_parsed,
+        reviewer="Codex",
+        human_requirements_resolved_flag=False,
+        prior_items=prior_items,
+        dispositions=structured_parsed.dispositions,
+    )
+
+    assert markdown_rendered == structured_rendered
 
 
 def test_format_unresolved_item_label_normalizes_multiline_text_and_preserves_origin_status():
@@ -4471,7 +4728,7 @@ def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(t
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert runner.comments[0].startswith("Still blocked.")
-    assert "Consider a broader cleanup later." in runner.comments[0]
+    assert "Consider a broader cleanup later." not in runner.comments[0]
     followup_prompt = next(
         cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Address the review below" in cmd[-1]
     )
@@ -4639,7 +4896,7 @@ def test_pr_loop_ignores_approved_followups_by_default(tmp_path):
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert runner.comments == [
-        "LGTM.\n\n### Non-blocking follow-ups\n- Add cleanup docs.\n"
+        "LGTM.\n\n### Future follow-ups\n- Add cleanup docs.\n"
         "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
     ]
 
@@ -5393,6 +5650,98 @@ def test_pr_loop_posts_human_readable_item_labels_in_new_and_prior_sections(tmp_
         "<!-- AGENT_STATE: approved -->\n"
         "-- OpenAI Codex"
     )
+
+
+def test_pr_loop_tracks_only_summary_when_blocking_items_phrase_the_issue_differently(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Implemented fixes.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=[
+            "Needs one more regression test before merge."
+            + blocking_issues("Add the mixed-history resume case to `tests/test_agent_loop.py`.")
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Looks good."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    second_coder_prompt = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]][0]
+    assert "Needs one more regression test before merge." in second_coder_prompt
+    assert "Add the mixed-history resume case" not in second_coder_prompt
+    assert runner.comments[0] == (
+        "Needs one more regression test before merge.\n\n"
+        "### Blocking issues\n"
+        "- Add the mixed-history resume case to `tests/test_agent_loop.py`.\n"
+        "<!-- AGENT_STATE: blocking -->\n"
+        "-- OpenAI Codex"
+    )
+
+
+def test_resume_pr_round_reparses_orchestrator_rendered_blocking_issues_comment():
+    carried_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Need one more regression test before merge.",
+        status="blocking",
+        source_status="blocking",
+    )
+    rendered_review = _render_public_pr_review_comment(
+        parse_pr_review(
+            "Need one more regression test before merge."
+            + blocking_issues("Exercise the structured-resume path.")
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            reviewer="OpenAI Codex",
+        ),
+        reviewer="Codex",
+        human_requirements_resolved_flag=False,
+        prior_items=(),
+        dispositions=(),
+    )
+    review_comment = _attach_round_metadata(
+        rendered_review,
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+            dispositions=(),
+            new_items=(),
+            state="blocking",
+        ),
+    )
+    coder_comment = _attach_round_metadata(
+        "Addressed the review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=review_comment),
+        ],
+        head_sha="abc123",
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    resumed_review = parse_review(resumed.completed_reviews[0].body, reviewer="Codex")
+    assert [item.text for item in resumed_review.blocking_items] == [
+        "Exercise the structured-resume path."
+    ]
+    assert resumed_review.summary == "Need one more regression test before merge."
 
 
 def test_pr_loop_does_not_expose_same_round_item_ids_to_later_reviewers(tmp_path):


### PR DESCRIPTION
## Summary
- add a structured-first PR review parser that accepts the live footer contract, preserves markdown fallback, and round-trips `### Blocking issues`
- render public PR review comments from normalized `ParsedReview` data in the orchestrator while keeping summary-only blocking item tracking
- extend prompts and regression coverage for structured parsing failures, fallback behavior, renderer ownership, tracking semantics, and resume safety

## Testing
- python3 -m pytest tests/test_agent_loop.py
- python3 -m pytest

Fixes #154
