### PR TITLE
Validate plan decomposition dependency ordering

### DIFF
--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -101,6 +101,14 @@ def parse_plan_decomposition(text: str) -> PlanDecomposition:
             f"MAX_DECOMPOSITION_PHASES={MAX_DECOMPOSITION_PHASES}; consolidate phases."
         )
 
+    title_keys = [
+        " ".join(phase_payload["title"].lower().split())
+        for phase_payload in phases_payload
+        if isinstance(phase_payload, dict)
+        and isinstance(phase_payload.get("title"), str)
+        and phase_payload["title"].strip()
+    ]
+    all_title_keys = set(title_keys)
     phases: list[PlanPhase] = []
     seen_titles: set[str] = set()
     for index, phase_payload in enumerate(phases_payload, start=1):
@@ -125,6 +133,21 @@ def parse_plan_decomposition(text: str) -> PlanDecomposition:
             raise AgentLoopError(
                 f"Invalid plan decomposition: phase {title!r} `depends_on` must be a list of titles."
             )
+        for dependency in depends_on_payload:
+            dependency_key = " ".join(dependency.lower().split())
+            if dependency_key == title_key:
+                raise AgentLoopError(
+                    f"Invalid plan decomposition: phase {title!r} cannot depend on itself."
+                )
+            if dependency_key not in all_title_keys:
+                raise AgentLoopError(
+                    f"Invalid plan decomposition: phase {title!r} depends on unknown phase {dependency!r}."
+                )
+            if dependency_key not in seen_titles:
+                raise AgentLoopError(
+                    f"Invalid plan decomposition: phase {title!r} depends on {dependency!r}, "
+                    "but dependencies must reference an earlier phase."
+                )
         phases.append(
             PlanPhase(
                 title=title,
@@ -138,15 +161,6 @@ def parse_plan_decomposition(text: str) -> PlanDecomposition:
                 depends_on=tuple(value.strip() for value in depends_on_payload),
             )
         )
-
-    known_titles = {phase.title for phase in phases}
-    known_keys = {" ".join(phase.title.lower().split()): phase.title for phase in phases}
-    for phase in phases:
-        for dependency in phase.depends_on:
-            if dependency not in known_titles and " ".join(dependency.lower().split()) not in known_keys:
-                raise AgentLoopError(
-                    f"Invalid plan decomposition: phase {phase.title!r} depends on unknown phase {dependency!r}."
-                )
     return PlanDecomposition(phases=tuple(phases))
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8742,6 +8742,83 @@ def test_parse_plan_decomposition_accepts_agent_and_human_phases():
         "Manual rollout checkpoint",
     ]
     assert parsed.phases[1].automation == "human-action"
+    assert parsed.phases[1].depends_on == ("Internal schema utilities",)
+
+
+def test_parse_plan_decomposition_accepts_normalized_earlier_phase_dependency():
+    parsed = parse_plan_decomposition(
+        plan_decomposition_json(
+            {
+                "title": "Internal schema utilities",
+                "scope": "Add helpers.",
+                "non_goals": "No live switch.",
+                "dependency_notes": "First phase.",
+                "rollout_risk": "low - internal only.",
+                "validation": "Run python -m pytest.",
+                "parent_context": "Approved plan slice and invariant details.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+            {
+                "title": "Manual rollout checkpoint",
+                "scope": "Human validates the deployed behavior.",
+                "non_goals": "No code changes.",
+                "dependency_notes": "After Internal schema utilities.",
+                "rollout_risk": "medium - live checkpoint.",
+                "validation": "Human remark and closure required.",
+                "parent_context": "Approved plan slice for the manual checkpoint.",
+                "automation": "human-action",
+                "depends_on": ["  internal   SCHEMA utilities  "],
+            },
+        )
+    )
+
+    assert parsed.phases[1].depends_on == ("internal   SCHEMA utilities",)
+
+
+def test_parse_plan_decomposition_rejects_self_dependency():
+    phase = {
+        "title": "Internal schema utilities",
+        "scope": "Add helpers.",
+        "non_goals": "No live switch.",
+        "dependency_notes": "First phase.",
+        "rollout_risk": "low - internal only.",
+        "validation": "Run python -m pytest.",
+        "parent_context": "Approved plan slice and invariant details.",
+        "automation": "agent-pr",
+        "depends_on": ["Internal schema utilities"],
+    }
+
+    with pytest.raises(AgentLoopError, match="cannot depend on itself"):
+        parse_plan_decomposition(plan_decomposition_json(phase))
+
+
+def test_parse_plan_decomposition_rejects_forward_dependency():
+    first_phase = {
+        "title": "Internal schema utilities",
+        "scope": "Add helpers.",
+        "non_goals": "No live switch.",
+        "dependency_notes": "First phase.",
+        "rollout_risk": "low - internal only.",
+        "validation": "Run python -m pytest.",
+        "parent_context": "Approved plan slice and invariant details.",
+        "automation": "agent-pr",
+        "depends_on": ["Manual rollout checkpoint"],
+    }
+    second_phase = {
+        "title": "Manual rollout checkpoint",
+        "scope": "Human validates the deployed behavior.",
+        "non_goals": "No code changes.",
+        "dependency_notes": "After Internal schema utilities.",
+        "rollout_risk": "medium - live checkpoint.",
+        "validation": "Human remark and closure required.",
+        "parent_context": "Approved plan slice for the manual checkpoint.",
+        "automation": "human-action",
+        "depends_on": [],
+    }
+
+    with pytest.raises(AgentLoopError, match="dependencies must reference an earlier phase"):
+        parse_plan_decomposition(plan_decomposition_json(first_phase, second_phase))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- validate decomposition phase dependencies against already accepted earlier phases
- reject self-dependencies and forward references while preserving unknown-title rejection
- add parser coverage for self, forward, and normalized earlier dependencies

Fixes #191

## Tests
- python -m pytest tests/test_agent_loop.py -k parse_plan_decomposition (failed: python not found)
- python3 -m pytest tests/test_agent_loop.py -k parse_plan_decomposition (passed)
- python3 -m pytest (passed)