### PR TITLE
Tolerate omitted empty structured review collections

### DIFF
--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -458,6 +458,23 @@ def _expect_string_list(
     return rendered
 
 
+def _expect_optional_string_list(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+    item_context: str,
+    min_length: int = 0,
+) -> tuple[str, ...]:
+    value = payload.get(field_name, [])
+    return _expect_string_list(
+        value,
+        context=context,
+        item_context=item_context,
+        min_length=min_length,
+    )
+
+
 def _expect_state(value: object, *, context: str) -> str:
     state = _expect_non_empty_string(value, context=context)
     if state not in {"approved", "blocking"}:
@@ -796,26 +813,27 @@ def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | No
             "kind",
             "state",
             "summary",
-            "blocking_items",
-            "same_pr_followups",
-            "future_followups",
             "prior_item_dispositions",
         },
+        optional={"blocking_items", "same_pr_followups", "future_followups"},
     )
     state = _expect_state(payload["state"], context="pr_review.state")
     summary = _expect_non_empty_string(payload["summary"], context="pr_review.summary")
-    blocking_items = _expect_string_list(
-        payload["blocking_items"],
+    blocking_items = _expect_optional_string_list(
+        payload,
+        "blocking_items",
         context="pr_review.blocking_items",
         item_context="pr_review.blocking_items",
     )
-    same_pr_followups = _expect_string_list(
-        payload["same_pr_followups"],
+    same_pr_followups = _expect_optional_string_list(
+        payload,
+        "same_pr_followups",
         context="pr_review.same_pr_followups",
         item_context="pr_review.same_pr_followups",
     )
-    future_followups = _expect_string_list(
-        payload["future_followups"],
+    future_followups = _expect_optional_string_list(
+        payload,
+        "future_followups",
         context="pr_review.future_followups",
         item_context="pr_review.future_followups",
     )
@@ -856,26 +874,27 @@ def parse_structured_plan_review(text: str, *, reviewer: str) -> ParsedPlanRevie
             "kind",
             "state",
             "summary",
-            "blocking_plan_issues",
-            "same_plan_followups",
-            "future_followups",
             "prior_plan_item_dispositions",
         },
+        optional={"blocking_plan_issues", "same_plan_followups", "future_followups"},
     )
     state = _expect_state(payload["state"], context="plan_review.state")
     summary = _expect_non_empty_string(payload["summary"], context="plan_review.summary")
-    blocking_items = _expect_string_list(
-        payload["blocking_plan_issues"],
+    blocking_items = _expect_optional_string_list(
+        payload,
+        "blocking_plan_issues",
         context="plan_review.blocking_plan_issues",
         item_context="plan_review.blocking_plan_issues",
     )
-    same_plan_followups = _expect_string_list(
-        payload["same_plan_followups"],
+    same_plan_followups = _expect_optional_string_list(
+        payload,
+        "same_plan_followups",
         context="plan_review.same_plan_followups",
         item_context="plan_review.same_plan_followups",
     )
-    future_followups = _expect_string_list(
-        payload["future_followups"],
+    future_followups = _expect_optional_string_list(
+        payload,
+        "future_followups",
         context="plan_review.future_followups",
         item_context="plan_review.future_followups",
     )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2283,6 +2283,34 @@ def test_parse_structured_pr_review_normalizes_v1_payload_with_footer_contract()
     ]
 
 
+def test_parse_structured_pr_review_tolerates_omitted_empty_collections():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Looks good after the latest fix.",
+                "prior_item_dispositions": [
+                    {"item_id": "item-1", "disposition": "resolved"},
+                ],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex\n"
+    )
+
+    parsed = parse_structured_pr_review(payload, reviewer="OpenAI Codex")
+
+    assert parsed is not None
+    assert parsed.state == "approved"
+    assert parsed.blocking_items == ()
+    assert parsed.followups.same_pr == ()
+    assert parsed.followups.future == ()
+    assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
+        ("item-1", "resolved")
+    ]
+
+
 def test_parse_structured_pr_review_rejects_kind_mismatch():
     payload = (
         json.dumps(
@@ -2553,6 +2581,31 @@ def test_parse_structured_plan_review_normalizes_v1_payload():
     assert parsed is not None
     assert parsed.summary == "Plan looks good."
     assert [item.text for item in parsed.items.future] == ["Consider a later cleanup pass."]
+    assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
+        ("item-1", "resolved")
+    ]
+
+
+def test_parse_structured_plan_review_tolerates_omitted_empty_collections():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "approved",
+                "summary": "Plan looks good.",
+                "prior_plan_item_dispositions": [{"item_id": "item-1", "disposition": "resolved"}],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    )
+
+    parsed = parse_structured_plan_review(payload, reviewer="OpenAI Codex")
+
+    assert parsed is not None
+    assert parsed.items.blocking == ()
+    assert parsed.items.same_plan == ()
+    assert parsed.items.future == ()
     assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
         ("item-1", "resolved")
     ]


### PR DESCRIPTION
Summary:
- default omitted structured PR review follow-up arrays to empty lists instead of rejecting the payload
- apply the same normalization to structured plan reviews for the analogous optional-empty collections
- add regression coverage for both parser paths

Tests:
- python3 -m pytest

Fixes #170