### PR TITLE
Fix orchestrator deadlock when reviewer approves without HUMAN_REQUIREMENTS_RESOLVED

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2719,12 +2719,30 @@ def run_pr_loop(
                         if not human_requirements_resolved(review_output)
                     ]
                     if missing_acknowledgements:
-                        raise AgentLoopError(
-                            "Signed human reviewer requirements remain unresolved or "
-                            "unacknowledged by approved reviewer response(s): "
-                            f"{', '.join(missing_acknowledgements)}. "
-                            "Human intervention is required."
+                        log(
+                            config,
+                            f"Round {round_number}: reviewer(s) {', '.join(missing_acknowledgements)} "
+                            "approved without acknowledging signed human requirements; "
+                            "re-injecting as blocking item",
                         )
+                        unresolved_items.append(
+                            _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer="Orchestrator",
+                                source_round=round_number,
+                                text=(
+                                    f"Reviewer(s) {', '.join(missing_acknowledgements)} approved without "
+                                    "acknowledging the signed human requirements. Coder must address the "
+                                    "human requirements and ensure the reviewer explicitly resolves them "
+                                    "before approval."
+                                ),
+                                status="blocking",
+                            )
+                        )
+                        next_unresolved_item_number += 1
+                        must_fix_items = [
+                            item for item in unresolved_items if item.status in {"blocking", "same-pr"}
+                        ]
                 sync_coder_pr_before_validation(config, runner, pr_number, pr_metadata)
                 migration_validation = validate_pr_migration_topology(
                     runner,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4758,7 +4758,9 @@ def test_pr_loop_does_not_retry_normal_missing_marker_response(tmp_path):
     assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
-def test_pr_loop_blocks_approval_without_human_requirement_resolution_marker(tmp_path):
+def test_pr_loop_reinjects_blocking_item_when_human_requirement_marker_missing(tmp_path):
+    # Reviewer approves without HUMAN_REQUIREMENTS_RESOLVED → synthetic blocking item,
+    # loop hits max_rounds (set to 1) instead of a terminal deadlock.
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
         pr_payload={
@@ -4785,15 +4787,62 @@ def test_pr_loop_blocks_approval_without_human_requirement_resolution_marker(tmp
         auto_merge=True,
         test_command=("pytest", "tests/test_agent_loop.py"),
         approved_followups="summarize",
+        max_rounds=1,
     )
 
-    with pytest.raises(AgentLoopError, match="Signed human reviewer requirements"):
+    # The old behaviour was a terminal deadlock; now the loop continues and hits max_rounds.
+    with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
         run_pr_loop(runner, pr_number=77, config=config)
 
     commands = [cmd for cmd, _cwd in runner.commands]
     assert ["pytest", "tests/test_agent_loop.py"] not in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] not in commands
     assert not any(comment.startswith("Approved-review future follow-ups") for comment in runner.comments)
+
+
+def test_pr_loop_recovers_when_second_reviewer_includes_human_requirement_marker(tmp_path):
+    # Round 1: reviewer approves without HUMAN_REQUIREMENTS_RESOLVED → blocking item injected.
+    # Round 2: coder addresses it; reviewer approves with the marker → success.
+    pr_payload = {
+        "number": 77,
+        "state": "OPEN",
+        "url": "https://github.com/OWNER/REPO/pull/77",
+        "title": "Improve review prompt context",
+        "headRefName": "feature/review-context",
+        "baseRefName": "main",
+        "headRefOid": "abc123",
+        "comments": [
+            {
+                "author": {"login": "maintainer"},
+                "createdAt": "2026-05-18T10:00:00Z",
+                "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+            }
+        ],
+        "reviews": [],
+    }
+    runner = FakeRunner(
+        claude_outputs=[
+            # Round 2: coder addresses the re-injected blocking item and acknowledges human requirements
+            "Addressed human requirements.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: used the absolute URL.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            # Round 1: approves but forgets the marker
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            # Round 2: resolves the synthetic blocking item and acknowledges human requirements
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload=pr_payload,
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
 
 def test_pr_loop_allows_approval_with_human_requirement_resolution_marker(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #178.

When a reviewer approved a PR but omitted `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`, the orchestrator raised a terminal `AgentLoopError` that no subsequent `agent-loop` run could escape (`calls=0` on every retry, permanently stuck).

- **Root cause**: `orchestrator.py` around line 2721 raised `AgentLoopError("Signed human reviewer requirements remain unresolved or unacknowledged…")` — a hard exit with no recovery path.
- **Fix**: Replace the hard raise with a synthetic `blocking` unresolved item attributed to `"Orchestrator"`. The loop falls through to the normal coder-followup path, gives the coder a chance to re-address the human requirements, and triggers a fresh reviewer pass that can include the acknowledgement marker. The human requirement guarantee is preserved without deadlocking the loop.

## Changes

- `src/coding_review_agent_loop/orchestrator.py`: inject synthetic blocking item instead of raising terminal error; log the re-injection event.
- `tests/test_agent_loop.py`:
  - Renamed `test_pr_loop_blocks_approval_without_human_requirement_resolution_marker` → `test_pr_loop_reinjects_blocking_item_when_human_requirement_marker_missing`; updated to use `max_rounds=1` so the loop now hits the max-rounds error (not the old terminal deadlock), and updated the `pytest.raises` match accordingly.
  - Added `test_pr_loop_recovers_when_second_reviewer_includes_human_requirement_marker` verifying the full end-to-end recovery: round 1 reviewer forgets the marker → blocking item injected → round 2 coder addresses it → round 2 reviewer approves with marker → loop returns 0.

## Test plan

- [x] `python3 -m pytest tests/test_agent_loop.py -q` — 434 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)