### PR TITLE
Stabilize mixed-history resume reconstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ separate coding and review passes:
 agent-loop pr 456 --repo OWNER/REPO --reviewer codex --reviewer claude
 ```
 
+Structured-response runs use a three-level interpretation order:
+
+1. Structured JSON payloads are authoritative when present in the agent output.
+2. For resume/replay, `AGENT_LOOP_META` attached to orchestrator-posted comments is the canonical source of the active round ledger, carried `prior_items`, completed reviewer dispositions, and next `item-N` allocation for that structured-response round.
+3. Markdown section parsing remains a compatibility fallback for interpreting comments that do not include a structured payload or metadata for the current round.
+
+Mixed histories are expected during rollout. Old raw-markdown comments can
+remain earlier in the issue or PR thread, while newer orchestrator-rendered
+comments carry `AGENT_LOOP_META`. When metadata exists for the current head or
+plan subject, resume reconstruction uses that metadata-backed ledger and ignores
+stale visible item IDs from older heads, superseded plans, or replayed rounds.
+
 When `--approved-followups` is set to `summarize`, `issue`, or a `fix-and-*`
 mode, approved reviews may include future work under:
 
@@ -279,6 +291,13 @@ Bullets and prose paragraphs inside the `Same-PR follow-ups`, `Future follow-ups
 and legacy `Non-blocking follow-ups` sections are parsed. Each section ends at
 the next heading, HTML marker, or agent signature, so final protocol markers
 are not mistaken for follow-up text.
+
+The remaining legacy compatibility surface is intentional:
+
+- Markdown review/plan parsing still accepts non-structured agent responses.
+- The legacy heading `### Non-blocking follow-ups` still maps to future work.
+- Resume reconstruction should not depend on reparsing old prose once
+  `AGENT_LOOP_META` exists for the active structured-response round.
 
 For trusted local automation that must run without approval prompts:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -402,6 +402,21 @@ include a final `AGENT_STATE` marker. Plan-first coder/reviewer responses use
 `AGENT_PLAN_STATE` instead. If a response quotes older markers, the final
 matching marker is treated as authoritative.
 
+Structured-response runs follow this fallback order:
+
+1. Structured JSON payloads in agent output are authoritative when present.
+2. `AGENT_LOOP_META` on orchestrator-posted comments is the canonical resume
+   source for the active structured-response round. It carries the current
+   ledger, reviewer dispositions, and item-number allocation.
+3. Markdown parsing is a compatibility fallback for comments that do not have a
+   structured payload or active-round metadata.
+
+Mixed histories are normal during rollout. A thread may contain old raw
+markdown comments, newer orchestrator-rendered comments, or both. When
+`AGENT_LOOP_META` exists for the current PR head or plan subject, resume uses
+that metadata-backed ledger and ignores stale visible item IDs from older heads,
+superseded plans, or replayed rounds.
+
 The loop validates required markers before posting agent output to GitHub. If
 an agent exits or returns only diagnostics, empty output, or normal prose
 without the required marker, the loop fails locally with `AgentLoopError` and
@@ -464,6 +479,15 @@ and legacy `Non-blocking follow-ups` sections are parsed; each section ends at
 the next heading, HTML marker, or agent signature. The same parsing is used
 when creating follow-up issues. The issue cap keeps one approved review from
 creating a large batch of low-value issues.
+
+The remaining legacy compatibility surface is intentionally narrow:
+
+- Markdown plan/review parsing stays enabled for agents that do not emit
+  structured JSON.
+- The legacy heading `### Non-blocking follow-ups` is still treated as future
+  work.
+- Resume reconstruction should rely on `AGENT_LOOP_META` instead of reparsing
+  old prose whenever metadata exists for the active round.
 
 ## Logs
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -179,6 +179,12 @@ class PostedRoundRecord:
 
 
 @dataclass(frozen=True)
+class ResumedRoundSelection:
+    anchor_record: PostedRoundRecord
+    current_round_records: tuple[PostedRoundRecord, ...]
+
+
+@dataclass(frozen=True)
 class ResumedReviewRound:
     round_number: int
     prior_items: tuple[UnresolvedReviewItem, ...]
@@ -1016,6 +1022,56 @@ def _extract_round_metadata_records(comments: Sequence[object], *, flow: str) ->
     return tuple(records)
 
 
+def _prior_item_ledger_signature(items: Sequence[UnresolvedReviewItem]) -> tuple[tuple[str, str, int, str, str, str | None, tuple[str, ...]], ...]:
+    return tuple(
+        (
+            item.item_id,
+            item.reviewer,
+            item.source_round,
+            item.text,
+            item.status,
+            item.source_status,
+            item.notes,
+        )
+        for item in items
+    )
+
+
+def _select_current_round_records(
+    records: Sequence[PostedRoundRecord],
+    *,
+    subject: str,
+) -> ResumedRoundSelection | None:
+    subject_records = [record for record in records if record.metadata.subject == subject]
+    if not subject_records:
+        return None
+    anchor_record = subject_records[-1]
+    anchor_metadata = anchor_record.metadata
+    prior_items_signature = _prior_item_ledger_signature(anchor_metadata.prior_items)
+    current_round_records = tuple(
+        record
+        for record in subject_records
+        if record.metadata.round_number == anchor_metadata.round_number
+        and _prior_item_ledger_signature(record.metadata.prior_items) == prior_items_signature
+    )
+    latest_coder_record = next(
+        (
+            record
+            for record in reversed(current_round_records)
+            if record.metadata.role == "coder"
+        ),
+        None,
+    )
+    if latest_coder_record is not None:
+        current_round_records = tuple(
+            record for record in current_round_records if record.index >= latest_coder_record.index
+        )
+    return ResumedRoundSelection(
+        anchor_record=anchor_record,
+        current_round_records=current_round_records,
+    )
+
+
 def _max_unresolved_item_number_from_records(records: Sequence[PostedRoundRecord]) -> int:
     max_number = 0
     for record in records:
@@ -1071,22 +1127,19 @@ def _resume_pr_round(
     records = _extract_round_metadata_records(comments, flow="pr")
     if not records:
         return None
-    current_subject_records = [record for record in records if record.metadata.subject == head_sha]
-    if not current_subject_records:
+    selection = _select_current_round_records(records, subject=head_sha)
+    if selection is None:
         return None
+    current_round_records = selection.current_round_records
+    anchor_metadata = selection.anchor_record.metadata
     latest_coder_record = next(
         (
             record
-            for record in reversed(current_subject_records)
+            for record in reversed(current_round_records)
             if record.metadata.role == "coder"
         ),
         None,
     )
-    current_round_records = current_subject_records
-    if latest_coder_record is not None:
-        current_round_records = [
-            record for record in current_round_records if record.index >= latest_coder_record.index
-        ]
     reviewer_records: dict[str, PostedRoundRecord] = {}
     configured_reviewer_names = {agent_display_name(agent) for agent in configured_reviewers}
     for record in current_round_records:
@@ -1096,22 +1149,17 @@ def _resume_pr_round(
         reviewer_records[metadata.agent] = record
     if latest_coder_record is None and not reviewer_records:
         return None
-    prior_items = ()
-    if latest_coder_record is not None:
-        prior_items = latest_coder_record.metadata.prior_items
-    elif reviewer_records:
-        prior_items = next(iter(reviewer_records.values())).metadata.prior_items
-    round_number = (
-        latest_coder_record.metadata.round_number
-        if latest_coder_record is not None
-        else next(iter(reviewer_records.values())).metadata.round_number
-    )
+    prior_items = anchor_metadata.prior_items
+    round_number = anchor_metadata.round_number
     return ResumedReviewRound(
         round_number=round_number,
         prior_items=prior_items,
         coder_output=latest_coder_record.body if latest_coder_record is not None else None,
         completed_reviews=tuple(reviewer_records[agent_display_name(agent)] for agent in configured_reviewers if agent_display_name(agent) in reviewer_records),
-        next_unresolved_item_number=_max_unresolved_item_number_from_records(records) + 1,
+        next_unresolved_item_number=_max_unresolved_item_number_from_records(
+            [record for record in records if record.metadata.subject == head_sha]
+        )
+        + 1,
     )
 
 
@@ -1123,18 +1171,15 @@ def _resume_plan_round(
     records = _extract_round_metadata_records(comments, flow="plan")
     if not records:
         return None
-    latest_coder_record = next(
-        (record for record in reversed(records) if record.metadata.role == "coder"),
-        None,
-    )
+    latest_coder_record = next((record for record in reversed(records) if record.metadata.role == "coder"), None)
     if latest_coder_record is None:
         return None
-    subject = latest_coder_record.metadata.subject
-    current_round_records = [
-        record
-        for record in records
-        if record.metadata.subject == subject and record.index >= latest_coder_record.index
-    ]
+    selection = _select_current_round_records(records, subject=latest_coder_record.metadata.subject)
+    if selection is None:
+        return None
+    current_round_records = selection.current_round_records
+    anchor_metadata = selection.anchor_record.metadata
+    current_plan = latest_coder_record.metadata.canonical_plan or latest_coder_record.body
     reviewer_records: dict[str, PostedRoundRecord] = {}
     configured_reviewer_names = {agent_display_name(agent) for agent in configured_reviewers}
     for record in current_round_records:
@@ -1143,15 +1188,37 @@ def _resume_plan_round(
             continue
         reviewer_records[metadata.agent] = record
     return (
-        latest_coder_record.metadata.canonical_plan or latest_coder_record.body,
+        current_plan,
         ResumedReviewRound(
-            round_number=latest_coder_record.metadata.round_number,
-            prior_items=latest_coder_record.metadata.prior_items,
-            coder_output=latest_coder_record.metadata.canonical_plan or latest_coder_record.body,
+            round_number=anchor_metadata.round_number,
+            prior_items=anchor_metadata.prior_items,
+            coder_output=current_plan,
             completed_reviews=tuple(reviewer_records[agent_display_name(agent)] for agent in configured_reviewers if agent_display_name(agent) in reviewer_records),
-            next_unresolved_item_number=_max_unresolved_item_number_from_records(records) + 1,
+            next_unresolved_item_number=_max_unresolved_item_number_from_records(
+                [record for record in records if record.metadata.subject == anchor_metadata.subject]
+            )
+            + 1,
         ),
     )
+
+
+def _record_prior_item_disposition(
+    prior_dispositions: dict[str, list[ReviewItemDisposition]],
+    disposition: ReviewItemDisposition,
+    *,
+    flow: str,
+    round_number: int,
+    subject: str,
+    reviewer_name: str,
+) -> None:
+    if disposition.item_id not in prior_dispositions:
+        raise AgentLoopError(
+            "Resumed "
+            f"{flow} round {round_number} reconstructed prior items "
+            f"{', '.join(sorted(prior_dispositions)) or '(none)'}, but {reviewer_name} "
+            f"dispositioned unknown item `{disposition.item_id}` for subject `{subject}`."
+        )
+    prior_dispositions[disposition.item_id].append(disposition)
 
 
 def _render_public_review_comment(
@@ -1888,7 +1955,14 @@ def _run_plan_first_loop(
                 f"{round_number}: {reviewer_name} outcome is {_describe_plan_review_outcome(parsed_review)}",
             )
             for disposition in parsed_review.dispositions:
-                prior_dispositions[disposition.item_id].append(disposition)
+                _record_prior_item_disposition(
+                    prior_dispositions,
+                    disposition,
+                    flow="plan",
+                    round_number=round_number,
+                    subject=_plan_subject(current_plan),
+                    reviewer_name=reviewer_name,
+                )
             if review_state == "blocking":
                 all_approved = False
                 blocking_reviews.append((reviewer_name, review_output))
@@ -2461,7 +2535,14 @@ def run_pr_loop(
                     reviewer_new_unresolved_items = []
 
                 for disposition in parsed_review.dispositions:
-                    prior_dispositions[disposition.item_id].append(disposition)
+                    _record_prior_item_disposition(
+                        prior_dispositions,
+                        disposition,
+                        flow="pr",
+                        round_number=round_number,
+                        subject=str(pr_metadata.head_sha or "unknown"),
+                        reviewer_name=reviewer_name,
+                    )
                 blocking_summary = parsed_review.summary
                 has_blocking_summary = _should_record_new_blocking_item(
                     blocking_summary,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -6457,6 +6457,194 @@ def test_resume_pr_round_reparses_orchestrator_rendered_blocking_issues_comment(
     assert resumed_review.summary == "Need one more regression test before merge."
 
 
+def test_resume_pr_round_prefers_latest_metadata_ledger_for_same_head_replay():
+    stale_item = UnresolvedReviewItem(
+        item_id="item-3",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Stale replay item.",
+        status="blocking",
+        source_status="blocking",
+    )
+    active_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Active replay item.",
+        status="blocking",
+        source_status="blocking",
+    )
+    stale_coder_comment = _attach_round_metadata(
+        "Stale replay.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(stale_item,),
+        ),
+    )
+    stale_reviewer_comment = _attach_round_metadata(
+        "Still blocked."
+        + prior_item_dispositions("[item-3] still blocking: stale replay")
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=2,
+            subject="abc123",
+            prior_items=(stale_item,),
+            dispositions=(
+                parse_unresolved_item_dispositions(
+                    prior_item_dispositions("[item-3] still blocking: stale replay"),
+                    reviewer="OpenAI Codex",
+                )[0],
+            ),
+            state="blocking",
+        ),
+    )
+    active_coder_comment = _attach_round_metadata(
+        "Current replay.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(active_item,),
+        ),
+    )
+    active_reviewer_comment = _attach_round_metadata(
+        "Looks good."
+        + prior_item_dispositions("[item-1] resolved")
+        + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Gemini",
+            round_number=2,
+            subject="abc123",
+            prior_items=(active_item,),
+            dispositions=(
+                parse_unresolved_item_dispositions(
+                    prior_item_dispositions("[item-1] resolved"),
+                    reviewer="Google Gemini",
+                )[0],
+            ),
+            state="approved",
+        ),
+    )
+    previous_head_comment = _attach_round_metadata(
+        "Older head.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=4,
+            subject="old-head",
+            prior_items=(
+                UnresolvedReviewItem(
+                    item_id="item-9",
+                    reviewer="OpenAI Codex",
+                    source_round=3,
+                    text="Older head item.",
+                    status="blocking",
+                ),
+            ),
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=previous_head_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=stale_coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:02:00Z", body=stale_reviewer_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:03:00Z", body=active_coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:04:00Z", body=active_reviewer_comment),
+        ],
+        head_sha="abc123",
+        configured_reviewers=("codex", "gemini"),
+    )
+
+    assert resumed is not None
+    assert [item.item_id for item in resumed.prior_items] == ["item-1"]
+    assert resumed.next_unresolved_item_number == 4
+    assert [record.metadata.agent for record in resumed.completed_reviews] == ["Gemini"]
+
+
+def test_pr_loop_resume_hybrid_history_prefers_metadata_ledger_over_legacy_markdown(tmp_path):
+    carried_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Add a regression test before merge.",
+        status="blocking",
+        source_status="blocking",
+    )
+    legacy_comment = (
+        "Legacy raw markdown review.\n\n"
+        "### Blocking issues\n"
+        "- Keep the legacy fallback path.\n"
+        "<!-- AGENT_STATE: blocking -->\n"
+        "-- OpenAI Codex"
+    )
+    coder_comment = _attach_round_metadata(
+        "Updated the PR.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+        ),
+    )
+    codex_comment = _attach_round_metadata(
+        "Looks good."
+        + prior_item_dispositions("[item-1] resolved")
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+            dispositions=(
+                parse_unresolved_item_dispositions(
+                    prior_item_dispositions("[item-1] resolved"),
+                    reviewer="OpenAI Codex",
+                )[0],
+            ),
+            state="approved",
+        ),
+    )
+    runner = FakeRunner(
+        gemini_outputs=[
+            "Ship it."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+        ],
+        pr_payload={
+            "comments": [
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:00:00Z", "body": legacy_comment},
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:05:00Z", "body": coder_comment},
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:06:00Z", "body": codex_comment},
+            ],
+        },
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    gemini_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"])
+    assert "[item-1]" in gemini_prompt
+    assert "Add a regression test before merge." in gemini_prompt
+    assert "Keep the legacy fallback path." not in gemini_prompt
+
+
 def test_reconcile_human_requirements_ack_item_accepts_stored_structured_coder_followup():
     human_requirements = (
         HumanReviewRequirement(
@@ -6615,6 +6803,63 @@ def test_pr_loop_resumes_with_only_missing_reviewer_for_current_head(tmp_path):
     gemini_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"])
     assert "[item-1]" in gemini_prompt
     assert "Add a regression test before merge." in gemini_prompt
+
+
+def test_pr_loop_resume_raises_agent_loop_error_for_missing_reconstructed_prior_item(tmp_path):
+    carried_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Actual active carried item.",
+        status="blocking",
+        source_status="blocking",
+    )
+    coder_comment = _attach_round_metadata(
+        "Updated the PR.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+        ),
+    )
+    invalid_disposition = ReviewItemDisposition(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        disposition="resolved",
+    )
+    codex_comment = _attach_round_metadata(
+        "Looks good."
+        + prior_item_dispositions("[item-1] resolved")
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+            dispositions=(invalid_disposition,),
+            state="approved",
+        ),
+    )
+    runner = FakeRunner(
+        pr_payload={
+            "comments": [
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T10:00:00Z", "body": coder_comment},
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T10:05:00Z", "body": codex_comment},
+            ],
+        },
+    )
+    config = make_config(tmp_path, reviewer=("codex",))
+
+    with pytest.raises(
+        AgentLoopError,
+        match=r"Resumed pr round 2 reconstructed prior items item-2, but Codex dispositioned unknown item `item-1`",
+    ):
+        run_pr_loop(runner, pr_number=77, config=config)
 
 
 @pytest.mark.parametrize(
@@ -7864,6 +8109,108 @@ def test_issue_loop_plan_first_resumes_with_only_missing_reviewer_for_current_pl
     agent_commands = [cmd[0] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"], ["gemini"])]
     assert agent_commands == ["gemini"]
     assert runner.comments[-1].startswith("Planning complete for issue #56.")
+
+
+def test_resume_plan_round_prefers_latest_metadata_ledger_for_same_plan_replay():
+    current_plan = "Revised plan.\n- Add the active-ledger replay test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    subject = _plan_subject(current_plan)
+    stale_item = UnresolvedReviewItem(
+        item_id="item-3",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Stale plan replay item.",
+        status="same-plan",
+        source_status="same-plan",
+    )
+    active_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Active plan replay item.",
+        status="same-plan",
+        source_status="same-plan",
+    )
+    stale_coder_comment = _attach_round_metadata(
+        current_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=subject,
+            prior_items=(stale_item,),
+            canonical_plan=current_plan,
+        ),
+    )
+    stale_reviewer_comment = _attach_round_metadata(
+        "Still needs work."
+        + prior_plan_item_dispositions("[item-3] same-plan: stale replay")
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="plan",
+            role="reviewer",
+            agent="Codex",
+            round_number=2,
+            subject=subject,
+            prior_items=(stale_item,),
+            dispositions=(
+                parse_plan_item_dispositions(
+                    prior_plan_item_dispositions("[item-3] same-plan: stale replay"),
+                    reviewer="OpenAI Codex",
+                )[0],
+            ),
+            state="blocking",
+        ),
+    )
+    active_coder_comment = _attach_round_metadata(
+        current_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=subject,
+            prior_items=(active_item,),
+            canonical_plan=current_plan,
+        ),
+    )
+    active_reviewer_comment = _attach_round_metadata(
+        "Plan looks sound."
+        + prior_plan_item_dispositions("[item-1] resolved")
+        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="plan",
+            role="reviewer",
+            agent="Gemini",
+            round_number=2,
+            subject=subject,
+            prior_items=(active_item,),
+            dispositions=(
+                parse_plan_item_dispositions(
+                    prior_plan_item_dispositions("[item-1] resolved"),
+                    reviewer="Google Gemini",
+                )[0],
+            ),
+            state="approved",
+        ),
+    )
+
+    resumed = _resume_plan_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=stale_coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=stale_reviewer_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:02:00Z", body=active_coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:03:00Z", body=active_reviewer_comment),
+        ],
+        configured_reviewers=("codex", "gemini"),
+    )
+
+    assert resumed is not None
+    current_plan_text, resumed_state = resumed
+    assert current_plan_text == current_plan
+    assert [item.item_id for item in resumed_state.prior_items] == ["item-1"]
+    assert resumed_state.next_unresolved_item_number == 4
+    assert [record.metadata.agent for record in resumed_state.completed_reviews] == ["Gemini"]
 
 
 def test_resume_plan_round_prefers_canonical_plan_metadata():


### PR DESCRIPTION
Fixes #157

## Summary
- stabilize mixed-history resume reconstruction around `AGENT_LOOP_META` so the active round ledger follows the latest metadata-backed subject/head state
- fail closed with `AgentLoopError` when resumed reviewer dispositions do not match the reconstructed prior-item ledger
- add mixed-history resume regressions and document the structured-response contract and legacy fallback surface

## Testing
- `python3 -m pytest tests/test_agent_loop.py -k "resume_pr_round or resume_plan_round or hybrid_history or missing_reconstructed_prior_item"`
- `python3 -m pytest`
