### PR TITLE
fix: repair prompt v9 — coder_followup fenced JSON and item ID confusion

### DIFF
--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -65,8 +65,8 @@ You are a format-repair assistant. An AI agent produced a code review or coder f
   "kind": "coder_followup",
   "state": "approved" | "blocking",
   "summary": "<short summary>",
-  "addressed_items": ["item-1", "item-human-requirements-acknowledgement"],
-  "remaining_items": [],
+  "addressed_items": ["item-1"],
+  "remaining_items": ["item-2"],
   "human_requirements": {
     "addressed_ids": ["Requirement 1"],
     "checked_discussion_directly": false
@@ -82,7 +82,7 @@ You are a format-repair assistant. An AI agent produced a code review or coder f
 
 ## ARRAY FIELD TYPES (Format C) — TWO DIFFERENT ID TYPES, DO NOT CONFUSE THEM:
 - addressed_items, remaining_items -> reviewer ITEM IDs only: short slugs matching [A-Za-z0-9][A-Za-z0-9._-]*
-  Examples: "item-1", "item-2", "item-human-requirements-acknowledgement"
+  Examples: "item-1", "item-2"
   NEVER put human requirement labels ("Requirement 1") here — they contain spaces and will fail.
 - human_requirements.addressed_ids -> human REQUIREMENT LABELS like "Requirement 1", "Requirement 2"
   These are different from item IDs and may contain spaces.
@@ -151,7 +151,7 @@ section and missing <!-- HUMAN_REQUIREMENTS_ADDRESSED --> marker.
   "kind": "coder_followup",
   "state": "blocking",
   "summary": "Implemented the quota exit policy.",
-  "addressed_items": ["item-human-requirements-acknowledgement"],
+  "addressed_items": ["item-1"],
   "remaining_items": [],
   "human_requirements": {
     "addressed_ids": ["Requirement 1"],
@@ -174,7 +174,7 @@ CORRECT repair — strip the fences, remove the prose, output bare JSON + footer
   "kind": "coder_followup",
   "state": "blocking",
   "summary": "Implemented the quota exit policy.",
-  "addressed_items": ["item-human-requirements-acknowledgement"],
+  "addressed_items": ["item-1"],
   "remaining_items": [],
   "human_requirements": {
     "addressed_ids": ["Requirement 1"],
@@ -185,8 +185,8 @@ CORRECT repair — strip the fences, remove the prose, output bare JSON + footer
 -- Anthropic Claude
 
 Notes:
-- "item-human-requirements-acknowledgement" stays in addressed_items (it is a reviewer item ID)
-- "Requirement 1" stays in human_requirements.addressed_ids (it is a human requirement label)
+- addressed_items contains real reviewer item IDs (like "item-1"), never the human-requirements ack pseudo-item
+- "Requirement 1" stays in human_requirements.addressed_ids (it is a human requirement label, not an item ID)
 - <!-- HUMAN_REQUIREMENTS_ADDRESSED --> is NOT needed in the structured path
 - No prose, no ### sections after the JSON
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -15,7 +15,9 @@ from .agents.gemini import _parse_gemini_payload
 
 _logger = logging.getLogger(__name__)
 
-# v8 prompt — extends v7 with Format C (coder_followup).
+# v9 prompt — fixes coder_followup repair bugs:
+#   - fenced JSON (```json ... ```) now explicitly handled
+#   - addressed_items vs human_requirements.addressed_ids distinction clarified
 # Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
@@ -63,10 +65,10 @@ You are a format-repair assistant. An AI agent produced a code review or coder f
   "kind": "coder_followup",
   "state": "approved" | "blocking",
   "summary": "<short summary>",
-  "addressed_items": ["item-1"],
-  "remaining_items": ["item-2"],
+  "addressed_items": ["item-1", "item-human-requirements-acknowledgement"],
+  "remaining_items": [],
   "human_requirements": {
-    "addressed_ids": [],
+    "addressed_ids": ["Requirement 1"],
     "checked_discussion_directly": false
   }
 }
@@ -78,9 +80,14 @@ You are a format-repair assistant. An AI agent produced a code review or coder f
 - prior_item_dispositions, prior_plan_item_dispositions -> OBJECTS {"item_id":..., "disposition":..., "note":...}
 - disposition values: "resolved", "blocking", "same-pr"/"same-plan", or "future" ONLY
 
-## ARRAY FIELD TYPES (Format C):
-- addressed_items, remaining_items -> STRINGS (item IDs like "item-1", "item-2")
+## ARRAY FIELD TYPES (Format C) — TWO DIFFERENT ID TYPES, DO NOT CONFUSE THEM:
+- addressed_items, remaining_items -> reviewer ITEM IDs only: short slugs matching [A-Za-z0-9][A-Za-z0-9._-]*
+  Examples: "item-1", "item-2", "item-human-requirements-acknowledgement"
+  NEVER put human requirement labels ("Requirement 1") here — they contain spaces and will fail.
+- human_requirements.addressed_ids -> human REQUIREMENT LABELS like "Requirement 1", "Requirement 2"
+  These are different from item IDs and may contain spaces.
 - Every reviewer item ID from the original must appear in EITHER addressed_items OR remaining_items, not both.
+- Do NOT include human requirement labels in addressed_items or remaining_items.
 
 ## STATE RULES (Format A/B):
 ### APPROVED: blocking_items=[], same_pr_followups=[], prior dispositions only "resolved"/"future"
@@ -133,28 +140,60 @@ CORRECT repair: OMIT item-1 from prior_item_dispositions entirely. Do not includ
 
 item-1 is omitted because it was already "future" — it stays future without needing to be re-dispositioned.
 
-## WORKED EXAMPLE 3 — malformed coder follow-up (wrong item classification):
+## WORKED EXAMPLE 3 — coder follow-up with JSON wrapped in fences and human requirements:
 
-Original (malformed): coder_followup, addressed_items has a typo in item ID.
+Original (malformed): coder_followup JSON wrapped in ```json fences, with a ### Human requirements
+section and missing <!-- HUMAN_REQUIREMENTS_ADDRESSED --> marker.
 
-CORRECT repair: fix item IDs to match the expected values from context.
+```json
 {
-  "schema_version": 1, "kind": "coder_followup", "state": "blocking",
-  "summary": "Addressed the CSS issue; one item remains.",
-  "addressed_items": ["item-1"],
-  "remaining_items": ["item-2"],
+  "schema_version": 1,
+  "kind": "coder_followup",
+  "state": "blocking",
+  "summary": "Implemented the quota exit policy.",
+  "addressed_items": ["item-human-requirements-acknowledgement"],
+  "remaining_items": [],
   "human_requirements": {
-    "addressed_ids": [],
+    "addressed_ids": ["Requirement 1"],
+    "checked_discussion_directly": false
+  }
+}
+```
+
+<!-- AGENT_STATE: blocking -->
+
+### Human requirements
+
+- **Requirement 1**: Implemented.
+
+-- Anthropic Claude
+
+CORRECT repair — strip the fences, remove the prose, output bare JSON + footer + signature:
+{
+  "schema_version": 1,
+  "kind": "coder_followup",
+  "state": "blocking",
+  "summary": "Implemented the quota exit policy.",
+  "addressed_items": ["item-human-requirements-acknowledgement"],
+  "remaining_items": [],
+  "human_requirements": {
+    "addressed_ids": ["Requirement 1"],
     "checked_discussion_directly": false
   }
 }
 <!-- AGENT_STATE: blocking -->
--- Coder
+-- Anthropic Claude
+
+Notes:
+- "item-human-requirements-acknowledgement" stays in addressed_items (it is a reviewer item ID)
+- "Requirement 1" stays in human_requirements.addressed_ids (it is a human requirement label)
+- <!-- HUMAN_REQUIREMENTS_ADDRESSED --> is NOT needed in the structured path
+- No prose, no ### sections after the JSON
 
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review). DIFFERENT MARKERS.
-3. JSON "state" matches X. Then: -- Agent Name. STOP.
+3. JSON "state" matches X. Then: -- Agent Name. STOP. Nothing else.
 
 Output ONLY the repaired response. No explanations.
 
@@ -175,7 +214,7 @@ def attempt_repair(raw: str, gemini_cmd: str) -> str | None:
     prompt = _REPAIR_PROMPT.replace("{raw_response}", raw, 1)
     try:
         result = subprocess.run(
-            [gemini_cmd, "--model", _REPAIR_MODEL, "--prompt", prompt],
+            [gemini_cmd, "--model", _REPAIR_MODEL, "--skip-trust", "--prompt", prompt],
             capture_output=True,
             text=True,
             timeout=120,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9638,3 +9638,37 @@ def test_repair_prompt_contains_coder_followup_format():
     assert "coder_followup" in _REPAIR_PROMPT
     assert "addressed_items" in _REPAIR_PROMPT
     assert "remaining_items" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_distinguishes_item_ids_from_requirement_labels():
+    """Repair prompt must warn that addressed_items uses item IDs, not requirement labels."""
+    assert "Requirement 1" in _REPAIR_PROMPT
+    assert "addressed_ids" in _REPAIR_PROMPT
+    # The prompt must explicitly state item IDs cannot contain spaces
+    assert "spaces" in _REPAIR_PROMPT or "DO NOT CONFUSE" in _REPAIR_PROMPT or "NEVER put" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_includes_skip_trust_in_cli_invocation():
+    """The CLI invocation must include --skip-trust so repair works outside trusted dirs."""
+    repaired = (
+        '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
+        '"blocking_items":[],"same_pr_followups":[],"future_followups":[],'
+        '"prior_item_dispositions":[]}\n<!-- AGENT_STATE: approved -->\n-- Gemini'
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        attempt_repair("malformed review", "gemini")
+
+    cmd = mock_run.call_args.args[0]
+    assert "--skip-trust" in cmd
+
+
+def test_repair_prompt_coder_followup_fenced_json_example():
+    """Repair prompt must include a worked example showing fenced JSON being stripped."""
+    assert "```json" in _REPAIR_PROMPT
+    assert "HUMAN_REQUIREMENTS_ADDRESSED" in _REPAIR_PROMPT
+    # The prompt explains the marker is not needed in structured path
+    assert "NOT needed" in _REPAIR_PROMPT or "not needed" in _REPAIR_PROMPT.lower()

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9672,3 +9672,19 @@ def test_repair_prompt_coder_followup_fenced_json_example():
     assert "HUMAN_REQUIREMENTS_ADDRESSED" in _REPAIR_PROMPT
     # The prompt explains the marker is not needed in structured path
     assert "NOT needed" in _REPAIR_PROMPT or "not needed" in _REPAIR_PROMPT.lower()
+
+
+def test_repair_prompt_does_not_suggest_ack_pseudo_item_in_addressed_items():
+    """The ack pseudo-item must never be suggested as a value for addressed_items.
+
+    The orchestrator's _validate_structured_coder_followup_items explicitly excludes
+    HUMAN_REQUIREMENTS_ACK_ITEM_ID from expected_ids, so any response that puts
+    'item-human-requirements-acknowledgement' in addressed_items will be rejected
+    as an unknown item ID.
+    """
+    from coding_review_agent_loop.orchestrator import HUMAN_REQUIREMENTS_ACK_ITEM_ID
+
+    # The ack pseudo-item must not appear in the repair prompt at all, because
+    # any mention of it in an addressed_items context will teach Gemini to produce
+    # responses that the validator rejects.
+    assert HUMAN_REQUIREMENTS_ACK_ITEM_ID not in _REPAIR_PROMPT


### PR DESCRIPTION
## Summary

Fixes two bugs in the `coder_followup` repair path observed on PR #184, plus a silent failure mode that prevented the repair from running at all outside trusted directories.

**Bug 1 — Fenced JSON not stripped**

When Claude wraps its `coder_followup` JSON in ` ```json ``` ` fences, `_extract_json_object_prefix` returns `None` (requires bare `{`), so the structured parser gives up and the markdown fallback runs. The markdown fallback then fails on the missing `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` marker. The repair model received this fenced response but produced an invalid `addressed_items` entry instead of stripping the fences. Fix: Worked Example 3 shows the exact strip-fences pattern and notes that `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` is not needed in the structured path.

**Bug 2 — \`addressed_items\` vs \`human_requirements.addressed_ids\` conflated**

The repair model put \`"Requirement 1"\` (a human requirement label, spaces allowed) into \`addressed_items\` (reviewer item IDs only, must match \`[A-Za-z0-9][A-Za-z0-9._-]*\`), causing: \`coder_followup.addressed_items item at index 1 must match [A-Za-z0-9][A-Za-z0-9._-]*\`. Fix: explicit warning distinguishing the two fields in the prompt.

**Bug 3 — \`--skip-trust\` missing from CLI invocation**

The Gemini CLI exits with code 55 when invoked outside a git workspace unless \`--skip-trust\` is passed. The reviewer invocation uses it via \`default_args\`; the repair pass did not, causing silent \`None\` returns in some environments.

## Test plan

- `test_repair_prompt_distinguishes_item_ids_from_requirement_labels` — prompt warns against putting requirement labels in `addressed_items`
- `test_repair_prompt_includes_skip_trust_in_cli_invocation` — subprocess call includes `--skip-trust`
- `test_repair_prompt_coder_followup_fenced_json_example` — prompt has fenced-JSON worked example and explains the marker is not needed
- All 16 repair tests pass; all 464 tests pass

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)