### PR TITLE
Use Gemini CLI for repair pass instead of google-genai SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 
-dependencies = [
-  "google-genai>=1.0",
-]
+dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest>=8"]

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -329,7 +329,7 @@ def _run_validated_agent(
                 )
                 if use_repair and not _is_transient_agent_output(text):
                     log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
-                    repaired = attempt_repair(text)
+                    repaired = attempt_repair(text, config.gemini_cmd)
                     if repaired is not None:
                         try:
                             marker_value = validate(repaired)

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -9,7 +9,9 @@ as blocking per the issue guardrails.
 from __future__ import annotations
 
 import logging
-import os
+import subprocess
+
+from .agents.gemini import _strip_gemini_preamble
 
 _logger = logging.getLogger(__name__)
 
@@ -116,44 +118,27 @@ Output ONLY the repaired response. No explanations.
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
 
 
-def attempt_repair(raw: str) -> str | None:
-    """Call gemini-3.1-flash-lite to reformat a malformed review response.
+def attempt_repair(raw: str, gemini_cmd: str) -> str | None:
+    """Call gemini-3.1-flash-lite via the Gemini CLI to reformat a malformed review response.
 
-    Returns the repaired text on success, or None when the repair service is
-    unavailable (missing SDK, missing API key) or returns an error.
+    Uses the same CLI auth path as the reviewer, so no API key is needed.
+    Returns the repaired text on success, or None when the CLI is unavailable
+    or returns an error.
     The caller is responsible for re-validating the returned text.
     """
-    try:
-        from google import genai as _genai  # type: ignore[import-untyped]
-    except ImportError:
-        _logger.debug("google-genai SDK not available; skipping repair pass")
-        return None
-
-    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if not api_key:
-        _logger.debug("No GEMINI_API_KEY or GOOGLE_API_KEY found; skipping repair pass")
-        return None
-
     prompt = _REPAIR_PROMPT.replace("{raw_response}", raw, 1)
     try:
-        client = _genai.Client(api_key=api_key)
-        response = client.models.generate_content(
-            model=_REPAIR_MODEL,
-            contents=prompt,
+        result = subprocess.run(
+            [gemini_cmd, "--model", _REPAIR_MODEL, "--prompt", prompt],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        text = response.text
-        if not isinstance(text, str) or not text.strip():
-            _logger.debug("repair model returned empty response")
-            return None
-        usage = getattr(response, "usage_metadata", None)
-        if usage is not None:
-            _logger.info(
-                "repair pass token usage: prompt=%s output=%s total=%s",
-                getattr(usage, "prompt_token_count", None),
-                getattr(usage, "candidates_token_count", None),
-                getattr(usage, "total_token_count", None),
-            )
-        return text
     except Exception as exc:
         _logger.debug("repair pass call failed: %s", exc)
         return None
+    if result.returncode != 0:
+        _logger.debug("repair pass exited with %d: %s", result.returncode, result.stderr[:200])
+        return None
+    text = _strip_gemini_preamble(result.stdout.strip())
+    return text or None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest fixtures."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_repair_pass():
+    """Prevent attempt_repair from making real subprocess calls during tests.
+
+    Tests that specifically exercise the repair pass override this by patching
+    coding_review_agent_loop.orchestrator.attempt_repair in their own body.
+    """
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
+        yield

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9136,36 +9136,41 @@ from unittest.mock import MagicMock, patch
 from coding_review_agent_loop.repair import attempt_repair, _REPAIR_PROMPT
 
 
-def test_attempt_repair_returns_none_when_no_api_key(monkeypatch):
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    result = attempt_repair("some malformed review text")
+def test_attempt_repair_returns_none_when_subprocess_fails(monkeypatch):
+    import subprocess as _subprocess
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    fake_result.stderr = "command not found"
+    fake_result.stdout = ""
+    with patch.object(_subprocess, "run", return_value=fake_result):
+        result = attempt_repair("some malformed review text", "gemini")
     assert result is None
 
 
-def test_attempt_repair_calls_sdk_and_returns_text(monkeypatch):
+def test_attempt_repair_calls_cli_and_returns_text(monkeypatch):
     repaired = (
         '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
         '"blocking_items":[],"same_pr_followups":[],"future_followups":[],'
         '"prior_item_dispositions":[]}\n<!-- AGENT_STATE: approved -->\n-- Gemini'
     )
-    mock_response = MagicMock()
-    mock_response.text = repaired
-    mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = mock_response
-
-    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-
-    # google-genai is installed; patch the Client class on the real module object
-    from google import genai as real_genai
-    with patch.object(real_genai, "Client", return_value=mock_client):
-        result = attempt_repair("malformed review")
+    import subprocess as _subprocess
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = repaired
+    fake_result.stderr = ""
+    with patch.object(_subprocess, "run", return_value=fake_result) as mock_run:
+        result = attempt_repair("malformed review", "gemini")
 
     assert result == repaired
-    mock_client.models.generate_content.assert_called_once()
-    call_kwargs = mock_client.models.generate_content.call_args
-    assert call_kwargs.kwargs.get("model") == "gemini-3.1-flash-lite"
-    assert "malformed review" in call_kwargs.kwargs.get("contents", "")
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    cmd = call_args[0][0]
+    assert cmd[0] == "gemini"
+    assert "--model" in cmd
+    assert "gemini-3.1-flash-lite" in cmd
+    assert "--prompt" in cmd
+    prompt_idx = cmd.index("--prompt")
+    assert "malformed review" in cmd[prompt_idx + 1]
 
 
 def test_repair_prompt_contains_raw_response_placeholder():
@@ -9200,7 +9205,7 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str) -> str | None:
         captured_repairs.append(raw)
         return repaired_review
 
@@ -9223,7 +9228,7 @@ def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
 
-    def fake_attempt_repair_fails(raw: str) -> str | None:
+    def fake_attempt_repair_fails(raw: str, gemini_cmd: str) -> str | None:
         return "still broken output without valid schema"
 
     with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair_fails):


### PR DESCRIPTION
## Summary

Fixes #180

The repair pass introduced in PR #176 called `gemini-3.1-flash-lite` via the `google-genai` Python SDK, requiring `GEMINI_API_KEY` in the environment. When absent, it silently returned `None` and skipped the repair.

This PR replaces the SDK call with a subprocess invocation of the Gemini CLI — exactly the same auth path used by the Gemini reviewer — so the repair pass works wherever `agent-loop` works with no extra setup.

## Changes

- **`repair.py`**: Replace `google-genai` SDK call with `subprocess.run([gemini_cmd, "--model", "gemini-3.1-flash-lite", "--prompt", prompt])`. Update `attempt_repair` signature to accept `gemini_cmd: str`. Add `_strip_gemini_preamble` to clean CLI output preamble. Non-zero exit code now returns `None` with a debug log instead of silently passing.
- **`orchestrator.py`**: Pass `config.gemini_cmd` to `attempt_repair`.
- **`pyproject.toml`**: Remove the `google-genai>=1.0` dependency (no longer needed).
- **`tests/test_agent_loop.py`**: Replace SDK-mocking tests with `subprocess.run`-mocking tests; update orchestrator fake repair functions to accept the new `gemini_cmd` parameter.

## Test plan

- [ ] All 426 existing tests pass locally (`python3 -m pytest tests/test_agent_loop.py -q`)
- [ ] New tests cover CLI subprocess success and non-zero exit code → `None`
- [ ] Orchestrator integration tests (`test_run_pr_loop_uses_repair_pass_on_format_failure`, `test_run_pr_loop_falls_back_to_error_when_repair_also_fails`, `test_run_pr_loop_skips_repair_when_repair_returns_none`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)