### PR TITLE
Add LLM repair pass for malformed review outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 
+dependencies = [
+  "google-genai>=1.0",
+]
+
 [project.optional-dependencies]
 dev = ["pytest>=8"]
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -85,6 +85,7 @@ from .protocol import (
     validate_structured_plan_revision,
 )
 from .protocol import ApprovedFollowup, parse_review
+from .repair import attempt_repair
 from .runner import Runner
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
@@ -279,6 +280,7 @@ def _run_validated_agent(
     validate: Callable[[str], object],
     session_id: str | None = None,
     usage_context: RunUsageContext | None = None,
+    use_repair: bool = False,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -325,6 +327,27 @@ def _run_validated_agent(
                 should_retry = _is_transient_agent_output(text) or (
                     attempt == 1 and _is_retryable_marker_near_miss(text)
                 )
+                if use_repair and not _is_transient_agent_output(text):
+                    log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
+                    repaired = attempt_repair(text)
+                    if repaired is not None:
+                        try:
+                            marker_value = validate(repaired)
+                        except AgentLoopError as repair_exc:
+                            log(
+                                config,
+                                f"{agent_name}: repair pass produced invalid output ({repair_exc})",
+                            )
+                        else:
+                            log(config, f"{agent_name}: repair pass recovered malformed response")
+                            if usage_record is not None:
+                                usage_record.validation_status = "validated"
+                            return ValidatedAgentResponse(
+                                text=repaired,
+                                session_id=result.session_id,
+                                marker_value=marker_value,
+                                usage=usage,
+                            )
             else:
                 if usage_record is not None:
                     usage_record.validation_status = "validated"
@@ -1942,6 +1965,7 @@ def _run_plan_first_loop(
                         unresolved_items=items,
                     ),
                     usage_context=usage_context,
+                    use_repair=True,
                 )
                 review_output = review_response.text
                 reviewer_session_ids[reviewer] = review_response.session_id
@@ -2526,6 +2550,7 @@ def run_pr_loop(
                             unresolved_items=items,
                         ),
                         usage_context=usage_context,
+                        use_repair=True,
                     )
                     review_output = review_response.text
                     reviewer_session_ids[reviewer] = review_response.session_id

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1,0 +1,151 @@
+"""LLM repair pass for malformed review outputs.
+
+When an agent produces a review that fails strict schema validation, this module
+attempts to recover it by calling gemini-3.1-flash-lite as a format-repair
+assistant.  If the repair also fails validation, the caller treats the result
+as blocking per the issue guardrails.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
+
+# v7 prompt — tested against all 34 historical format-failure samples (100%).
+# Uses str.replace("{raw_response}", raw) for substitution because the prompt
+# itself contains literal { } characters in the JSON examples.
+_REPAIR_PROMPT = """\
+You are a format-repair assistant. An AI agent produced a code review that failed strict schema validation. Extract its intent and reformat it into one of these two valid formats.
+
+## Valid Format A — PR Review:
+
+{
+  "schema_version": 1,
+  "kind": "pr_review",
+  "state": "approved" | "blocking",
+  "summary": "<short summary>",
+  "blocking_items": [],
+  "same_pr_followups": [],
+  "future_followups": [],
+  "prior_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved"},
+    {"item_id": "item-2", "disposition": "same-pr", "note": "reason still needed"}
+  ]
+}
+<!-- AGENT_STATE: approved -->
+-- <Reviewer Name>
+
+## Valid Format B — Plan Review:
+
+{
+  "schema_version": 1,
+  "kind": "plan_review",
+  "state": "approved" | "blocking",
+  "summary": "<short summary>",
+  "blocking_plan_issues": [],
+  "same_plan_followups": [],
+  "future_followups": [],
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved"}
+  ]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Reviewer Name>
+
+## ARRAY FIELD TYPES:
+- blocking_items, same_pr_followups, future_followups, blocking_plan_issues, same_plan_followups -> STRINGS
+- prior_item_dispositions, prior_plan_item_dispositions -> OBJECTS {"item_id":..., "disposition":..., "note":...}
+- disposition values: "resolved", "blocking", "same-pr"/"same-plan", or "future" ONLY
+
+## STATE RULES:
+### APPROVED: blocking_items=[], same_pr_followups=[], prior dispositions only "resolved"/"future"
+### BLOCKING: future_followups=[], prior dispositions MUST NOT use "future"
+
+## WORKED EXAMPLE 1 — approved + same-PR items (change to blocking, DISCARD futures):
+
+Original (malformed): approved state, has same-PR items AND future items.
+
+CORRECT repair: change state to blocking, keep same-PR items, DISCARD future items entirely.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": [],
+  "same_pr_followups": ["Fix the CSS class name"],
+  "future_followups": [],
+  "prior_item_dispositions": []
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+The future item ("Consider improving contrast ratio") is DISCARDED. It can be raised again in a later round.
+
+## WORKED EXAMPLE 2 — prior item already filed as "future", now in a blocking review:
+
+Original (malformed): blocking review, prior item-1 was already "future" in a previous round.
+
+CORRECT repair: OMIT item-1 from prior_item_dispositions entirely. Do not include it at all.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": [],
+  "same_pr_followups": ["Fix the CLI flag in error message"],
+  "future_followups": [],
+  "prior_item_dispositions": [
+    {"item_id": "item-2", "disposition": "same-pr", "note": "CLI flag still wrong"}
+  ]
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+item-1 is omitted because it was already "future" — it stays future without needing to be re-dispositioned.
+
+## FORMAT:
+1. Start DIRECTLY with { — no prose, no markdown fences.
+2. After }: <!-- AGENT_STATE: X --> (pr_review) OR <!-- AGENT_PLAN_STATE: X --> (plan_review). DIFFERENT MARKERS.
+3. JSON "state" matches X. Then: -- Reviewer Name. STOP.
+4. plan_review if original has AGENT_PLAN_STATE / blocking_plan_issues / same_plan_followups / prior_plan_item_dispositions.
+
+Output ONLY the repaired response. No explanations.
+
+## Original (malformed) response:
+
+{raw_response}"""
+
+_REPAIR_MODEL = "gemini-3.1-flash-lite"
+
+
+def attempt_repair(raw: str) -> str | None:
+    """Call gemini-3.1-flash-lite to reformat a malformed review response.
+
+    Returns the repaired text on success, or None when the repair service is
+    unavailable (missing SDK, missing API key) or returns an error.
+    The caller is responsible for re-validating the returned text.
+    """
+    try:
+        from google import genai as _genai  # type: ignore[import-untyped]
+    except ImportError:
+        _logger.debug("google-genai SDK not available; skipping repair pass")
+        return None
+
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        _logger.debug("No GEMINI_API_KEY or GOOGLE_API_KEY found; skipping repair pass")
+        return None
+
+    prompt = _REPAIR_PROMPT.replace("{raw_response}", raw)
+    try:
+        client = _genai.Client(api_key=api_key)
+        response = client.models.generate_content(
+            model=_REPAIR_MODEL,
+            contents=prompt,
+        )
+        text = response.text
+        if not isinstance(text, str) or not text.strip():
+            _logger.debug("repair model returned empty response")
+            return None
+        return text
+    except Exception as exc:
+        _logger.debug("repair pass call failed: %s", exc)
+        return None

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -14,7 +14,7 @@ import os
 _logger = logging.getLogger(__name__)
 
 # v7 prompt — tested against all 34 historical format-failure samples (100%).
-# Uses str.replace("{raw_response}", raw) for substitution because the prompt
+# Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
 You are a format-repair assistant. An AI agent produced a code review that failed strict schema validation. Extract its intent and reformat it into one of these two valid formats.
@@ -134,7 +134,7 @@ def attempt_repair(raw: str) -> str | None:
         _logger.debug("No GEMINI_API_KEY or GOOGLE_API_KEY found; skipping repair pass")
         return None
 
-    prompt = _REPAIR_PROMPT.replace("{raw_response}", raw)
+    prompt = _REPAIR_PROMPT.replace("{raw_response}", raw, 1)
     try:
         client = _genai.Client(api_key=api_key)
         response = client.models.generate_content(
@@ -145,6 +145,14 @@ def attempt_repair(raw: str) -> str | None:
         if not isinstance(text, str) or not text.strip():
             _logger.debug("repair model returned empty response")
             return None
+        usage = getattr(response, "usage_metadata", None)
+        if usage is not None:
+            _logger.info(
+                "repair pass token usage: prompt=%s output=%s total=%s",
+                getattr(usage, "prompt_token_count", None),
+                getattr(usage, "candidates_token_count", None),
+                getattr(usage, "total_token_count", None),
+            )
         return text
     except Exception as exc:
         _logger.debug("repair pass call failed: %s", exc)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9174,7 +9174,7 @@ def test_repair_prompt_contains_raw_response_placeholder():
 
 def test_repair_prompt_substitution_leaves_json_examples_intact():
     raw = "some {curly} braces {in} the review text"
-    substituted = _REPAIR_PROMPT.replace("{raw_response}", raw)
+    substituted = _REPAIR_PROMPT.replace("{raw_response}", raw, 1)
     assert raw in substituted
     assert "{raw_response}" not in substituted
     assert "schema_version" in substituted

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9125,3 +9125,124 @@ def test_claude_review_loop_rejects_non_open_pr(tmp_path):
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+# ---------------------------------------------------------------------------
+# Repair pass tests
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch
+
+from coding_review_agent_loop.repair import attempt_repair, _REPAIR_PROMPT
+
+
+def test_attempt_repair_returns_none_when_no_api_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    result = attempt_repair("some malformed review text")
+    assert result is None
+
+
+def test_attempt_repair_calls_sdk_and_returns_text(monkeypatch):
+    repaired = (
+        '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
+        '"blocking_items":[],"same_pr_followups":[],"future_followups":[],'
+        '"prior_item_dispositions":[]}\n<!-- AGENT_STATE: approved -->\n-- Gemini'
+    )
+    mock_response = MagicMock()
+    mock_response.text = repaired
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = mock_response
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    # google-genai is installed; patch the Client class on the real module object
+    from google import genai as real_genai
+    with patch.object(real_genai, "Client", return_value=mock_client):
+        result = attempt_repair("malformed review")
+
+    assert result == repaired
+    mock_client.models.generate_content.assert_called_once()
+    call_kwargs = mock_client.models.generate_content.call_args
+    assert call_kwargs.kwargs.get("model") == "gemini-3.1-flash-lite"
+    assert "malformed review" in call_kwargs.kwargs.get("contents", "")
+
+
+def test_repair_prompt_contains_raw_response_placeholder():
+    assert "{raw_response}" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_substitution_leaves_json_examples_intact():
+    raw = "some {curly} braces {in} the review text"
+    substituted = _REPAIR_PROMPT.replace("{raw_response}", raw)
+    assert raw in substituted
+    assert "{raw_response}" not in substituted
+    assert "schema_version" in substituted
+
+
+def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
+    """Repair pass is invoked when schema validation fails; repaired output is used."""
+    malformed_review = (
+        "Looks good overall.\n\n"
+        "AGENT_STATE: approved\n"
+        "-- OpenAI Codex"
+    )
+    repaired_review = (
+        '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"Looks good overall.",'
+        '"blocking_items":[],"same_pr_followups":[],"future_followups":[],'
+        '"prior_item_dispositions":[]}'
+        "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+    runner = FakeRunner(
+        codex_outputs=[malformed_review],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
+
+    captured_repairs = []
+
+    def fake_attempt_repair(raw: str) -> str | None:
+        captured_repairs.append(raw)
+        return repaired_review
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(captured_repairs) == 1
+    assert "AGENT_STATE: approved" in captured_repairs[0]
+
+
+def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
+    """When repair also produces invalid output, the original error is raised."""
+    malformed_review = (
+        "Something went wrong with the format.\n"
+        "AGENT_STATE: approved\n"
+        "-- OpenAI Codex"
+    )
+    runner = FakeRunner(
+        codex_outputs=[malformed_review],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
+
+    def fake_attempt_repair_fails(raw: str) -> str | None:
+        return "still broken output without valid schema"
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair_fails):
+        with pytest.raises(AgentLoopError, match="Codex"):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+
+def test_run_pr_loop_skips_repair_when_repair_returns_none(tmp_path):
+    """When attempt_repair returns None (e.g. no API key), normal error is raised."""
+    malformed_review = (
+        "Something went wrong.\n"
+        "AGENT_STATE: approved\n"
+        "-- OpenAI Codex"
+    )
+    runner = FakeRunner(
+        codex_outputs=[malformed_review],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
+        with pytest.raises(AgentLoopError, match="Codex"):
+            run_pr_loop(runner, pr_number=77, config=config)


### PR DESCRIPTION
## Summary

Fixes #175

When a reviewer agent produces a response that fails strict schema
validation, this PR adds a `gemini-3.1-flash-lite` repair pass as a
fallback before the normal retry/error path.

### Key changes

- **`repair.py`** — new module containing the v7 repair prompt (validated
  against all 34 historical format-failure samples at 100% success rate)
  and `attempt_repair(raw) -> str | None` which calls the Gemini API via
  `google-genai`. Returns `None` if the SDK is missing or no API key is
  configured, so the repair is purely optional.

- **`orchestrator.py`** — `_run_validated_agent` gains `use_repair: bool = False`.
  When validation fails and the error is not transient, the repair pass is
  attempted. If the repaired text also fails validation the original error
  path proceeds unchanged. `use_repair=True` is set on both the PR-review
  and plan-review invocation sites.

### Implementation notes from the issue investigation

- Uses `str.replace("{raw_response}", raw)` (not `.format()`) to avoid
  corrupting the literal `{}` in the JSON examples inside the prompt.
- API key is read from `GEMINI_API_KEY` or `GOOGLE_API_KEY`.
- The repair model is `gemini-3.1-flash-lite` (free-tier quota available).
- If repair fails (model error, invalid repaired output), the orchestrator
  falls through to the existing retry/error logic — no new failure modes.

## Test plan

- `test_attempt_repair_returns_none_when_no_api_key` — graceful no-op when key absent
- `test_attempt_repair_calls_sdk_and_returns_text` — SDK path with mocked Client
- `test_repair_prompt_contains_raw_response_placeholder` — prompt structure
- `test_repair_prompt_substitution_leaves_json_examples_intact` — `str.replace` correctness
- `test_run_pr_loop_uses_repair_pass_on_format_failure` — end-to-end: malformed → repaired → loop succeeds
- `test_run_pr_loop_falls_back_to_error_when_repair_also_fails` — repair produces garbage → error raised
- `test_run_pr_loop_skips_repair_when_repair_returns_none` — None from repair → normal error path

All 426 tests pass (`pytest tests/test_agent_loop.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)