### PR TITLE
Add post-plan decomposition modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,33 @@ default the loop posts the approved plan summary and stops; add
 agent-loop issue 123 --repo OWNER/REPO --plan-first --implement-after-approval
 ```
 
+`--plan-first` also supports explicit post-approval modes:
+
+```bash
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode plan-only
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode decompose-only
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode implement-one-shot
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode implement-by-phase
+```
+
+`plan-only` is the default. `implement-one-shot` is the same behavior selected
+by the backward-compatible `--implement-after-approval` flag. `decompose-only`
+asks the coder to turn the approved plan into ordered phases, always creates
+one GitHub child issue per phase, posts a parent summary table, and stops.
+`implement-by-phase` creates every child issue, then implements only the first
+`agent-pr` phase and stops after that PR review loop. If the first phase is
+`human-action` or `manual-close`, the loop creates and reports all child issues
+but stops so a human can do the required work, add a remark/update, and close
+that child issue.
+
+Each generated child issue copies the relevant parent-plan slice, constraints
+and invariants, dependency notes, scope and non-goals, rollout risk,
+validation/soak requirements, automation classification, and instructions for
+agent execution or human closure. Decomposition is capped at 8 phases; an
+over-cap response is rejected and must be consolidated, not truncated. This cap
+is separate from the approved-review follow-up issue cap used by
+`--approved-followups`.
+
 Provide a one-off task directly when there is no issue yet:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -174,6 +174,48 @@ normal implementation and PR review loop using the approved plan:
 agent-loop issue 56 --repo OWNER/REPO --plan-first --implement-after-approval
 ```
 
+For larger plans, choose the post-approval behavior explicitly with
+`--plan-execution-mode`:
+
+```bash
+agent-loop issue 56 --repo OWNER/REPO --plan-first --plan-execution-mode plan-only
+agent-loop issue 56 --repo OWNER/REPO --plan-first --plan-execution-mode decompose-only
+agent-loop issue 56 --repo OWNER/REPO --plan-first --plan-execution-mode implement-one-shot
+agent-loop issue 56 --repo OWNER/REPO --plan-first --plan-execution-mode implement-by-phase
+```
+
+The modes are:
+
+- `plan-only`: post the approved plan summary and stop. This is the default.
+- `decompose-only`: ask the coder to decompose the approved plan, validate the
+  structured JSON response, create one GitHub child issue per phase, post a
+  parent summary, and stop. The summary table is not a substitute for child
+  issues.
+- `implement-one-shot`: keep the existing post-approval implementation handoff.
+  This is also what `--implement-after-approval` selects for compatibility.
+- `implement-by-phase`: create/link every phase issue, implement only the first
+  `agent-pr` child issue, then stop after that PR review loop.
+
+Generated child issues are self-contained: each body includes the parent issue
+link, the relevant approved parent-plan slice, constraints/invariants,
+dependency notes, scope and non-goals, rollout risk, validation/soak
+requirements, automation classification, and explicit instructions for either
+`agent-loop issue <N>` execution or human remark/closure. Dependency links are
+filled in after earlier child issue numbers or URLs are known.
+
+Automation classification is required for every phase. `agent-pr` means the
+phase is expected to be implemented through a child issue and PR.
+`human-action` and `manual-close` phases are still created as child issues, but
+their titles, bodies, and parent summary call out that a human must perform the
+work or checkpoint, add the required remark/update, and close the issue. If
+`implement-by-phase` sees a human-only first phase, it stops instead of
+pretending the agent can implement it.
+
+Plan decomposition allows at most 8 phases. Over-cap responses are validation
+failures and must be consolidated; phases are never silently truncated. This
+limit is independent of `--approved-followups`, whose issue mode still caps
+approved-review future follow-up issues separately.
+
 Implement a free-form task:
 
 ```bash

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -270,6 +270,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="With --plan-first, continue into implementation after reviewers approve the plan.",
     )
+    issue.add_argument(
+        "--plan-execution-mode",
+        choices=("plan-only", "decompose-only", "implement-one-shot", "implement-by-phase"),
+        default=None,
+        help=(
+            "With --plan-first, choose what happens after approval: plan-only, "
+            "decompose-only, implement-one-shot, or implement-by-phase. "
+            "Defaults to plan-only unless --implement-after-approval is used."
+        ),
+    )
     add_common(issue)
 
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
@@ -334,12 +344,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "issue":
             if args.implement_after_approval and not args.plan_first:
                 raise AgentLoopError("--implement-after-approval requires --plan-first.")
+            if args.plan_execution_mode and not args.plan_first:
+                raise AgentLoopError("--plan-execution-mode requires --plan-first.")
+            plan_execution_mode = args.plan_execution_mode
+            if plan_execution_mode is None:
+                plan_execution_mode = (
+                    "implement-one-shot" if args.implement_after_approval else "plan-only"
+                )
+            elif args.implement_after_approval and plan_execution_mode != "implement-one-shot":
+                raise AgentLoopError(
+                    "--implement-after-approval is only compatible with "
+                    "--plan-execution-mode implement-one-shot."
+                )
+            config = AgentLoopConfig(
+                **{
+                    **config.__dict__,
+                    "plan_execution_mode": plan_execution_mode,
+                }
+            )
             return run_issue_loop(
                 runner,
                 issue_number=args.issue_number,
                 config=config,
                 plan_first=args.plan_first,
-                implement_after_approval=args.implement_after_approval,
+                implement_after_approval=plan_execution_mode == "implement-one-shot",
             )
         if args.command == "pr":
             return run_pr_loop(runner, pr_number=args.pr_number, config=config)

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -54,6 +54,7 @@ class AgentLoopConfig:
     agent_memory_dir: Path
     refresh_test_profile: bool
     approved_followups: str = "ignore"
+    plan_execution_mode: str = "plan-only"
     auto_agent_dirs: tuple[AgentName, ...] = ()
 
     def __post_init__(self) -> None:
@@ -512,5 +513,6 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ),
         refresh_test_profile=args.refresh_test_profile,
         approved_followups=args.approved_followups,
+        plan_execution_mode=getattr(args, "plan_execution_mode", None) or "plan-only",
         auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -1,0 +1,430 @@
+"""Approved-plan decomposition parsing and publishing helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .config import AgentLoopConfig
+from .errors import AgentLoopError
+from .github import create_issue, post_issue_comment
+from .runner import Runner
+
+MAX_DECOMPOSITION_PHASES = 8
+AUTOMATION_CLASSES = {"agent-pr", "human-action", "manual-close"}
+DECOMPOSITION_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_DECOMPOSITION:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)(?:\b|$)|#(\d+)\b")
+
+
+@dataclass(frozen=True)
+class PlanPhase:
+    title: str
+    scope: str
+    non_goals: str
+    dependency_notes: str
+    rollout_risk: str
+    validation: str
+    parent_context: str
+    automation: str
+    depends_on: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlanDecomposition:
+    phases: tuple[PlanPhase, ...]
+
+
+@dataclass(frozen=True)
+class CreatedPhaseIssue:
+    phase: PlanPhase
+    issue_url: str | None
+    issue_number: int | None
+
+
+@dataclass(frozen=True)
+class DecompositionMetadata:
+    parent_issue: int
+    plan_hash: str
+    mode: str
+    phase_count: int
+    phase_titles: tuple[str, ...]
+    automation: tuple[str, ...]
+    children: tuple[tuple[str, str | None, int | None], ...]
+
+
+def approved_plan_hash(approved_plan: str) -> str:
+    return hashlib.sha256(approved_plan.strip().encode("utf-8")).hexdigest()[:16]
+
+
+def _extract_json_object(text: str) -> dict[str, object]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^\s*```(?:json)?\s*", "", stripped, count=1, flags=re.I)
+        stripped = re.sub(r"\s*```\s*$", "", stripped, count=1)
+    decoder = json.JSONDecoder()
+    try:
+        payload, end = decoder.raw_decode(stripped)
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError(f"Invalid plan decomposition JSON: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise AgentLoopError("Invalid plan decomposition JSON: top-level payload must be an object.")
+    trailing = stripped[end:].strip()
+    if trailing and not trailing.startswith("<!--"):
+        raise AgentLoopError("Invalid plan decomposition JSON: unexpected text after JSON payload.")
+    return payload
+
+
+def _required_text(payload: dict[str, object], key: str, *, phase_title: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AgentLoopError(f"Invalid plan decomposition: phase {phase_title!r} is missing `{key}`.")
+    return value.strip()
+
+
+def parse_plan_decomposition(text: str) -> PlanDecomposition:
+    payload = _extract_json_object(text)
+    if payload.get("kind") not in (None, "plan_decomposition"):
+        raise AgentLoopError("Invalid plan decomposition: `kind` must be `plan_decomposition`.")
+    phases_payload = payload.get("phases")
+    if not isinstance(phases_payload, list) or not phases_payload:
+        raise AgentLoopError("Invalid plan decomposition: `phases` must be a non-empty list.")
+    if len(phases_payload) > MAX_DECOMPOSITION_PHASES:
+        raise AgentLoopError(
+            f"Invalid plan decomposition: {len(phases_payload)} phases exceeds "
+            f"MAX_DECOMPOSITION_PHASES={MAX_DECOMPOSITION_PHASES}; consolidate phases."
+        )
+
+    phases: list[PlanPhase] = []
+    seen_titles: set[str] = set()
+    for index, phase_payload in enumerate(phases_payload, start=1):
+        if not isinstance(phase_payload, dict):
+            raise AgentLoopError(f"Invalid plan decomposition: phase {index} must be an object.")
+        title = _required_text(phase_payload, "title", phase_title=f"#{index}")
+        title_key = " ".join(title.lower().split())
+        if title_key in seen_titles:
+            raise AgentLoopError(f"Invalid plan decomposition: duplicate phase title {title!r}.")
+        seen_titles.add(title_key)
+        automation = _required_text(phase_payload, "automation", phase_title=title)
+        if automation not in AUTOMATION_CLASSES:
+            raise AgentLoopError(
+                f"Invalid plan decomposition: phase {title!r} has invalid automation {automation!r}."
+            )
+        depends_on_payload = phase_payload.get("depends_on", [])
+        if depends_on_payload is None:
+            depends_on_payload = []
+        if not isinstance(depends_on_payload, list) or not all(
+            isinstance(value, str) and value.strip() for value in depends_on_payload
+        ):
+            raise AgentLoopError(
+                f"Invalid plan decomposition: phase {title!r} `depends_on` must be a list of titles."
+            )
+        phases.append(
+            PlanPhase(
+                title=title,
+                scope=_required_text(phase_payload, "scope", phase_title=title),
+                non_goals=_required_text(phase_payload, "non_goals", phase_title=title),
+                dependency_notes=_required_text(phase_payload, "dependency_notes", phase_title=title),
+                rollout_risk=_required_text(phase_payload, "rollout_risk", phase_title=title),
+                validation=_required_text(phase_payload, "validation", phase_title=title),
+                parent_context=_required_text(phase_payload, "parent_context", phase_title=title),
+                automation=automation,
+                depends_on=tuple(value.strip() for value in depends_on_payload),
+            )
+        )
+
+    known_titles = {phase.title for phase in phases}
+    known_keys = {" ".join(phase.title.lower().split()): phase.title for phase in phases}
+    for phase in phases:
+        for dependency in phase.depends_on:
+            if dependency not in known_titles and " ".join(dependency.lower().split()) not in known_keys:
+                raise AgentLoopError(
+                    f"Invalid plan decomposition: phase {phase.title!r} depends on unknown phase {dependency!r}."
+                )
+    return PlanDecomposition(phases=tuple(phases))
+
+
+def _issue_number_from_url(issue_url: str | None) -> int | None:
+    if not issue_url:
+        return None
+    match = ISSUE_NUMBER_RE.search(issue_url)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))
+
+
+def _phase_issue_title(parent_issue: int, index: int, phase: PlanPhase) -> str:
+    prefix = "[Human] " if phase.automation in {"human-action", "manual-close"} else ""
+    return f"{prefix}Phase {index}: {phase.title} (from #{parent_issue})"[:120]
+
+
+def _dependency_lines(phase: PlanPhase, created: Sequence[CreatedPhaseIssue]) -> list[str]:
+    if not phase.depends_on:
+        return ["- None."]
+    by_title = {item.phase.title: item for item in created}
+    lines: list[str] = []
+    for dependency in phase.depends_on:
+        created_issue = by_title.get(dependency)
+        if created_issue and created_issue.issue_number is not None:
+            lines.append(f"- depends on #{created_issue.issue_number}: {dependency}")
+        elif created_issue and created_issue.issue_url:
+            lines.append(f"- depends on {created_issue.issue_url}: {dependency}")
+        elif created_issue:
+            lines.append(f"- depends on previously created phase with unavailable issue URL: {dependency}")
+        else:
+            lines.append(f"- depends on prior phase: {dependency}")
+    return lines
+
+
+def format_phase_issue_body(
+    *,
+    repo: str,
+    parent_issue: int,
+    approved_plan: str,
+    phase: PlanPhase,
+    created_so_far: Sequence[CreatedPhaseIssue],
+) -> str:
+    parent_url = f"https://github.com/{repo}/issues/{parent_issue}"
+    if phase.automation == "agent-pr":
+        execution = (
+            "Run `agent-loop issue <this issue number>` to implement this phase in its own PR. "
+            "Keep the PR scoped to this phase."
+        )
+    elif phase.automation == "human-action":
+        execution = (
+            "This phase requires human action before agent implementation continues. A human should perform "
+            "the work, add a remark/update describing the result, and close this issue."
+        )
+    else:
+        execution = (
+            "This phase is a manual closure/checkpoint. A human should add the required remark/update and "
+            "close this issue when the checkpoint is satisfied."
+        )
+    return "\n".join(
+        [
+            f"Child phase issue for parent #{parent_issue}: {parent_url}",
+            "",
+            "## Approved parent-plan excerpt for this phase",
+            phase.parent_context,
+            "",
+            "## Scope",
+            phase.scope,
+            "",
+            "## Non-goals",
+            phase.non_goals,
+            "",
+            "## Constraints and invariants from the parent plan",
+            approved_plan.strip(),
+            "",
+            "## Dependency notes",
+            phase.dependency_notes,
+            "",
+            "## Dependency links",
+            *_dependency_lines(phase, created_so_far),
+            "",
+            "## Rollout risk",
+            phase.rollout_risk,
+            "",
+            "## Validation / soak requirement",
+            phase.validation,
+            "",
+            "## Automation classification",
+            phase.automation,
+            "",
+            "## Execution instructions",
+            execution,
+        ]
+    )
+
+
+def create_decomposition_child_issues(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    approved_plan: str,
+    decomposition: PlanDecomposition,
+) -> tuple[CreatedPhaseIssue, ...]:
+    created: list[CreatedPhaseIssue] = []
+    for index, phase in enumerate(decomposition.phases, start=1):
+        issue_url = create_issue(
+            runner,
+            config=config,
+            title=_phase_issue_title(parent_issue, index, phase),
+            body=format_phase_issue_body(
+                repo=config.repo,
+                parent_issue=parent_issue,
+                approved_plan=approved_plan,
+                phase=phase,
+                created_so_far=created,
+            ),
+        )
+        created.append(
+            CreatedPhaseIssue(
+                phase=phase,
+                issue_url=issue_url,
+                issue_number=_issue_number_from_url(issue_url),
+            )
+        )
+    return tuple(created)
+
+
+def _encode_metadata(metadata: DecompositionMetadata) -> str:
+    payload = {
+        "parent_issue": metadata.parent_issue,
+        "plan_hash": metadata.plan_hash,
+        "mode": metadata.mode,
+        "phase_count": metadata.phase_count,
+        "phase_titles": list(metadata.phase_titles),
+        "automation": list(metadata.automation),
+        "children": [
+            {"title": title, "url": url, "number": number}
+            for title, url, number in metadata.children
+        ],
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_metadata(encoded: str) -> DecompositionMetadata:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.") from exc
+    children_payload = payload.get("children")
+    if not isinstance(children_payload, list):
+        raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.")
+    children: list[tuple[str, str | None, int | None]] = []
+    for child in children_payload:
+        if not isinstance(child, dict) or not isinstance(child.get("title"), str):
+            raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.")
+        url = child.get("url")
+        number = child.get("number")
+        children.append(
+            (
+                child["title"],
+                url if isinstance(url, str) else None,
+                number if isinstance(number, int) else None,
+            )
+        )
+    try:
+        return DecompositionMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            plan_hash=str(payload["plan_hash"]),
+            mode=str(payload["mode"]),
+            phase_count=int(payload["phase_count"]),
+            phase_titles=tuple(str(value) for value in payload["phase_titles"]),
+            automation=tuple(str(value) for value in payload["automation"]),
+            children=tuple(children),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.") from exc
+
+
+def find_existing_decomposition(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+    plan_hash: str,
+    mode: str,
+) -> DecompositionMetadata | None:
+    found: DecompositionMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in DECOMPOSITION_MARKER_RE.finditer(body):
+            metadata = _decode_metadata(match.group("payload"))
+            if (
+                metadata.parent_issue == parent_issue
+                and metadata.plan_hash == plan_hash
+                and metadata.mode == mode
+            ):
+                found = metadata
+    if found is None:
+        return None
+    if found.phase_count != len(found.children):
+        known = ", ".join(url or f"#{number}" for _title, url, number in found.children if url or number)
+        raise AgentLoopError(
+            "Existing plan decomposition metadata is incomplete; manual recovery required before rerun. "
+            f"Known child issues: {known or 'none'}."
+        )
+    return found
+
+
+def format_decomposition_parent_summary(
+    *,
+    parent_issue: int,
+    mode: str,
+    plan_hash: str,
+    created: Sequence[CreatedPhaseIssue],
+) -> str:
+    metadata = DecompositionMetadata(
+        parent_issue=parent_issue,
+        plan_hash=plan_hash,
+        mode=mode,
+        phase_count=len(created),
+        phase_titles=tuple(item.phase.title for item in created),
+        automation=tuple(item.phase.automation for item in created),
+        children=tuple(
+            (item.phase.title, item.issue_url, item.issue_number)
+            for item in created
+        ),
+    )
+    lines = [
+        f"Approved plan decomposed for issue #{parent_issue}.",
+        "",
+        f"Mode: {mode}",
+        "",
+        "| Phase | Automation | Child issue | Risk |",
+        "| --- | --- | --- | --- |",
+    ]
+    for index, item in enumerate(created, start=1):
+        if item.issue_url:
+            child = item.issue_url
+        elif item.issue_number is not None:
+            child = f"#{item.issue_number}"
+        else:
+            child = "Created issue URL unavailable from GitHub CLI output."
+        human_note = " Human remark and closure required." if item.phase.automation != "agent-pr" else ""
+        lines.append(
+            f"| {index}. {item.phase.title} | {item.phase.automation} | {child} | {item.phase.rollout_risk}{human_note} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Every phase above has a GitHub child issue; this table is only a summary.",
+            "",
+            f"<!-- AGENT_PLAN_DECOMPOSITION: {_encode_metadata(metadata)} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def post_decomposition_parent_summary(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    mode: str,
+    plan_hash: str,
+    created: Sequence[CreatedPhaseIssue],
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=parent_issue,
+        body=format_decomposition_parent_summary(
+            parent_issue=parent_issue,
+            mode=mode,
+            plan_hash=plan_hash,
+            created=created,
+        ),
+    )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -18,6 +18,14 @@ from .config import (
     sync_coder_pr_before_validation,
     sync_reviewer_pr_before_review,
 )
+from .decomposition import (
+    CreatedPhaseIssue,
+    approved_plan_hash,
+    create_decomposition_child_issues,
+    find_existing_decomposition,
+    parse_plan_decomposition,
+    post_decomposition_parent_summary,
+)
 from .errors import AgentLoopError, QuotaResetExceededError
 from .github import (
     IssueContext,
@@ -41,6 +49,7 @@ from .prompts import (
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
     build_issue_prompt,
+    build_plan_decomposition_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
     build_review_prompt,
@@ -604,6 +613,151 @@ def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
     return "blocking with blocking plan issues"
 
 
+def _implement_approved_issue(
+    runner: Runner,
+    *,
+    issue_number: int,
+    approved_plan: str,
+    config: AgentLoopConfig,
+    memory,
+    issue_context: IssueContext,
+    coder_session_id: str | None,
+    usage_context: RunUsageContext,
+) -> int:
+    coder_name = agent_display_name(config.coder)
+    sync_coder_base_before_implementation(config, runner)
+    log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
+    coder_response = _run_validated_agent(
+        runner,
+        agent=config.coder,
+        config=config,
+        prompt=build_issue_implementation_prompt(
+            issue_number,
+            approved_plan,
+            config,
+            memory,
+            issue_context=issue_context,
+        ),
+        session_id=coder_session_id,
+        marker_description="<!-- AGENT_PR: <number> --> or PR URL",
+        validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
+            text,
+            marker_validator=_require_pr_number,
+            human_requirements=human_requirements,
+            requirement_scope="implementation requirements",
+            full_omission_fallback="Fetch the issue discussion directly before implementing.",
+        ),
+        usage_context=usage_context,
+    )
+    coder_output = coder_response.text
+    pr_number = int(coder_response.marker_value)
+    log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
+    validate_open_pr(runner, config=config, pr_number=pr_number)
+    validate_pr_references_issue(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        issue_number=issue_number,
+    )
+    post_pr_comment(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        body=_attach_round_metadata(
+            coder_output,
+            PostedRoundMetadata(
+                flow="pr",
+                role="coder",
+                agent=coder_name,
+                round_number=1,
+                subject=str(get_pr_review_context(runner, config=config, pr_number=pr_number).metadata.head_sha or "unknown"),
+                prior_items=(),
+            ),
+        ),
+    )
+    return run_pr_loop(
+        runner,
+        pr_number=pr_number,
+        config=config,
+        coder_session_id=coder_response.session_id,
+        issue_context=issue_context,
+        workdirs_ready=True,
+        usage_context=usage_context,
+        pre_review_test_pending=True,
+    )
+
+
+def _decompose_approved_plan(
+    runner: Runner,
+    *,
+    issue_number: int,
+    approved_plan: str,
+    config: AgentLoopConfig,
+    memory,
+    issue_context: IssueContext,
+    mode: str,
+    coder_session_id: str | None,
+    usage_context: RunUsageContext,
+) -> tuple[CreatedPhaseIssue, ...]:
+    plan_hash = approved_plan_hash(approved_plan)
+    existing = find_existing_decomposition(
+        issue_context.comments,
+        parent_issue=issue_number,
+        plan_hash=plan_hash,
+        mode=mode,
+    )
+    if existing is not None:
+        log(config, f"Plan decomposition already exists for issue #{issue_number} ({mode}); not recreating children")
+        return tuple(
+            CreatedPhaseIssue(
+                phase=type(
+                    "_ExistingPhase",
+                    (),
+                    {"title": title, "automation": automation, "rollout_risk": "recorded"},
+                )(),
+                issue_url=url,
+                issue_number=number,
+            )
+            for (title, url, number), automation in zip(existing.children, existing.automation, strict=False)
+        )
+
+    coder_name = agent_display_name(config.coder)
+    log(config, f"Planning approved; invoking {coder_name} to decompose issue #{issue_number}")
+    decomposition_response = _run_validated_agent(
+        runner,
+        agent=config.coder,
+        config=config,
+        prompt=build_plan_decomposition_prompt(
+            issue_number,
+            approved_plan,
+            config,
+            memory,
+            issue_context=issue_context,
+        ),
+        session_id=coder_session_id,
+        marker_description="plan decomposition JSON",
+        validate=parse_plan_decomposition,
+        usage_context=usage_context,
+    )
+    decomposition = decomposition_response.marker_value
+    created = create_decomposition_child_issues(
+        runner,
+        config=config,
+        parent_issue=issue_number,
+        approved_plan=approved_plan,
+        decomposition=decomposition,
+    )
+    post_decomposition_parent_summary(
+        runner,
+        config=config,
+        parent_issue=issue_number,
+        mode=mode,
+        plan_hash=plan_hash,
+        created=created,
+    )
+    return created
+
+
 def _run_plan_first_loop(
     runner: Runner,
     *,
@@ -840,73 +994,76 @@ def _run_plan_first_loop(
                     approved_future_followups,
                 ),
             )
-            if not implement_after_approval:
+            mode = config.plan_execution_mode
+            if implement_after_approval:
+                mode = "implement-one-shot"
+            if mode == "plan-only":
                 print(
                     f"Issue #{issue_number} plan approved by {format_agent_list(configured_reviewers)}."
                 )
                 return 0
 
-            sync_coder_base_before_implementation(config, runner)
-            log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
-            coder_response = _run_validated_agent(
-                runner,
-                agent=config.coder,
-                config=config,
-                prompt=build_issue_implementation_prompt(
-                    issue_number,
-                    current_plan,
-                    config,
-                    memory,
+            if mode in {"decompose-only", "implement-by-phase"}:
+                created = _decompose_approved_plan(
+                    runner,
+                    issue_number=issue_number,
+                    approved_plan=current_plan,
+                    config=config,
+                    memory=memory,
                     issue_context=issue_context,
-                ),
-                session_id=coder_session_id,
-                marker_description="<!-- AGENT_PR: <number> --> or PR URL",
-                validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
-                    text,
-                    marker_validator=_require_pr_number,
-                    human_requirements=human_requirements,
-                    requirement_scope="implementation requirements",
-                    full_omission_fallback="Fetch the issue discussion directly before implementing.",
-                ),
-                usage_context=usage_context,
-            )
-            coder_output = coder_response.text
-            coder_session_id = coder_response.session_id
-            pr_number = int(coder_response.marker_value)
-            log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
-            validate_open_pr(runner, config=config, pr_number=pr_number)
-            validate_pr_references_issue(
-                runner,
-                config=config,
-                pr_number=pr_number,
-                issue_number=issue_number,
-            )
-            post_pr_comment(
-                runner,
-                config=config,
-                pr_number=pr_number,
-                body=_attach_round_metadata(
-                    coder_output,
-                    PostedRoundMetadata(
-                        flow="pr",
-                        role="coder",
-                        agent=coder_name,
-                        round_number=1,
-                        subject=str(get_pr_review_context(runner, config=config, pr_number=pr_number).metadata.head_sha or "unknown"),
-                        prior_items=(),
-                    ),
-                ),
-            )
-            return run_pr_loop(
-                runner,
-                pr_number=pr_number,
-                config=config,
-                coder_session_id=coder_session_id,
-                issue_context=issue_context,
-                workdirs_ready=True,
-                usage_context=usage_context,
-                pre_review_test_pending=True,
-            )
+                    mode=mode,
+                    coder_session_id=coder_session_id,
+                    usage_context=usage_context,
+                )
+                if mode == "decompose-only":
+                    print(f"Issue #{issue_number} approved plan decomposed into child issues.")
+                    return 0
+                first_agent_phase = next(
+                    (item for item in created if item.phase.automation == "agent-pr"),
+                    None,
+                )
+                first_phase = created[0] if created else None
+                if first_phase is None:
+                    raise AgentLoopError("Plan decomposition produced no phases.")
+                if first_phase.phase.automation != "agent-pr":
+                    print(
+                        f"Issue #{issue_number} approved plan decomposed; first phase requires human work "
+                        f"({first_phase.phase.automation}), so implementation is stopping."
+                    )
+                    return 0
+                if first_agent_phase is None or first_agent_phase.issue_number is None:
+                    raise AgentLoopError(
+                        "Cannot implement first decomposed phase because its child issue number "
+                        "was not available from GitHub CLI output."
+                    )
+                child_issue_context = get_issue_context(
+                    runner,
+                    config=config,
+                    issue_number=first_agent_phase.issue_number,
+                )
+                return _implement_approved_issue(
+                    runner,
+                    issue_number=first_agent_phase.issue_number,
+                    approved_plan=getattr(first_agent_phase.phase, "parent_context", current_plan),
+                    config=config,
+                    memory=memory,
+                    issue_context=child_issue_context,
+                    coder_session_id=coder_session_id,
+                    usage_context=usage_context,
+                )
+
+            if mode == "implement-one-shot":
+                return _implement_approved_issue(
+                    runner,
+                    issue_number=issue_number,
+                    approved_plan=current_plan,
+                    config=config,
+                    memory=memory,
+                    issue_context=issue_context,
+                    coder_session_id=coder_session_id,
+                    usage_context=usage_context,
+                )
+            raise AgentLoopError(f"Unknown plan execution mode: {mode}")
 
         if round_number == config.max_rounds:
             raise AgentLoopError(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -10,6 +10,7 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
+from .decomposition import MAX_DECOMPOSITION_PHASES
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
 from .protocol import (
@@ -733,6 +734,70 @@ the `AGENT_PLAN_STATE` footer immediately after that payload, and end with only
 your standalone signature. If you fall back to markdown, keep the exact section
 headings above. Always sign your response:
 -- {reviewer_signature}
+"""
+
+
+def build_plan_decomposition_prompt(
+    issue_number: int,
+    approved_plan: str,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
+) -> str:
+    coder_signature = agent_signature(config.coder)
+    return f"""Decompose the approved implementation plan for GitHub issue #{issue_number} in {config.repo}.
+
+Use this local checkout only to inspect context. Do not edit files, create a
+branch, commit, push, or open a pull request during this decomposition stage.
+{_scratch_file_guidance()}
+{_issue_context_block(issue_context)}
+{_memory_block(memory)}
+
+Approved implementation plan:
+
+{approved_plan}
+
+Return exactly one JSON object. The orchestrator will validate it and create one
+GitHub child issue for every phase. A parent checklist or table is only summary
+text and cannot replace child issues.
+
+Schema:
+{{
+  "schema_version": 1,
+  "kind": "plan_decomposition",
+  "phases": [
+    {{
+      "title": "Short phase title",
+      "scope": "What this phase implements.",
+      "non_goals": "What this phase explicitly does not do.",
+      "dependency_notes": "Ordering and dependency notes.",
+      "rollout_risk": "low|medium|high plus a short reason.",
+      "validation": "Expected validation and soak/checkpoint before the next phase.",
+      "parent_context": "Self-contained excerpt of the approved parent-plan slice and constraints needed to run this child issue independently.",
+      "automation": "agent-pr",
+      "depends_on": []
+    }}
+  ]
+}}
+
+Rules:
+- Use between 1 and {MAX_DECOMPOSITION_PHASES} phases. If the plan seems larger,
+  consolidate related steps; do not exceed the cap.
+- Preserve dependency ordering. `depends_on` must reference earlier phase titles.
+- Every child issue must be self-contained enough for `agent-loop issue <N>` to
+  run without rediscovering the full parent thread.
+- Classify automation as exactly one of: `agent-pr`, `human-action`, or
+  `manual-close`.
+- Most implementation phases should be `agent-pr`: each one should be automatable
+  through a child issue and later PR.
+- Use `human-action` or `manual-close` only when a human must perform extra work,
+  add a remark/update, and close that child issue manually.
+- Include explicit scope boundaries, risk, validation/soak requirements, parent
+  constraints/invariants, and non-goals for every phase.
+
+Do not wrap the JSON in markdown fences. Signatures and AGENT markers are not
+needed for this response.
+-- {coder_signature}
 """
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -47,6 +47,12 @@ from coding_review_agent_loop.config import (
     default_agent_workdir,
     default_cache_root,
 )
+from coding_review_agent_loop.decomposition import (
+    MAX_DECOMPOSITION_PHASES,
+    approved_plan_hash,
+    format_decomposition_parent_summary,
+    parse_plan_decomposition,
+)
 from coding_review_agent_loop.github import (
     HumanReviewRequirement,
     IssueComment,
@@ -574,6 +580,30 @@ def _make_migration(revision: str, down_revision: str | tuple[str, ...] | None) 
         f"down_revision = {repr(down_revision)}\n"
         "branch_labels = None\n"
         "depends_on = None\n"
+    )
+
+
+def plan_decomposition_json(*phases):
+    if not phases:
+        phases = (
+            {
+                "title": "Internal schema utilities",
+                "scope": "Add internal helpers only.",
+                "non_goals": "No live orchestrator behavior changes.",
+                "dependency_notes": "First phase; no dependencies.",
+                "rollout_risk": "low - internal only.",
+                "validation": "Run parser and orchestrator tests before the next phase.",
+                "parent_context": "Approved plan slice: add helpers and tests while preserving existing behavior.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+        )
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_decomposition",
+            "phases": list(phases),
+        }
     )
 
 
@@ -7540,6 +7570,33 @@ def test_approved_followups_cli_mode_is_configurable(tmp_path, mode):
     assert config.approved_followups == mode
 
 
+@pytest.mark.parametrize(
+    "mode",
+    ["plan-only", "decompose-only", "implement-one-shot", "implement-by-phase"],
+)
+def test_plan_execution_mode_cli_is_configurable(tmp_path, mode):
+    parser = build_parser()
+    args = parser.parse_args([
+        "issue",
+        "56",
+        "--repo",
+        "OWNER/REPO",
+        "--plan-first",
+        "--plan-execution-mode",
+        mode,
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+        "--gemini-dir",
+        str(tmp_path / "gemini"),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.plan_execution_mode == mode
+
+
 def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):
     parser = build_parser()
     codex_dir = tmp_path / "codex"
@@ -8235,6 +8292,89 @@ def test_issue_loop_plan_first_stops_after_approved_plan(tmp_path):
     assert not any(cmd[:2] == ["git", "switch"] for cmd, _cwd in runner.commands)
 
 
+def test_parse_plan_decomposition_accepts_agent_and_human_phases():
+    parsed = parse_plan_decomposition(
+        plan_decomposition_json(
+            {
+                "title": "Internal schema utilities",
+                "scope": "Add helpers.",
+                "non_goals": "No live switch.",
+                "dependency_notes": "First phase.",
+                "rollout_risk": "low - internal only.",
+                "validation": "Run python -m pytest.",
+                "parent_context": "Approved plan slice and invariant details.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+            {
+                "title": "Manual rollout checkpoint",
+                "scope": "Human validates the deployed behavior.",
+                "non_goals": "No code changes.",
+                "dependency_notes": "After Internal schema utilities.",
+                "rollout_risk": "medium - live checkpoint.",
+                "validation": "Human remark and closure required.",
+                "parent_context": "Approved plan slice for the manual checkpoint.",
+                "automation": "human-action",
+                "depends_on": ["Internal schema utilities"],
+            },
+        )
+    )
+
+    assert [phase.title for phase in parsed.phases] == [
+        "Internal schema utilities",
+        "Manual rollout checkpoint",
+    ]
+    assert parsed.phases[1].automation == "human-action"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda phase: phase.pop("parent_context"), "parent_context"),
+        (lambda phase: phase.pop("rollout_risk"), "rollout_risk"),
+        (lambda phase: phase.pop("validation"), "validation"),
+        (lambda phase: phase.__setitem__("automation", "robot"), "invalid automation"),
+        (lambda phase: phase.__setitem__("depends_on", ["Missing phase"]), "unknown phase"),
+    ],
+)
+def test_parse_plan_decomposition_rejects_invalid_phase_fields(mutate, message):
+    phase = {
+        "title": "Internal schema utilities",
+        "scope": "Add helpers.",
+        "non_goals": "No live switch.",
+        "dependency_notes": "First phase.",
+        "rollout_risk": "low - internal only.",
+        "validation": "Run python -m pytest.",
+        "parent_context": "Approved plan slice and invariant details.",
+        "automation": "agent-pr",
+        "depends_on": [],
+    }
+    mutate(phase)
+
+    with pytest.raises(AgentLoopError, match=message):
+        parse_plan_decomposition(plan_decomposition_json(phase))
+
+
+def test_parse_plan_decomposition_rejects_duplicates_and_over_cap():
+    phase = {
+        "title": "Repeated phase",
+        "scope": "Add helpers.",
+        "non_goals": "No live switch.",
+        "dependency_notes": "First phase.",
+        "rollout_risk": "low - internal only.",
+        "validation": "Run python -m pytest.",
+        "parent_context": "Approved plan slice and invariant details.",
+        "automation": "agent-pr",
+        "depends_on": [],
+    }
+    with pytest.raises(AgentLoopError, match="duplicate phase title"):
+        parse_plan_decomposition(plan_decomposition_json(phase, dict(phase)))
+
+    phases = [dict(phase, title=f"Phase {index}") for index in range(MAX_DECOMPOSITION_PHASES + 1)]
+    with pytest.raises(AgentLoopError, match="MAX_DECOMPOSITION_PHASES"):
+        parse_plan_decomposition(plan_decomposition_json(*phases))
+
+
 def test_issue_loop_plan_first_rejects_missing_initial_plan_human_requirements_acknowledgement(
     tmp_path,
 ):
@@ -8791,6 +8931,165 @@ def test_issue_loop_plan_first_approved_future_followups_are_summarized_without_
     assert "Approved plan future follow-ups:" in runner.comments[-1]
     assert "document parser helper reuse separately" in runner.comments[-1]
     assert "Add a later cleanup to dedupe shared prompt rendering." in runner.comments[-1]
+
+
+def test_issue_loop_plan_first_decompose_only_creates_child_issues(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            plan_decomposition_json(
+                {
+                    "title": "Schema helpers",
+                    "scope": "Add parser dataclasses and tests.",
+                    "non_goals": "No live orchestrator switch.",
+                    "dependency_notes": "First phase; no dependencies.",
+                    "rollout_risk": "low - internal only.",
+                    "validation": "Run python -m pytest tests/test_agent_loop.py.",
+                    "parent_context": "Approved plan slice: add schema helpers and preserve behavior.",
+                    "automation": "agent-pr",
+                    "depends_on": [],
+                },
+                {
+                    "title": "Human rollout checkpoint",
+                    "scope": "Human validates rollout readiness.",
+                    "non_goals": "No code changes.",
+                    "dependency_notes": "Depends on Schema helpers.",
+                    "rollout_risk": "medium - manual checkpoint.",
+                    "validation": "Human must add a remark and close the issue.",
+                    "parent_context": "Approved plan slice: stop for human validation.",
+                    "automation": "manual-close",
+                    "depends_on": ["Schema helpers"],
+                },
+            ),
+        ],
+        codex_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+    )
+    config = make_config(tmp_path, plan_execution_mode="decompose-only")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(runner.issues) == 2
+    assert runner.issues[0]["title"] == "Phase 1: Schema helpers (from #56)"
+    assert "Run `agent-loop issue <this issue number>`" in runner.issues[0]["body"]
+    assert "Approved plan slice: add schema helpers" in runner.issues[0]["body"]
+    assert runner.issues[1]["title"] == "[Human] Phase 2: Human rollout checkpoint (from #56)"
+    assert "depends on #101: Schema helpers" in runner.issues[1]["body"]
+    assert "human should add the required remark/update and close this issue" in runner.issues[1]["body"]
+    summary = runner.comments[-1]
+    assert summary.startswith("Approved plan decomposed for issue #56.")
+    assert "Every phase above has a GitHub child issue" in summary
+    assert "<!-- AGENT_PLAN_DECOMPOSITION:" in summary
+    assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_decompose_only_is_idempotent(tmp_path):
+    plan = "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    summary = format_decomposition_parent_summary(
+        parent_issue=56,
+        mode="decompose-only",
+        plan_hash=approved_plan_hash(plan),
+        created=(),
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": summary},
+        ],
+    )
+    config = make_config(tmp_path, plan_execution_mode="decompose-only")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.issues == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_implement_by_phase_stops_on_human_first_phase(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Validate migration manually first.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            plan_decomposition_json(
+                {
+                    "title": "Manual readiness check",
+                    "scope": "Human validates external readiness.",
+                    "non_goals": "No agent PR.",
+                    "dependency_notes": "First phase; no dependencies.",
+                    "rollout_risk": "medium - manual readiness gate.",
+                    "validation": "Human remark and closure required.",
+                    "parent_context": "Approved plan slice: manual readiness gate.",
+                    "automation": "human-action",
+                    "depends_on": [],
+                }
+            ),
+        ],
+        codex_outputs=["Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-by-phase")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"].startswith("[Human] Phase 1")
+    assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_implement_by_phase_implements_first_agent_phase(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            plan_decomposition_json(),
+            "Implemented first phase.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/99"],
+        pr_payload={"body": "Fixes #99"},
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-by-phase")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(runner.issues) == 1
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 3
+    assert "GitHub issue #99" in claude_calls[2][-1]
+    assert "Approved implementation plan" in claude_calls[2][-1]
 
 
 def test_issue_loop_plan_first_keeps_blocking_review_when_future_followups_are_misclassified(tmp_path):


### PR DESCRIPTION
## Summary
- add explicit plan execution modes for plan-only, decompose-only, implement-one-shot, and implement-by-phase
- add strict approved-plan decomposition parsing, child issue creation, parent metadata markers, and rerun idempotency
- document phased child issue behavior, human-only phases, and the separate decomposition phase cap

Fixes #151

<!-- HUMAN_REQUIREMENTS_ADDRESSED -->

### Human requirements
- Requirement 1: Automatable phases are represented as self-contained child issues intended for later `agent-loop issue <N>` execution and PRs. Non-automatable `human-action` and `manual-close` phases also create child issues with explicit human remark/update and closure instructions in the child body and parent summary.

## Tests
- `python3 -m pytest`