### PR TITLE
Add LLM repair pass for malformed review outputs

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -279,12 +279,14 @@ def _run_validated_agent(
     validate: Callable[[str], object],
     session_id: str | None = None,
     usage_context: RunUsageContext | None = None,
+    enable_repair: bool = False,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
     max_attempts = config.agent_max_retries + 1
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
+    last_text_for_repair: str | None = None
 
     for attempt in range(1, max_attempts + 1):
         result = run_agent_result(
@@ -325,6 +327,8 @@ def _run_validated_agent(
                 should_retry = _is_transient_agent_output(text) or (
                     attempt == 1 and _is_retryable_marker_near_miss(text)
                 )
+                if not _is_transient_agent_output(text):
+                    last_text_for_repair = text
             else:
                 if usage_record is not None:
                     usage_record.validation_status = "validated"
@@ -345,6 +349,26 @@ def _run_validated_agent(
             runner.run(("sleep", str(delay)), cwd=active_workdir(config))
             continue
         break
+
+    if enable_repair and last_text_for_repair is not None:
+        from .repair import REPAIR_MODEL, repair_review_response
+        log(config, f"{agent_name} response failed validation; attempting format repair via {REPAIR_MODEL}")
+        repaired_text = repair_review_response(last_text_for_repair)
+        if repaired_text is not None and repaired_text.strip():
+            try:
+                marker_value = validate(repaired_text)
+            except AgentLoopError:
+                log(config, f"Format repair of {agent_name} response did not pass validation; treating as blocking")
+            else:
+                log(config, f"Format repair of {agent_name} response succeeded")
+                return ValidatedAgentResponse(
+                    text=repaired_text,
+                    session_id=last_result.session_id if last_result is not None else None,
+                    marker_value=marker_value,
+                    usage=None,
+                )
+        else:
+            log(config, f"Format repair of {agent_name} response was skipped (no API key or repair unavailable)")
 
     raise AgentLoopError(
         _format_invalid_agent_response_error(
@@ -1942,6 +1966,7 @@ def _run_plan_first_loop(
                         unresolved_items=items,
                     ),
                     usage_context=usage_context,
+                    enable_repair=True,
                 )
                 review_output = review_response.text
                 reviewer_session_ids[reviewer] = review_response.session_id
@@ -2526,6 +2551,7 @@ def run_pr_loop(
                             unresolved_items=items,
                         ),
                         usage_context=usage_context,
+                        enable_repair=True,
                     )
                     review_output = review_response.text
                     reviewer_session_ids[reviewer] = review_response.session_id

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1,0 +1,140 @@
+"""LLM repair pass for malformed review outputs."""
+
+from __future__ import annotations
+
+import os
+
+REPAIR_MODEL = "gemini-3.1-flash-lite"
+
+# v7 prompt — 34/34 repair rate on historical format failures across both repos.
+# Use str.replace("{raw_response}", raw) to substitute — do NOT use .format()
+# because the prompt contains literal { } characters in the JSON examples.
+_REPAIR_PROMPT_TEMPLATE = """\
+You are a format-repair assistant. An AI agent produced a code review that failed strict schema validation. Extract its intent and reformat it into one of these two valid formats.
+
+## Valid Format A — PR Review:
+
+{
+  "schema_version": 1,
+  "kind": "pr_review",
+  "state": "approved" | "blocking",
+  "summary": "<short summary>",
+  "blocking_items": [],
+  "same_pr_followups": [],
+  "future_followups": [],
+  "prior_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved"},
+    {"item_id": "item-2", "disposition": "same-pr", "note": "reason still needed"}
+  ]
+}
+<!-- AGENT_STATE: approved -->
+-- <Reviewer Name>
+
+## Valid Format B — Plan Review:
+
+{
+  "schema_version": 1,
+  "kind": "plan_review",
+  "state": "approved" | "blocking",
+  "summary": "<short summary>",
+  "blocking_plan_issues": [],
+  "same_plan_followups": [],
+  "future_followups": [],
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved"}
+  ]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Reviewer Name>
+
+## ARRAY FIELD TYPES:
+- blocking_items, same_pr_followups, future_followups, blocking_plan_issues, same_plan_followups -> STRINGS
+- prior_item_dispositions, prior_plan_item_dispositions -> OBJECTS {"item_id":..., "disposition":..., "note":...}
+- disposition values: "resolved", "blocking", "same-pr"/"same-plan", or "future" ONLY
+
+## STATE RULES:
+### APPROVED: blocking_items=[], same_pr_followups=[], prior dispositions only "resolved"/"future"
+### BLOCKING: future_followups=[], prior dispositions MUST NOT use "future"
+
+## WORKED EXAMPLE 1 — approved + same-PR items (change to blocking, DISCARD futures):
+
+Original (malformed): approved state, has same-PR items AND future items.
+
+CORRECT repair: change state to blocking, keep same-PR items, DISCARD future items entirely.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": [],
+  "same_pr_followups": ["Fix the CSS class name"],
+  "future_followups": [],
+  "prior_item_dispositions": []
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+The future item ("Consider improving contrast ratio") is DISCARDED. It can be raised again in a later round.
+
+## WORKED EXAMPLE 2 — prior item already filed as "future", now in a blocking review:
+
+Original (malformed): blocking review, prior item-1 was already "future" in a previous round.
+
+CORRECT repair: OMIT item-1 from prior_item_dispositions entirely. Do not include it at all.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": [],
+  "same_pr_followups": ["Fix the CLI flag in error message"],
+  "future_followups": [],
+  "prior_item_dispositions": [
+    {"item_id": "item-2", "disposition": "same-pr", "note": "CLI flag still wrong"}
+  ]
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+item-1 is omitted because it was already "future" — it stays future without needing to be re-dispositioned.
+
+## FORMAT:
+1. Start DIRECTLY with { — no prose, no markdown fences.
+2. After }: <!-- AGENT_STATE: X --> (pr_review) OR <!-- AGENT_PLAN_STATE: X --> (plan_review). DIFFERENT MARKERS.
+3. JSON "state" matches X. Then: -- Reviewer Name. STOP.
+4. plan_review if original has AGENT_PLAN_STATE / blocking_plan_issues / same_plan_followups / prior_plan_item_dispositions.
+
+Output ONLY the repaired response. No explanations.
+
+## Original (malformed) response:
+
+{raw_response}"""
+
+
+def _build_repair_prompt(raw_text: str) -> str:
+    return _REPAIR_PROMPT_TEMPLATE.replace("{raw_response}", raw_text)
+
+
+def repair_review_response(raw_text: str) -> str | None:
+    """Attempt to repair a malformed review response using gemini-3.1-flash-lite.
+
+    Returns the repaired text on success, or None if the SDK is unavailable,
+    no API key is configured, or the repair call fails.
+    """
+    try:
+        from google import genai  # type: ignore[import]
+    except ImportError:
+        return None
+
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = client.models.generate_content(
+            model=REPAIR_MODEL,
+            contents=_build_repair_prompt(raw_text),
+        )
+        text = response.text
+        if not isinstance(text, str) or not text.strip():
+            return None
+        return text
+    except Exception:
+        return None

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9125,3 +9125,118 @@ def test_claude_review_loop_rejects_non_open_pr(tmp_path):
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+# ---------------------------------------------------------------------------
+# Repair pass tests
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch
+
+from coding_review_agent_loop.repair import (
+    REPAIR_MODEL,
+    _build_repair_prompt,
+    repair_review_response,
+)
+
+
+def test_repair_prompt_substitutes_raw_response():
+    raw = "some malformed review content { with braces }"
+    prompt = _build_repair_prompt(raw)
+    assert raw in prompt
+    assert "{raw_response}" not in prompt
+    assert "format-repair assistant" in prompt
+    assert "AGENT_STATE" in prompt
+
+
+def test_repair_prompt_does_not_corrupt_json_examples():
+    prompt = _build_repair_prompt("dummy")
+    assert '"schema_version": 1' in prompt
+    assert '"kind": "pr_review"' in prompt
+
+
+def test_repair_returns_none_when_no_api_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    result = repair_review_response("some malformed text")
+    assert result is None
+
+
+def test_repair_returns_repaired_text_on_success(monkeypatch):
+    repaired = (
+        '{"schema_version": 1, "kind": "pr_review", "state": "approved", '
+        '"summary": "LGTM", "blocking_items": [], "same_pr_followups": [], '
+        '"future_followups": [], "prior_item_dispositions": []}\n'
+        "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    )
+    mock_response = MagicMock()
+    mock_response.text = repaired
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = mock_response
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    with patch("google.genai.Client", return_value=mock_client):
+        result = repair_review_response("malformed")
+
+    assert result == repaired
+    mock_client.models.generate_content.assert_called_once()
+    call_kwargs = mock_client.models.generate_content.call_args
+    assert call_kwargs.kwargs.get("model") == REPAIR_MODEL or call_kwargs.args[0] == REPAIR_MODEL
+
+
+def test_repair_returns_none_when_sdk_raises(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    mock_client = MagicMock()
+    mock_client.models.generate_content.side_effect = Exception("API error")
+
+    with patch("google.genai.Client", return_value=mock_client):
+        result = repair_review_response("malformed")
+
+    assert result is None
+
+
+def test_pr_loop_uses_repair_when_review_format_fails(tmp_path):
+    """Repair is attempted when a reviewer produces a malformed-but-salvageable response."""
+    malformed = "LGTM — the PR looks great.\nAGENT_STATE: approved\n-- Google Gemini"
+    repaired = (
+        '{"schema_version": 1, "kind": "pr_review", "state": "approved", '
+        '"summary": "LGTM", "blocking_items": [], "same_pr_followups": [], '
+        '"future_followups": [], "prior_item_dispositions": []}\n'
+        "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    )
+
+    runner = FakeRunner(gemini_outputs=[malformed])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.repair.repair_review_response", return_value=repaired):
+        result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    assert any("approved" in comment.lower() for comment in runner.comments)
+
+
+def test_pr_loop_raises_when_repair_also_fails(tmp_path):
+    """When repair returns None (unavailable), the original validation error is surfaced."""
+    malformed = "I reviewed it. Still needs work."
+    runner = FakeRunner(gemini_outputs=[malformed])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.repair.repair_review_response", return_value=None):
+        with pytest.raises(AgentLoopError, match="AGENT_STATE"):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+    assert runner.comments == []
+
+
+def test_pr_loop_raises_when_repaired_output_still_invalid(tmp_path):
+    """When repair returns a still-invalid response, the original error is surfaced."""
+    malformed = "I reviewed it. Still needs work."
+    still_invalid = "This is also not a valid format."
+    runner = FakeRunner(gemini_outputs=[malformed])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.repair.repair_review_response", return_value=still_invalid):
+        with pytest.raises(AgentLoopError, match="No review result was recorded"):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+    assert runner.comments == []


### PR DESCRIPTION
## Summary

Fixes #175.

When a reviewer agent produces a response that contains valid review intent but fails the strict schema/grammar check, the orchestrator now invokes `gemini-3.1-flash-lite` as a cheap repair model to normalize the output before surfacing an error.

**Implementation:**

- `src/coding_review_agent_loop/repair.py` — new module containing:
  - The v7 repair prompt (validated at 34/34 repair rate on historical format failures across both repos per the issue investigation)
  - `repair_review_response(raw_text)` which calls `gemini-3.1-flash-lite` via the `google-genai` SDK and returns the repaired text or `None` on any failure
- `orchestrator.py` — adds `enable_repair: bool = False` parameter to `_run_validated_agent()`, enabled for PR review and plan review calls only. After retries are exhausted, if the last response was non-empty and non-transient, the repair pass is attempted, the repaired output re-validated, and (if valid) returned as the final response.

**Guardrails (per issue spec):**
- Repair is only attempted when the primary validation fails
- If `GEMINI_API_KEY` / `GOOGLE_API_KEY` is absent, the SDK is unavailable, or the API call fails, the repair is silently skipped
- If the repaired output still fails validation, the original validation error is surfaced (conservative fallback — no invented approvals)

**Most common failures repaired (from issue investigation):**
1. `approved` state + non-empty `same_pr_followups` → move items to `future_followups` or escalate to `blocking`
2. Missing `<!-- AGENT_STATE: -->` / `<!-- AGENT_PLAN_STATE: -->` marker
3. `blocking_plan_issues` array containing rich objects instead of plain strings
4. Prior item dispositions in blocking review using `"future"` (forbidden combination)

## Test plan

- [x] `test_repair_prompt_substitutes_raw_response` — verifies `{raw_response}` is replaced without corrupting JSON examples
- [x] `test_repair_prompt_does_not_corrupt_json_examples` — verifies literal `{` / `}` in the prompt template survive substitution
- [x] `test_repair_returns_none_when_no_api_key` — no API key → returns None
- [x] `test_repair_returns_repaired_text_on_success` — mocked SDK → returns repaired text
- [x] `test_repair_returns_none_when_sdk_raises` — SDK error → returns None
- [x] `test_pr_loop_uses_repair_when_review_format_fails` — end-to-end: malformed reviewer output → repair succeeds → PR loop approves
- [x] `test_pr_loop_raises_when_repair_also_fails` — repair unavailable (None) → original validation error surfaced
- [x] `test_pr_loop_raises_when_repaired_output_still_invalid` — repair returns still-invalid text → original error surfaced
- [x] All 427 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)