### PR TITLE
Use Gemini CLI for repair pass instead of google-genai SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 
-dependencies = [
-  "google-genai>=1.0",
-]
+dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest>=8"]

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -14,7 +14,7 @@ from .base import (
     with_public_response_file_instruction,
 )
 from ..logging import agent_log_path, log
-from ..protocol import CLARIFY_RE, STATE_RE
+from ..protocol import CLARIFY_RE, PLAN_STATE_RE, STATE_RE
 from ..runner import Runner
 from ..usage import UsageMetadata, coerce_int, first_present
 
@@ -55,7 +55,7 @@ def _strip_gemini_preamble(raw: str) -> str:
     if marker_stripped != raw:
         return marker_stripped
 
-    marker_matches = [*STATE_RE.finditer(raw), *CLARIFY_RE.finditer(raw)]
+    marker_matches = [*STATE_RE.finditer(raw), *PLAN_STATE_RE.finditer(raw), *CLARIFY_RE.finditer(raw)]
     if not marker_matches:
         return raw
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -329,7 +329,7 @@ def _run_validated_agent(
                 )
                 if use_repair and not _is_transient_agent_output(text):
                     log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
-                    repaired = attempt_repair(text)
+                    repaired = attempt_repair(text, config.gemini_cmd)
                     if repaired is not None:
                         try:
                             marker_value = validate(repaired)

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import subprocess
 
-from .agents.gemini import _strip_gemini_preamble
+from .agents.gemini import _parse_gemini_payload
 
 _logger = logging.getLogger(__name__)
 
@@ -139,5 +139,5 @@ def attempt_repair(raw: str, gemini_cmd: str) -> str | None:
     if result.returncode != 0:
         _logger.debug("repair pass CLI exited with code %d", result.returncode)
         return None
-    text = _strip_gemini_preamble(result.stdout.strip())
+    text, _, _, _ = _parse_gemini_payload(result.stdout.strip())
     return text or None

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -9,7 +9,9 @@ as blocking per the issue guardrails.
 from __future__ import annotations
 
 import logging
-import os
+import subprocess
+
+from .agents.gemini import _strip_gemini_preamble
 
 _logger = logging.getLogger(__name__)
 
@@ -116,44 +118,26 @@ Output ONLY the repaired response. No explanations.
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
 
 
-def attempt_repair(raw: str) -> str | None:
-    """Call gemini-3.1-flash-lite to reformat a malformed review response.
+def attempt_repair(raw: str, gemini_cmd: str) -> str | None:
+    """Call gemini-3.1-flash-lite via the Gemini CLI to reformat a malformed review response.
 
-    Returns the repaired text on success, or None when the repair service is
-    unavailable (missing SDK, missing API key) or returns an error.
+    Uses the same CLI invocation path as the reviewer so no extra auth is needed.
+    Returns the repaired text on success, or None when the CLI fails or returns empty output.
     The caller is responsible for re-validating the returned text.
     """
-    try:
-        from google import genai as _genai  # type: ignore[import-untyped]
-    except ImportError:
-        _logger.debug("google-genai SDK not available; skipping repair pass")
-        return None
-
-    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if not api_key:
-        _logger.debug("No GEMINI_API_KEY or GOOGLE_API_KEY found; skipping repair pass")
-        return None
-
     prompt = _REPAIR_PROMPT.replace("{raw_response}", raw, 1)
     try:
-        client = _genai.Client(api_key=api_key)
-        response = client.models.generate_content(
-            model=_REPAIR_MODEL,
-            contents=prompt,
+        result = subprocess.run(
+            [gemini_cmd, "--model", _REPAIR_MODEL, "--prompt", prompt],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        text = response.text
-        if not isinstance(text, str) or not text.strip():
-            _logger.debug("repair model returned empty response")
-            return None
-        usage = getattr(response, "usage_metadata", None)
-        if usage is not None:
-            _logger.info(
-                "repair pass token usage: prompt=%s output=%s total=%s",
-                getattr(usage, "prompt_token_count", None),
-                getattr(usage, "candidates_token_count", None),
-                getattr(usage, "total_token_count", None),
-            )
-        return text
     except Exception as exc:
-        _logger.debug("repair pass call failed: %s", exc)
+        _logger.debug("repair pass CLI invocation failed: %s", exc)
         return None
+    if result.returncode != 0:
+        _logger.debug("repair pass CLI exited with code %d", result.returncode)
+        return None
+    text = _strip_gemini_preamble(result.stdout.strip())
+    return text or None

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -117,6 +117,21 @@ from coding_review_agent_loop.protocol import (
     validate_structured_plan_revision,
 )
 
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(autouse=True)
+def _no_real_repair(request):
+    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
+
+    Tests that explicitly test repair behaviour patch the orchestrator-level
+    import themselves, which takes precedence over this fixture.  Unit tests
+    for attempt_repair itself patch subprocess.run directly, so they are
+    unaffected here.
+    """
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
+        yield
+
 
 class FakeRunner(Runner):
     def __init__(
@@ -9152,8 +9167,6 @@ def test_claude_review_loop_rejects_non_open_pr(tmp_path):
 # ---------------------------------------------------------------------------
 # Repair pass tests
 # ---------------------------------------------------------------------------
-
-from unittest.mock import MagicMock, patch
 
 from coding_review_agent_loop.repair import attempt_repair, _REPAIR_PROMPT
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -869,6 +869,28 @@ Looks good.
     assert raw_usage is None
 
 
+def test_parse_gemini_output_strips_cli_preamble_before_plan_state_marker():
+    raw = """Warning: True color (24-bit) support not detected.
+YOLO mode is enabled.
+I will now review the plan.
+
+---
+
+## Plan Review
+
+Looks like a solid approach.
+
+<!-- AGENT_PLAN_STATE: approved -->
+
+-- Google Gemini
+"""
+    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    assert text.startswith("## Plan Review")
+    assert "YOLO mode" not in text
+    assert "<!-- AGENT_PLAN_STATE: approved -->" in text
+    assert sid is None
+
+
 def test_parse_gemini_output_preserves_markdown_rules_after_preamble():
     raw = """Warning: True color (24-bit) support not detected.
 YOLO mode is enabled.
@@ -9174,6 +9196,23 @@ def test_attempt_repair_calls_cli_and_returns_text():
     assert "--prompt" in cmd
     prompt_idx = cmd.index("--prompt")
     assert "malformed review" in cmd[prompt_idx + 1]
+
+
+def test_attempt_repair_handles_json_wrapped_cli_output():
+    repaired_text = (
+        '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
+        '"blocking_items":[],"same_pr_followups":[],"future_followups":[],'
+        '"prior_item_dispositions":[]}\n<!-- AGENT_STATE: approved -->\n-- Gemini'
+    )
+    json_wrapped = json.dumps({"response": repaired_text, "session_id": "s1"})
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json_wrapped
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result):
+        result = attempt_repair("malformed review", "gemini")
+
+    assert result == repaired_text
 
 
 def test_repair_prompt_contains_raw_response_placeholder():

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9136,36 +9136,44 @@ from unittest.mock import MagicMock, patch
 from coding_review_agent_loop.repair import attempt_repair, _REPAIR_PROMPT
 
 
-def test_attempt_repair_returns_none_when_no_api_key(monkeypatch):
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    result = attempt_repair("some malformed review text")
+def test_attempt_repair_returns_none_when_subprocess_fails(monkeypatch):
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result):
+        result = attempt_repair("some malformed review text", "gemini")
     assert result is None
 
 
-def test_attempt_repair_calls_sdk_and_returns_text(monkeypatch):
+def test_attempt_repair_returns_none_when_subprocess_raises(monkeypatch):
+    with patch("coding_review_agent_loop.repair.subprocess.run", side_effect=FileNotFoundError("gemini not found")):
+        result = attempt_repair("some malformed review text", "gemini")
+    assert result is None
+
+
+def test_attempt_repair_calls_cli_and_returns_text():
     repaired = (
         '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
         '"blocking_items":[],"same_pr_followups":[],"future_followups":[],'
         '"prior_item_dispositions":[]}\n<!-- AGENT_STATE: approved -->\n-- Gemini'
     )
-    mock_response = MagicMock()
-    mock_response.text = repaired
-    mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = mock_response
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
 
-    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-
-    # google-genai is installed; patch the Client class on the real module object
-    from google import genai as real_genai
-    with patch.object(real_genai, "Client", return_value=mock_client):
-        result = attempt_repair("malformed review")
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair("malformed review", "gemini")
 
     assert result == repaired
-    mock_client.models.generate_content.assert_called_once()
-    call_kwargs = mock_client.models.generate_content.call_args
-    assert call_kwargs.kwargs.get("model") == "gemini-3.1-flash-lite"
-    assert "malformed review" in call_kwargs.kwargs.get("contents", "")
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    cmd = call_args.args[0]
+    assert cmd[0] == "gemini"
+    assert "--model" in cmd
+    assert "gemini-3.1-flash-lite" in cmd
+    assert "--prompt" in cmd
+    prompt_idx = cmd.index("--prompt")
+    assert "malformed review" in cmd[prompt_idx + 1]
 
 
 def test_repair_prompt_contains_raw_response_placeholder():
@@ -9200,7 +9208,7 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str) -> str | None:
         captured_repairs.append(raw)
         return repaired_review
 
@@ -9223,7 +9231,7 @@ def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
 
-    def fake_attempt_repair_fails(raw: str) -> str | None:
+    def fake_attempt_repair_fails(raw: str, gemini_cmd: str) -> str | None:
         return "still broken output without valid schema"
 
     with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair_fails):


### PR DESCRIPTION
## Summary

- Replaces the `google-genai` SDK call in `attempt_repair` with a `subprocess.run` invocation of the Gemini CLI, using `--model gemini-3.1-flash-lite`
- Passes `config.gemini_cmd` from the orchestrator through to `attempt_repair` so the same binary is used as the reviewer
- Removes the `google-genai>=1.0` dependency from `pyproject.toml`
- Updates tests to verify the CLI path instead of the SDK mock

## Why

The old SDK approach required `GEMINI_API_KEY` to be set. When it was absent, `attempt_repair` silently returned `None` and the format error was surfaced as-is — no warning, no recovery. The Gemini CLI uses OAuth credentials set up at install time, the same auth already working for review runs.

Fixes #180

## Test plan

- [ ] `test_attempt_repair_returns_none_when_subprocess_fails` — subprocess non-zero exit → `None`
- [ ] `test_attempt_repair_returns_none_when_subprocess_raises` — e.g. binary not found → `None`
- [ ] `test_attempt_repair_calls_cli_and_returns_text` — verifies `gemini --model gemini-3.1-flash-lite --prompt <prompt>` is called and output is returned
- [ ] All existing orchestrator repair integration tests updated for new signature and passing
- [ ] Full test suite: 427 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)