### PR TITLE
Prevent duplicate blocking and Same-PR review items

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1059,6 +1059,11 @@ under this exact heading:
 Use Same-PR follow-ups only for narrow current-PR cleanup in files already
 touched by this PR or directly adjacent code. Do not use this section for
 larger redesigns, broad refactors, or independent future work.
+Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
+`blocking_items` for defects, missing requirements, regressions, security
+issues, or consistency gaps that make the PR not merge-ready. Use
+`same_pr_followups` only for small localized cleanup that should be handled in
+this PR but is not itself the reason the PR is blocked.
 Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
 follow-up remains, including a carried-forward prior item that stays
 `still blocking` or `same-pr`, the review is not approved yet.
@@ -1155,6 +1160,12 @@ exactly one top-level JSON object and no prose or code fences before it:
     {{"item_id": "item-2", "disposition": "future", "note": "brief reason"}}
   ]
 }}
+
+`blocking_items` and `same_pr_followups` must be mutually exclusive: a single
+concern belongs in exactly one list. Put merge-blocking defects, missing
+requirements, regressions, security issues, and consistency gaps in
+`blocking_items`; put only small Same-PR cleanup that is not itself the reason
+the PR is blocked in `same_pr_followups`.
 
 After the JSON object, include only:
 1. optional `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -803,6 +803,34 @@ def _structured_followups(items: tuple[str, ...], *, reviewer: str) -> tuple[App
     return tuple(ApprovedFollowup(reviewer=reviewer, text=item) for item in items)
 
 
+def _normalized_review_item_text(text: str) -> str:
+    normalized = text.strip()
+    normalized = re.sub(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)+", "", normalized)
+    normalized = normalized.strip("`*_ \t\r\n")
+    normalized = re.sub(r"`([^`]+)`", r"\1", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = normalized.strip("`*_ \t\r\n.,;:!?-")
+    return normalized.casefold()
+
+
+def _dedupe_same_pr_against_blocking(
+    blocking_items: tuple[ApprovedFollowup, ...],
+    same_pr_followups: tuple[ApprovedFollowup, ...],
+) -> tuple[ApprovedFollowup, ...]:
+    blocking_texts = {
+        normalized
+        for item in blocking_items
+        if (normalized := _normalized_review_item_text(item.text))
+    }
+    if not blocking_texts:
+        return same_pr_followups
+    return tuple(
+        item
+        for item in same_pr_followups
+        if _normalized_review_item_text(item.text) not in blocking_texts
+    )
+
+
 def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | None:
     payload = _extract_structured_pr_review_payload(text)
     if payload is None:
@@ -854,12 +882,17 @@ def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | No
     )
     if state == "blocking" and future_followups:
         raise AgentLoopError("Blocking structured reviews may not include future follow-ups.")
+    structured_blocking_items = _structured_followups(blocking_items, reviewer=reviewer)
+    structured_same_pr_followups = _dedupe_same_pr_against_blocking(
+        structured_blocking_items,
+        _structured_followups(same_pr_followups, reviewer=reviewer),
+    )
     return _finalize_parsed_review(
         state=state,
         summary=summary,
-        blocking_items=_structured_followups(blocking_items, reviewer=reviewer),
+        blocking_items=structured_blocking_items,
         followups=ApprovedFollowups(
-            same_pr=_structured_followups(same_pr_followups, reviewer=reviewer),
+            same_pr=structured_same_pr_followups,
             future=_structured_followups(future_followups, reviewer=reviewer),
         ),
         dispositions=dispositions,
@@ -1412,6 +1445,10 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
     summary = review_freeform_summary_text(text)
     blocking_items = parse_pr_blocking_items(text, reviewer=reviewer)
     followups = parse_approved_followups(text, reviewer=reviewer)
+    followups = ApprovedFollowups(
+        same_pr=_dedupe_same_pr_against_blocking(blocking_items, followups.same_pr),
+        future=followups.future,
+    )
     dispositions = parse_unresolved_item_dispositions(text, reviewer=reviewer)
     return _finalize_parsed_review(
         state=state,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2544,6 +2544,71 @@ def test_parse_review_round_trips_blocking_issues_section_without_polluting_summ
     ]
 
 
+def test_parse_review_dedupes_same_pr_items_that_duplicate_blocking_items():
+    review = (
+        "Blocking issue summary."
+        + blocking_issues("`Add the missing share.html CSS update.`")
+        + "\n\n### Same-PR follow-ups\n"
+        + "- Add the missing share.html CSS update.\n"
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = parse_review(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in parsed.blocking_items] == [
+        "`Add the missing share.html CSS update.`"
+    ]
+    assert parsed.followups.same_pr == ()
+
+
+def test_parse_structured_pr_review_dedupes_exact_normalized_same_pr_duplicates():
+    review = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "blocking",
+            "summary": "Blocked.",
+            "blocking_items": ["- Add the missing `share.html` CSS update."],
+            "same_pr_followups": ["Add the missing share.html CSS update"],
+            "future_followups": [],
+            "prior_item_dispositions": [],
+        }
+    )
+    review += "\n\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+
+    parsed = parse_pr_review(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in parsed.blocking_items] == [
+        "- Add the missing `share.html` CSS update."
+    ]
+    assert parsed.followups.same_pr == ()
+
+
+def test_parse_structured_pr_review_keeps_near_but_distinct_same_pr_items():
+    review = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "blocking",
+            "summary": "Blocked.",
+            "blocking_items": ["Add the missing share.html CSS update."],
+            "same_pr_followups": ["Add the missing share.html print CSS update."],
+            "future_followups": [],
+            "prior_item_dispositions": [],
+        }
+    )
+    review += "\n\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+
+    parsed = parse_pr_review(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in parsed.blocking_items] == [
+        "Add the missing share.html CSS update."
+    ]
+    assert [item.text for item in parsed.followups.same_pr] == [
+        "Add the missing share.html print CSS update."
+    ]
+
+
 def test_legacy_plan_review_helpers_populate_summary_from_markdown():
     review = """
     Plan needs one more regression test.
@@ -6184,6 +6249,7 @@ def test_review_prompt_requests_future_followups_when_processed(tmp_path):
     prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
     assert "### Future follow-ups" in prompt
     assert "legacy heading `### Non-blocking follow-ups`" in prompt
+    assert "Do not use the Same-PR follow-ups section in this mode" in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt
 
 
@@ -6198,10 +6264,31 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     assert "### Future follow-ups" in prompt
     assert "small, localized, low-risk cleanup" in prompt
     assert "narrow current-PR cleanup in files already\ntouched by this PR or directly adjacent code" in prompt
+    assert "Keep `blocking_items` and `same_pr_followups` mutually exclusive." in prompt
+    assert (
+        "Use\n`blocking_items` for defects, missing requirements, regressions, security\n"
+        "issues, or consistency gaps that make the PR not merge-ready."
+    ) in prompt
+    assert (
+        "Use\n`same_pr_followups` only for small localized cleanup that should be handled in\n"
+        "this PR but is not itself the reason the PR is blocked."
+    ) in prompt
     assert "Same-PR follow-ups may appear only in blocking reviews." in prompt
     assert "will be sent back to Claude and require another review" in prompt
     assert "Approved means there are no blocking issues, no Same-PR follow-ups, and no\ncarried-forward prior unresolved items left active" in prompt
     assert "If you return `<!-- AGENT_STATE: blocking -->`, do not use structured\nFuture follow-ups" in prompt
+    assert (
+        "`blocking_items` and `same_pr_followups` must be mutually exclusive: a single\n"
+        "concern belongs in exactly one list."
+    ) in prompt
+    assert (
+        "Put merge-blocking defects, missing\nrequirements, regressions, security "
+        "issues, and consistency gaps in\n`blocking_items`"
+    ) in prompt
+    assert (
+        "put only small Same-PR cleanup that is not itself the reason\n"
+        "the PR is blocked in `same_pr_followups`."
+    ) in prompt
 
 
 def test_same_pr_followup_prompt_no_longer_claims_pr_was_approved(tmp_path):


### PR DESCRIPTION
## Summary
- clarify PR review prompts that blocking items and Same-PR follow-ups are mutually exclusive
- define when concerns belong in blocking_items versus same_pr_followups
- conservatively dedupe exact-normalized Same-PR duplicates against blocking items during parsing
- add prompt and parser regression coverage

Fixes #201

## Tests
- python3 -m pytest tests/test_agent_loop.py