### PR TITLE
Migrate plan reviews and revisions to structured responses

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -59,6 +59,7 @@ from .protocol import (
     FUTURE_FOLLOWUP_HEADING_RE,
     HUMAN_REQUIREMENTS_HEADING_RE,
     LEGACY_FOLLOWUP_HEADING_RE,
+    PLAN_STATE_RE,
     ParsedPlanReview,
     HTML_COMMENT_RE,
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
@@ -67,6 +68,7 @@ from .protocol import (
     SIGNATURE_RE,
     ParsedReview,
     ReviewItemDisposition,
+    StructuredPlanRevision,
     UnresolvedReviewItem,
     human_requirements_resolved,
     is_clarification_request,
@@ -77,6 +79,7 @@ from .protocol import (
     parse_pr_number,
     review_freeform_summary_text,
     validate_human_requirements_acknowledgement,
+    validate_structured_plan_revision,
 )
 from .protocol import ApprovedFollowup, parse_review
 from .runner import Runner
@@ -162,6 +165,7 @@ class PostedRoundMetadata:
     dispositions: tuple[ReviewItemDisposition, ...] = ()
     new_items: tuple[UnresolvedReviewItem, ...] = ()
     state: str | None = None
+    canonical_plan: str | None = None
 
 
 @dataclass(frozen=True)
@@ -654,6 +658,13 @@ def _validate_plan_review_response(
     )
 
 
+def _validate_plan_revision_response(text: str) -> StructuredPlanRevision | str:
+    parsed = validate_structured_plan_revision(text)
+    if parsed is not None:
+        return parsed
+    return parse_plan_state(text)
+
+
 def _review_freeform_summary_text(text: str) -> str:
     return review_freeform_summary_text(text)
 
@@ -845,6 +856,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "dispositions": [_serialize_disposition(item) for item in metadata.dispositions],
         "new_items": [_serialize_unresolved_item(item) for item in metadata.new_items],
         "state": metadata.state,
+        "canonical_plan": metadata.canonical_plan,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -868,6 +880,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             dispositions=tuple(_deserialize_disposition(item) for item in payload.get("dispositions", [])),
             new_items=tuple(_deserialize_unresolved_item(item) for item in payload.get("new_items", [])),
             state=str(payload["state"]) if payload.get("state") is not None else None,
+            canonical_plan=(
+                str(payload["canonical_plan"])
+                if payload.get("canonical_plan") is not None
+                else None
+            ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc
@@ -940,6 +957,36 @@ def _max_unresolved_item_number_from_records(records: Sequence[PostedRoundRecord
 
 def _plan_subject(text: str) -> str:
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def render_canonical_plan_steps(plan_steps: Sequence[str]) -> str:
+    return "\n".join(f"{index}. {step}" for index, step in enumerate(plan_steps, start=1))
+
+
+def render_canonical_plan_revision(
+    parsed_revision: StructuredPlanRevision,
+    prior_items: Sequence[UnresolvedReviewItem],
+) -> str:
+    sections = [parsed_revision.summary.strip()]
+    if prior_items or parsed_revision.prior_plan_item_dispositions:
+        sections.append(
+            _render_prior_dispositions_section(
+                heading="### Prior plan review item dispositions",
+                prior_items=prior_items,
+                dispositions=parsed_revision.prior_plan_item_dispositions,
+            )
+        )
+    else:
+        sections.append("### Prior plan review item dispositions\n- None.")
+    sections.append(
+        "\n".join(
+            [
+                "### Plan steps",
+                render_canonical_plan_steps(parsed_revision.plan_steps),
+            ]
+        )
+    )
+    return "\n\n".join(sections)
 
 
 def _resume_pr_round(
@@ -1025,11 +1072,11 @@ def _resume_plan_round(
             continue
         reviewer_records[metadata.agent] = record
     return (
-        latest_coder_record.body,
+        latest_coder_record.metadata.canonical_plan or latest_coder_record.body,
         ResumedReviewRound(
             round_number=latest_coder_record.metadata.round_number,
             prior_items=latest_coder_record.metadata.prior_items,
-            coder_output=latest_coder_record.body,
+            coder_output=latest_coder_record.metadata.canonical_plan or latest_coder_record.body,
             completed_reviews=tuple(reviewer_records[agent_display_name(agent)] for agent in configured_reviewers if agent_display_name(agent) in reviewer_records),
             next_unresolved_item_number=_max_unresolved_item_number_from_records(records) + 1,
         ),
@@ -1117,6 +1164,91 @@ def _render_public_pr_review_comment(
     return "\n\n".join(section for section in sections if section) + (
         ("\n\n" if sections else "") + "\n".join(footer)
     )
+
+
+def _render_public_plan_review_comment(
+    parsed_review: ParsedPlanReview,
+    *,
+    reviewer: str,
+    prior_items: Sequence[UnresolvedReviewItem],
+    dispositions: Sequence[ReviewItemDisposition],
+) -> str:
+    sections: list[str] = []
+    if parsed_review.summary:
+        sections.append(parsed_review.summary.strip())
+    if parsed_review.items.blocking:
+        sections.append(
+            "\n".join(
+                [
+                    "### Blocking plan issues",
+                    *[f"- {item.text}" for item in parsed_review.items.blocking],
+                ]
+            )
+        )
+    if parsed_review.items.same_plan:
+        sections.append(
+            "\n".join(
+                [
+                    "### Same-plan follow-ups",
+                    *[f"- {item.text}" for item in parsed_review.items.same_plan],
+                ]
+            )
+        )
+    if parsed_review.items.future:
+        sections.append(
+            "\n".join(
+                [
+                    "### Future follow-ups",
+                    *[f"- {item.text}" for item in parsed_review.items.future],
+                ]
+            )
+        )
+    if prior_items:
+        sections.append(
+            _render_prior_dispositions_section(
+                heading="### Prior unresolved plan item dispositions",
+                prior_items=prior_items,
+                dispositions=dispositions,
+            )
+        )
+    footer = [
+        f"<!-- AGENT_PLAN_STATE: {parsed_review.state} -->",
+        f"-- {_public_reviewer_name(reviewer)}",
+    ]
+    return "\n\n".join(section for section in sections if section) + (
+        ("\n\n" if sections else "") + "\n".join(footer)
+    )
+
+
+def _extract_plan_revision_human_requirements_block(text: str) -> str:
+    stripped = text.lstrip()
+    if not stripped.startswith("{"):
+        return ""
+    decoder = json.JSONDecoder()
+    payload, end = decoder.raw_decode(stripped)
+    if not isinstance(payload, dict):
+        return ""
+    trailing = stripped[end:].lstrip()
+    state_match = PLAN_STATE_RE.search(trailing)
+    if state_match is None:
+        return ""
+    return trailing[: state_match.start()].strip()
+
+
+def _render_public_plan_revision_comment(
+    parsed_revision: StructuredPlanRevision,
+    *,
+    prior_items: Sequence[UnresolvedReviewItem],
+    raw_text: str,
+    signature: str,
+) -> str:
+    sections = [render_canonical_plan_revision(parsed_revision, prior_items)]
+    human_requirements_block = _extract_plan_revision_human_requirements_block(raw_text)
+    if human_requirements_block:
+        sections.append(human_requirements_block)
+    sections.append(f"<!-- AGENT_PLAN_STATE: {parsed_revision.state} -->")
+    sections.append(f"-- {signature}")
+    return "\n\n".join(section for section in sections if section)
 
 
 def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
@@ -1729,12 +1861,11 @@ def _run_plan_first_loop(
                     config=config,
                     issue_number=issue_number,
                     body=_attach_round_metadata(
-                        _render_public_review_comment(
-                            review_output,
-                            review_kind="plan",
+                        _render_public_plan_review_comment(
+                            parsed_review,
+                            reviewer=reviewer_name,
                             prior_items=prior_unresolved_items,
                             dispositions=parsed_review.dispositions,
-                            new_items=reviewer_new_unresolved_items,
                         ),
                         PostedRoundMetadata(
                             flow="plan",
@@ -1876,21 +2007,33 @@ def _run_plan_first_loop(
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
             validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
                 text,
-                marker_validator=parse_plan_state,
+                marker_validator=_validate_plan_revision_response,
                 human_requirements=human_requirements,
                 requirement_scope="planning requirements",
                 full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
             ),
             usage_context=usage_context,
         )
-        current_plan = plan_response.text
+        canonical_plan: str | None = None
+        public_comment = plan_response.text
+        if isinstance(plan_response.marker_value, StructuredPlanRevision):
+            canonical_plan = render_canonical_plan_revision(plan_response.marker_value, must_fix_items)
+            current_plan = canonical_plan
+            public_comment = _render_public_plan_revision_comment(
+                plan_response.marker_value,
+                prior_items=must_fix_items,
+                raw_text=plan_response.text,
+                signature=agent_signature(config.coder),
+            )
+        else:
+            current_plan = plan_response.text
         coder_session_id = plan_response.session_id
         post_issue_comment(
             runner,
             config=config,
             issue_number=issue_number,
             body=_attach_round_metadata(
-                current_plan,
+                public_comment,
                 PostedRoundMetadata(
                     flow="plan",
                     role="coder",
@@ -1898,6 +2041,7 @@ def _run_plan_first_loop(
                     round_number=round_number + 1,
                     subject=_plan_subject(current_plan),
                     prior_items=tuple(must_fix_items),
+                    canonical_plan=canonical_plan,
                 ),
             ),
         )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -617,7 +617,26 @@ Plan from {coder_name}:
 {plan}
 
 Review the plan for correctness, architecture fit, missing edge cases, test
-strategy, and ambiguity. Use this exact structured format in your response body:
+strategy, and ambiguity. Prefer this structured JSON response format first:
+
+```json
+{{
+  "schema_version": 1,
+  "kind": "plan_review",
+  "state": "approved",
+  "summary": "Plan looks good.",
+  "blocking_plan_issues": [],
+  "same_plan_followups": [],
+  "future_followups": ["Consider a later cleanup pass."],
+  "prior_plan_item_dispositions": [
+    {{"item_id": "item-1", "disposition": "resolved", "note": "Covered by the revised tests."}}
+  ]
+}}
+<!-- AGENT_PLAN_STATE: approved -->
+-- {reviewer_signature}
+```
+
+If you do not use the structured JSON format, use this exact markdown compatibility format instead:
 
 ### Blocking plan issues
 - Required corrections that must be resolved before the plan can be approved.
@@ -659,7 +678,10 @@ or:
 
 Use approved only if there are no blocking plan issues, no Same-plan
 follow-ups, and no carried-forward plan items left active for this planning
-round. Always sign your response:
+round. Structured responses must start with one top-level JSON object, place
+the `AGENT_PLAN_STATE` footer immediately after that payload, and end with only
+your standalone signature. If you fall back to markdown, keep the exact section
+headings above. Always sign your response:
 -- {reviewer_signature}
 """
 
@@ -718,6 +740,33 @@ your response and address each item ID exactly once:
 Then provide the revised implementation plan with concrete file areas, edge
 cases, and tests. Use `same-plan`, never `same-pr`, when describing plan-only
 current-round refinements.
+
+Prefer this structured JSON response format first:
+
+```json
+{{
+  "schema_version": 1,
+  "kind": "plan_revision",
+  "state": "blocking",
+  "summary": "Updated the plan to cover parser hard-fail behavior and resume state reconstruction.",
+  "prior_plan_item_dispositions": [
+    {{"item_id": "item-3", "disposition": "resolved", "note": "Added the carry-forward metadata step."}}
+  ],
+  "plan_steps": [
+    "Update `src/coding_review_agent_loop/protocol.py` to hard-fail invalid structured plan payloads after JSON-prefix detection.",
+    "Normalize structured plan rendering and metadata-backed resume behavior in `src/coding_review_agent_loop/orchestrator.py`.",
+    "Extend prompts and targeted tests for structured planning flows."
+  ]
+}}
+<!-- AGENT_PLAN_STATE: blocking -->
+-- {coder_signature}
+```
+
+The orchestrator will normalize structured plan revisions into canonical
+markdown for stored plan state, reviewer prompts, subject hashing, and resume.
+If you do not use the structured JSON format, fall back to markdown
+compatibility by keeping the `### Prior plan review item dispositions` section
+and then providing the full revised plan in markdown prose.
 
 This is planning round {round_number}. End your final response with exactly one
 planning marker:

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -188,6 +188,7 @@ class StructuredPlanRevision:
     kind: str
     state: str
     summary: str
+    prior_plan_item_dispositions: tuple[ReviewItemDisposition, ...]
     plan_steps: tuple[str, ...]
 
 
@@ -416,13 +417,17 @@ def _expect_string_list(
     *,
     context: str,
     item_context: str,
+    min_length: int = 0,
 ) -> tuple[str, ...]:
     if not isinstance(value, list):
         raise AgentLoopError(f"{context} must be a JSON array.")
-    return tuple(
+    rendered = tuple(
         _expect_non_empty_string(item, context=f"{item_context} at index {index}")
         for index, item in enumerate(value)
     )
+    if len(rendered) < min_length:
+        raise AgentLoopError(f"{context} must contain at least {min_length} item(s).")
+    return rendered
 
 
 def _expect_state(value: object, *, context: str) -> str:
@@ -484,10 +489,60 @@ def _extract_json_object_prefix(text: str) -> tuple[dict[str, object], str] | No
     try:
         payload, end = decoder.raw_decode(stripped)
     except json.JSONDecodeError as exc:
-        raise AgentLoopError("Structured PR review must begin with one top-level JSON object.") from exc
+        raise AgentLoopError("Structured response must begin with one top-level JSON object.") from exc
     if not isinstance(payload, dict):
-        raise AgentLoopError("Structured PR review must begin with a JSON object.")
+        raise AgentLoopError("Structured response must begin with a JSON object.")
     return payload, stripped[end:]
+
+
+def _consume_structured_footer_and_signature(
+    *,
+    payload: dict[str, object],
+    trailing: str,
+    state_re: re.Pattern[str],
+    state_marker_name: str,
+    context_label: str,
+    allow_human_requirements_prefix: bool = False,
+    allow_human_requirements_marker_after_footer: bool = False,
+) -> dict[str, object]:
+    trailing = trailing.lstrip()
+    state_match = state_re.search(trailing)
+    if state_match is None:
+        raise AgentLoopError(
+            f"{context_label} must place <!-- {state_marker_name}: approved|blocking --> after the JSON object."
+        )
+
+    before_footer = trailing[: state_match.start()].strip()
+    if before_footer:
+        if not allow_human_requirements_prefix:
+            raise AgentLoopError(
+                f"{context_label} may not include prose between the JSON object and the {state_marker_name} footer."
+            )
+        parsed_human_requirements = parse_human_requirements_acknowledgement(before_footer)
+        if not parsed_human_requirements.marker_present or not parsed_human_requirements.section_present:
+            raise AgentLoopError(
+                f"{context_label} may only include a signed human requirements acknowledgement before the {state_marker_name} footer."
+            )
+
+    trailing = trailing[state_match.end() :].lstrip()
+    if allow_human_requirements_marker_after_footer and HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing):
+        marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing)
+        assert marker_match is not None
+        trailing = trailing[marker_match.end() :].lstrip()
+    signature_match = re.match(r"^--\s+\S[^\n]*(?:\n)?$", trailing)
+    if signature_match is None or trailing[signature_match.end() :].strip():
+        raise AgentLoopError(
+            f"{context_label} may not include trailing prose after the JSON footer and signature."
+        )
+
+    footer_state = state_match.group(1).lower()
+    payload_state = payload.get("state")
+    if isinstance(payload_state, str) and payload_state.strip():
+        if payload_state.strip() != footer_state:
+            raise AgentLoopError(
+                f"{context_label} footer {state_marker_name} must match the payload state."
+            )
+    return payload
 
 
 def _extract_structured_pr_review_payload(text: str) -> dict[str, object] | None:
@@ -499,24 +554,44 @@ def _extract_structured_pr_review_payload(text: str) -> dict[str, object] | None
     if HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing):
         marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing)
         assert marker_match is not None
-        trailing = trailing[marker_match.end() :].lstrip()
-    state_match = STATE_RE.match(trailing)
-    if state_match is None:
-        raise AgentLoopError(
-            "Structured PR review must place <!-- AGENT_STATE: approved|blocking --> after the JSON object."
-        )
-    trailing = trailing[state_match.end() :].lstrip()
-    signature_match = re.match(r"^--\s+\S[^\n]*(?:\n)?$", trailing)
-    if signature_match is None or trailing[signature_match.end() :].strip():
-        raise AgentLoopError(
-            "Structured PR review may not include trailing prose after the JSON footer and signature."
-        )
-    footer_state = state_match.group(1).lower()
-    payload_state = payload.get("state")
-    if isinstance(payload_state, str) and payload_state.strip():
-        if payload_state.strip() != footer_state:
-            raise AgentLoopError("Structured PR review footer AGENT_STATE must match the payload state.")
-    return payload
+        trailing = trailing[marker_match.end() :]
+    return _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=STATE_RE,
+        state_marker_name="AGENT_STATE",
+        context_label="Structured PR review",
+        allow_human_requirements_marker_after_footer=True,
+    )
+
+
+def _extract_structured_plan_review_payload(text: str) -> dict[str, object] | None:
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    return _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=PLAN_STATE_RE,
+        state_marker_name="AGENT_PLAN_STATE",
+        context_label="Structured plan review",
+    )
+
+
+def _extract_structured_plan_revision_payload(text: str) -> dict[str, object] | None:
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    return _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=PLAN_STATE_RE,
+        state_marker_name="AGENT_PLAN_STATE",
+        context_label="Structured plan revision",
+        allow_human_requirements_prefix=True,
+    )
 
 
 def _require_supported_schema_version(payload: dict[str, object]) -> None:
@@ -724,54 +799,51 @@ def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | No
 
 
 def parse_structured_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview | None:
-    payload = _extract_structured_response_object(text)
+    payload = _extract_structured_plan_review_payload(text)
     if payload is None:
         return None
     _require_supported_schema_version(payload)
     kind = payload.get("kind")
     if isinstance(kind, str) and kind != "plan_review":
         raise AgentLoopError("Structured response kind mismatch: expected `plan_review`.")
-    try:
-        _expect_exact_keys(
-            payload,
-            context="plan_review",
-            required={
-                "schema_version",
-                "kind",
-                "state",
-                "summary",
-                "blocking_plan_issues",
-                "same_plan_followups",
-                "future_followups",
-                "prior_plan_item_dispositions",
-            },
-        )
-        state = _expect_state(payload["state"], context="plan_review.state")
-        summary = _expect_non_empty_string(payload["summary"], context="plan_review.summary")
-        blocking_items = _expect_string_list(
-            payload["blocking_plan_issues"],
-            context="plan_review.blocking_plan_issues",
-            item_context="plan_review.blocking_plan_issues",
-        )
-        same_plan_followups = _expect_string_list(
-            payload["same_plan_followups"],
-            context="plan_review.same_plan_followups",
-            item_context="plan_review.same_plan_followups",
-        )
-        future_followups = _expect_string_list(
-            payload["future_followups"],
-            context="plan_review.future_followups",
-            item_context="plan_review.future_followups",
-        )
-        dispositions = _expect_disposition_list(
-            payload["prior_plan_item_dispositions"],
-            context="plan_review.prior_plan_item_dispositions",
-            reviewer=reviewer,
-            allowed_same_status="same-plan",
-            is_plan_review=True,
-        )
-    except AgentLoopError:
-        return None
+    _expect_exact_keys(
+        payload,
+        context="plan_review",
+        required={
+            "schema_version",
+            "kind",
+            "state",
+            "summary",
+            "blocking_plan_issues",
+            "same_plan_followups",
+            "future_followups",
+            "prior_plan_item_dispositions",
+        },
+    )
+    state = _expect_state(payload["state"], context="plan_review.state")
+    summary = _expect_non_empty_string(payload["summary"], context="plan_review.summary")
+    blocking_items = _expect_string_list(
+        payload["blocking_plan_issues"],
+        context="plan_review.blocking_plan_issues",
+        item_context="plan_review.blocking_plan_issues",
+    )
+    same_plan_followups = _expect_string_list(
+        payload["same_plan_followups"],
+        context="plan_review.same_plan_followups",
+        item_context="plan_review.same_plan_followups",
+    )
+    future_followups = _expect_string_list(
+        payload["future_followups"],
+        context="plan_review.future_followups",
+        item_context="plan_review.future_followups",
+    )
+    dispositions = _expect_disposition_list(
+        payload["prior_plan_item_dispositions"],
+        context="plan_review.prior_plan_item_dispositions",
+        reviewer=reviewer,
+        allowed_same_status="same-plan",
+        is_plan_review=True,
+    )
     if state == "blocking" and future_followups:
         raise AgentLoopError("Blocking structured plan reviews may not include future follow-ups.")
     return _finalize_parsed_plan_review(
@@ -858,35 +930,48 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
 
 
 def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | None:
-    payload = _extract_structured_response_object(text)
+    payload = _extract_structured_plan_revision_payload(text)
     if payload is None:
         return None
     _require_supported_schema_version(payload)
     kind = payload.get("kind")
     if isinstance(kind, str) and kind != "plan_revision":
         raise AgentLoopError("Structured response kind mismatch: expected `plan_revision`.")
-    try:
-        _expect_exact_keys(
-            payload,
-            context="plan_revision",
-            required={"schema_version", "kind", "state", "summary", "plan_steps"},
-        )
-        state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
-        if state != "blocking":
-            raise AgentLoopError("plan_revision.state must be `blocking`.")
-        summary = _expect_non_empty_string(payload["summary"], context="plan_revision.summary")
-        plan_steps = _expect_string_list(
-            payload["plan_steps"],
-            context="plan_revision.plan_steps",
-            item_context="plan_revision.plan_steps",
-        )
-    except AgentLoopError:
-        return None
+    _expect_exact_keys(
+        payload,
+        context="plan_revision",
+        required={
+            "schema_version",
+            "kind",
+            "state",
+            "summary",
+            "prior_plan_item_dispositions",
+            "plan_steps",
+        },
+    )
+    state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
+    if state != "blocking":
+        raise AgentLoopError("plan_revision.state must be `blocking`.")
+    summary = _expect_non_empty_string(payload["summary"], context="plan_revision.summary")
+    dispositions = _expect_disposition_list(
+        payload["prior_plan_item_dispositions"],
+        context="plan_revision.prior_plan_item_dispositions",
+        reviewer="coder",
+        allowed_same_status="same-plan",
+        is_plan_review=True,
+    )
+    plan_steps = _expect_string_list(
+        payload["plan_steps"],
+        context="plan_revision.plan_steps",
+        item_context="plan_revision.plan_steps",
+        min_length=1,
+    )
     return StructuredPlanRevision(
         schema_version=1,
         kind="plan_revision",
         state="blocking",
         summary=summary,
+        prior_plan_item_dispositions=dispositions,
         plan_steps=plan_steps,
     )
 
@@ -1281,6 +1366,9 @@ def parse_pr_review(text: str, *, reviewer: str) -> ParsedReview:
 
 def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
     """Parse a plan review, including state, structured plan items, and dispositions."""
+    parsed = parse_structured_plan_review(text, reviewer=reviewer)
+    if parsed is not None:
+        return parsed
     state = parse_plan_state(text)
     summary = review_freeform_summary_text(text)
     items = parse_plan_review_items(text, reviewer=reviewer)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -59,15 +59,21 @@ from coding_review_agent_loop.orchestrator import (
     _apply_unresolved_item_dispositions,
     _attach_round_metadata,
     _decode_round_metadata,
+    _encode_round_metadata,
     _format_unresolved_item_label,
     _plan_subject,
+    _render_public_plan_review_comment,
+    _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
     _render_public_review_comment,
     _review_freeform_summary_text,
     _resume_pr_round,
+    _resume_plan_round,
     _strip_round_metadata,
     _validate_review_response,
     _validate_plan_review_response,
+    render_canonical_plan_revision,
+    render_canonical_plan_steps,
 )
 from coding_review_agent_loop.prompts import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
@@ -85,6 +91,9 @@ from coding_review_agent_loop.prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from coding_review_agent_loop.protocol import (
+    _expect_string_list,
+    _extract_structured_plan_review_payload,
+    _extract_structured_plan_revision_payload,
     parse_approved_followups,
     parse_human_requirements_acknowledgement,
     parse_pr_review,
@@ -2475,7 +2484,10 @@ def test_parse_structured_pr_review_rejects_trailing_content_before_footer(suffi
         }
     )
 
-    with pytest.raises(AgentLoopError, match="place <!-- AGENT_STATE|may not include trailing prose"):
+    with pytest.raises(
+        AgentLoopError,
+        match="place <!-- AGENT_STATE|may not include prose between|may not include trailing prose",
+    ):
         parse_structured_pr_review(payload + suffix, reviewer="OpenAI Codex")
 
 
@@ -2517,17 +2529,20 @@ def test_parse_structured_pr_review_falls_back_when_json_is_embedded_in_markdown
 
 
 def test_parse_structured_plan_review_normalizes_v1_payload():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "plan_review",
-            "state": "approved",
-            "summary": "Plan looks good.",
-            "blocking_plan_issues": [],
-            "same_plan_followups": [],
-            "future_followups": ["Consider a later cleanup pass."],
-            "prior_plan_item_dispositions": [{"item_id": "item-1", "disposition": "resolved"}],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "approved",
+                "summary": "Plan looks good.",
+                "blocking_plan_issues": [],
+                "same_plan_followups": [],
+                "future_followups": ["Consider a later cleanup pass."],
+                "prior_plan_item_dispositions": [{"item_id": "item-1", "disposition": "resolved"}],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
     )
 
     parsed = parse_structured_plan_review(payload, reviewer="OpenAI Codex")
@@ -2541,17 +2556,20 @@ def test_parse_structured_plan_review_normalizes_v1_payload():
 
 
 def test_parse_structured_plan_review_rejects_blocking_future_followups():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "plan_review",
-            "state": "blocking",
-            "summary": "Still blocked.",
-            "blocking_plan_issues": ["Need clearer rollback coverage."],
-            "same_plan_followups": [],
-            "future_followups": ["Refactor the prompt later."],
-            "prior_plan_item_dispositions": [],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "blocking",
+                "summary": "Still blocked.",
+                "blocking_plan_issues": ["Need clearer rollback coverage."],
+                "same_plan_followups": [],
+                "future_followups": ["Refactor the prompt later."],
+                "prior_plan_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
     )
 
     with pytest.raises(AgentLoopError, match="Blocking structured plan reviews may not include future"):
@@ -2604,49 +2622,182 @@ def test_validate_structured_coder_followup_rejects_unknown_keys_via_fallback():
 
 
 def test_validate_structured_plan_revision_accepts_v1_payload():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "plan_revision",
-            "state": "blocking",
-            "summary": "Revised the plan to cover rollback testing.",
-            "plan_steps": ["Update protocol.py.", "Add regression tests."],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Revised the plan to cover rollback testing.",
+                "prior_plan_item_dispositions": [
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Covered in the new tests."}
+                ],
+                "plan_steps": ["Update protocol.py.", "Add regression tests."],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
     )
 
     parsed = validate_structured_plan_revision(payload)
 
     assert parsed is not None
     assert parsed.state == "blocking"
+    assert [(item.item_id, item.disposition) for item in parsed.prior_plan_item_dispositions] == [
+        ("item-1", "resolved")
+    ]
     assert parsed.plan_steps == ("Update protocol.py.", "Add regression tests.")
 
 
-def test_validate_structured_plan_revision_rejects_non_blocking_state_via_fallback():
+@pytest.mark.parametrize(
+    ("payload", "pattern"),
+    [
+        (
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "approved",
+                "summary": "Wrong state.",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": ["Update protocol.py."],
+            },
+            "plan_revision.state must be `blocking`",
+        ),
+        (
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": ["Update protocol.py."],
+            },
+            "plan_revision.summary must be a non-empty string",
+        ),
+        (
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Missing steps.",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": [],
+            },
+            "plan_revision.plan_steps must contain at least 1 item",
+        ),
+    ],
+)
+def test_validate_structured_plan_revision_rejects_invalid_payload(payload, pattern):
+    footer_state = payload["state"]
+    text = json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: {footer_state} -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match=pattern):
+        validate_structured_plan_revision(text)
+
+
+def test_extract_structured_plan_review_payload_rejects_embedded_json_markdown():
+    review = """
+    Here is an example:
+
+    ```json
+    {"schema_version": 1, "kind": "plan_review"}
+    ```
+
+    <!-- AGENT_PLAN_STATE: approved -->
+    -- OpenAI Codex
+    """
+
+    assert _extract_structured_plan_review_payload(review) is None
+
+
+def test_extract_structured_plan_review_payload_rejects_footer_state_mismatch():
     payload = json.dumps(
         {
             "schema_version": 1,
-            "kind": "plan_revision",
+            "kind": "plan_review",
             "state": "approved",
-            "summary": "Wrong state.",
-            "plan_steps": ["Update protocol.py."],
+            "summary": "Plan looks good.",
+            "blocking_plan_issues": [],
+            "same_plan_followups": [],
+            "future_followups": [],
+            "prior_plan_item_dispositions": [],
         }
     )
+    text = payload + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
 
-    assert validate_structured_plan_revision(payload) is None
+    with pytest.raises(AgentLoopError, match="footer AGENT_PLAN_STATE must match"):
+        _extract_structured_plan_review_payload(text)
 
 
-def test_validate_structured_plan_revision_falls_back_on_empty_summary():
+def test_extract_structured_plan_review_payload_rejects_trailing_prose_after_signature():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "approved",
+            "summary": "Plan looks good.",
+            "blocking_plan_issues": [],
+            "same_plan_followups": [],
+            "future_followups": [],
+            "prior_plan_item_dispositions": [],
+        }
+    )
+    text = payload + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex\nextra"
+
+    with pytest.raises(AgentLoopError, match="trailing prose"):
+        _extract_structured_plan_review_payload(text)
+
+
+def test_parse_plan_review_hard_fails_after_top_level_json_prefix():
+    review = (
+        '{"schema_version":1,"kind":"plan_review","state":"approved","summary":"Plan looks good.",'
+        '"blocking_plan_issues":[],"same_plan_followups":[],"future_followups":[]}\n'
+        "<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="plan_review is missing required field"):
+        parse_plan_review(review, reviewer="OpenAI Codex")
+
+
+def test_extract_structured_plan_revision_payload_accepts_human_requirements_prefix():
     payload = json.dumps(
         {
             "schema_version": 1,
             "kind": "plan_revision",
             "state": "blocking",
-            "summary": "",
+            "summary": "Revised the plan.",
+            "prior_plan_item_dispositions": [],
             "plan_steps": ["Update protocol.py."],
         }
     )
+    text = (
+        payload
+        + "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n### Human requirements\n- Requirement 1: covered in step 1.\n"
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
+    )
 
-    assert validate_structured_plan_revision(payload) is None
+    assert _extract_structured_plan_revision_payload(text) is not None
+
+
+def test_extract_structured_plan_revision_payload_rejects_bad_footer_ordering():
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "Revised the plan.",
+            "prior_plan_item_dispositions": [],
+            "plan_steps": ["Update protocol.py."],
+        }
+    )
+    text = payload + "\n-- OpenAI Codex\n<!-- AGENT_PLAN_STATE: blocking -->"
+
+    with pytest.raises(AgentLoopError, match="AGENT_PLAN_STATE"):
+        _extract_structured_plan_revision_payload(text)
+
+
+def test_expect_string_list_enforces_min_length():
+    with pytest.raises(AgentLoopError, match="must contain at least 1 item"):
+        _expect_string_list([], context="plan_revision.plan_steps", item_context="plan_revision.plan_steps", min_length=1)
 
 
 def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions(tmp_path):
@@ -2769,6 +2920,9 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
     assert "Same-plan\nfollow-ups may appear only in blocking plan reviews" in prompt
     assert "do not use structured Future follow-ups" in prompt
     assert "no blocking plan issues, no Same-plan\nfollow-ups, and no carried-forward plan items left active" in prompt
+    assert '"kind": "plan_review"' in prompt
+    assert '"prior_plan_item_dispositions"' in prompt
+    assert "If you do not use the structured JSON format, use this exact markdown compatibility format instead" in prompt
 
 
 def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositions(tmp_path):
@@ -2795,6 +2949,114 @@ def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositio
     assert "### Prior plan review item dispositions" in prompt
     assert "- [item-id] same-plan:" in prompt
     assert "Use `same-plan`, never `same-pr`" in prompt
+    assert '"kind": "plan_revision"' in prompt
+    assert '"plan_steps"' in prompt
+    assert "normalize structured plan revisions into canonical\nmarkdown for stored plan state" in prompt
+    assert "If you do not use the structured JSON format, fall back to markdown\ncompatibility" in prompt
+
+
+def test_render_canonical_plan_steps_numbers_items():
+    assert render_canonical_plan_steps(("Update protocol.py.", "Add tests.")) == (
+        "1. Update protocol.py.\n2. Add tests."
+    )
+
+
+def test_render_canonical_plan_revision_and_public_comment():
+    parsed = validate_structured_plan_revision(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Revised the plan to cover rollback behavior.",
+                "prior_plan_item_dispositions": [
+                    {"item_id": "item-4", "disposition": "resolved", "note": "Added a resume-path step."}
+                ],
+                "plan_steps": ["Update protocol.py.", "Add orchestrator resume tests."],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
+    )
+    assert parsed is not None
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-4",
+            reviewer="OpenAI Codex",
+            source_round=2,
+            text="Add a resume-path step.",
+            status="blocking",
+        ),
+    )
+
+    canonical = render_canonical_plan_revision(parsed, prior_items)
+    public = _render_public_plan_revision_comment(
+        parsed,
+        prior_items=prior_items,
+        raw_text='{"schema_version":1}\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex',
+        signature="OpenAI Codex",
+    )
+
+    assert canonical == (
+        "Revised the plan to cover rollback behavior.\n\n"
+        "### Prior plan review item dispositions\n"
+        "- [item-4] Blocking issue from OpenAI Codex, round 2: Add a resume-path step. -> "
+        "resolved: Added a resume-path step.\n\n"
+        "### Plan steps\n"
+        "1. Update protocol.py.\n"
+        "2. Add orchestrator resume tests."
+    )
+    assert public == canonical + "\n\n<!-- AGENT_PLAN_STATE: blocking -->\n\n-- OpenAI Codex"
+
+
+def test_render_public_plan_review_comment_normalizes_sections():
+    parsed = parse_structured_plan_review(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "blocking",
+                "summary": "Still blocked on coverage.",
+                "blocking_plan_issues": ["Add a resume coverage test."],
+                "same_plan_followups": ["Mention canonical hashing explicitly."],
+                "future_followups": [],
+                "prior_plan_item_dispositions": [
+                    {"item_id": "item-2", "disposition": "same-plan", "note": "Still needs one more prompt assertion."}
+                ],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+        reviewer="OpenAI Codex",
+    )
+    assert parsed is not None
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="Google Gemini",
+            source_round=1,
+            text="Mention canonical hashing explicitly.",
+            status="same-plan",
+        ),
+    )
+
+    rendered = _render_public_plan_review_comment(
+        parsed,
+        reviewer="OpenAI Codex",
+        prior_items=prior_items,
+        dispositions=parsed.dispositions,
+    )
+
+    assert rendered == (
+        "Still blocked on coverage.\n\n"
+        "### Blocking plan issues\n"
+        "- Add a resume coverage test.\n\n"
+        "### Same-plan follow-ups\n"
+        "- Mention canonical hashing explicitly.\n\n"
+        "### Prior unresolved plan item dispositions\n"
+        "- [item-2] Same-plan follow-up from Google Gemini, round 1: Mention canonical hashing explicitly. -> "
+        "same-plan: Still needs one more prompt assertion.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n"
+        "-- OpenAI Codex"
+    )
 
 
 def test_review_freeform_summary_text_strips_structured_followup_sections():
@@ -7194,6 +7456,7 @@ def test_issue_loop_plan_first_posts_human_readable_item_labels_in_new_and_prior
     assert runner.comments[1] == (
         "### Blocking plan issues\n"
         "- Keep plan-review wording distinct from PR wording.\n"
+        "\n"
         "### Same-plan follow-ups\n"
         "- Add one carry-forward plan test.\n"
         "<!-- AGENT_PLAN_STATE: blocking -->\n"
@@ -7283,6 +7546,64 @@ def test_issue_loop_plan_first_resumes_with_only_missing_reviewer_for_current_pl
     assert runner.comments[-1].startswith("Planning complete for issue #56.")
 
 
+def test_resume_plan_round_prefers_canonical_plan_metadata():
+    public_body = (
+        "Revised plan summary.\n\n### Plan steps\n1. Public body copy.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    canonical_plan = (
+        "Revised plan summary.\n\n### Prior plan review item dispositions\n- None.\n\n"
+        "### Plan steps\n1. Canonical copy."
+    )
+    coder_comment = _attach_round_metadata(
+        public_body,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=_plan_subject(canonical_plan),
+            prior_items=(),
+            canonical_plan=canonical_plan,
+        ),
+    )
+
+    resumed = _resume_plan_round(
+        [IssueComment(author="bot", created_at="2026-05-20T09:00:00Z", body=coder_comment)],
+        configured_reviewers=("codex", "gemini"),
+    )
+
+    assert resumed is not None
+    current_plan, state = resumed
+    assert current_plan == canonical_plan
+    assert state.coder_output == canonical_plan
+
+
+def test_resume_plan_round_falls_back_to_raw_body_for_markdown_plan():
+    plan = "Revised plan.\n- Add state reconstruction.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    coder_comment = _attach_round_metadata(
+        plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=_plan_subject(plan),
+            prior_items=(),
+        ),
+    )
+
+    resumed = _resume_plan_round(
+        [IssueComment(author="bot", created_at="2026-05-20T09:00:00Z", body=coder_comment)],
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    current_plan, state = resumed
+    assert current_plan == plan
+    assert state.coder_output == plan
+
+
 def test_plan_subject_ignores_trailing_whitespace_added_by_metadata_round_trip():
     plan = "Revised plan.\n- Add state reconstruction.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
 
@@ -7299,6 +7620,19 @@ def test_plan_subject_ignores_trailing_whitespace_added_by_metadata_round_trip()
     )
 
     assert _plan_subject(f"{plan}\n") == _plan_subject(_strip_round_metadata(attached))
+
+
+def test_round_metadata_round_trip_preserves_canonical_plan():
+    metadata = PostedRoundMetadata(
+        flow="plan",
+        role="coder",
+        agent="Claude",
+        round_number=2,
+        subject="abc",
+        canonical_plan="Summary\n\n### Plan steps\n1. Canonical step.",
+    )
+
+    assert _decode_round_metadata(_encode_round_metadata(metadata)).canonical_plan == metadata.canonical_plan
 
 
 @pytest.mark.parametrize(
@@ -7406,7 +7740,7 @@ def test_issue_loop_plan_first_keeps_blocking_review_when_future_followups_are_m
     assert "Add parser coverage for blocking reviews with stray future follow-ups." in claude_calls[1][-1]
     assert "Tighten the plan-review prompt wording." in claude_calls[1][-1]
     assert runner.comments[1].startswith("Still blocked.")
-    assert "### Future follow-ups" in runner.comments[1]
+    assert "### Future follow-ups" not in runner.comments[1]
 
 
 def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):


### PR DESCRIPTION
Fixes #155

## Summary
- route plan review and plan revision through structured parsing first with strict JSON-prefix/footer validation
- normalize structured planning comments and canonical plan rendering for prompts, hashing, posting, and resume
- update planning prompts and add regression coverage for structured parsing, rendering, and resume behavior

## Testing
- python3 -m pytest tests/test_agent_loop.py