### PR TITLE
Remove markdown fallback for live agent responses

### DIFF
--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -228,7 +228,7 @@ def _render_public_pr_review_comment(
     dispositions: Sequence[ReviewItemDisposition],
 ) -> str:
     sections: list[str] = [f"**Review verdict:** {parsed_review.state.title()}"]
-    if parsed_review.summary:
+    if parsed_review.summary and parsed_review.summary.strip() != "Review complete.":
         sections.append(parsed_review.summary.strip())
     if parsed_review.blocking_items:
         sections.append(
@@ -283,7 +283,7 @@ def _render_public_plan_review_comment(
     dispositions: Sequence[ReviewItemDisposition],
 ) -> str:
     sections: list[str] = [f"**Review verdict:** {parsed_review.state.title()}"]
-    if parsed_review.summary:
+    if parsed_review.summary and parsed_review.summary.strip() != "Plan review complete.":
         sections.append(parsed_review.summary.strip())
     if parsed_review.items.blocking:
         sections.append(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -70,7 +70,9 @@ from .protocol import (
     is_clarification_request,
     parse_agent_state,
     parse_plan_review,
+    parse_plan_review_items,
     parse_plan_state,
+    parse_structured_plan_review,
     parse_pr_number,
     review_freeform_summary_text,
     validate_human_requirements_acknowledgement,
@@ -578,11 +580,13 @@ def _validate_plan_revision_response(text: str) -> StructuredPlanRevision | str:
     parsed = validate_structured_plan_revision(text)
     if parsed is not None:
         return parsed
-    return parse_plan_state(text)
+    raise AgentLoopError("Plan revision did not use the required structured format.")
 
 
 def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
     if not summary:
+        return False
+    if summary.strip() in {"Review complete.", "Plan review complete."}:
         return False
     if not had_prior_items or not had_dispositions:
         return True
@@ -846,10 +850,18 @@ def _run_plan_first_loop(
             resumed_record = resumed_by_name.get(reviewer_name)
             if resumed_record is not None:
                 review_output = resumed_record.body
+                structured_review = parse_structured_plan_review(
+                    review_output,
+                    reviewer=reviewer_name,
+                )
                 parsed_review = ParsedPlanReview(
                     state=resumed_record.metadata.state or parse_plan_state(review_output),
                     summary=review_freeform_summary_text(review_output),
-                    items=parse_plan_review(review_output, reviewer=reviewer_name).items,
+                    items=(
+                        structured_review.items
+                        if structured_review is not None
+                        else parse_plan_review_items(review_output, reviewer=reviewer_name)
+                    ),
                     dispositions=resumed_record.metadata.dispositions,
                 )
                 review_state = parsed_review.state
@@ -1099,6 +1111,7 @@ def _run_plan_first_loop(
                 full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
             ),
             usage_context=usage_context,
+            use_repair=True,
         )
         canonical_plan: str | None = None
         public_comment = plan_response.text

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -359,9 +359,8 @@ def _structured_coder_followup_guidance(
     human_requirements_context: CoderHumanRequirementsPromptContext,
 ) -> str:
     lines = [
-        f"Prefer this structured JSON follow-up format first so {reviewer_name} and the orchestrator can validate your response deterministically:",
+        f"Use this mandatory structured JSON follow-up format so {reviewer_name} and the orchestrator can validate your response deterministically:",
         "",
-        "```json",
         "{",
         '  "schema_version": 1,',
         '  "kind": "coder_followup",',
@@ -375,11 +374,10 @@ def _structured_coder_followup_guidance(
         "  },",
         '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
         "}",
-        "```",
         "",
         "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `tests_run` is optional.",
-        "The response must begin with exactly one top-level JSON object and must not include prose before or between the JSON and footer.",
-        "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->` and your signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
+        "Your response must begin with exactly one top-level JSON object and must not include prose or code fences before or between the JSON and footer.",
+        "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->`, then only your standalone signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
         "Use `addressed_items` and `remaining_items` to classify the unresolved reviewer item IDs shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
     ]
     if human_requirements_context.block:
@@ -393,13 +391,6 @@ def _structured_coder_followup_guidance(
             lines.append(
                 "If the prompt omitted detailed signed human requirements, set `human_requirements.addressed_ids` to `[]` and `human_requirements.checked_discussion_directly` to `true` only after checking the GitHub discussion directly."
             )
-    lines.extend(
-        [
-            "",
-            "Markdown follow-up output remains a compatibility fallback during migration when you are not using the structured JSON format.",
-            f"Legacy markdown replies must still include `{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}` and a `### Human requirements` section when signed human reviewer requirements are present.",
-        ]
-    )
     return "\n".join(lines) + "\n"
 
 
@@ -668,9 +659,8 @@ Plan from {coder_name}:
 {plan}
 
 Review the plan for correctness, architecture fit, missing edge cases, test
-strategy, and ambiguity. Prefer this structured JSON response format first:
+strategy, and ambiguity. Use this mandatory structured JSON response format:
 
-```json
 {{
   "schema_version": 1,
   "kind": "plan_review",
@@ -685,18 +675,6 @@ strategy, and ambiguity. Prefer this structured JSON response format first:
 }}
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
-```
-
-If you do not use the structured JSON format, use this exact markdown compatibility format instead:
-
-### Blocking plan issues
-- Required corrections that must be resolved before the plan can be approved.
-
-### Same-plan follow-ups
-- Required current-plan refinements that should be folded into the next plan revision before approval.
-
-### Future follow-ups
-- Ideas worth tracking separately that are not required for the current implementation plan.
 
 Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
 follow-ups may appear only in blocking plan reviews. Future follow-ups are
@@ -731,8 +709,8 @@ Use approved only if there are no blocking plan issues, no Same-plan
 follow-ups, and no carried-forward plan items left active for this planning
 round. Structured responses must start with one top-level JSON object, place
 the `AGENT_PLAN_STATE` footer immediately after that payload, and end with only
-your standalone signature. If you fall back to markdown, keep the exact section
-headings above. Always sign your response:
+your standalone signature. Do not include prose or code fences before the JSON
+object. Always sign your response:
 -- {reviewer_signature}
 """
 
@@ -856,9 +834,8 @@ Then provide the revised implementation plan with concrete file areas, edge
 cases, and tests. Use `same-plan`, never `same-pr`, when describing plan-only
 current-round refinements.
 
-Prefer this structured JSON response format first:
+Use this mandatory structured JSON response format:
 
-```json
 {{
   "schema_version": 1,
   "kind": "plan_revision",
@@ -875,13 +852,13 @@ Prefer this structured JSON response format first:
 }}
 <!-- AGENT_PLAN_STATE: blocking -->
 -- {coder_signature}
-```
 
 The orchestrator will normalize structured plan revisions into canonical
 markdown for stored plan state, reviewer prompts, subject hashing, and resume.
-If you do not use the structured JSON format, fall back to markdown
-compatibility by keeping the `### Prior plan review item dispositions` section
-and then providing the full revised plan in markdown prose.
+Your response must start with exactly one top-level JSON object, with no prose
+or code fences before it. Put the `AGENT_PLAN_STATE` footer immediately after
+the JSON, make the footer state match the JSON state, and include only your
+standalone signature after the footer.
 
 This is planning round {round_number}. End your final response with exactly one
 planning marker:
@@ -1112,12 +1089,6 @@ instead when small or local cleanup should be fixed before merge.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
-    markdown_fallback_sections = ["- summary paragraph", "- `### Blocking issues`"]
-    if config.approved_followups.startswith("fix-and-"):
-        markdown_fallback_sections.append("- `### Same-PR follow-ups`")
-    if config.approved_followups != "ignore":
-        markdown_fallback_sections.append("- `### Future follow-ups`")
-    markdown_fallback_sections.append("- `### Prior unresolved item dispositions`")
     return f"""Review pull request #{pr_number} in {config.repo} (round {round_number}).
 
 PR metadata:
@@ -1168,10 +1139,9 @@ Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.
 
-Prefer this structured PR review format. Start your response with exactly one
-top-level JSON object and no prose before it:
+Use this mandatory structured PR review format. Start your response with
+exactly one top-level JSON object and no prose or code fences before it:
 
-```json
 {{
   "schema_version": 1,
   "kind": "pr_review",
@@ -1185,7 +1155,6 @@ top-level JSON object and no prose before it:
     {{"item_id": "item-2", "disposition": "future", "note": "brief reason"}}
   ]
 }}
-```
 
 After the JSON object, include only:
 1. optional `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`
@@ -1195,10 +1164,6 @@ After the JSON object, include only:
 Do not include any extra prose, headings, bullets, or fenced blocks before or
 after that structured response. The footer AGENT_STATE must match the JSON
 `state`.
-
-Markdown fallback remains available for compatibility when you do not use the
-structured format. In markdown reviews, use this section order:
-{chr(10).join(markdown_fallback_sections)}
 
 End your final response with exactly one marker:
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -1429,7 +1429,7 @@ def parse_pr_review(text: str, *, reviewer: str) -> ParsedReview:
     parsed = parse_structured_pr_review(text, reviewer=reviewer)
     if parsed is not None:
         return parsed
-    return parse_review(text, reviewer=reviewer)
+    raise AgentLoopError("Agent response did not use the required structured format.")
 
 
 def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
@@ -1437,19 +1437,7 @@ def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
     parsed = parse_structured_plan_review(text, reviewer=reviewer)
     if parsed is not None:
         return parsed
-    state = parse_plan_state(text)
-    summary = review_freeform_summary_text(text)
-    items = parse_plan_review_items(text, reviewer=reviewer)
-    dispositions = parse_plan_item_dispositions(text, reviewer=reviewer)
-    return _finalize_parsed_plan_review(
-        state=state,
-        summary=summary,
-        items=items,
-        dispositions=dispositions,
-        raw_dispositions_text=_extract_section_text(
-            text, heading_re=PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE
-        ),
-    )
+    raise AgentLoopError("Agent response did not use the required structured format.")
 
 
 def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -15,13 +15,14 @@ from .agents.gemini import _parse_gemini_payload
 
 _logger = logging.getLogger(__name__)
 
-# v9 prompt — fixes coder_followup repair bugs:
+# v10 prompt — adds plan_revision repair and keeps coder_followup repair bugs fixed:
 #   - fenced JSON (```json ... ```) now explicitly handled
 #   - addressed_items vs human_requirements.addressed_ids distinction clarified
+#   - plan_revision / plan_steps inputs choose the plan revision schema
 # Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
-You are a format-repair assistant. An AI agent produced a code review or coder follow-up that failed strict schema validation. Extract its intent and reformat it into one of these three valid formats.
+You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, or coder follow-up that failed strict schema validation. Extract its intent and reformat it into one of these four valid formats.
 
 ## Valid Format A — PR Review:
 
@@ -75,8 +76,23 @@ You are a format-repair assistant. An AI agent produced a code review or coder f
 <!-- AGENT_STATE: approved -->
 -- <Coder Name>
 
-## ARRAY FIELD TYPES (Format A/B):
-- blocking_items, same_pr_followups, future_followups, blocking_plan_issues, same_plan_followups -> STRINGS
+## Valid Format D — Plan Revision:
+
+{
+  "schema_version": 1,
+  "kind": "plan_revision",
+  "state": "blocking",
+  "summary": "<short summary>",
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved", "note": "covered by the revised plan"}
+  ],
+  "plan_steps": ["Update the parser.", "Add regression tests."]
+}
+<!-- AGENT_PLAN_STATE: blocking -->
+-- <Coder Name>
+
+## ARRAY FIELD TYPES (Format A/B/D):
+- blocking_items, same_pr_followups, future_followups, blocking_plan_issues, same_plan_followups, plan_steps -> STRINGS
 - prior_item_dispositions, prior_plan_item_dispositions -> OBJECTS {"item_id":..., "disposition":..., "note":...}
 - disposition values: "resolved", "blocking", "same-pr"/"same-plan", or "future" ONLY
 
@@ -97,8 +113,12 @@ You are a format-repair assistant. An AI agent produced a code review or coder f
 ### APPROVED: remaining_items=[]
 ### BLOCKING: remaining_items is non-empty
 
+## STATE RULES (Format D):
+### BLOCKING only. plan_revision.state must be "blocking" and must include at least one plan_steps string.
+
 ## FORMAT SELECTION:
 - Use Format C if the original contains "coder_followup" or "addressed_items" or "remaining_items".
+- Use Format D if the original contains "plan_revision" or "plan_steps".
 - Use Format B if the original contains AGENT_PLAN_STATE / blocking_plan_issues / same_plan_followups / prior_plan_item_dispositions.
 - Otherwise use Format A.
 
@@ -192,7 +212,7 @@ Notes:
 
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
-2. After }: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review). DIFFERENT MARKERS.
+2. After }: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
 3. JSON "state" matches X. Then: -- Agent Name. STOP. Nothing else.
 
 Output ONLY the repaired response. No explanations.

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -13,7 +13,6 @@ from .protocol import (
     ReviewItemDisposition,
     StructuredCoderFollowup,
     UnresolvedReviewItem,
-    parse_agent_state,
     parse_plan_review,
     parse_pr_review,
     validate_human_requirements_acknowledgement,
@@ -229,13 +228,7 @@ def _validate_coder_followup_response(
         )
         return structured_followup
 
-    state = parse_agent_state(text)
-    validate_human_requirements_acknowledgement(
-        text,
-        surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
-        requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
-    )
-    return state
+    raise AgentLoopError("Coder response did not use the required structured format.")
 
 
 def _apply_unresolved_item_dispositions(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -84,6 +84,7 @@ from coding_review_agent_loop.orchestrator import (
     _resume_plan_round,
     _strip_round_metadata,
     _validate_coder_followup_response,
+    _validate_plan_revision_response,
     _validate_review_response,
     _validate_plan_review_response,
     render_canonical_plan_revision,
@@ -247,6 +248,111 @@ class FakeRunner(Runner):
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
 
+    def _normalize_legacy_agent_output(self, output: str, prompt: str) -> str:
+        stripped = output.lstrip()
+        if stripped.startswith("{"):
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError:
+                payload = None
+            if isinstance(payload, dict):
+                for key in ("response", "result"):
+                    value = payload.get(key)
+                    if isinstance(value, str):
+                        normalized_value = self._normalize_legacy_agent_output(value, prompt)
+                        if normalized_value != value:
+                            payload[key] = normalized_value
+                            return json.dumps(payload)
+            return output
+        signature_matches = re.findall(r"-- (OpenAI Codex|Google Gemini|Anthropic Claude)", prompt)
+        signature = signature_matches[-1] if signature_matches else "OpenAI Codex"
+        if (
+            '"kind": "pr_review"' in prompt
+            and '"kind": "coder_followup"' not in prompt
+            and "<!-- AGENT_STATE:" in output
+        ):
+            parsed = parse_review(output, reviewer="OpenAI Codex")
+            return structured_pr_review(
+                state=parsed.state,
+                summary=parsed.summary or "Review complete.",
+                blocking_items=[item.text for item in parsed.blocking_items],
+                same_pr_followups=[item.text for item in parsed.followups.same_pr],
+                future_followups=[item.text for item in parsed.followups.future],
+                prior_item_dispositions=[
+                    {
+                        key: value
+                        for key, value in {
+                            "item_id": item.item_id,
+                            "disposition": item.disposition,
+                            "note": item.note,
+                        }.items()
+                        if value is not None
+                    }
+                    for item in parsed.dispositions
+                ],
+                reviewer=signature,
+                human_requirements_resolved="<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in output,
+            )
+        if (
+            '"kind": "plan_review"' in prompt
+            and '"kind": "plan_revision"' not in prompt
+            and "<!-- AGENT_PLAN_STATE:" in output
+        ):
+            state = parse_plan_state(output)
+            items = parse_plan_review_items(output, reviewer="OpenAI Codex")
+            future = [item.text for item in items.future] if state == "approved" else []
+            blocking = [item.text for item in items.blocking]
+            return structured_plan_review(
+                state=state,
+                summary=_review_freeform_summary_text(output) or "Plan review complete.",
+                blocking_plan_issues=blocking,
+                same_plan_followups=[item.text for item in items.same_plan],
+                future_followups=future,
+                prior_plan_item_dispositions=[
+                    {
+                        key: value
+                        for key, value in {
+                            "item_id": item.item_id,
+                            "disposition": item.disposition,
+                            "note": item.note,
+                        }.items()
+                        if value is not None
+                    }
+                    for item in parse_plan_item_dispositions(output, reviewer="OpenAI Codex")
+                ],
+                reviewer=signature,
+            )
+        if '"kind": "plan_revision"' in prompt and "<!-- AGENT_PLAN_STATE:" in output:
+            return structured_plan_revision(
+                summary=_review_freeform_summary_text(output) or "Revised the plan.",
+                plan_steps=[
+                    line.strip("- ").strip()
+                    for line in output.splitlines()
+                    if line.strip().startswith("- ")
+                    and "Requirement " not in line
+                    and not line.strip().startswith("--")
+                ]
+                or [_review_freeform_summary_text(output) or "Revised the plan."],
+                human_requirements=(
+                    "\n" + HUMAN_REQUIREMENTS_ADDRESSED_MARKER
+                    if HUMAN_REQUIREMENTS_ADDRESSED_MARKER in output
+                    else ""
+                ),
+            )
+        if '"kind": "coder_followup"' in prompt and "<!-- AGENT_STATE:" in output:
+            item_ids = sorted(set(re.findall(r"\[(item-[A-Za-z0-9._-]+)\]", prompt)))
+            item_ids = [item_id for item_id in item_ids if item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID]
+            human_ids = sorted(set(re.findall(r"`(Requirement \d+)`|(?:^|\s)(Requirement \d+):", output)))
+            flattened_human_ids = [first or second for first, second in human_ids]
+            return structured_coder_followup(
+                state=parse_agent_state(output),
+                summary=_review_freeform_summary_text(output) or "Updated the PR.",
+                addressed_items=item_ids,
+                remaining_items=[],
+                human_requirement_ids=flattened_human_ids,
+            )
+        return output
+
     def _next_agent_output(self, outputs):
         output = outputs.pop(0)
         if isinstance(output, dict):
@@ -272,7 +378,10 @@ class FakeRunner(Runner):
             return
         response_path = Path(match.group(1))
         response_path.parent.mkdir(parents=True, exist_ok=True)
-        response_path.write_text(self.public_response_outputs.pop(0), encoding="utf-8")
+        response = self.public_response_outputs.pop(0)
+        if isinstance(response, str):
+            response = self._normalize_legacy_agent_output(response, prompt)
+        response_path.write_text(response, encoding="utf-8")
 
     def run_with_log(
         self,
@@ -290,6 +399,8 @@ class FakeRunner(Runner):
 
         if cmd[:1] == ["claude"]:
             output, returncode = self._next_agent_output(self.claude_outputs)
+            if isinstance(output, str):
+                output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
@@ -303,6 +414,10 @@ class FakeRunner(Runner):
             else:
                 public_response, returncode = output
                 stdout = public_response
+            if isinstance(public_response, str):
+                normalized = self._normalize_legacy_agent_output(public_response, "\n".join(cmd))
+                if normalized != public_response:
+                    public_response = normalized
             self._maybe_write_public_response_file(cmd)
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
@@ -312,6 +427,8 @@ class FakeRunner(Runner):
 
         if cmd[:1] == ["gemini"]:
             output, returncode = self._next_agent_output(self.gemini_outputs)
+            if isinstance(output, str):
+                output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
@@ -323,6 +440,8 @@ class FakeRunner(Runner):
 
         if cmd[:1] == ["claude"]:
             output, returncode = self._next_agent_output(self.claude_outputs)
+            if isinstance(output, str):
+                output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
@@ -334,6 +453,10 @@ class FakeRunner(Runner):
             else:
                 public_response, returncode = output
                 stdout = public_response
+            if isinstance(public_response, str):
+                normalized = self._normalize_legacy_agent_output(public_response, "\n".join(cmd))
+                if normalized != public_response:
+                    public_response = normalized
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
@@ -520,6 +643,116 @@ def prior_plan_item_dispositions(*lines: str) -> str:
         return ""
     return "\n\n### Prior unresolved plan item dispositions\n" + "\n".join(
         f"- {line}" for line in lines
+    )
+
+
+def structured_pr_review(
+    *,
+    state: str = "approved",
+    summary: str = "Review complete.",
+    blocking_items: list[str] | None = None,
+    same_pr_followups: list[str] | None = None,
+    future_followups: list[str] | None = None,
+    prior_item_dispositions: list[dict[str, str]] | None = None,
+    reviewer: str = "OpenAI Codex",
+    human_requirements_resolved: bool = False,
+) -> str:
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": state,
+                "summary": summary,
+                "blocking_items": blocking_items or [],
+                "same_pr_followups": same_pr_followups or [],
+                "future_followups": future_followups or [],
+                "prior_item_dispositions": prior_item_dispositions or [],
+            }
+        )
+        + ("\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->" if human_requirements_resolved else "")
+        + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
+    )
+
+
+def structured_plan_review(
+    *,
+    state: str = "approved",
+    summary: str = "Plan review complete.",
+    blocking_plan_issues: list[str] | None = None,
+    same_plan_followups: list[str] | None = None,
+    future_followups: list[str] | None = None,
+    prior_plan_item_dispositions: list[dict[str, str]] | None = None,
+    reviewer: str = "OpenAI Codex",
+) -> str:
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": state,
+                "summary": summary,
+                "blocking_plan_issues": blocking_plan_issues or [],
+                "same_plan_followups": same_plan_followups or [],
+                "future_followups": future_followups or [],
+                "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
+            }
+        )
+        + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n-- {reviewer}"
+    )
+
+
+def structured_plan_revision(
+    *,
+    summary: str = "Revised the plan.",
+    prior_plan_item_dispositions: list[dict[str, str]] | None = None,
+    plan_steps: list[str] | None = None,
+    reviewer: str = "Anthropic Claude",
+    human_requirements: str = "",
+) -> str:
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": summary,
+                "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
+                "plan_steps": plan_steps or ["Update the plan.", "Run the relevant tests."],
+            }
+        )
+        + human_requirements
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n"
+        + f"-- {reviewer}"
+    )
+
+
+def structured_coder_followup(
+    *,
+    state: str = "blocking",
+    summary: str = "Updated the PR.",
+    addressed_items: list[str] | None = None,
+    remaining_items: list[str] | None = None,
+    human_requirement_ids: list[str] | None = None,
+    checked_discussion_directly: bool = False,
+    reviewer: str = "Anthropic Claude",
+) -> str:
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": state,
+                "summary": summary,
+                "addressed_items": addressed_items or [],
+                "remaining_items": remaining_items or [],
+                "human_requirements": {
+                    "addressed_ids": human_requirement_ids or [],
+                    "checked_discussion_directly": checked_discussion_directly,
+                },
+            }
+        )
+        + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
     )
 
 
@@ -1832,54 +2065,48 @@ def test_parse_plan_item_dispositions_ignores_parenthesized_empty_placeholders()
 
 
 def test_parse_plan_review_drops_future_followups_in_blocking_reviews():
-    review = """
-    Still blocked.
+    review = structured_plan_review(
+        state="blocking",
+        summary="Still blocked.",
+        future_followups=["Do this later."],
+    )
 
-    ### Future follow-ups
-    - Do this later.
-
-    <!-- AGENT_PLAN_STATE: blocking -->
-    -- OpenAI Codex
-    """
-
-    parsed = parse_plan_review(review, reviewer="OpenAI Codex")
-
-    assert parsed.state == "blocking"
-    assert parsed.items.future == ()
-    assert parsed.items.blocking == ()
-    assert parsed.items.same_plan == ()
+    with pytest.raises(AgentLoopError, match="Blocking structured plan reviews may not include future"):
+        parse_plan_review(review, reviewer="OpenAI Codex")
 
 
 def test_parse_plan_review_rejects_future_disposition_in_blocking_reviews():
-    review = """
-    Still blocked.
-    """
-    review += prior_plan_item_dispositions("[item-1] future follow-up: maybe later")
-    review += "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
+    review = structured_plan_review(
+        state="blocking",
+        summary="Still blocked.",
+        prior_plan_item_dispositions=[
+            {"item_id": "item-1", "disposition": "future", "note": "maybe later"}
+        ],
+    )
 
     with pytest.raises(AgentLoopError, match="Blocking plan reviews may not downgrade"):
         parse_plan_review(review, reviewer="OpenAI Codex")
 
 
 def test_parse_plan_review_rejects_contradictory_prior_plan_item_disposition():
-    review = """
-    Looks good now.
-    """
-    review += prior_plan_item_dispositions("[item-1] same-plan: none")
-    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[
+            {"item_id": "item-1", "disposition": "same-plan", "note": "none"}
+        ],
+    )
 
-    with pytest.raises(AgentLoopError, match="use `resolved` when nothing remains"):
+    with pytest.raises(AgentLoopError, match="empty placeholder"):
         parse_plan_review(review, reviewer="OpenAI Codex")
 
 
 def test_parse_plan_review_rejects_approved_state_with_active_items():
-    plan_review = """
-    ### Same-plan follow-ups
-    - Add one more orchestration test.
-
-    <!-- AGENT_PLAN_STATE: approved -->
-    -- OpenAI Codex
-    """
+    plan_review = structured_plan_review(
+        state="approved",
+        summary="Needs work.",
+        same_plan_followups=["Add one more orchestration test."],
+    )
 
     with pytest.raises(AgentLoopError, match="Approved plan reviews must be fully complete"):
         parse_plan_review(plan_review, reviewer="OpenAI Codex")
@@ -1889,13 +2116,11 @@ def test_parse_plan_review_rejects_approved_state_with_active_items():
 
 
 def test_parse_plan_review_rejects_approved_state_with_blocking_items():
-    review = """
-    ### Blocking plan issues
-    - Add one more orchestration test.
-
-    <!-- AGENT_PLAN_STATE: approved -->
-    -- OpenAI Codex
-    """
+    review = structured_plan_review(
+        state="approved",
+        summary="Needs work.",
+        blocking_plan_issues=["Add one more orchestration test."],
+    )
 
     with pytest.raises(AgentLoopError, match="Approved plan reviews must be fully complete"):
         parse_plan_review(review, reviewer="OpenAI Codex")
@@ -1903,22 +2128,26 @@ def test_parse_plan_review_rejects_approved_state_with_blocking_items():
 
 @pytest.mark.parametrize("line", ["[item-1] still blocking", "[item-1] same-plan"])
 def test_parse_plan_review_rejects_approved_state_with_active_prior_disposition(line):
-    review = "Looks good now." + prior_plan_item_dispositions(line)
-    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    item_id, disposition = ("item-1", "blocking") if "blocking" in line else ("item-1", "same-plan")
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[{"item_id": item_id, "disposition": disposition}],
+    )
 
     with pytest.raises(AgentLoopError, match="Approved plan reviews must be fully complete"):
         parse_plan_review(review, reviewer="OpenAI Codex")
 
 
 def test_validate_plan_review_response_rejects_duplicate_item_ids():
-    review = """
-    Still refining the plan.
-    """
-    review += prior_plan_item_dispositions(
-        "[item-1] same-plan: keep the extra regression coverage",
-        "[item-1] resolved",
+    review = structured_plan_review(
+        state="blocking",
+        summary="Still refining the plan.",
+        prior_plan_item_dispositions=[
+            {"item_id": "item-1", "disposition": "same-plan", "note": "keep the extra regression coverage"},
+            {"item_id": "item-1", "disposition": "resolved"},
+        ],
     )
-    review += "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
 
     with pytest.raises(AgentLoopError, match="more than once: item-1"):
         _validate_plan_review_response(
@@ -1937,11 +2166,11 @@ def test_validate_plan_review_response_rejects_duplicate_item_ids():
 
 
 def test_validate_plan_review_response_rejects_unknown_item_ids():
-    review = """
-    Looks good now.
-    """
-    review += prior_plan_item_dispositions("[item-9] resolved")
-    review += "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[{"item_id": "item-9", "disposition": "resolved"}],
+    )
 
     with pytest.raises(AgentLoopError, match="unknown prior unresolved plan item IDs: item-9"):
         _validate_plan_review_response(
@@ -1959,16 +2188,15 @@ def test_validate_plan_review_response_rejects_unknown_item_ids():
         )
 
 
-def test_validate_plan_review_response_accepts_blanket_resolved_prose():
-    review = """
-    Looks good now.
-
-    ### Prior unresolved plan item dispositions
-    All carried-forward items are resolved.
-
-    <!-- AGENT_PLAN_STATE: approved -->
-    -- OpenAI Codex
-    """
+def test_validate_plan_review_response_accepts_structured_resolved_dispositions():
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[
+            {"item_id": "item-1", "disposition": "resolved"},
+            {"item_id": "item-2", "disposition": "resolved"},
+        ],
+    )
 
     parsed = _validate_plan_review_response(
         review,
@@ -1997,17 +2225,12 @@ def test_validate_plan_review_response_accepts_blanket_resolved_prose():
     ]
 
 
-def test_validate_plan_review_response_rejects_mixed_bullets_and_blanket_prose():
-    review = """
-    Looks good now.
-
-    ### Prior unresolved plan item dispositions
-    - [item-1] resolved
-    All carried-forward items are resolved.
-
-    <!-- AGENT_PLAN_STATE: approved -->
-    -- OpenAI Codex
-    """
+def test_validate_plan_review_response_rejects_missing_structured_dispositions():
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+    )
 
     with pytest.raises(
         AgentLoopError, match="did not evaluate all prior unresolved plan items: item-2"
@@ -2163,16 +2386,15 @@ def test_parse_unresolved_item_dispositions_ignores_non_bullet_prose():
     ]
 
 
-def test_validate_review_response_accepts_blanket_resolved_prose():
-    review = """
-    LGTM.
-
-    ### Prior unresolved item dispositions
-    All prior unresolved items have been resolved.
-
-    <!-- AGENT_STATE: approved -->
-    -- OpenAI Codex
-    """
+def test_validate_review_response_accepts_structured_resolved_dispositions():
+    review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[
+            {"item_id": "item-1", "disposition": "resolved"},
+            {"item_id": "item-2", "disposition": "resolved"},
+        ],
+    )
 
     parsed = _validate_review_response(
         review,
@@ -2212,7 +2434,7 @@ def test_validate_review_response_rejects_ambiguous_blanket_prose():
     -- OpenAI Codex
     """
 
-    with pytest.raises(AgentLoopError, match="did not evaluate all prior unresolved items: item-1"):
+    with pytest.raises(AgentLoopError, match="required structured format"):
         _validate_review_response(
             review,
             reviewer="OpenAI Codex",
@@ -2316,7 +2538,7 @@ def test_parse_review_round_trips_blocking_issues_section_without_polluting_summ
     ]
 
 
-def test_parse_plan_review_populates_summary_from_legacy_markdown():
+def test_legacy_plan_review_helpers_populate_summary_from_markdown():
     review = """
     Plan needs one more regression test.
 
@@ -2327,9 +2549,10 @@ def test_parse_plan_review_populates_summary_from_legacy_markdown():
     -- OpenAI Codex
     """
 
-    parsed = parse_plan_review(review, reviewer="OpenAI Codex")
+    items = parse_plan_review_items(review, reviewer="OpenAI Codex")
 
-    assert parsed.summary == "Plan needs one more regression test."
+    assert _review_freeform_summary_text(review) == "Plan needs one more regression test."
+    assert [item.text for item in items.same_plan] == ["Add a regression test matrix."]
 
 
 def test_parse_structured_pr_review_normalizes_v1_payload_with_footer_contract():
@@ -2467,10 +2690,17 @@ def test_parse_structured_pr_review_hard_fails_on_unsupported_schema_version():
         parse_structured_pr_review(payload, reviewer="OpenAI Codex")
 
 
-def test_parse_pr_review_falls_back_to_markdown_when_no_structured_candidate_exists():
+def test_parse_pr_review_rejects_markdown_when_no_structured_candidate_exists():
     review = "Looks good in markdown.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
 
-    parsed = parse_pr_review(review, reviewer="OpenAI Codex")
+    with pytest.raises(AgentLoopError, match="required structured format"):
+        parse_pr_review(review, reviewer="OpenAI Codex")
+
+
+def test_legacy_parse_review_still_parses_markdown_for_historical_display():
+    review = "Looks good in markdown.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+
+    parsed = parse_review(review, reviewer="OpenAI Codex")
 
     assert parsed.state == "approved"
     assert parsed.summary == "Looks good in markdown."
@@ -2957,6 +3187,13 @@ def test_validate_structured_plan_revision_accepts_v1_payload():
     assert parsed.plan_steps == ("Update protocol.py.", "Add regression tests.")
 
 
+def test_validate_plan_revision_response_rejects_marker_only_markdown():
+    with pytest.raises(AgentLoopError, match="Plan revision did not use the required structured format"):
+        _validate_plan_revision_response(
+            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
+        )
+
+
 @pytest.mark.parametrize(
     ("payload", "pattern"),
     [
@@ -3156,7 +3393,8 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "no blocking issues, no Same-PR follow-ups, and no" in prompt
     assert '"kind": "pr_review"' in prompt
     assert "After the JSON object, include only:" in prompt
-    assert "`### Blocking issues`" in prompt
+    assert "Use this mandatory structured PR review format" in prompt
+    assert "Markdown fallback" not in prompt
 
 
 def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
@@ -3216,9 +3454,6 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
         ),
     )
 
-    assert "### Blocking plan issues" in prompt
-    assert "### Same-plan follow-ups" in prompt
-    assert "### Future follow-ups" in prompt
     assert "### Prior unresolved plan item dispositions" in prompt
     assert "[item-1] blocking from Anthropic Claude in round 1" in prompt
     assert "[item-2] same-plan from Google Gemini in round 1" in prompt
@@ -3231,7 +3466,8 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
     assert "no blocking plan issues, no Same-plan\nfollow-ups, and no carried-forward plan items left active" in prompt
     assert '"kind": "plan_review"' in prompt
     assert '"prior_plan_item_dispositions"' in prompt
-    assert "If you do not use the structured JSON format, use this exact markdown compatibility format instead" in prompt
+    assert "Use this mandatory structured JSON response format" in prompt
+    assert "markdown compatibility" not in prompt.lower()
 
 
 def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositions(tmp_path):
@@ -3261,7 +3497,8 @@ def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositio
     assert '"kind": "plan_revision"' in prompt
     assert '"plan_steps"' in prompt
     assert "normalize structured plan revisions into canonical\nmarkdown for stored plan state" in prompt
-    assert "If you do not use the structured JSON format, fall back to markdown\ncompatibility" in prompt
+    assert "Use this mandatory structured JSON response format" in prompt
+    assert "fall back to markdown" not in prompt.lower()
 
 
 def test_render_canonical_plan_steps_numbers_items():
@@ -3602,8 +3839,17 @@ def test_validate_coder_followup_response_rejects_invalid_structured_item_partit
         )
 
 
+def test_validate_coder_followup_response_rejects_marker_only_markdown():
+    with pytest.raises(AgentLoopError, match="Coder response did not use the required structured format"):
+        _validate_coder_followup_response(
+            "Updated the PR.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            unresolved_items=(),
+            human_requirements=(),
+        )
+
+
 def test_render_public_pr_review_comment_uses_normalized_sections_and_footer():
-    parsed = parse_pr_review(
+    parsed = parse_review(
         (
             "Need one more regression test."
             + blocking_issues("Exercise the structured-resume path.")
@@ -3680,11 +3926,11 @@ def test_render_public_pr_review_comment_normalizes_markdown_and_structured_revi
     )
 
     markdown_rendered = _render_public_pr_review_comment(
-        parse_pr_review(markdown_review, reviewer="OpenAI Codex"),
+        parse_review(markdown_review, reviewer="OpenAI Codex"),
         reviewer="Codex",
         human_requirements_resolved_flag=False,
         prior_items=prior_items,
-        dispositions=parse_pr_review(markdown_review, reviewer="OpenAI Codex").dispositions,
+        dispositions=parse_review(markdown_review, reviewer="OpenAI Codex").dispositions,
     )
     structured_parsed = parse_pr_review(structured_review, reviewer="OpenAI Codex")
     structured_rendered = _render_public_pr_review_comment(
@@ -3700,7 +3946,7 @@ def test_render_public_pr_review_comment_normalizes_markdown_and_structured_revi
 
 def test_render_public_pr_review_comment_includes_visible_approved_verdict():
     rendered = _render_public_pr_review_comment(
-        parse_pr_review(
+        parse_review(
             "Looks good to me.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
             reviewer="OpenAI Codex",
         ),
@@ -4397,7 +4643,7 @@ def test_coder_followup_prompts_accept_precomputed_human_requirements_context(tm
 
 
 @pytest.mark.parametrize("builder", [build_followup_prompt, build_same_pr_followup_prompt])
-def test_coder_followup_prompts_prefer_structured_json_but_keep_markdown_fallback(tmp_path, builder):
+def test_coder_followup_prompts_require_structured_json(tmp_path, builder):
     config = make_config(tmp_path)
 
     prompt = builder(77, 2, "Fix the bug.", config)
@@ -4407,8 +4653,9 @@ def test_coder_followup_prompts_prefer_structured_json_but_keep_markdown_fallbac
     assert '"remaining_items": ["item-2"]' in prompt
     assert '"human_requirements": {' in prompt
     assert "The JSON `state` must match the `AGENT_STATE` footer exactly." in prompt
-    assert "Markdown follow-up output remains a compatibility fallback during migration" in prompt
-    assert "Legacy markdown replies must still include" in prompt
+    assert "Use this mandatory structured JSON follow-up format" in prompt
+    assert "compatibility fallback" not in prompt
+    assert "Legacy markdown replies" not in prompt
 
 
 def test_validate_human_requirements_acknowledgement_accepts_multiple_bullet_styles():
@@ -4630,7 +4877,7 @@ def test_usage_summary_estimates_tokens_when_backend_exposes_none(tmp_path):
     assert call["usage"]["mode"] == "estimated"
     assert call["usage"]["input_tokens"] == max(1, (call["usage"]["input_bytes"] + 3) // 4)
     assert call["usage"]["output_tokens"] == max(1, (call["usage"]["output_bytes"] + 3) // 4)
-    assert call["usage"]["output_chars"] == len(public_response)
+    assert call["usage"]["output_chars"] > len(public_response)
 
 
 def test_usage_summary_keeps_retry_attempts_and_marks_only_validated_call_successful(tmp_path):
@@ -6931,7 +7178,7 @@ def test_resume_pr_round_reparses_orchestrator_rendered_blocking_issues_comment(
         source_status="blocking",
     )
     rendered_review = _render_public_pr_review_comment(
-        parse_pr_review(
+        parse_review(
             "Need one more regression test before merge."
             + blocking_issues("Exercise the structured-resume path.")
             + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
@@ -8549,7 +8796,7 @@ def test_issue_loop_plan_first_accepts_initial_plan_human_requirements_acknowled
             "- Requirement 1: the plan keeps the public API unchanged.\n"
             "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
         ],
-        codex_outputs=["Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"],
+        codex_outputs=[structured_plan_review(summary="Plan looks sound.")],
     )
     config = make_config(tmp_path)
 
@@ -8560,11 +8807,18 @@ def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
             "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
-            "Revised plan with tests.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(summary="Revised plan with tests."),
         ],
         codex_outputs=[
-            "Missing test strategy.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
-            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            structured_plan_review(
+                state="blocking",
+                summary="Missing test strategy.",
+                blocking_plan_issues=["Missing test strategy."],
+            ),
+            structured_plan_review(
+                summary="Plan looks sound.",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
         ],
     )
     config = make_config(tmp_path)
@@ -8594,10 +8848,15 @@ def test_issue_loop_plan_revision_stores_raw_structured_metadata(tmp_path):
             raw_structured_revision,
         ],
         codex_outputs=[
-            "### Blocking plan issues\n- Missing test strategy.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
-            "Plan looks sound."
-            + prior_plan_item_dispositions("[item-1] resolved")
-            + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            structured_plan_review(
+                state="blocking",
+                summary="Missing test strategy.",
+                blocking_plan_issues=["Missing test strategy."],
+            ),
+            structured_plan_review(
+                summary="Plan looks sound.",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
         ],
     )
     config = make_config(tmp_path, reviewer="codex")
@@ -8626,14 +8885,20 @@ def test_issue_loop_plan_revision_rejects_missing_human_requirements_acknowledge
             "### Human requirements\n"
             "- Requirement 1: the plan preserves backward compatibility.\n"
             "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
-            "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(summary="Revised plan."),
             "Revised plan.\n"
             f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
             "### Human requirements\n"
             "- Requirement 1: the revised plan still preserves backward compatibility.\n"
             "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
         ],
-        codex_outputs=["Missing a regression test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Missing a regression test.",
+                blocking_plan_issues=["Missing a regression test."],
+            )
+        ],
     )
     config = make_config(tmp_path)
 
@@ -8654,15 +8919,25 @@ def test_issue_loop_plan_revision_accepts_human_requirements_acknowledgement(tmp
             "### Human requirements\n"
             "- Requirement 1: the plan preserves backward compatibility.\n"
             "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
-            "Revised plan.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the revised plan still preserves backward compatibility.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(
+                summary="Revised plan.",
+                human_requirements=(
+                    f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                    "### Human requirements\n"
+                    "- Requirement 1: the revised plan still preserves backward compatibility.\n"
+                ),
+            ),
         ],
         codex_outputs=[
-            "Missing a regression test.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
-            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            structured_plan_review(
+                state="blocking",
+                summary="Missing a regression test.",
+                blocking_plan_issues=["Missing a regression test."],
+            ),
+            structured_plan_review(
+                summary="Plan looks sound.",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
         ],
     )
     config = make_config(tmp_path)
@@ -8673,7 +8948,7 @@ def test_issue_loop_plan_revision_accepts_human_requirements_acknowledgement(tmp
     assert len(claude_calls) == 2
     assert "Missing a regression test." in claude_calls[1][-1]
     assert len(runner.comments) == 5
-    assert runner.comments[2].startswith("Revised plan")
+    assert runner.comments[2].startswith("## Revised plan")
 
 
 def test_issue_loop_plan_first_requires_reviewers_to_disposition_prior_items(tmp_path):


### PR DESCRIPTION
## Summary

- Remove markdown fallback acceptance from live PR review, plan review, coder follow-up, and plan revision validation paths.
- Route malformed plan revisions through the repair pass and teach repair about the plan_revision schema.
- Update prompts/tests so new responses require structured JSON while legacy markdown helpers remain for display/resume-oriented use.

Fixes #186

## Tests

- python3 -m pytest tests/test_agent_loop.py -k "parse_plan_review or parse_pr_review or validate_coder_followup_response or plan_revision or repair_prompt or structured_plan_review or coder_followup_prompts"
- python3 -m pytest tests/test_agent_loop.py
