### PR TITLE
Fix plan revision repair with human requirements

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -415,6 +415,7 @@ def _run_validated_agent(
     session_id: str | None = None,
     usage_context: RunUsageContext | None = None,
     use_repair: bool = False,
+    repair_expected_kind: str | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -463,11 +464,16 @@ def _run_validated_agent(
                 )
                 if use_repair and not _is_transient_agent_output(text):
                     log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
-                    repaired = attempt_repair(text, config.gemini_cmd)
+                    repaired = attempt_repair(
+                        text,
+                        config.gemini_cmd,
+                        expected_kind=repair_expected_kind,
+                    )
                     if repaired is not None:
                         try:
                             marker_value = validate(repaired)
                         except AgentLoopError as repair_exc:
+                            last_error = str(repair_exc)
                             log(
                                 config,
                                 f"{agent_name}: repair pass produced invalid output ({repair_exc})",
@@ -891,6 +897,7 @@ def _run_plan_first_loop(
                     ),
                     usage_context=usage_context,
                     use_repair=True,
+                    repair_expected_kind="plan_review",
                 )
                 review_output = review_response.text
                 reviewer_session_ids[reviewer] = review_response.session_id
@@ -1137,6 +1144,7 @@ def _run_plan_first_loop(
             ),
             usage_context=usage_context,
             use_repair=True,
+            repair_expected_kind="plan_revision",
         )
         canonical_plan: str | None = None
         public_comment = plan_response.text
@@ -1509,6 +1517,7 @@ def run_pr_loop(
                         ),
                         usage_context=usage_context,
                         use_repair=True,
+                        repair_expected_kind="pr_review",
                     )
                     review_output = review_response.text
                     reviewer_session_ids[reviewer] = review_response.session_id
@@ -1830,6 +1839,7 @@ def run_pr_loop(
                 ),
                 usage_context=usage_context,
                 use_repair=True,
+                repair_expected_kind="coder_followup",
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -15,6 +15,10 @@ from .agents.gemini import _parse_gemini_payload
 
 _logger = logging.getLogger(__name__)
 
+# v11 prompt — constrains repair to the caller's expected response kind when supplied
+# and preserves signed human-requirements acknowledgements on plan revisions:
+#   - expected_kind prevents plan_revision repair from drifting into coder_followup
+#   - plan_revision repair may include the signed human requirements marker/section before AGENT_PLAN_STATE
 # v10 prompt — adds plan_revision repair and keeps coder_followup repair bugs fixed:
 #   - fenced JSON (```json ... ```) now explicitly handled
 #   - addressed_items vs human_requirements.addressed_ids distinction clarified
@@ -23,6 +27,8 @@ _logger = logging.getLogger(__name__)
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
 You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, or coder follow-up that failed strict schema validation. Extract its intent and reformat it into one of these four valid formats.
+
+{expected_kind_instruction}
 
 ## Valid Format A — PR Review:
 
@@ -88,6 +94,11 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
   ],
   "plan_steps": ["Update the parser.", "Add regression tests."]
 }
+<!-- HUMAN_REQUIREMENTS_ADDRESSED -->
+
+### Human requirements
+
+- Requirement 1: <how the revised plan addresses this signed human requirement, if present in the original>
 <!-- AGENT_PLAN_STATE: blocking -->
 -- <Coder Name>
 
@@ -117,6 +128,7 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 ### BLOCKING only. plan_revision.state must be "blocking" and must include at least one plan_steps string.
 
 ## FORMAT SELECTION:
+- If an expected response kind is provided above, use ONLY that format. Do not infer a different kind from keywords in the malformed response.
 - Use Format C if the original contains "coder_followup" or "addressed_items" or "remaining_items".
 - Use Format D if the original contains "plan_revision" or "plan_steps".
 - Use Format B if the original contains AGENT_PLAN_STATE / blocking_plan_issues / same_plan_followups / prior_plan_item_dispositions.
@@ -210,9 +222,54 @@ Notes:
 - <!-- HUMAN_REQUIREMENTS_ADDRESSED --> is NOT needed in the structured path
 - No prose, no ### sections after the JSON
 
+## WORKED EXAMPLE 4 — plan revision with signed human requirements:
+
+Original (malformed): markdown revised plan, with a signed human-requirements acknowledgement.
+
+### Prior plan review item dispositions
+
+- item-1: resolved by adding API compatibility checks.
+
+### Revised plan
+
+- Keep the public API unchanged.
+- Add regression tests for compatibility.
+
+<!-- HUMAN_REQUIREMENTS_ADDRESSED -->
+
+### Human requirements
+
+- Requirement 1: The revised plan preserves backward compatibility.
+
+<!-- AGENT_PLAN_STATE: blocking -->
+-- Anthropic Claude
+
+CORRECT repair — output plan_revision JSON first, preserve the human requirements marker and section before AGENT_PLAN_STATE:
+{
+  "schema_version": 1,
+  "kind": "plan_revision",
+  "state": "blocking",
+  "summary": "Revised the plan to preserve backward compatibility.",
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved", "note": "Added API compatibility checks."}
+  ],
+  "plan_steps": ["Keep the public API unchanged.", "Add regression tests for compatibility."]
+}
+<!-- HUMAN_REQUIREMENTS_ADDRESSED -->
+
+### Human requirements
+
+- Requirement 1: The revised plan preserves backward compatibility.
+<!-- AGENT_PLAN_STATE: blocking -->
+-- Anthropic Claude
+
+Notes:
+- When repairing plan_revision, do not output coder_followup even if the original contains a Human requirements section.
+- If the original plan revision includes <!-- HUMAN_REQUIREMENTS_ADDRESSED --> and a ### Human requirements section, preserve both after the JSON and before <!-- AGENT_PLAN_STATE: blocking -->.
+
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
-2. After }: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
+2. After }: optional signed human requirements acknowledgement for plan_revision only, then <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
 3. JSON "state" matches X. Then: -- Agent Name. STOP. Nothing else.
 
 Output ONLY the repaired response. No explanations.
@@ -222,16 +279,26 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
+_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision"}
 
 
-def attempt_repair(raw: str, gemini_cmd: str) -> str | None:
+def attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
     """Call gemini-3.1-flash-lite via the Gemini CLI to reformat a malformed review response.
 
     Uses the same CLI invocation path as the reviewer so no extra auth is needed.
     Returns the repaired text on success, or None when the CLI fails or returns empty output.
     The caller is responsible for re-validating the returned text.
     """
-    prompt = _REPAIR_PROMPT.replace("{raw_response}", raw, 1)
+    if expected_kind is not None and expected_kind not in _SUPPORTED_EXPECTED_KINDS:
+        raise ValueError(f"Unsupported expected repair kind: {expected_kind}")
+    expected_kind_instruction = (
+        "## Expected response kind:\n"
+        f"You MUST repair this response as `{expected_kind}`. Output no other `kind` value.\n"
+        if expected_kind is not None
+        else "## Expected response kind:\nNo expected response kind was provided; choose from the format-selection rules.\n"
+    )
+    prompt = _REPAIR_PROMPT.replace("{expected_kind_instruction}", expected_kind_instruction, 1)
+    prompt = prompt.replace("{raw_response}", raw, 1)
     try:
         result = subprocess.run(
             [gemini_cmd, "--model", _REPAIR_MODEL, "--skip-trust", "--prompt", prompt],

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9148,6 +9148,183 @@ def test_issue_loop_plan_revision_accepts_human_requirements_acknowledgement(tmp
     assert runner.comments[2].startswith("## Revised plan")
 
 
+def test_issue_loop_plan_revision_repair_preserves_signed_human_requirements(tmp_path):
+    malformed_revision = (
+        "### Prior plan review item dispositions\n"
+        "- item-1: resolved by adding compatibility tests.\n\n"
+        "### Revised plan\n"
+        "- Preserve backward compatibility.\n"
+        "- Add regression tests.\n\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: the revised plan preserves backward compatibility.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    repaired_revision = structured_plan_revision(
+        summary="Revised plan with compatibility tests.",
+        prior_plan_item_dispositions=[
+            {
+                "item_id": "item-1",
+                "disposition": "resolved",
+                "note": "Added compatibility tests.",
+            }
+        ],
+        plan_steps=["Preserve backward compatibility.", "Add regression tests."],
+        human_requirements=(
+            f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the revised plan preserves backward compatibility.\n"
+        ),
+    )
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Initial plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            malformed_revision,
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Missing a regression test.",
+                blocking_plan_issues=["Missing a regression test."],
+            ),
+            structured_plan_review(
+                summary="Plan looks sound.",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, agent_max_retries=0)
+    captured_repairs = []
+
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+        captured_repairs.append((raw, expected_kind))
+        return repaired_revision
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
+        assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(captured_repairs) == 1
+    assert captured_repairs[0][1] == "plan_revision"
+    assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER in captured_repairs[0][0]
+    public_revision = _strip_round_metadata(runner.comments[2])
+    assert '"kind": "plan_revision"' not in public_revision
+    assert HUMAN_REQUIREMENTS_ADDRESSED_MARKER in public_revision
+    assert "### Human requirements" in public_revision
+
+
+def test_issue_loop_plan_revision_repair_rejects_wrong_kind_from_human_requirements_text(tmp_path):
+    malformed_revision = (
+        "### Revised plan\n"
+        "- Preserve backward compatibility.\n\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: the revised plan preserves backward compatibility.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    wrong_kind_repair = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Revised the plan.",
+                "addressed_items": [],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": ["Requirement 1"],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Initial plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            malformed_revision,
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Missing a regression test.",
+                blocking_plan_issues=["Missing a regression test."],
+            )
+        ],
+    )
+    config = make_config(tmp_path, agent_max_retries=0)
+    captured_kinds = []
+
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+        captured_kinds.append(expected_kind)
+        return wrong_kind_repair
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
+        with pytest.raises(AgentLoopError, match="expected `plan_revision`"):
+            run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert captured_kinds == ["plan_revision"]
+
+
+def test_issue_loop_plan_revision_repair_without_human_ack_fails_clearly(tmp_path):
+    malformed_revision = (
+        "### Revised plan\n"
+        "- Preserve backward compatibility.\n\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: the revised plan preserves backward compatibility.\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    repaired_without_ack = structured_plan_revision(
+        summary="Revised plan with compatibility tests.",
+        plan_steps=["Preserve backward compatibility.", "Add regression tests."],
+    )
+    runner = FakeRunner(
+        issue_payload={
+            "author": {"login": "maintainer"},
+            "createdAt": "2026-05-17T08:00:00Z",
+            "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Initial plan.\n"
+            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves backward compatibility.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            malformed_revision,
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Missing a regression test.",
+                blocking_plan_issues=["Missing a regression test."],
+            )
+        ],
+    )
+    config = make_config(tmp_path, agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_without_ack):
+        with pytest.raises(AgentLoopError, match="missing required signed human requirements marker"):
+            run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+
 def test_issue_loop_plan_first_requires_reviewers_to_disposition_prior_items(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
@@ -10686,6 +10863,30 @@ def test_attempt_repair_calls_cli_and_returns_text():
     assert "malformed review" in cmd[prompt_idx + 1]
 
 
+def test_attempt_repair_includes_expected_kind_instruction():
+    repaired = (
+        '{"schema_version":1,"kind":"plan_revision","state":"blocking","summary":"Revised.",'
+        '"prior_plan_item_dispositions":[],"plan_steps":["Add tests."]}'
+        "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Gemini"
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            "malformed response mentioning human requirements and addressed_items",
+            "gemini",
+            expected_kind="plan_revision",
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert "You MUST repair this response as `plan_revision`" in prompt
+    assert "Output no other `kind` value" in prompt
+
+
 def test_attempt_repair_handles_json_wrapped_cli_output():
     repaired_text = (
         '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
@@ -10735,8 +10936,9 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
         captured_repairs.append(raw)
+        assert expected_kind == "pr_review"
         return repaired_review
 
     with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
@@ -10767,8 +10969,9 @@ def test_run_pr_loop_repairs_format_failure_with_5xx_source_line_reference(tmp_p
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
         captured_repairs.append(raw)
+        assert expected_kind == "pr_review"
         return repaired_review
 
     with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
@@ -10790,7 +10993,8 @@ def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
 
-    def fake_attempt_repair_fails(raw: str, gemini_cmd: str) -> str | None:
+    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+        assert expected_kind == "pr_review"
         return "still broken output without valid schema"
 
     with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair_fails):
@@ -10844,8 +11048,9 @@ def test_run_pr_loop_uses_repair_pass_on_coder_followup_format_failure(tmp_path)
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
         captured_repairs.append(raw)
+        assert expected_kind == "coder_followup"
         return repaired_followup
 
     with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
@@ -10941,6 +11146,12 @@ def test_repair_prompt_coder_followup_fenced_json_example():
     assert "HUMAN_REQUIREMENTS_ADDRESSED" in _REPAIR_PROMPT
     # The prompt explains the marker is not needed in structured path
     assert "NOT needed" in _REPAIR_PROMPT or "not needed" in _REPAIR_PROMPT.lower()
+
+
+def test_repair_prompt_plan_revision_preserves_human_requirements_acknowledgement():
+    assert "WORKED EXAMPLE 4" in _REPAIR_PROMPT
+    assert "do not output coder_followup" in _REPAIR_PROMPT
+    assert "preserve both after the JSON and before <!-- AGENT_PLAN_STATE: blocking -->" in _REPAIR_PROMPT
 
 
 def test_repair_prompt_does_not_suggest_ack_pseudo_item_in_addressed_items():


### PR DESCRIPTION
## Summary
- constrain repair passes to the caller's expected structured response kind
- teach plan-revision repair to preserve signed human-requirements acknowledgement blocks
- report post-repair validation failures directly and add regressions for issue #211

## Tests
- python3 -m pytest

Fixes #211