### PR TITLE
Harden markdown response parsing against formatting drift

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -111,6 +111,11 @@ NEAR_MISS_AGENT_MARKER_RE = re.compile(
     re.I,
 )
 ROUND_RESUME_MARKER_RE = re.compile(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", re.I)
+ALL_RESOLVED_PROSE_RE = re.compile(
+    r"^all (?:prior items|listed items|carried-forward items) are resolved\.?$"
+    r"|^all prior unresolved items have been resolved\.?$",
+    re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -119,6 +124,31 @@ class ValidatedAgentResponse:
     session_id: str | None
     marker_value: object
     usage: UsageMetadata | None = None
+
+
+def _normalize_disposition_section_prose(text: str) -> str:
+    return " ".join(text.strip().split())
+
+
+def _maybe_fill_resolved_dispositions_from_prose(
+    parsed: ParsedReview | ParsedPlanReview,
+    *,
+    reviewer: str,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+) -> tuple[ReviewItemDisposition, ...]:
+    if not unresolved_items or parsed.dispositions:
+        return parsed.dispositions
+    normalized = _normalize_disposition_section_prose(parsed.raw_dispositions_text)
+    if not normalized or not ALL_RESOLVED_PROSE_RE.fullmatch(normalized):
+        return parsed.dispositions
+    return tuple(
+        ReviewItemDisposition(
+            item_id=item.item_id,
+            reviewer=reviewer,
+            disposition="resolved",
+        )
+        for item in unresolved_items
+    )
 
 
 @dataclass(frozen=True)
@@ -383,7 +413,12 @@ def _validate_review_response(
         return parsed
 
     unresolved_by_id = {item.item_id: item for item in unresolved_items}
-    disposition_ids = [item.item_id for item in parsed.dispositions]
+    dispositions = _maybe_fill_resolved_dispositions_from_prose(
+        parsed,
+        reviewer=reviewer,
+        unresolved_items=unresolved_items,
+    )
+    disposition_ids = [item.item_id for item in dispositions]
     duplicates = sorted({item_id for item_id in disposition_ids if disposition_ids.count(item_id) > 1})
     if duplicates:
         raise AgentLoopError(
@@ -399,7 +434,14 @@ def _validate_review_response(
         raise AgentLoopError(
             "Review did not evaluate all prior unresolved items: " + ", ".join(missing)
         )
-    return parsed
+    return ParsedReview(
+        state=parsed.state,
+        summary=parsed.summary,
+        blocking_items=parsed.blocking_items,
+        followups=parsed.followups,
+        dispositions=dispositions,
+        raw_dispositions_text=parsed.raw_dispositions_text,
+    )
 
 
 def _upsert_human_requirements_ack_item(
@@ -579,7 +621,12 @@ def _validate_plan_review_response(
         return parsed
 
     unresolved_by_id = {item.item_id: item for item in unresolved_items}
-    disposition_ids = [item.item_id for item in parsed.dispositions]
+    dispositions = _maybe_fill_resolved_dispositions_from_prose(
+        parsed,
+        reviewer=reviewer,
+        unresolved_items=unresolved_items,
+    )
+    disposition_ids = [item.item_id for item in dispositions]
     duplicates = sorted({item_id for item_id in disposition_ids if disposition_ids.count(item_id) > 1})
     if duplicates:
         raise AgentLoopError(
@@ -598,7 +645,13 @@ def _validate_plan_review_response(
             "Plan review did not evaluate all prior unresolved plan items: "
             + ", ".join(missing)
         )
-    return parsed
+    return ParsedPlanReview(
+        state=parsed.state,
+        summary=parsed.summary,
+        items=parsed.items,
+        dispositions=dispositions,
+        raw_dispositions_text=parsed.raw_dispositions_text,
+    )
 
 
 def _review_freeform_summary_text(text: str) -> str:

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -68,7 +68,7 @@ ITEM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 def _empty_placeholder_re(*phrases: str) -> re.Pattern[str]:
     joined = "|".join(phrases)
-    return re.compile(rf"^(?:none|n/a|{joined})\.?$", re.I)
+    return re.compile(rf"^\(?\s*(?:none|n/a|{joined})\s*\)?\.?$", re.I)
 
 
 EMPTY_FOLLOWUP_RE = _empty_placeholder_re(
@@ -121,6 +121,7 @@ class ParsedReview:
     blocking_items: tuple[ApprovedFollowup, ...]
     followups: ApprovedFollowups
     dispositions: tuple[ReviewItemDisposition, ...]
+    raw_dispositions_text: str = ""
 
 
 @dataclass(frozen=True)
@@ -136,6 +137,7 @@ class ParsedPlanReview:
     summary: str
     items: PlanReviewItems
     dispositions: tuple[ReviewItemDisposition, ...]
+    raw_dispositions_text: str = ""
 
 
 @dataclass(frozen=True)
@@ -596,6 +598,7 @@ def _finalize_parsed_review(
     blocking_items: tuple[ApprovedFollowup, ...],
     followups: ApprovedFollowups,
     dispositions: tuple[ReviewItemDisposition, ...],
+    raw_dispositions_text: str = "",
 ) -> ParsedReview:
     if state == "blocking" and followups.future:
         followups = ApprovedFollowups(same_pr=followups.same_pr, future=())
@@ -619,6 +622,7 @@ def _finalize_parsed_review(
         blocking_items=blocking_items,
         followups=followups,
         dispositions=dispositions,
+        raw_dispositions_text=raw_dispositions_text,
     )
 
 
@@ -628,6 +632,7 @@ def _finalize_parsed_plan_review(
     summary: str,
     items: PlanReviewItems,
     dispositions: tuple[ReviewItemDisposition, ...],
+    raw_dispositions_text: str = "",
 ) -> ParsedPlanReview:
     if state == "blocking" and items.future:
         items = PlanReviewItems(blocking=items.blocking, same_plan=items.same_plan, future=())
@@ -650,6 +655,7 @@ def _finalize_parsed_plan_review(
         summary=summary,
         items=items,
         dispositions=dispositions,
+        raw_dispositions_text=raw_dispositions_text,
     )
 
 
@@ -1019,6 +1025,21 @@ def _collect_section_items(
     flush_current()
 
 
+def _extract_section_text(text: str, *, heading_re: re.Pattern[str]) -> str:
+    active = False
+    lines: list[str] = []
+    for line in text.splitlines():
+        if heading_re.match(line):
+            active = True
+            continue
+        if not active:
+            continue
+        if ANY_HEADING_RE.match(line) or HTML_COMMENT_RE.match(line) or SIGNATURE_RE.match(line):
+            break
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
 def parse_approved_followups(text: str, *, reviewer: str) -> ApprovedFollowups:
     """Extract same-PR and future follow-ups from an approved review."""
     same_pr: list[ApprovedFollowup] = []
@@ -1141,10 +1162,12 @@ def _parse_unresolved_item_dispositions(
 ) -> tuple[ReviewItemDisposition, ...]:
     dispositions: list[ReviewItemDisposition] = []
     active = False
+    section_heading: str | None = None
 
-    for line in text.splitlines():
+    for line_number, line in enumerate(text.splitlines(), start=1):
         if heading_re.match(line):
             active = True
+            section_heading = line.strip()
             continue
         if not active:
             continue
@@ -1161,7 +1184,10 @@ def _parse_unresolved_item_dispositions(
             continue
         match = disposition_re.match(entry)
         if not match:
-            raise AgentLoopError(error_message)
+            raise AgentLoopError(
+                f"{error_message} In section `{section_heading or 'unknown section'}`, "
+                f"line {line_number}: `{entry}`."
+            )
         note = match.group("note")
         normalized_note = note.strip() if note else None
         disposition = _normalize_disposition(match.group("status"), same_status=same_status)
@@ -1171,7 +1197,10 @@ def _parse_unresolved_item_dispositions(
             same_status=same_status,
             is_plan_review=is_plan_review,
         ):
-            raise AgentLoopError(error_message)
+            raise AgentLoopError(
+                f"{error_message} In section `{section_heading or 'unknown section'}`, "
+                f"line {line_number}: `{entry}`."
+            )
         dispositions.append(
             ReviewItemDisposition(
                 item_id=match.group("item_id"),
@@ -1237,6 +1266,9 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
         blocking_items=blocking_items,
         followups=followups,
         dispositions=dispositions,
+        raw_dispositions_text=_extract_section_text(
+            text, heading_re=PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE
+        ),
     )
 
 
@@ -1258,6 +1290,9 @@ def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
         summary=summary,
         items=items,
         dispositions=dispositions,
+        raw_dispositions_text=_extract_section_text(
+            text, heading_re=PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE
+        ),
     )
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1456,6 +1456,8 @@ def test_parse_approved_followups_keeps_multiline_markdown_finding_as_one_item()
     [
         "None",
         "none.",
+        "(none)",
+        "(n/a)",
         "N/A",
         "No follow-ups",
         "No same-PR follow-ups.",
@@ -1588,6 +1590,8 @@ def test_parse_plan_review_items_keeps_multiline_markdown_blocking_item_as_one_e
     "placeholder",
     [
         "None",
+        "(none)",
+        "(n/a)",
         "No blocking plan issues.",
         "No same-plan follow-ups",
         "No future follow-ups.",
@@ -1712,6 +1716,21 @@ def test_parse_plan_item_dispositions_allows_resolved_none_and_substantive_same_
         ("item-1", "resolved", "none"),
         ("item-2", "same-plan", "still need the mixed-reviewer case"),
     ]
+
+
+def test_parse_plan_item_dispositions_ignores_parenthesized_empty_placeholders():
+    review = """
+    Approved after the latest revision.
+
+    ### Prior unresolved plan item dispositions
+    - (none)
+    - (n/a)
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    assert parse_plan_item_dispositions(review, reviewer="OpenAI Codex") == ()
 
 
 def test_parse_plan_review_drops_future_followups_in_blocking_reviews():
@@ -1842,6 +1861,81 @@ def test_validate_plan_review_response_rejects_unknown_item_ids():
         )
 
 
+def test_validate_plan_review_response_accepts_blanket_resolved_prose():
+    review = """
+    Looks good now.
+
+    ### Prior unresolved plan item dispositions
+    All carried-forward items are resolved.
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    parsed = _validate_plan_review_response(
+        review,
+        reviewer="OpenAI Codex",
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Keep the extra regression coverage.",
+                status="same-plan",
+            ),
+            UnresolvedReviewItem(
+                item_id="item-2",
+                reviewer="Google Gemini",
+                source_round=1,
+                text="Clarify the fallback trigger.",
+                status="blocking",
+            ),
+        ),
+    )
+
+    assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
+        ("item-1", "resolved"),
+        ("item-2", "resolved"),
+    ]
+
+
+def test_validate_plan_review_response_rejects_mixed_bullets_and_blanket_prose():
+    review = """
+    Looks good now.
+
+    ### Prior unresolved plan item dispositions
+    - [item-1] resolved
+    All carried-forward items are resolved.
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    with pytest.raises(
+        AgentLoopError, match="did not evaluate all prior unresolved plan items: item-2"
+    ):
+        _validate_plan_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Keep the extra regression coverage.",
+                    status="same-plan",
+                ),
+                UnresolvedReviewItem(
+                    item_id="item-2",
+                    reviewer="Google Gemini",
+                    source_round=1,
+                    text="Clarify the fallback trigger.",
+                    status="blocking",
+                ),
+            ),
+        )
+
+
 def test_parse_unresolved_item_dispositions_extracts_structured_updates():
     review = """
     LGTM.
@@ -1911,7 +2005,10 @@ def test_parse_unresolved_item_dispositions_rejects_contradictory_active_notes(l
 def test_parse_unresolved_item_dispositions_rejects_trailing_colon_syntax(line):
     review = "LGTM." + prior_item_dispositions(line) + "\n\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
 
-    with pytest.raises(AgentLoopError, match="Invalid prior unresolved item disposition"):
+    with pytest.raises(
+        AgentLoopError,
+        match=r"Invalid prior unresolved item disposition.*section `### Prior unresolved item dispositions`, line 4",
+    ):
         parse_unresolved_item_dispositions(review, reviewer="OpenAI Codex")
 
 
@@ -1933,6 +2030,21 @@ def test_parse_unresolved_item_dispositions_allows_resolved_none_and_substantive
     ]
 
 
+def test_parse_unresolved_item_dispositions_ignores_parenthesized_empty_placeholders():
+    review = """
+    LGTM.
+
+    ### Prior unresolved item dispositions
+    - (none)
+    - (n/a)
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    assert parse_unresolved_item_dispositions(review, reviewer="OpenAI Codex") == ()
+
+
 def test_parse_unresolved_item_dispositions_ignores_non_bullet_prose():
     review = """
     LGTM.
@@ -1951,6 +2063,71 @@ def test_parse_unresolved_item_dispositions_ignores_non_bullet_prose():
     assert [(item.item_id, item.disposition, item.note) for item in dispositions] == [
         ("item-1", "resolved", None),
     ]
+
+
+def test_validate_review_response_accepts_blanket_resolved_prose():
+    review = """
+    LGTM.
+
+    ### Prior unresolved item dispositions
+    All prior unresolved items have been resolved.
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    parsed = _validate_review_response(
+        review,
+        reviewer="OpenAI Codex",
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Rename the helper.",
+                status="same-pr",
+            ),
+            UnresolvedReviewItem(
+                item_id="item-2",
+                reviewer="Google Gemini",
+                source_round=1,
+                text="Keep the PR body issue reference.",
+                status="blocking",
+            ),
+        ),
+    )
+
+    assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
+        ("item-1", "resolved"),
+        ("item-2", "resolved"),
+    ]
+
+
+def test_validate_review_response_rejects_ambiguous_blanket_prose():
+    review = """
+    LGTM.
+
+    ### Prior unresolved item dispositions
+    All prior items look resolved.
+
+    <!-- AGENT_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    with pytest.raises(AgentLoopError, match="did not evaluate all prior unresolved items: item-1"):
+        _validate_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Rename the helper.",
+                    status="same-pr",
+                ),
+            ),
+        )
 
 
 def test_parse_review_drops_future_followups_in_blocking_reviews():


### PR DESCRIPTION
## Summary
- accept parenthesized empty placeholders like `(none)` and `(n/a)` in follow-up and prior-disposition sections
- preserve raw prior-disposition prose for validation, add precise malformed-bullet errors with section and line context, and keep contradictory active placeholders invalid
- add a narrow prose-only fallback for explicit blanket resolution language and cover the new parser/validator behavior with regressions

## Testing
- python3 -m pytest tests/test_agent_loop.py -k "plan_review or approved_followups or unresolved_item_dispositions"
- python3 -m pytest

Fixes #144