### PR TITLE
Reconcile approved follow-up publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,17 @@ larger redesigns and independent work belong under Future follow-ups. Approved
 future follow-ups remain in the round-to-round
 ledger so later reviewers can explicitly confirm they are still future work,
 resolved, or should be promoted back to same-PR or blocking status. The final
-summary or issue creation uses the remaining future items from that ledger. The
-issue modes create at most three follow-up issues to avoid issue noise.
+summary or issue creation uses the remaining future items from that reconciled
+ledger, not only the final round's newly written Future follow-ups.
+
+Before posting summaries or creating issues, the loop deduplicates the remaining
+future items across reviewers using deterministic topic keys from headings,
+code identifiers, docs/files, and normalized wording. The selected issue body
+keeps the canonical wording plus an `Original reviewer notes` section so
+reviewer provenance and later disposition notes are not lost. The issue modes
+create at most three follow-up issues to avoid issue noise, and the final PR
+comment reports how many items were filed or summarized, deduplicated, or
+skipped by the cap.
 
 Plan reviews follow the same rule: approved plan reviews may include Future
 follow-ups only. Blocking plan issues, Same-plan follow-ups, or carried-forward

--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -17,6 +18,7 @@ APPROVED_FOLLOWUP_MARKER_RE = re.compile(
     r"<!--\s*AGENT_APPROVED_FOLLOWUPS:\s*pr=(?P<pr>\d+)\s+head=(?P<head>\S+)\s+mode=(?P<mode>[a-z-]+)\s*-->",
     re.I,
 )
+FOLLOWUP_UPDATE_SPLIT_RE = re.compile(r"\n{2,}Update from ", re.I)
 
 
 @dataclass(frozen=True)
@@ -33,6 +35,170 @@ class GroupedApprovedFollowup:
         return tuple(reviewers)
 
 
+@dataclass(frozen=True)
+class ApprovedFollowupReconciliation:
+    groups: tuple[GroupedApprovedFollowup, ...]
+    selected_groups: tuple[GroupedApprovedFollowup, ...]
+    skipped_by_cap: int
+    deduplicated_count: int
+
+
+_FOLLOWUP_STOPWORDS = {
+    "a",
+    "about",
+    "across",
+    "add",
+    "after",
+    "against",
+    "all",
+    "also",
+    "and",
+    "another",
+    "around",
+    "as",
+    "before",
+    "behavior",
+    "better",
+    "broader",
+    "but",
+    "by",
+    "can",
+    "cleanup",
+    "consider",
+    "coverage",
+    "doc",
+    "docs",
+    "document",
+    "documentation",
+    "ensure",
+    "for",
+    "from",
+    "future",
+    "handle",
+    "handled",
+    "in",
+    "include",
+    "issue",
+    "later",
+    "make",
+    "mention",
+    "note",
+    "of",
+    "on",
+    "or",
+    "pr",
+    "separate",
+    "should",
+    "so",
+    "that",
+    "the",
+    "this",
+    "to",
+    "track",
+    "update",
+    "use",
+    "when",
+    "with",
+    "work",
+}
+
+
+_CODE_OR_PATH_RE = re.compile(
+    r"`([^`]+)`|"
+    r"\b(?:[A-Za-z_][\w]*\.)+[A-Za-z_][\w]*\b|"
+    r"\b[\w.-]+/[\w./-]+\b|"
+    r"\b[\w.-]+\.(?:py|md|txt|toml|yaml|yml|json|js|ts|tsx|jsx|html|css|rst)\b"
+)
+
+
+def _followup_identifier_keys(text: str) -> set[str]:
+    text = _followup_main_text(text)
+    keys: set[str] = set()
+    for match in _CODE_OR_PATH_RE.finditer(text):
+        identifier = next((group for group in match.groups() if group), match.group(0))
+        normalized = _normalize_followup_key(identifier)
+        if normalized:
+            keys.add(normalized)
+    return keys
+
+
+def _followup_topic_terms(text: str) -> set[str]:
+    text = _followup_main_text(text)
+    normalized = _normalize_followup_key(text)
+    terms = {
+        term
+        for term in normalized.split()
+        if len(term) >= 4 and term not in _FOLLOWUP_STOPWORDS and not term.isdigit()
+    }
+    return terms
+
+
+def _followup_candidate_keys(text: str) -> set[str]:
+    text = _followup_main_text(text)
+    keys = {_normalize_followup_key(text)}
+    heading_key = _followup_heading_key(text)
+    if heading_key:
+        keys.add(f"heading:{heading_key}")
+    identifiers = _followup_identifier_keys(text)
+    keys.update(f"id:{identifier}" for identifier in identifiers)
+    terms = _followup_topic_terms(text)
+    if len(terms) >= 3:
+        keys.add("terms:" + "+".join(sorted(terms)))
+    if identifiers and len(terms) >= 2:
+        for identifier in identifiers:
+            for term in sorted(terms):
+                keys.add(f"id-term:{identifier}+{term}")
+    return {key for key in keys if key}
+
+
+def _followup_similarity(left: ApprovedFollowup, right: ApprovedFollowup) -> float:
+    left_terms = _followup_topic_terms(left.text)
+    right_terms = _followup_topic_terms(right.text)
+    if not left_terms or not right_terms:
+        return 0.0
+    common_terms = left_terms & right_terms
+    if len(common_terms) < 3:
+        return 0.0
+    left_ids = _followup_identifier_keys(left.text)
+    right_ids = _followup_identifier_keys(right.text)
+    if left_ids or right_ids:
+        id_overlap = left_ids & right_ids
+        if left_ids and right_ids and not id_overlap:
+            return 0.0
+        if id_overlap and len(common_terms) >= 2:
+            return 1.0
+    if common_terms == left_terms or common_terms == right_terms:
+        return 1.0
+    return len(common_terms) / len(left_terms | right_terms)
+
+
+def _followup_specificity_score(followup: ApprovedFollowup, reviewer_counts: Counter[str]) -> tuple[int, int, int, int]:
+    identifiers = _followup_identifier_keys(followup.text)
+    normalized_length = len(_normalize_followup_key(_followup_main_text(followup.text)))
+    has_disposition_note = int("Update from " in followup.text)
+    reviewer_support = reviewer_counts[followup.text]
+    return (
+        len(identifiers),
+        has_disposition_note,
+        reviewer_support,
+        normalized_length,
+    )
+
+
+def _select_canonical_followup(items: Sequence[ApprovedFollowup]) -> ApprovedFollowup:
+    reviewer_counts = Counter(item.text for item in items)
+    return max(items, key=lambda item: _followup_specificity_score(item, reviewer_counts))
+
+
+def _followup_main_text(text: str) -> str:
+    return FOLLOWUP_UPDATE_SPLIT_RE.split(text, maxsplit=1)[0].strip()
+
+
+def _followup_update_notes(text: str) -> tuple[str, ...]:
+    parts = FOLLOWUP_UPDATE_SPLIT_RE.split(text)
+    return tuple(f"Update from {part.strip()}" for part in parts[1:] if part.strip())
+
+
 def _approved_followup_from_unresolved_item(item: UnresolvedReviewItem) -> ApprovedFollowup:
     text = item.text
     for note in item.notes:
@@ -42,15 +208,63 @@ def _approved_followup_from_unresolved_item(item: UnresolvedReviewItem) -> Appro
     return ApprovedFollowup(reviewer=item.reviewer, text=text)
 
 
-def _format_approved_followup_summary(pr_number: int, followups: list[ApprovedFollowup]) -> str:
+def reconcile_approved_followups(
+    followups: Sequence[ApprovedFollowup],
+    *,
+    issue_limit: int = MAX_APPROVED_FOLLOWUP_ISSUES,
+) -> ApprovedFollowupReconciliation:
+    grouped: list[GroupedApprovedFollowup] = []
+    indexes: dict[str, int] = {}
+    for followup in followups:
+        keys = _followup_candidate_keys(followup.text)
+        existing_index = next((indexes[key] for key in keys if key in indexes), None)
+        if existing_index is None:
+            for index, group in enumerate(grouped):
+                if any(_followup_similarity(followup, item) >= 0.55 for item in group.items):
+                    existing_index = index
+                    break
+        if existing_index is None:
+            indexes.update((key, len(grouped)) for key in keys)
+            grouped.append(GroupedApprovedFollowup(text=followup.text, items=(followup,)))
+            continue
+
+        existing = grouped[existing_index]
+        items = (*existing.items, followup)
+        canonical = _select_canonical_followup(items)
+        grouped[existing_index] = GroupedApprovedFollowup(text=canonical.text, items=items)
+        indexes.update((key, existing_index) for key in keys)
+
+    selected_groups = tuple(grouped[:issue_limit])
+    return ApprovedFollowupReconciliation(
+        groups=tuple(grouped),
+        selected_groups=selected_groups,
+        skipped_by_cap=max(0, len(grouped) - len(selected_groups)),
+        deduplicated_count=len(followups) - len(grouped),
+    )
+
+
+def _format_approved_followup_summary(
+    pr_number: int,
+    reconciliation: ApprovedFollowupReconciliation,
+) -> str:
     lines = [
         f"Approved-review future follow-ups for PR #{pr_number}:",
         "",
     ]
-    for followup in followups:
-        lines.append(f"- {followup.text} ({followup.reviewer})")
+    for followup in reconciliation.selected_groups:
+        reviewers = ", ".join(followup.reviewers)
+        lines.append(f"- {_followup_main_text(followup.text)} ({reviewers})")
+        for item in followup.items:
+            for note in _followup_update_notes(item.text):
+                lines.append(f"  - {note}")
     lines.extend(
         [
+            "",
+            (
+                f"Reconciliation: {len(reconciliation.selected_groups)} filed/summarized, "
+                f"{reconciliation.deduplicated_count} deduplicated, "
+                f"{reconciliation.skipped_by_cap} skipped by cap."
+            ),
             "",
             "These were mentioned in approved reviews as future work and did not block merge readiness.",
             "",
@@ -110,12 +324,13 @@ def _has_approved_followups_marker(
 
 
 def _followup_issue_title(followup: ApprovedFollowup) -> str:
-    text = " ".join(followup.text.split())
+    text = " ".join(_followup_main_text(followup.text).split())
     title = f"Follow up future review note: {text}"
     return title[:120]
 
 
 def _normalize_followup_key(text: str) -> str:
+    text = _followup_main_text(text)
     key = re.sub(r"`([^`]+)`", r"\1", text)
     key = re.sub(r"\*\*([^*]+)\*\*", r"\1", key)
     key = re.sub(r"[_*#>]+", " ", key)
@@ -124,6 +339,7 @@ def _normalize_followup_key(text: str) -> str:
 
 
 def _followup_heading_key(text: str) -> str | None:
+    text = _followup_main_text(text)
     heading_match = re.match(r"^\s*\*\*(?P<title>[^*]+)\*\*\s*:?", text)
     if heading_match:
         return _normalize_followup_key(heading_match.group("title"))
@@ -134,25 +350,7 @@ def _followup_heading_key(text: str) -> str | None:
 
 
 def _dedupe_approved_followups(followups: Sequence[ApprovedFollowup]) -> list[GroupedApprovedFollowup]:
-    grouped: list[GroupedApprovedFollowup] = []
-    indexes: dict[str, int] = {}
-    for followup in followups:
-        keys = [_normalize_followup_key(followup.text)]
-        heading_key = _followup_heading_key(followup.text)
-        if heading_key:
-            keys.append(heading_key)
-        existing_index = next((indexes[key] for key in keys if key in indexes), None)
-        if existing_index is None:
-            indexes.update((key, len(grouped)) for key in keys if key)
-            grouped.append(GroupedApprovedFollowup(text=followup.text, items=(followup,)))
-            continue
-        existing = grouped[existing_index]
-        grouped[existing_index] = GroupedApprovedFollowup(
-            text=existing.text,
-            items=(*existing.items, followup),
-        )
-        indexes.update((key, existing_index) for key in keys if key)
-    return grouped
+    return list(reconcile_approved_followups(followups, issue_limit=len(followups) or 0).groups)
 
 
 def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> str:
@@ -170,12 +368,11 @@ def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> s
         [
             "",
             "Follow-up:",
-            f"- {followup.text}",
+            f"- {_followup_main_text(followup.text)}",
         ]
     )
-    if len(followup.items) > 1:
-        lines.extend(["", "Original reviewer notes:"])
-        lines.extend(f"- {item.reviewer}: {item.text}" for item in followup.items)
+    lines.extend(["", "Original reviewer notes:"])
+    lines.extend(f"- {item.reviewer}: {item.text}" for item in followup.items)
     lines.extend(
         [
             "",
@@ -190,12 +387,10 @@ def _create_approved_followup_issues(
     *,
     config: AgentLoopConfig,
     pr_number: int,
-    followups: list[ApprovedFollowup],
-) -> tuple[list[str], int]:
+    reconciliation: ApprovedFollowupReconciliation,
+) -> list[str]:
     issue_urls: list[str] = []
-    deduped_followups = _dedupe_approved_followups(followups)
-    selected_followups = deduped_followups[:MAX_APPROVED_FOLLOWUP_ISSUES]
-    for followup in selected_followups:
+    for followup in reconciliation.selected_groups:
         issue_url = create_issue(
             runner,
             config=config,
@@ -206,14 +401,13 @@ def _create_approved_followup_issues(
         )
         if issue_url is not None:
             issue_urls.append(issue_url)
-    skipped_count = len(deduped_followups) - len(selected_followups)
-    return issue_urls, skipped_count
+    return issue_urls
 
 
 def _format_created_followup_issue_summary(
     pr_number: int,
     issue_urls: list[str],
-    skipped_count: int,
+    reconciliation: ApprovedFollowupReconciliation,
 ) -> str:
     unique_issue_urls = list(dict.fromkeys(issue_urls))
     lines = [
@@ -227,14 +421,20 @@ def _format_created_followup_issue_summary(
     lines.extend(
         [
             "",
+            (
+                f"Reconciliation: {len(unique_issue_urls)} filed, "
+                f"{reconciliation.deduplicated_count} deduplicated, "
+                f"{reconciliation.skipped_by_cap} skipped by cap."
+            ),
+            "",
             "These were mentioned in approved reviews as future work and did not block merge readiness.",
         ]
     )
-    if skipped_count > 0:
+    if reconciliation.skipped_by_cap > 0:
         lines.extend(
             [
                 "",
-                f"Skipped {skipped_count} additional item(s) to avoid issue noise; reviewers should reserve "
+                f"Skipped {reconciliation.skipped_by_cap} additional item(s) to avoid issue noise; reviewers should reserve "
                 "this section for substantial independent follow-up work.",
             ]
         )
@@ -253,6 +453,19 @@ def _publish_approved_followups(
 ) -> bool:
     if not followups or config.approved_followups == "ignore":
         return False
+    reconciliation = reconcile_approved_followups(
+        followups,
+        issue_limit=MAX_APPROVED_FOLLOWUP_ISSUES,
+    )
+    if not reconciliation.selected_groups:
+        return False
+    log(
+        config,
+        f"Approved-review future follow-up reconciliation for PR #{pr_number}: "
+        f"{len(reconciliation.selected_groups)} selected, "
+        f"{reconciliation.deduplicated_count} deduplicated, "
+        f"{reconciliation.skipped_by_cap} skipped by cap",
+    )
 
     if config.approved_followups in ("summarize", "fix-and-summarize"):
         mode = "summarize"
@@ -267,7 +480,7 @@ def _publish_approved_followups(
                 f"Approved-review future follow-ups already recorded for PR #{pr_number} at {head_sha or 'unknown'} ({mode})",
             )
             return False
-        body = _format_approved_followup_summary(pr_number, followups)
+        body = _format_approved_followup_summary(pr_number, reconciliation)
         body = _append_approved_followups_marker(
             body,
             pr_number=pr_number,
@@ -290,14 +503,14 @@ def _publish_approved_followups(
                 f"Approved-review future follow-ups already recorded for PR #{pr_number} at {head_sha or 'unknown'} ({mode})",
             )
             return False
-        issue_urls, skipped_count = _create_approved_followup_issues(
+        issue_urls = _create_approved_followup_issues(
             runner,
             config=config,
             pr_number=pr_number,
-            followups=followups,
+            reconciliation=reconciliation,
         )
         if issue_urls:
-            body = _format_created_followup_issue_summary(pr_number, issue_urls, skipped_count)
+            body = _format_created_followup_issue_summary(pr_number, issue_urls, reconciliation)
             body = _append_approved_followups_marker(
                 body,
                 pr_number=pr_number,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -401,6 +401,7 @@ def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewI
         "Prior unresolved review items from earlier rounds",
         "",
         "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
+        "For carried future follow-ups, restate `future follow-up: reason` only when the item still deserves separate tracking; use `resolved` if later PR changes already handled it, or promote it to `same-pr`/`still blocking` if it must be fixed before merge.",
         "",
     ]
     for item in unresolved_items:
@@ -425,6 +426,7 @@ def _format_unresolved_plan_items(unresolved_items: Sequence[UnresolvedReviewIte
         "Prior unresolved plan items from earlier rounds",
         "",
         "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
+        "For carried future follow-ups, restate `future follow-up: reason` only when the item still deserves separate tracking; use `resolved` if later plan changes already handled it, or promote it to `same-plan`/`still blocking` if it must be fixed before implementation.",
         "",
     ]
     for item in unresolved_items:
@@ -642,6 +644,7 @@ Use one bullet per listed item and cover every item exactly once. Allowed forms:
 - [item-id] future follow-up: brief reason
 
 Only use `future follow-up` when returning `approved`. If a current-plan item still needs to be fixed before implementation starts, keep it as `still blocking` or `same-plan` instead of downgrading it.
+For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later plan changes, or now belongs back in same-plan/blocking work.
 Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
 """
     else:
@@ -1039,6 +1042,7 @@ Use one bullet per listed item and cover every item exactly once. Allowed forms:
 - [item-id] future follow-up: brief reason
 
 Only use `future follow-up` when returning `approved`. If an item should still be fixed before merge, keep it as `still blocking` or `same-pr` instead of downgrading it.
+For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later commits, or now belongs back in same-PR/blocking work.
 Contradictory forms like `same-pr: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
 """
     else:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -68,6 +68,10 @@ from coding_review_agent_loop.github import (
     get_issue_context,
     get_pr_checks,
 )
+from coding_review_agent_loop.followups import (
+    MAX_APPROVED_FOLLOWUP_ISSUES,
+    reconcile_approved_followups,
+)
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
 from coding_review_agent_loop.orchestrator import (
     ITEM_SUMMARY_LIMIT,
@@ -112,6 +116,7 @@ from coding_review_agent_loop.prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from coding_review_agent_loop.protocol import (
+    ApprovedFollowup,
     _expect_string_list,
     _extract_structured_plan_review_payload,
     _extract_structured_plan_revision_payload,
@@ -6562,6 +6567,8 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
                 "Reviewer: Codex\n\n"
                 "Follow-up:\n"
                 "- Add cleanup docs.\n\n"
+                "Original reviewer notes:\n"
+                "- Codex: Add cleanup docs.\n\n"
                 "This was mentioned in an approved review as future work and did not block merge readiness."
             ),
         },
@@ -6572,6 +6579,8 @@ def test_pr_loop_creates_issues_for_approved_followups(tmp_path):
                 "Reviewer: Claude\n\n"
                 "Follow-up:\n"
                 "- Add regression coverage.\n\n"
+                "Original reviewer notes:\n"
+                "- Claude: Add regression coverage.\n\n"
                 "This was mentioned in an approved review as future work and did not block merge readiness."
             ),
         },
@@ -6626,6 +6635,227 @@ def test_pr_loop_deduplicates_approved_followup_issues_across_reviewers(tmp_path
     assert "- https://github.com/OWNER/REPO/issues/99" in issue_summary
     assert "- https://github.com/OWNER/REPO/issues/100" in issue_summary
     assert "- https://github.com/OWNER/REPO/issues/101" in issue_summary
+
+
+def test_reconcile_approved_followups_groups_semantic_duplicates_and_preserves_distinct_items():
+    reconciliation = reconcile_approved_followups(
+        [
+            ApprovedFollowup(
+                reviewer="Claude",
+                text="Clarify repair-pass ownership across the flowchart and sequence diagram.",
+            ),
+            ApprovedFollowup(
+                reviewer="Gemini",
+                text="Document repair pass ownership in the flowchart and sequence diagram so the handoff is clear.",
+            ),
+            ApprovedFollowup(
+                reviewer="Codex",
+                text="Add memory freshness checks before planning starts.",
+            ),
+            ApprovedFollowup(
+                reviewer="Claude",
+                text="Add sync-before-planning coverage for reviewer workdirs.",
+            ),
+        ],
+        issue_limit=MAX_APPROVED_FOLLOWUP_ISSUES,
+    )
+
+    assert len(reconciliation.groups) == 3
+    assert reconciliation.deduplicated_count == 1
+    assert reconciliation.skipped_by_cap == 0
+    grouped_reviewers = [group.reviewers for group in reconciliation.groups]
+    assert ("Claude", "Gemini") in grouped_reviewers
+    assert any("memory freshness" in group.text for group in reconciliation.groups)
+    assert any("sync-before-planning" in group.text for group in reconciliation.groups)
+
+
+def test_reconcile_approved_followups_selects_more_specific_canonical_wording_and_caps():
+    reconciliation = reconcile_approved_followups(
+        [
+            ApprovedFollowup(reviewer="Claude", text="Clarify repair-pass ownership."),
+            ApprovedFollowup(
+                reviewer="Gemini",
+                text="Clarify repair-pass ownership in `docs/local_agent_loop.md` and the sequence diagram.",
+            ),
+            ApprovedFollowup(reviewer="Codex", text="Follow up two."),
+            ApprovedFollowup(reviewer="Claude", text="Follow up three."),
+            ApprovedFollowup(reviewer="Gemini", text="Follow up four."),
+        ],
+        issue_limit=3,
+    )
+
+    assert reconciliation.groups[0].text == (
+        "Clarify repair-pass ownership in `docs/local_agent_loop.md` and the sequence diagram."
+    )
+    assert len(reconciliation.selected_groups) == 3
+    assert reconciliation.skipped_by_cap == 1
+    assert reconciliation.deduplicated_count == 1
+
+
+def test_pr_loop_files_earlier_future_followup_not_repeated_in_final_round(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves with a later cleanup.",
+                future_followups=["Add memory freshness checks before planning starts."],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Codex final approval.",
+                prior_item_dispositions=[
+                    {
+                        "item_id": "item-1",
+                        "disposition": "future",
+                        "note": "Still useful as separate tracking.",
+                    },
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Need one current-PR fix.",
+                blocking_items=["Fix the current sync regression."],
+                reviewer="Anthropic Claude",
+            ),
+            structured_coder_followup(
+                addressed_items=["item-2"],
+                remaining_items=["item-1"],
+                reviewer="Anthropic Claude",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Claude final approval.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "future", "note": "Still valid."},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="Anthropic Claude",
+            ),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        approved_followups="issue",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == (
+        "Follow up future review note: Add memory freshness checks before planning starts."
+    )
+    assert "Update from Codex: Still useful as separate tracking." in runner.issues[0]["body"]
+
+
+def test_pr_loop_does_not_file_resolved_earlier_future_followup(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves with a later cleanup.",
+                future_followups=["Remove stale final-round-only follow-up handling."],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Codex final approval.",
+                prior_item_dispositions=[
+                    {
+                        "item_id": "item-1",
+                        "disposition": "resolved",
+                        "note": "Fixed in the second commit.",
+                    },
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Need one current-PR fix.",
+                blocking_items=["Fix the current sync regression."],
+                reviewer="Anthropic Claude",
+            ),
+            structured_coder_followup(
+                addressed_items=["item-2"],
+                remaining_items=["item-1"],
+                reviewer="Anthropic Claude",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Claude final approval.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Fixed."},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="Anthropic Claude",
+            ),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        approved_followups="issue",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.issues == []
+    assert not any(comment.startswith("Created approved-review future follow-up issues") for comment in runner.comments)
+
+
+def test_pr_loop_semantically_deduplicates_followup_issues_and_keeps_provenance(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves.",
+                reviewer="OpenAI Codex",
+            )
+        ],
+        claude_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Claude approves.",
+                future_followups=[
+                    "Clarify repair-pass ownership across the flowchart and sequence diagram."
+                ],
+                reviewer="Anthropic Claude",
+            )
+        ],
+        gemini_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Gemini approves.",
+                future_followups=[
+                    "Document repair pass ownership in the flowchart and sequence diagram so the handoff is clear."
+                ],
+                reviewer="Google Gemini",
+            )
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude", "gemini"),
+        approved_followups="issue",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(runner.issues) == 1
+    body = runner.issues[0]["body"]
+    assert "Reviewers:\n- Claude\n- Gemini" in body
+    assert "Original reviewer notes:" in body
+    assert "- Claude: Clarify repair-pass ownership" in body
+    assert "- Gemini: Document repair pass ownership" in body
+    assert "Reconciliation: 1 filed, 1 deduplicated, 0 skipped by cap." in runner.comments[-1]
 
 
 def test_pr_loop_suppresses_followup_issue_summary_when_no_urls_returned(tmp_path):


### PR DESCRIPTION
## Summary
- reconcile approved-review future follow-ups from the remaining unresolved-item ledger before publishing
- group semantic duplicates deterministically while preserving reviewer provenance and disposition notes
- update prompts, docs, and regression coverage for stale, missing, duplicate, and capped follow-up cases

Fixes #85

## Tests
- python3 -m compileall -q src tests
- git diff --check
- python3 -m pytest