### PR TITLE
Define implement-by-phase rerun handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,14 @@ by the backward-compatible `--implement-after-approval` flag. `decompose-only`
 asks the coder to turn the approved plan into ordered phases, always creates
 one GitHub child issue per phase, posts a parent summary table, and stops.
 `implement-by-phase` creates every child issue, then implements only the first
-`agent-pr` phase and stops after that PR review loop. If the first phase is
-`human-action` or `manual-close`, the loop creates and reports all child issues
-but stops so a human can do the required work, add a remark/update, and close
-that child issue.
+`agent-pr` phase and stops after that PR review loop. Before entering that child
+implementation, the parent issue records a one-time handoff marker. Parent
+reruns after that marker do not re-run the child implementation; resume directly
+with `agent-loop issue <child>`. If decomposition already exists without a
+handoff marker, the first child is treated as not yet attempted and the handoff
+is recorded once. If the first phase is `human-action` or `manual-close`, the
+loop creates and reports all child issues but stops so a human can do the
+required work, add a remark/update, and close that child issue.
 
 Each generated child issue copies the relevant parent-plan slice, constraints
 and invariants, dependency notes, scope and non-goals, rollout risk,

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -194,7 +194,11 @@ The modes are:
 - `implement-one-shot`: keep the existing post-approval implementation handoff.
   This is also what `--implement-after-approval` selects for compatibility.
 - `implement-by-phase`: create/link every phase issue, implement only the first
-  `agent-pr` child issue, then stop after that PR review loop.
+  `agent-pr` child issue, then stop after that PR review loop. The parent issue
+  records a one-time handoff before child implementation starts; parent reruns
+  after that handoff do not re-run the child and should be resumed directly with
+  `agent-loop issue <child>`. Older decomposition summaries without this marker
+  are treated as not yet handed off, so the first child handoff is recorded once.
 
 Generated child issues are self-contained: each body includes the parent issue
 link, the relevant approved parent-plan slice, constraints/invariants,
@@ -209,7 +213,7 @@ phase is expected to be implemented through a child issue and PR.
 their titles, bodies, and parent summary call out that a human must perform the
 work or checkpoint, add the required remark/update, and close the issue. If
 `implement-by-phase` sees a human-only first phase, it stops instead of
-pretending the agent can implement it.
+recording an implementation handoff.
 
 Plan decomposition allows at most 8 phases. Over-cap responses are validation
 failures and must be consolidated; phases are never silently truncated. This

--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -20,6 +20,10 @@ DECOMPOSITION_MARKER_RE = re.compile(
     r"<!--\s*AGENT_PLAN_DECOMPOSITION:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
     re.I,
 )
+PHASE_IMPLEMENTATION_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_PHASE_IMPLEMENTATION:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
 ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)(?:\b|$)|#(\d+)\b")
 
 
@@ -42,8 +46,16 @@ class PlanDecomposition:
 
 
 @dataclass(frozen=True)
+class RecordedPhase:
+    title: str
+    automation: str
+    rollout_risk: str = "recorded"
+    parent_context: str | None = None
+
+
+@dataclass(frozen=True)
 class CreatedPhaseIssue:
-    phase: PlanPhase
+    phase: PlanPhase | RecordedPhase
     issue_url: str | None
     issue_number: int | None
 
@@ -57,6 +69,18 @@ class DecompositionMetadata:
     phase_titles: tuple[str, ...]
     automation: tuple[str, ...]
     children: tuple[tuple[str, str | None, int | None], ...]
+
+
+@dataclass(frozen=True)
+class PhaseImplementationHandoffMetadata:
+    parent_issue: int
+    plan_hash: str
+    mode: str
+    phase_index: int
+    phase_title: str
+    automation: str
+    child_issue_number: int
+    child_issue_url: str | None
 
 
 def approved_plan_hash(approved_plan: str) -> str:
@@ -289,28 +313,40 @@ def create_decomposition_child_issues(
     return tuple(created)
 
 
-def _encode_metadata(metadata: DecompositionMetadata) -> str:
-    payload = {
-        "parent_issue": metadata.parent_issue,
-        "plan_hash": metadata.plan_hash,
-        "mode": metadata.mode,
-        "phase_count": metadata.phase_count,
-        "phase_titles": list(metadata.phase_titles),
-        "automation": list(metadata.automation),
-        "children": [
-            {"title": title, "url": url, "number": number}
-            for title, url, number in metadata.children
-        ],
-    }
+def _encode_json_payload(payload: dict[str, object]) -> str:
     raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
     return base64.urlsafe_b64encode(raw).decode("ascii")
 
 
-def _decode_metadata(encoded: str) -> DecompositionMetadata:
+def _decode_json_payload(encoded: str, *, marker_name: str) -> dict[str, object]:
     try:
         payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
     except (ValueError, json.JSONDecodeError) as exc:
-        raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.") from exc
+        raise AgentLoopError(f"Invalid {marker_name} payload.") from exc
+    if not isinstance(payload, dict):
+        raise AgentLoopError(f"Invalid {marker_name} payload.")
+    return payload
+
+
+def _encode_metadata(metadata: DecompositionMetadata) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "plan_hash": metadata.plan_hash,
+            "mode": metadata.mode,
+            "phase_count": metadata.phase_count,
+            "phase_titles": list(metadata.phase_titles),
+            "automation": list(metadata.automation),
+            "children": [
+                {"title": title, "url": url, "number": number}
+                for title, url, number in metadata.children
+            ],
+        }
+    )
+
+
+def _decode_metadata(encoded: str) -> DecompositionMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_PLAN_DECOMPOSITION")
     children_payload = payload.get("children")
     if not isinstance(children_payload, list):
         raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.")
@@ -341,6 +377,41 @@ def _decode_metadata(encoded: str) -> DecompositionMetadata:
         raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.") from exc
 
 
+def _encode_phase_implementation_handoff_metadata(
+    metadata: PhaseImplementationHandoffMetadata,
+) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "plan_hash": metadata.plan_hash,
+            "mode": metadata.mode,
+            "phase_index": metadata.phase_index,
+            "phase_title": metadata.phase_title,
+            "automation": metadata.automation,
+            "child_issue_number": metadata.child_issue_number,
+            "child_issue_url": metadata.child_issue_url,
+        }
+    )
+
+
+def _decode_phase_implementation_handoff_metadata(encoded: str) -> PhaseImplementationHandoffMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_PLAN_PHASE_IMPLEMENTATION")
+    try:
+        child_issue_url = payload.get("child_issue_url")
+        return PhaseImplementationHandoffMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            plan_hash=str(payload["plan_hash"]),
+            mode=str(payload["mode"]),
+            phase_index=int(payload["phase_index"]),
+            phase_title=str(payload["phase_title"]),
+            automation=str(payload["automation"]),
+            child_issue_number=int(payload["child_issue_number"]),
+            child_issue_url=child_issue_url if isinstance(child_issue_url, str) else None,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_PLAN_PHASE_IMPLEMENTATION payload.") from exc
+
+
 def find_existing_decomposition(
     comments: Sequence[object],
     *,
@@ -369,6 +440,33 @@ def find_existing_decomposition(
             "Existing plan decomposition metadata is incomplete; manual recovery required before rerun. "
             f"Known child issues: {known or 'none'}."
         )
+    return found
+
+
+def find_existing_phase_implementation_handoff(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+    plan_hash: str,
+    mode: str,
+    phase_index: int,
+    child_issue_number: int,
+) -> PhaseImplementationHandoffMetadata | None:
+    found: PhaseImplementationHandoffMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in PHASE_IMPLEMENTATION_MARKER_RE.finditer(body):
+            metadata = _decode_phase_implementation_handoff_metadata(match.group("payload"))
+            if (
+                metadata.parent_issue == parent_issue
+                and metadata.plan_hash == plan_hash
+                and metadata.mode == mode
+                and metadata.phase_index == phase_index
+                and metadata.child_issue_number == child_issue_number
+            ):
+                found = metadata
     return found
 
 
@@ -420,6 +518,69 @@ def format_decomposition_parent_summary(
         ]
     )
     return "\n".join(lines)
+
+
+def format_phase_implementation_handoff_comment(
+    *,
+    parent_issue: int,
+    mode: str,
+    plan_hash: str,
+    phase_index: int,
+    created: CreatedPhaseIssue,
+) -> str:
+    if created.issue_number is None:
+        raise AgentLoopError(
+            "Cannot record decomposed phase implementation handoff because the child issue number is unavailable."
+        )
+    metadata = PhaseImplementationHandoffMetadata(
+        parent_issue=parent_issue,
+        plan_hash=plan_hash,
+        mode=mode,
+        phase_index=phase_index,
+        phase_title=created.phase.title,
+        automation=created.phase.automation,
+        child_issue_number=created.issue_number,
+        child_issue_url=created.issue_url,
+    )
+    child = created.issue_url or f"#{created.issue_number}"
+    lines = [
+        f"Approved plan implementation for issue #{parent_issue} handed off to phase {phase_index}: {child}.",
+        "",
+        f"Mode: {mode}",
+        f"Phase: {created.phase.title}",
+        f"Automation: {created.phase.automation}",
+        "",
+        "Parent reruns will not automatically re-run this child implementation. "
+        f"Resume directly with `agent-loop issue {created.issue_number}`.",
+        "",
+        f"<!-- AGENT_PLAN_PHASE_IMPLEMENTATION: {_encode_phase_implementation_handoff_metadata(metadata)} -->",
+        "-- coding-review-agent-loop",
+    ]
+    return "\n".join(lines)
+
+
+def post_phase_implementation_handoff_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    mode: str,
+    plan_hash: str,
+    phase_index: int,
+    created: CreatedPhaseIssue,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=parent_issue,
+        body=format_phase_implementation_handoff_comment(
+            parent_issue=parent_issue,
+            mode=mode,
+            plan_hash=plan_hash,
+            phase_index=phase_index,
+            created=created,
+        ),
+    )
 
 
 def post_decomposition_parent_summary(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -20,11 +20,14 @@ from .config import (
 )
 from .decomposition import (
     CreatedPhaseIssue,
+    RecordedPhase,
     approved_plan_hash,
     create_decomposition_child_issues,
     find_existing_decomposition,
+    find_existing_phase_implementation_handoff,
     parse_plan_decomposition,
     post_decomposition_parent_summary,
+    post_phase_implementation_handoff_comment,
 )
 from .errors import AgentLoopError, QuotaResetExceededError
 from .github import (
@@ -716,11 +719,7 @@ def _decompose_approved_plan(
         log(config, f"Plan decomposition already exists for issue #{issue_number} ({mode}); not recreating children")
         return tuple(
             CreatedPhaseIssue(
-                phase=type(
-                    "_ExistingPhase",
-                    (),
-                    {"title": title, "automation": automation, "rollout_risk": "recorded"},
-                )(),
+                phase=RecordedPhase(title=title, automation=automation),
                 issue_url=url,
                 issue_number=number,
             )
@@ -1050,15 +1049,41 @@ def _run_plan_first_loop(
                         "Cannot implement first decomposed phase because its child issue number "
                         "was not available from GitHub CLI output."
                     )
+                plan_hash = approved_plan_hash(current_plan)
+                handoff = find_existing_phase_implementation_handoff(
+                    issue_context.comments,
+                    parent_issue=issue_number,
+                    plan_hash=plan_hash,
+                    mode=mode,
+                    phase_index=1,
+                    child_issue_number=first_agent_phase.issue_number,
+                )
+                if handoff is not None:
+                    print(
+                        f"Issue #{issue_number} approved plan already handed off to child issue "
+                        f"#{handoff.child_issue_number}; resume directly with "
+                        f"`agent-loop issue {handoff.child_issue_number}`."
+                    )
+                    return 0
+                post_phase_implementation_handoff_comment(
+                    runner,
+                    config=config,
+                    parent_issue=issue_number,
+                    mode=mode,
+                    plan_hash=plan_hash,
+                    phase_index=1,
+                    created=first_agent_phase,
+                )
                 child_issue_context = get_issue_context(
                     runner,
                     config=config,
                     issue_number=first_agent_phase.issue_number,
                 )
+                phase_parent_context = first_agent_phase.phase.parent_context or current_plan
                 return _implement_approved_issue(
                     runner,
                     issue_number=first_agent_phase.issue_number,
-                    approved_plan=getattr(first_agent_phase.phase, "parent_context", current_plan),
+                    approved_plan=phase_parent_context,
                     config=config,
                     memory=memory,
                     issue_context=child_issue_context,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -50,9 +50,13 @@ from coding_review_agent_loop.config import (
     default_cache_root,
 )
 from coding_review_agent_loop.decomposition import (
+    CreatedPhaseIssue,
     MAX_DECOMPOSITION_PHASES,
+    RecordedPhase,
     approved_plan_hash,
+    find_existing_phase_implementation_handoff,
     format_decomposition_parent_summary,
+    format_phase_implementation_handoff_comment,
     parse_plan_decomposition,
 )
 from coding_review_agent_loop.github import (
@@ -9649,6 +9653,194 @@ def test_issue_loop_plan_first_decompose_only_is_idempotent(tmp_path):
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
 
+def test_issue_loop_plan_first_implement_by_phase_rerun_without_handoff_implements_once(tmp_path):
+    plan = "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    child = CreatedPhaseIssue(
+        phase=RecordedPhase(title="Schema helpers", automation="agent-pr"),
+        issue_url="https://github.com/OWNER/REPO/issues/99",
+        issue_number=99,
+    )
+    summary = format_decomposition_parent_summary(
+        parent_issue=56,
+        mode="implement-by-phase",
+        plan_hash=approved_plan_hash(plan),
+        created=(child,),
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented first phase.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": summary},
+        ],
+        pr_payload={"body": "Fixes #99"},
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-by-phase")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.issues == []
+    assert any("<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment for comment in runner.comments)
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 1
+    assert "GitHub issue #99" in claude_calls[0][-1]
+
+
+def test_issue_loop_plan_first_implement_by_phase_rerun_with_handoff_stops(tmp_path, capsys):
+    plan = "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    child = CreatedPhaseIssue(
+        phase=RecordedPhase(title="Schema helpers", automation="agent-pr"),
+        issue_url="https://github.com/OWNER/REPO/issues/99",
+        issue_number=99,
+    )
+    summary = format_decomposition_parent_summary(
+        parent_issue=56,
+        mode="implement-by-phase",
+        plan_hash=approved_plan_hash(plan),
+        created=(child,),
+    )
+    handoff = format_phase_implementation_handoff_comment(
+        parent_issue=56,
+        mode="implement-by-phase",
+        plan_hash=approved_plan_hash(plan),
+        phase_index=1,
+        created=child,
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": summary},
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:03Z", "body": handoff},
+        ],
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-by-phase")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    output = capsys.readouterr().out
+    assert "already handed off to child issue #99" in output
+    assert "agent-loop issue 99" in output
+    assert runner.issues == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_implement_by_phase_human_first_rerun_does_not_handoff(tmp_path):
+    plan = "Plan:\n- Validate migration manually first.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    child = CreatedPhaseIssue(
+        phase=RecordedPhase(title="Manual readiness check", automation="human-action"),
+        issue_url="https://github.com/OWNER/REPO/issues/99",
+        issue_number=99,
+    )
+    summary = format_decomposition_parent_summary(
+        parent_issue=56,
+        mode="implement-by-phase",
+        plan_hash=approved_plan_hash(plan),
+        created=(child,),
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": summary},
+        ],
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-by-phase")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.issues == []
+    assert not any("<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment for comment in runner.comments)
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
 def test_issue_loop_plan_first_implement_by_phase_stops_on_human_first_phase(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
@@ -9675,6 +9867,7 @@ def test_issue_loop_plan_first_implement_by_phase_stops_on_human_first_phase(tmp
 
     assert len(runner.issues) == 1
     assert runner.issues[0]["title"].startswith("[Human] Phase 1")
+    assert not any("<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment for comment in runner.comments)
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
 
 
@@ -9697,10 +9890,57 @@ def test_issue_loop_plan_first_implement_by_phase_implements_first_agent_phase(t
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
 
     assert len(runner.issues) == 1
+    decomposition_index = next(
+        index for index, comment in enumerate(runner.comments) if "<!-- AGENT_PLAN_DECOMPOSITION:" in comment
+    )
+    handoff_index = next(
+        index for index, comment in enumerate(runner.comments) if "<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment
+    )
+    implementation_index = next(
+        index for index, comment in enumerate(runner.comments) if comment.startswith("Implemented first phase.")
+    )
+    assert decomposition_index < handoff_index < implementation_index
     claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert len(claude_calls) == 3
     assert "GitHub issue #99" in claude_calls[2][-1]
     assert "Approved implementation plan" in claude_calls[2][-1]
+
+
+def test_issue_loop_plan_first_implement_by_phase_missing_child_number_does_not_handoff(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            plan_decomposition_json(),
+        ],
+        codex_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        issue_urls=[None],
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-by-phase")
+
+    with pytest.raises(AgentLoopError, match="child issue number"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert not any("<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment for comment in runner.comments)
+
+
+def test_phase_implementation_handoff_rejects_malformed_marker():
+    comment = IssueComment(
+        author="bot",
+        created_at="2026-05-23T00:00:00Z",
+        body="<!-- AGENT_PLAN_PHASE_IMPLEMENTATION: not-valid-base64 -->",
+    )
+
+    with pytest.raises(AgentLoopError, match="Invalid AGENT_PLAN_PHASE_IMPLEMENTATION payload"):
+        find_existing_phase_implementation_handoff(
+            (comment,),
+            parent_issue=56,
+            plan_hash="abc123",
+            mode="implement-by-phase",
+            phase_index=1,
+            child_issue_number=99,
+        )
 
 
 def test_issue_loop_plan_first_keeps_blocking_review_when_future_followups_are_misclassified(tmp_path):


### PR DESCRIPTION
## Summary
- add durable implement-by-phase handoff metadata and typed recorded phases for existing decomposition reconstruction
- stop parent reruns after a recorded first-child handoff and point operators at the child issue
- document rerun semantics and cover fresh, rerun, human-first, missing-child, and malformed marker cases

Fixes #192

## Tests
- python3 -m pytest tests/test_agent_loop.py -k "decomposition or implement_by_phase"
- python3 -m pytest