### PR TITLE
Render structured coder follow-up comments

### DIFF
--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -17,6 +17,7 @@ from .protocol import (
     ParsedPlanReview,
     ParsedReview,
     ReviewItemDisposition,
+    StructuredCoderFollowup,
     StructuredPlanRevision,
     UnresolvedReviewItem,
     review_freeform_summary_text,
@@ -173,7 +174,7 @@ def render_canonical_plan_revision(
     if prior_items or parsed_revision.prior_plan_item_dispositions:
         sections.append(
             _render_prior_dispositions_section(
-                heading="### Prior plan review item dispositions",
+                heading="### Prior plan item dispositions",
                 prior_items=prior_items,
                 dispositions=parsed_revision.prior_plan_item_dispositions,
             )
@@ -328,6 +329,36 @@ def _render_public_plan_review_comment(
     )
 
 
+def _render_public_coder_followup_comment(
+    parsed_followup: StructuredCoderFollowup,
+    *,
+    signature: str,
+) -> str:
+    addressed_items = (
+        [f"- {item_id}" for item_id in parsed_followup.addressed_items]
+        if parsed_followup.addressed_items
+        else ["- None."]
+    )
+    remaining_items = (
+        [f"- {item_id}" for item_id in parsed_followup.remaining_items]
+        if parsed_followup.remaining_items
+        else ["- None."]
+    )
+    sections = [
+        "## Coder follow-up",
+        parsed_followup.summary.strip(),
+        "\n".join(["### Addressed items", *addressed_items]),
+        "\n".join(["### Remaining items", *remaining_items]),
+    ]
+    if parsed_followup.tests_run:
+        sections.append(
+            "\n".join(["### Tests run", *[f"- {test}" for test in parsed_followup.tests_run]])
+        )
+    sections.append(f"<!-- AGENT_STATE: {parsed_followup.state} -->")
+    sections.append(f"-- {signature}")
+    return "\n\n".join(section for section in sections if section)
+
+
 def _extract_plan_revision_human_requirements_block(text: str) -> str:
     stripped = text.lstrip()
     if not stripped.startswith("{"):
@@ -350,7 +381,7 @@ def _render_public_plan_revision_comment(
     raw_text: str,
     signature: str,
 ) -> str:
-    sections = [render_canonical_plan_revision(parsed_revision, prior_items)]
+    sections = ["## Revised plan", render_canonical_plan_revision(parsed_revision, prior_items)]
     human_requirements_block = _extract_plan_revision_human_requirements_block(raw_text)
     if human_requirements_block:
         sections.append(human_requirements_block)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -63,6 +63,7 @@ from .protocol import (
     ParsedPlanReview,
     ParsedReview,
     ReviewItemDisposition,
+    StructuredCoderFollowup,
     StructuredPlanRevision,
     UnresolvedReviewItem,
     human_requirements_resolved,
@@ -96,6 +97,7 @@ from .comment_rendering import (
     _item_label_status,
     _normalize_item_summary,
     _public_reviewer_name,
+    _render_public_coder_followup_comment,
     _render_disposition_status,
     _render_prior_dispositions_section,
     _render_public_plan_review_comment,
@@ -1791,6 +1793,14 @@ def run_pr_loop(
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id
             latest_coder_output = coder_output
+            public_comment = coder_output
+            raw_structured_coder_response: str | None = None
+            if isinstance(coder_response.marker_value, StructuredCoderFollowup):
+                raw_structured_coder_response = coder_output
+                public_comment = _render_public_coder_followup_comment(
+                    coder_response.marker_value,
+                    signature=agent_signature(config.coder),
+                )
 
             unresolved_items = _reconcile_human_requirements_ack_item(
                 unresolved_items,
@@ -1805,7 +1815,7 @@ def run_pr_loop(
                 config=config,
                 pr_number=pr_number,
                 body=_attach_round_metadata(
-                    coder_output,
+                    public_comment,
                     PostedRoundMetadata(
                         flow="pr",
                         role="coder",
@@ -1813,6 +1823,7 @@ def run_pr_loop(
                         round_number=round_number + 1,
                         subject=str(updated_pr_context.metadata.head_sha or "unknown"),
                         prior_items=tuple(unresolved_items),
+                        raw_structured_coder_response=raw_structured_coder_response,
                     ),
                 ),
             )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1102,7 +1102,9 @@ def _run_plan_first_loop(
         )
         canonical_plan: str | None = None
         public_comment = plan_response.text
+        raw_structured_coder_response: str | None = None
         if isinstance(plan_response.marker_value, StructuredPlanRevision):
+            raw_structured_coder_response = plan_response.text
             canonical_plan = render_canonical_plan_revision(plan_response.marker_value, must_fix_items)
             current_plan = canonical_plan
             public_comment = _render_public_plan_revision_comment(
@@ -1128,6 +1130,7 @@ def _run_plan_first_loop(
                     subject=_plan_subject(current_plan),
                     prior_items=tuple(must_fix_items),
                     canonical_plan=canonical_plan,
+                    raw_structured_coder_response=raw_structured_coder_response,
                 ),
             ),
         )

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -346,6 +346,7 @@ def _resume_plan_round(
     current_round_records = selection.current_round_records
     anchor_metadata = selection.anchor_record.metadata
     current_plan = latest_coder_record.metadata.canonical_plan or latest_coder_record.body
+    coder_output = latest_coder_record.metadata.raw_structured_coder_response or current_plan
     reviewer_records: dict[str, PostedRoundRecord] = {}
     configured_reviewer_names = {agent_display_name(agent) for agent in configured_reviewers}
     for record in current_round_records:
@@ -358,7 +359,7 @@ def _resume_plan_round(
         ResumedReviewRound(
             round_number=anchor_metadata.round_number,
             prior_items=anchor_metadata.prior_items,
-            coder_output=current_plan,
+            coder_output=coder_output,
             completed_reviews=tuple(reviewer_records[agent_display_name(agent)] for agent in configured_reviewers if agent_display_name(agent) in reviewer_records),
             next_unresolved_item_number=_max_unresolved_item_number_from_records(
                 [record for record in records if record.metadata.subject == anchor_metadata.subject]

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -34,6 +34,7 @@ class PostedRoundMetadata:
     new_items: tuple[UnresolvedReviewItem, ...] = ()
     state: str | None = None
     canonical_plan: str | None = None
+    raw_structured_coder_response: str | None = None
 
 
 @dataclass(frozen=True)
@@ -118,6 +119,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "new_items": [_serialize_unresolved_item(item) for item in metadata.new_items],
         "state": metadata.state,
         "canonical_plan": metadata.canonical_plan,
+        "raw_structured_coder_response": metadata.raw_structured_coder_response,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -144,6 +146,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             canonical_plan=(
                 str(payload["canonical_plan"])
                 if payload.get("canonical_plan") is not None
+                else None
+            ),
+            raw_structured_coder_response=(
+                str(payload["raw_structured_coder_response"])
+                if payload.get("raw_structured_coder_response") is not None
                 else None
             ),
         )
@@ -308,7 +315,12 @@ def _resume_pr_round(
     return ResumedReviewRound(
         round_number=round_number,
         prior_items=prior_items,
-        coder_output=latest_coder_record.body if latest_coder_record is not None else None,
+        coder_output=(
+            latest_coder_record.metadata.raw_structured_coder_response
+            or latest_coder_record.body
+            if latest_coder_record is not None
+            else None
+        ),
         completed_reviews=tuple(reviewer_records[agent_display_name(agent)] for agent in configured_reviewers if agent_display_name(agent) in reviewer_records),
         next_unresolved_item_number=_max_unresolved_item_number_from_records(
             [record for record in records if record.metadata.subject == head_sha]

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -73,6 +73,7 @@ from coding_review_agent_loop.orchestrator import (
     _encode_round_metadata,
     _format_unresolved_item_label,
     _plan_subject,
+    _render_public_coder_followup_comment,
     _render_public_plan_review_comment,
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
@@ -3306,14 +3307,88 @@ def test_render_canonical_plan_revision_and_public_comment():
 
     assert canonical == (
         "Revised the plan to cover rollback behavior.\n\n"
-        "### Prior plan review item dispositions\n"
+        "### Prior plan item dispositions\n"
         "- [item-4] Blocking issue from OpenAI Codex, round 2: Add a resume-path step. -> "
         "resolved: Added a resume-path step.\n\n"
         "### Plan steps\n"
         "1. Update protocol.py.\n"
         "2. Add orchestrator resume tests."
     )
-    assert public == canonical + "\n\n<!-- AGENT_PLAN_STATE: blocking -->\n\n-- OpenAI Codex"
+    assert public == (
+        "## Revised plan\n\n"
+        + canonical
+        + "\n\n<!-- AGENT_PLAN_STATE: blocking -->\n\n-- OpenAI Codex"
+    )
+    assert '"kind": "plan_revision"' not in public
+
+
+def test_render_public_coder_followup_comment():
+    parsed = validate_structured_coder_followup(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Added the requested regression test.",
+                "addressed_items": ["item-1", "item-2"],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": ["Requirement 1"],
+                    "checked_discussion_directly": False,
+                },
+                "tests_run": [
+                    "python -m pytest tests/test_agent_loop.py -k coder_followup"
+                ],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    assert parsed is not None
+
+    rendered = _render_public_coder_followup_comment(parsed, signature="Anthropic Claude")
+
+    assert rendered == (
+        "## Coder follow-up\n\n"
+        "Added the requested regression test.\n\n"
+        "### Addressed items\n"
+        "- item-1\n"
+        "- item-2\n\n"
+        "### Remaining items\n"
+        "- None.\n\n"
+        "### Tests run\n"
+        "- python -m pytest tests/test_agent_loop.py -k coder_followup\n\n"
+        "<!-- AGENT_STATE: blocking -->\n\n"
+        "-- Anthropic Claude"
+    )
+    assert "```json" not in rendered
+    assert '"kind": "coder_followup"' not in rendered
+
+    without_tests = validate_structured_coder_followup(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Still working through the review.",
+                "addressed_items": [],
+                "remaining_items": ["item-3"],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+                "tests_run": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    assert without_tests is not None
+    rendered_without_tests = _render_public_coder_followup_comment(
+        without_tests,
+        signature="Anthropic Claude",
+    )
+    assert "### Tests run" not in rendered_without_tests
+    assert "### Addressed items\n- None." in rendered_without_tests
+    assert "### Remaining items\n- item-3" in rendered_without_tests
 
 
 def test_render_public_plan_review_comment_normalizes_sections():
@@ -5116,7 +5191,17 @@ def test_pr_loop_accepts_structured_coder_followup_in_pr_round(tmp_path):
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    assert any('"kind": "coder_followup"' in comment for comment in runner.comments)
+    followup_comments = [comment for comment in runner.comments if "## Coder follow-up" in comment]
+    assert len(followup_comments) == 1
+    visible_followup = _strip_round_metadata(followup_comments[0])
+    assert "Added the requested regression test." in visible_followup
+    assert "### Addressed items\n- item-1" in visible_followup
+    assert "### Remaining items\n- None." in visible_followup
+    assert (
+        "### Tests run\n- pytest tests/test_agent_loop.py -k structured_coder_followup"
+        in visible_followup
+    )
+    assert '"kind": "coder_followup"' not in visible_followup
 
 
 def test_pr_loop_rejects_malformed_structured_coder_followup_before_re_review(tmp_path):
@@ -6898,6 +6983,62 @@ def test_resume_pr_round_reparses_orchestrator_rendered_blocking_issues_comment(
         "Exercise the structured-resume path."
     ]
     assert resumed_review.summary == "Need one more regression test before merge."
+
+
+def test_resume_pr_round_prefers_structured_coder_followup_metadata():
+    carried_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Need one more regression test before merge.",
+        status="blocking",
+        source_status="blocking",
+    )
+    raw_structured_followup = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Added the requested regression test.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": ["Requirement 1"],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    parsed = validate_structured_coder_followup(raw_structured_followup)
+    assert parsed is not None
+    public_comment = _render_public_coder_followup_comment(parsed, signature="Anthropic Claude")
+    coder_comment = _attach_round_metadata(
+        public_comment,
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(carried_item,),
+            raw_structured_coder_response=raw_structured_followup,
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=coder_comment)],
+        head_sha="abc123",
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    assert resumed.coder_output == raw_structured_followup
+    resumed_followup = validate_structured_coder_followup(resumed.coder_output)
+    assert resumed_followup is not None
+    assert resumed_followup.human_requirements.addressed_ids == ("Requirement 1",)
+    assert '"kind": "coder_followup"' not in _strip_round_metadata(coder_comment)
 
 
 def test_resume_pr_round_prefers_latest_metadata_ledger_for_same_head_replay():

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8572,6 +8572,47 @@ def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
 
 
+def test_issue_loop_plan_revision_stores_raw_structured_metadata(tmp_path):
+    raw_structured_revision = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Revised plan with tests.",
+                "prior_plan_item_dispositions": [
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Added the missing test step."}
+                ],
+                "plan_steps": ["Add the regression test.", "Run the focused suite."],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            raw_structured_revision,
+        ],
+        codex_outputs=[
+            "### Blocking plan issues\n- Missing test strategy.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Plan looks sound."
+            + prior_plan_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.comments[2].startswith("## Revised plan")
+    assert '"kind": "plan_revision"' not in _strip_round_metadata(runner.comments[2])
+    raw_comment = runner.issue_comments[2]["body"]
+    match = re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", raw_comment)
+    assert match is not None
+    metadata = _decode_round_metadata(match.group("payload"))
+    assert metadata.raw_structured_coder_response == raw_structured_revision
+
+
 def test_issue_loop_plan_revision_rejects_missing_human_requirements_acknowledgement(tmp_path):
     runner = FakeRunner(
         issue_payload={
@@ -8940,6 +8981,54 @@ def test_resume_plan_round_prefers_canonical_plan_metadata():
     current_plan, state = resumed
     assert current_plan == canonical_plan
     assert state.coder_output == canonical_plan
+
+
+def test_resume_plan_round_prefers_structured_plan_revision_metadata_for_coder_output():
+    public_body = (
+        "## Revised plan\n\nRevised plan summary.\n\n### Plan steps\n1. Public body copy.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    raw_structured_revision = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Revised plan summary.",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": ["Canonical copy."],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    parsed = validate_structured_plan_revision(raw_structured_revision)
+    assert parsed is not None
+    canonical_plan = render_canonical_plan_revision(parsed, ())
+    coder_comment = _attach_round_metadata(
+        public_body,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=_plan_subject(canonical_plan),
+            prior_items=(),
+            canonical_plan=canonical_plan,
+            raw_structured_coder_response=raw_structured_revision,
+        ),
+    )
+
+    resumed = _resume_plan_round(
+        [IssueComment(author="bot", created_at="2026-05-20T09:00:00Z", body=coder_comment)],
+        configured_reviewers=("codex", "gemini"),
+    )
+
+    assert resumed is not None
+    current_plan, state = resumed
+    assert current_plan == canonical_plan
+    assert state.coder_output == raw_structured_revision
+    assert validate_structured_plan_revision(state.coder_output) is not None
+    assert '"kind": "plan_revision"' not in _strip_round_metadata(coder_comment)
 
 
 def test_resume_plan_round_falls_back_to_raw_body_for_markdown_plan():


### PR DESCRIPTION
## Summary

- render structured coder follow-up responses as readable GitHub markdown
- preserve raw structured coder payloads in AGENT_LOOP_META for resume/reconciliation
- add focused regressions for coder follow-up rendering, metadata resume, and plan-revision prose

Fixes #188

## Tests

- python3 -m pytest tests/test_agent_loop.py -k 'coder_followup or plan_revision or resume_pr_round or resume_plan_round'\n- python3 -m pytest