### PR TITLE
#140 Phase 5: migrate coder follow-ups and human-requirements handling

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -68,6 +68,7 @@ from .protocol import (
     SIGNATURE_RE,
     ParsedReview,
     ReviewItemDisposition,
+    StructuredCoderFollowup,
     StructuredPlanRevision,
     UnresolvedReviewItem,
     human_requirements_resolved,
@@ -79,6 +80,8 @@ from .protocol import (
     parse_pr_number,
     review_freeform_summary_text,
     validate_human_requirements_acknowledgement,
+    validate_structured_coder_followup,
+    validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_revision,
 )
 from .protocol import ApprovedFollowup, parse_review
@@ -488,11 +491,20 @@ def _reconcile_human_requirements_ack_item(
 
     prompt_context = render_coder_human_requirements_prompt_context(human_requirements)
     try:
-        validate_human_requirements_acknowledgement(
-            coder_output,
-            surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
-            requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
-        )
+        structured_followup = validate_structured_coder_followup(coder_output)
+        if structured_followup is not None:
+            validate_structured_human_requirements_acknowledgement(
+                structured_followup.human_requirements.addressed_ids,
+                checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
+                surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+                requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+            )
+        else:
+            validate_human_requirements_acknowledgement(
+                coder_output,
+                surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+                requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+            )
     except AgentLoopError as exc:
         return _upsert_human_requirements_ack_item(
             unresolved_items,
@@ -531,6 +543,65 @@ def _merge_human_requirements(
     combined = list(issue_context.human_requirements if issue_context is not None else ())
     combined.extend(pr_context.human_requirements)
     return tuple(sorted(combined, key=lambda requirement: requirement.created_at or ""))
+
+
+def _validate_structured_coder_followup_items(
+    parsed: StructuredCoderFollowup,
+    *,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+) -> None:
+    expected_ids = [
+        item.item_id for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+    ]
+    listed_ids = [*parsed.addressed_items, *parsed.remaining_items]
+    duplicates = sorted({item_id for item_id in listed_ids if listed_ids.count(item_id) > 1})
+    if duplicates:
+        raise AgentLoopError(
+            "Coder follow-up listed unresolved reviewer item IDs more than once: "
+            + ", ".join(duplicates)
+        )
+    unknown = sorted(set(listed_ids) - set(expected_ids))
+    if unknown:
+        raise AgentLoopError(
+            "Coder follow-up referenced unknown unresolved reviewer item IDs: "
+            + ", ".join(unknown)
+        )
+    missing = sorted(set(expected_ids) - set(listed_ids))
+    if missing:
+        raise AgentLoopError(
+            "Coder follow-up did not classify all unresolved reviewer items into addressed or remaining: "
+            + ", ".join(missing)
+        )
+
+
+def _validate_coder_followup_response(
+    text: str,
+    *,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    human_requirements,
+) -> StructuredCoderFollowup | str:
+    prompt_context = render_coder_human_requirements_prompt_context(human_requirements)
+    structured_followup = validate_structured_coder_followup(text)
+    if structured_followup is not None:
+        _validate_structured_coder_followup_items(
+            structured_followup,
+            unresolved_items=unresolved_items,
+        )
+        validate_structured_human_requirements_acknowledgement(
+            structured_followup.human_requirements.addressed_ids,
+            checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
+            surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+            requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+        )
+        return structured_followup
+
+    state = parse_agent_state(text)
+    validate_human_requirements_acknowledgement(
+        text,
+        surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+        requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+    )
+    return state
 
 
 def _apply_unresolved_item_dispositions(
@@ -2670,7 +2741,11 @@ def run_pr_loop(
                 prompt=followup_prompt,
                 session_id=coder_session_id,
                 marker_description="<!-- AGENT_STATE: approved|blocking -->",
-                validate=parse_agent_state,
+                validate=lambda text, items=tuple(unresolved_items), human_requirements=human_requirements: _validate_coder_followup_response(
+                    text,
+                    unresolved_items=items,
+                    human_requirements=human_requirements,
+                ),
                 usage_context=usage_context,
             )
             coder_output = coder_response.text

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -352,6 +352,56 @@ If any signed human requirement in this set is unresolved, return blocking.
 """
 
 
+def _structured_coder_followup_guidance(
+    *,
+    reviewer_name: str,
+    human_requirements_context: CoderHumanRequirementsPromptContext,
+) -> str:
+    lines = [
+        f"Prefer this structured JSON follow-up format first so {reviewer_name} and the orchestrator can validate your response deterministically:",
+        "",
+        "```json",
+        "{",
+        '  "schema_version": 1,',
+        '  "kind": "coder_followup",',
+        '  "state": "blocking",',
+        '  "summary": "Implemented the requested fix and left one reviewer item for follow-up.",',
+        '  "addressed_items": ["item-1"],',
+        '  "remaining_items": ["item-2"],',
+        '  "human_requirements": {',
+        '    "addressed_ids": ["Requirement 1"],',
+        '    "checked_discussion_directly": false',
+        "  },",
+        '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
+        "}",
+        "```",
+        "",
+        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `tests_run` is optional.",
+        "The response must begin with exactly one top-level JSON object and must not include prose before or between the JSON and footer.",
+        "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->` and your signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
+        "Use `addressed_items` and `remaining_items` to classify the unresolved reviewer item IDs shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
+    ]
+    if human_requirements_context.block:
+        if human_requirements_context.surfaced_requirement_ids:
+            surfaced = ", ".join(f"`{item}`" for item in human_requirements_context.surfaced_requirement_ids)
+            lines.append(
+                "In structured replies, set `human_requirements.addressed_ids` to exactly the surfaced signed human requirement IDs you addressed in this prompt: "
+                f"{surfaced}."
+            )
+        elif human_requirements_context.requires_direct_discussion_ack:
+            lines.append(
+                "If the prompt omitted detailed signed human requirements, set `human_requirements.addressed_ids` to `[]` and `human_requirements.checked_discussion_directly` to `true` only after checking the GitHub discussion directly."
+            )
+    lines.extend(
+        [
+            "",
+            "Markdown follow-up output remains a compatibility fallback during migration when you are not using the structured JSON format.",
+            f"Legacy markdown replies must still include `{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}` and a `### Human requirements` section when signed human reviewer requirements are present.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
 def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewItem] | None) -> str:
     if not unresolved_items:
         return ""
@@ -1130,7 +1180,10 @@ Do not create a new PR.
 
 {review}
 
-This is round {round_number}. End your final response with exactly one marker:
+{_structured_coder_followup_guidance(
+    reviewer_name=reviewer_name,
+    human_requirements_context=human_requirements_context,
+)}This is round {round_number}. End your final response with exactly one marker:
 
 <!-- AGENT_STATE: blocking -->
 
@@ -1175,7 +1228,10 @@ Same-PR follow-ups:
 
 {review}
 
-This is round {round_number}. End your final response with exactly one marker:
+{_structured_coder_followup_guidance(
+    reviewer_name=reviewer_name,
+    human_requirements_context=human_requirements_context,
+)}This is round {round_number}. End your final response with exactly one marker:
 
 <!-- AGENT_STATE: blocking -->
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -291,20 +291,48 @@ def validate_human_requirements_acknowledgement(
     surfaced_requirement_ids: Sequence[str],
     requires_direct_discussion_ack: bool,
 ) -> None:
+    parsed = parse_human_requirements_acknowledgement(text)
+    validate_structured_human_requirements_acknowledgement(
+        parsed.addressed_ids,
+        checked_discussion_directly=HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK_RE.search(
+            parsed.section_text
+        )
+        is not None,
+        surfaced_requirement_ids=surfaced_requirement_ids,
+        requires_direct_discussion_ack=requires_direct_discussion_ack,
+        marker_present=parsed.marker_present,
+        section_present=parsed.section_present,
+    )
+
+
+def validate_structured_human_requirements_acknowledgement(
+    addressed_ids: Sequence[str],
+    *,
+    checked_discussion_directly: bool,
+    surfaced_requirement_ids: Sequence[str],
+    requires_direct_discussion_ack: bool,
+    marker_present: bool = True,
+    section_present: bool = True,
+) -> None:
     if not surfaced_requirement_ids and not requires_direct_discussion_ack:
         return
 
-    parsed = parse_human_requirements_acknowledgement(text)
-    if not parsed.marker_present:
+    if not marker_present:
         raise AgentLoopError(
             "Coder response missing required signed human requirements marker "
             f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}."
         )
-    if not parsed.section_present:
+    if not section_present:
         raise AgentLoopError("Coder response missing required `### Human requirements` section.")
 
-    addressed_ids = list(parsed.addressed_ids)
-    duplicates = sorted({item_id for item_id in addressed_ids if addressed_ids.count(item_id) > 1})
+    normalized_addressed_ids = [_normalize_requirement_label(item_id) for item_id in addressed_ids]
+    duplicates = sorted(
+        {
+            item_id
+            for item_id in normalized_addressed_ids
+            if normalized_addressed_ids.count(item_id) > 1
+        }
+    )
     if duplicates:
         raise AgentLoopError(
             "Coder response listed signed human requirement IDs more than once: "
@@ -312,7 +340,7 @@ def validate_human_requirements_acknowledgement(
         )
 
     expected_ids = tuple(_normalize_requirement_label(item_id) for item_id in surfaced_requirement_ids)
-    unknown = sorted(set(addressed_ids) - set(expected_ids))
+    unknown = sorted(set(normalized_addressed_ids) - set(expected_ids))
     if unknown:
         raise AgentLoopError(
             "Coder response referenced unknown signed human requirement IDs: "
@@ -320,7 +348,7 @@ def validate_human_requirements_acknowledgement(
         )
 
     if expected_ids:
-        missing = sorted(set(expected_ids) - set(addressed_ids))
+        missing = sorted(set(expected_ids) - set(normalized_addressed_ids))
         if missing:
             raise AgentLoopError(
                 "Coder response did not address all surfaced signed human requirement IDs: "
@@ -328,7 +356,7 @@ def validate_human_requirements_acknowledgement(
             )
         return
 
-    if not HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK_RE.search(parsed.section_text):
+    if not checked_discussion_directly:
         raise AgentLoopError(
             "Coder response must acknowledge that the prompt omitted the detailed signed human requirements "
             f"and that it {HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK}."
@@ -591,6 +619,20 @@ def _extract_structured_plan_revision_payload(text: str) -> dict[str, object] | 
         state_marker_name="AGENT_PLAN_STATE",
         context_label="Structured plan revision",
         allow_human_requirements_prefix=True,
+    )
+
+
+def _extract_structured_coder_followup_payload(text: str) -> dict[str, object] | None:
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    return _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=STATE_RE,
+        state_marker_name="AGENT_STATE",
+        context_label="Structured coder follow-up",
     )
 
 
@@ -859,74 +901,71 @@ def parse_structured_plan_review(text: str, *, reviewer: str) -> ParsedPlanRevie
 
 
 def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | None:
-    payload = _extract_structured_response_object(text)
+    payload = _extract_structured_coder_followup_payload(text)
     if payload is None:
         return None
     _require_supported_schema_version(payload)
     kind = payload.get("kind")
     if isinstance(kind, str) and kind != "coder_followup":
         raise AgentLoopError("Structured response kind mismatch: expected `coder_followup`.")
-    try:
-        _expect_exact_keys(
-            payload,
-            context="coder_followup",
-            required={
-                "schema_version",
-                "kind",
-                "state",
-                "summary",
-                "addressed_items",
-                "remaining_items",
-                "human_requirements",
-            },
-            optional={"tests_run"},
+    _expect_exact_keys(
+        payload,
+        context="coder_followup",
+        required={
+            "schema_version",
+            "kind",
+            "state",
+            "summary",
+            "addressed_items",
+            "remaining_items",
+            "human_requirements",
+        },
+        optional={"tests_run"},
+    )
+    human_requirements_payload = _expect_object(
+        payload["human_requirements"],
+        context="coder_followup.human_requirements",
+    )
+    _expect_exact_keys(
+        human_requirements_payload,
+        context="coder_followup.human_requirements",
+        required={"addressed_ids", "checked_discussion_directly"},
+    )
+    tests_run_value = payload.get("tests_run")
+    tests_run = (
+        _expect_string_list(
+            tests_run_value,
+            context="coder_followup.tests_run",
+            item_context="coder_followup.tests_run",
         )
-        human_requirements_payload = _expect_object(
-            payload["human_requirements"],
-            context="coder_followup.human_requirements",
-        )
-        _expect_exact_keys(
-            human_requirements_payload,
-            context="coder_followup.human_requirements",
-            required={"addressed_ids", "checked_discussion_directly"},
-        )
-        tests_run_value = payload.get("tests_run")
-        tests_run = (
-            _expect_string_list(
-                tests_run_value,
-                context="coder_followup.tests_run",
-                item_context="coder_followup.tests_run",
-            )
-            if tests_run_value is not None
-            else None
-        )
-        return StructuredCoderFollowup(
-            schema_version=1,
-            kind="coder_followup",
-            state=_expect_state(payload["state"], context="coder_followup.state"),
-            summary=_expect_non_empty_string(payload["summary"], context="coder_followup.summary"),
-            addressed_items=_expect_item_id_list(
-                payload["addressed_items"],
-                context="coder_followup.addressed_items",
+        if tests_run_value is not None
+        else None
+    )
+    return StructuredCoderFollowup(
+        schema_version=1,
+        kind="coder_followup",
+        state=_expect_state(payload["state"], context="coder_followup.state"),
+        summary=_expect_non_empty_string(payload["summary"], context="coder_followup.summary"),
+        addressed_items=_expect_item_id_list(
+            payload["addressed_items"],
+            context="coder_followup.addressed_items",
+        ),
+        remaining_items=_expect_item_id_list(
+            payload["remaining_items"],
+            context="coder_followup.remaining_items",
+        ),
+        human_requirements=StructuredHumanRequirementsPayload(
+            addressed_ids=_expect_requirement_id_list(
+                human_requirements_payload["addressed_ids"],
+                context="coder_followup.human_requirements.addressed_ids",
             ),
-            remaining_items=_expect_item_id_list(
-                payload["remaining_items"],
-                context="coder_followup.remaining_items",
+            checked_discussion_directly=_expect_bool(
+                human_requirements_payload["checked_discussion_directly"],
+                context="coder_followup.human_requirements.checked_discussion_directly",
             ),
-            human_requirements=StructuredHumanRequirementsPayload(
-                addressed_ids=_expect_requirement_id_list(
-                    human_requirements_payload["addressed_ids"],
-                    context="coder_followup.human_requirements.addressed_ids",
-                ),
-                checked_discussion_directly=_expect_bool(
-                    human_requirements_payload["checked_discussion_directly"],
-                    context="coder_followup.human_requirements.checked_discussion_directly",
-                ),
-            ),
-            tests_run=tests_run,
-        )
-    except AgentLoopError:
-        return None
+        ),
+        tests_run=tests_run,
+    )
 
 
 def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | None:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -66,10 +66,12 @@ from coding_review_agent_loop.orchestrator import (
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
     _render_public_review_comment,
+    _reconcile_human_requirements_ack_item,
     _review_freeform_summary_text,
     _resume_pr_round,
     _resume_plan_round,
     _strip_round_metadata,
+    _validate_coder_followup_response,
     _validate_review_response,
     _validate_plan_review_response,
     render_canonical_plan_revision,
@@ -111,6 +113,7 @@ from coding_review_agent_loop.protocol import (
     UnresolvedReviewItem,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
+    validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_revision,
 )
 
@@ -2577,20 +2580,23 @@ def test_parse_structured_plan_review_rejects_blocking_future_followups():
 
 
 def test_validate_structured_coder_followup_accepts_v1_payload():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "coder_followup",
-            "state": "blocking",
-            "summary": "Addressed the first item; one remains.",
-            "addressed_items": ["item-1"],
-            "remaining_items": ["item-2"],
-            "human_requirements": {
-                "addressed_ids": ["Requirement 1"],
-                "checked_discussion_directly": False,
-            },
-            "tests_run": ["python -m pytest tests/test_agent_loop.py -k structured"],
-        }
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Addressed the first item; one remains.",
+                "addressed_items": ["item-1"],
+                "remaining_items": ["item-2"],
+                "human_requirements": {
+                    "addressed_ids": ["Requirement 1"],
+                    "checked_discussion_directly": False,
+                },
+                "tests_run": ["python -m pytest tests/test_agent_loop.py -k structured"],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
     )
 
     parsed = validate_structured_coder_followup(payload)
@@ -2601,24 +2607,132 @@ def test_validate_structured_coder_followup_accepts_v1_payload():
     assert parsed.human_requirements.addressed_ids == ("Requirement 1",)
 
 
-def test_validate_structured_coder_followup_rejects_unknown_keys_via_fallback():
-    payload = json.dumps(
-        {
-            "schema_version": 1,
-            "kind": "coder_followup",
-            "state": "approved",
-            "summary": "Done.",
-            "addressed_items": [],
-            "remaining_items": [],
-            "human_requirements": {
-                "addressed_ids": [],
-                "checked_discussion_directly": True,
-                "extra": "nope",
-            },
-        }
+def test_validate_structured_coder_followup_returns_none_when_no_structured_candidate_exists():
+    assert (
+        validate_structured_coder_followup(
+            "Implemented the fix.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+        )
+        is None
     )
 
-    assert validate_structured_coder_followup(payload) is None
+
+def test_validate_structured_coder_followup_rejects_unknown_keys_in_structured_candidate():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "approved",
+                "summary": "Done.",
+                "addressed_items": [],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": True,
+                    "extra": "nope",
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="unknown field\\(s\\): extra"):
+        validate_structured_coder_followup(payload)
+
+
+def test_validate_structured_coder_followup_rejects_footer_state_mismatch():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Done.",
+                "addressed_items": [],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": True,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="footer AGENT_STATE must match the payload state"):
+        validate_structured_coder_followup(payload)
+
+
+def test_validate_structured_coder_followup_rejects_trailing_prose_after_footer():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Done.",
+                "addressed_items": [],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": True,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex\nextra"
+    )
+
+    with pytest.raises(AgentLoopError, match="may not include trailing prose"):
+        validate_structured_coder_followup(payload)
+
+
+@pytest.mark.parametrize(
+    ("addressed_ids", "checked_discussion_directly", "surfaced_ids", "requires_direct_discussion_ack", "message"),
+    [
+        (
+            ("Requirement 1",),
+            False,
+            ("Requirement 1", "Requirement 2"),
+            False,
+            "did not address all surfaced signed human requirement IDs",
+        ),
+        (
+            ("Requirement 1", "Requirement 1"),
+            False,
+            ("Requirement 1",),
+            False,
+            "listed signed human requirement IDs more than once",
+        ),
+        (
+            ("Requirement 99",),
+            False,
+            ("Requirement 1",),
+            False,
+            "referenced unknown signed human requirement IDs",
+        ),
+        (
+            (),
+            False,
+            (),
+            True,
+            "must acknowledge that the prompt omitted the detailed signed human requirements",
+        ),
+    ],
+)
+def test_validate_structured_human_requirements_acknowledgement_rejects_invalid_payloads(
+    addressed_ids,
+    checked_discussion_directly,
+    surfaced_ids,
+    requires_direct_discussion_ack,
+    message,
+):
+    with pytest.raises(AgentLoopError, match=message):
+        validate_structured_human_requirements_acknowledgement(
+            addressed_ids,
+            checked_discussion_directly=checked_discussion_directly,
+            surfaced_requirement_ids=surfaced_ids,
+            requires_direct_discussion_ack=requires_direct_discussion_ack,
+        )
 
 
 def test_validate_structured_plan_revision_accepts_v1_payload():
@@ -3107,6 +3221,113 @@ def test_validate_review_response_accepts_structured_pr_review():
     assert [item.text for item in parsed.blocking_items] == [
         "Add the mixed-history regression case to the suite."
     ]
+
+
+def test_validate_coder_followup_response_accepts_structured_item_partition():
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Add a regression test.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="Anthropic Claude",
+            source_round=1,
+            text="Rename the helper.",
+            status="same-pr",
+        ),
+        UnresolvedReviewItem(
+            item_id=HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=1,
+            text="Ack missing.",
+            status="blocking",
+        ),
+    )
+    response = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Addressed the test, helper rename still pending.",
+                "addressed_items": ["item-1"],
+                "remaining_items": ["item-2"],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = _validate_coder_followup_response(
+        response,
+        unresolved_items=unresolved_items,
+        human_requirements=(),
+    )
+
+    assert parsed.addressed_items == ("item-1",)
+    assert parsed.remaining_items == ("item-2",)
+
+
+@pytest.mark.parametrize(
+    ("addressed_items", "remaining_items", "message"),
+    [
+        (["item-1"], ["item-1"], "listed unresolved reviewer item IDs more than once"),
+        (["item-9"], [], "referenced unknown unresolved reviewer item IDs"),
+        (["item-1"], [], "did not classify all unresolved reviewer items"),
+    ],
+)
+def test_validate_coder_followup_response_rejects_invalid_structured_item_partition(
+    addressed_items,
+    remaining_items,
+    message,
+):
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Add a regression test.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="Anthropic Claude",
+            source_round=1,
+            text="Rename the helper.",
+            status="same-pr",
+        ),
+    )
+    response = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Status update.",
+                "addressed_items": addressed_items,
+                "remaining_items": remaining_items,
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match=message):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=unresolved_items,
+            human_requirements=(),
+        )
 
 
 def test_render_public_pr_review_comment_uses_normalized_sections_and_footer():
@@ -3850,8 +4071,8 @@ def test_coder_followup_prompts_require_human_requirements_acknowledgement_only_
     assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER in with_requirements
     assert "### Human requirements" in with_requirements
     assert "`Requirement 1`" in with_requirements
-    assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER not in without_requirements
-    assert "### Human requirements" not in without_requirements
+    assert "mandatory next-revision requirements" not in without_requirements
+    assert "`Requirement 1`" not in without_requirements
 
 
 @pytest.mark.parametrize("builder", [build_followup_prompt, build_same_pr_followup_prompt])
@@ -3880,6 +4101,21 @@ def test_coder_followup_prompts_accept_precomputed_human_requirements_context(tm
     assert context.block in prompt
     assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER in prompt
     assert "`Requirement 1`" in prompt
+
+
+@pytest.mark.parametrize("builder", [build_followup_prompt, build_same_pr_followup_prompt])
+def test_coder_followup_prompts_prefer_structured_json_but_keep_markdown_fallback(tmp_path, builder):
+    config = make_config(tmp_path)
+
+    prompt = builder(77, 2, "Fix the bug.", config)
+
+    assert '"kind": "coder_followup"' in prompt
+    assert '"addressed_items": ["item-1"]' in prompt
+    assert '"remaining_items": ["item-2"]' in prompt
+    assert '"human_requirements": {' in prompt
+    assert "The JSON `state` must match the `AGENT_STATE` footer exactly." in prompt
+    assert "Markdown follow-up output remains a compatibility fallback during migration" in prompt
+    assert "Legacy markdown replies must still include" in prompt
 
 
 def test_validate_human_requirements_acknowledgement_accepts_multiple_bullet_styles():
@@ -4409,103 +4645,137 @@ def test_pr_loop_allows_approval_with_human_requirement_resolution_marker(tmp_pa
     assert ["pytest", "tests/test_agent_loop.py"] in commands
 
 
-def test_pr_loop_surfaces_coder_human_requirements_acknowledgement_blocker_next_round(tmp_path):
+def test_pr_loop_accepts_structured_coder_followup_in_pr_round(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "coder_followup",
+                    "state": "blocking",
+                    "summary": "Added the requested regression test.",
+                    "addressed_items": ["item-1"],
+                    "remaining_items": [],
+                    "human_requirements": {
+                        "addressed_ids": [],
+                        "checked_discussion_directly": False,
+                    },
+                    "tests_run": ["pytest tests/test_agent_loop.py -k structured_coder_followup"],
+                }
+            )
+            + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
         ],
         codex_outputs=[
-            "Blocking issue."
-            "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "Still blocked."
-            + prior_item_dispositions(
-                "[item-1] resolved",
-                f"[{HUMAN_REQUIREMENTS_ACK_ITEM_ID}] still blocking",
-            )
+            "Need one more regression test before merge."
+            + blocking_issues("Add the structured coder follow-up regression case.")
             + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
-        pr_payload={
-            "number": 77,
-            "state": "OPEN",
-            "url": "https://github.com/OWNER/REPO/pull/77",
-            "title": "Improve review prompt context",
-            "headRefName": "feature/review-context",
-            "baseRefName": "main",
-            "headRefOid": "abc123",
-            "comments": [
-                {
-                    "author": {"login": "maintainer"},
-                    "createdAt": "2026-05-18T10:00:00Z",
-                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
-                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
-                }
-            ],
-            "reviews": [],
-        },
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
 
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert any('"kind": "coder_followup"' in comment for comment in runner.comments)
+
+
+def test_pr_loop_rejects_malformed_structured_coder_followup_before_re_review(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "coder_followup",
+                    "state": "blocking",
+                    "summary": "Tried to handle the feedback.",
+                    "addressed_items": ["item-9"],
+                    "remaining_items": [],
+                    "human_requirements": {
+                        "addressed_ids": [],
+                        "checked_discussion_directly": False,
+                    },
+                }
+            )
+            + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+        ],
+        codex_outputs=[
+            "Need one more regression test before merge."
+            + blocking_issues("Add the structured coder follow-up regression case.")
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer="codex",
+        max_rounds=2,
+        agent_max_retries=0,
+    )
+
     with pytest.raises(
         AgentLoopError,
-        match="One or more reviewers still reported blocking issues after round 2",
+        match="Coder follow-up referenced unknown unresolved reviewer item IDs: item-9",
     ):
         run_pr_loop(runner, pr_number=77, config=config)
 
-    review_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
-    assert len(review_prompts) == 2
-    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID in review_prompts[1]
-    assert "Coder response missing required signed human requirements marker" in review_prompts[1]
-    assert "Orchestrator" in review_prompts[1]
+
+def test_reconcile_human_requirements_ack_item_surfaces_markdown_ack_blocker():
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+            body="Please use the absolute URL.",
+        ),
+    )
+
+    reconciled = _reconcile_human_requirements_ack_item(
+        (),
+        coder_output="Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        human_requirements=human_requirements,
+        source_round=2,
+    )
+
+    assert [item.item_id for item in reconciled] == [HUMAN_REQUIREMENTS_ACK_ITEM_ID]
+    assert "missing required signed human requirements marker" in reconciled[0].text
 
 
-def test_pr_loop_clears_human_requirements_acknowledgement_blocker_before_next_review(tmp_path):
-    runner = FakeRunner(
-        claude_outputs=[
-            "Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+def test_reconcile_human_requirements_ack_item_clears_markdown_ack_blocker():
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+            body="Please use the absolute URL.",
+        ),
+    )
+
+    reconciled = _reconcile_human_requirements_ack_item(
+        (
+            UnresolvedReviewItem(
+                item_id=HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+                reviewer="Orchestrator",
+                source_round=1,
+                text="Ack missing.",
+                status="blocking",
+            ),
+        ),
+        coder_output=(
             "Implemented follow-up.\n"
             f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
             "### Human requirements\n"
             "- Requirement 1: updated the URL handling.\n"
-            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
-        ],
-        codex_outputs=[
-            "Blocking issue."
-            "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "Need coder acknowledgement."
-            + prior_item_dispositions(
-                "[item-1] resolved",
-                f"[{HUMAN_REQUIREMENTS_ACK_ITEM_ID}] still blocking",
-            )
-            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
-            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
-        ],
-        pr_payload={
-            "number": 77,
-            "state": "OPEN",
-            "url": "https://github.com/OWNER/REPO/pull/77",
-            "title": "Improve review prompt context",
-            "headRefName": "feature/review-context",
-            "baseRefName": "main",
-            "headRefOid": "abc123",
-            "comments": [
-                {
-                    "author": {"login": "maintainer"},
-                    "createdAt": "2026-05-18T10:00:00Z",
-                    "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
-                    "body": "Please use the absolute URL.\n\n-- Human Reviewer",
-                }
-            ],
-            "reviews": [],
-        },
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+        ),
+        human_requirements=human_requirements,
+        source_round=2,
     )
-    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
 
-    assert run_pr_loop(runner, pr_number=77, config=config) == 0
-
-    review_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
-    assert len(review_prompts) == 3
-    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID in review_prompts[1]
-    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID not in review_prompts[2]
+    assert reconciled == []
 
 
 def test_pr_loop_revalidates_latest_coder_output_against_refreshed_human_requirements(
@@ -4513,7 +4783,11 @@ def test_pr_loop_revalidates_latest_coder_output_against_refreshed_human_require
 ):
     runner = FakeRunner(
         claude_outputs=[
-            "Implemented fix without the extra acknowledgement.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Implemented fix with the required acknowledgement.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: updated the URL handling.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],
         codex_outputs=[
             "Blocking issue.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
@@ -6181,6 +6455,52 @@ def test_resume_pr_round_reparses_orchestrator_rendered_blocking_issues_comment(
         "Exercise the structured-resume path."
     ]
     assert resumed_review.summary == "Need one more regression test before merge."
+
+
+def test_reconcile_human_requirements_ack_item_accepts_stored_structured_coder_followup():
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="PR comment",
+            author="reviewer",
+            created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+            body="Please use the absolute URL.",
+        ),
+    )
+    structured_followup = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Implemented the requested URL fix.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": ["Requirement 1"],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+
+    reconciled = _reconcile_human_requirements_ack_item(
+        (
+            UnresolvedReviewItem(
+                item_id=HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+                reviewer="Orchestrator",
+                source_round=1,
+                text="Ack missing.",
+                status="blocking",
+            ),
+        ),
+        coder_output=structured_followup,
+        human_requirements=human_requirements,
+        source_round=2,
+    )
+
+    assert reconciled == []
 
 
 def test_pr_loop_does_not_expose_same_round_item_ids_to_later_reviewers(tmp_path):


### PR DESCRIPTION
## Summary
- add strict structured `coder_followup` parsing with required `AGENT_STATE` footer/state matching
- validate structured human-requirements acknowledgement and unresolved-item addressed/remaining mapping in PR follow-up turns
- document the preferred structured follow-up contract while keeping markdown fallback instructions and expand regression coverage

## Testing
- python3 -m pytest tests/test_agent_loop.py

Fixes #156