### PR TITLE
Distinguish plan review follow-up categories

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -680,13 +680,18 @@ strategy, and ambiguity. Use this mandatory structured JSON response format:
 -- {reviewer_signature}
 
 Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
-follow-ups may appear only in blocking plan reviews. Future follow-ups are
-allowed only in approved plan reviews. Approved means there are no blocking
-plan issues, no Same-plan follow-ups, and no carried-forward plan items left
-active for this planning round. If you return `<!-- AGENT_PLAN_STATE:
-blocking -->`, do not use structured Future follow-ups; keep all required
-current-round issues in the main blocking content so they are not missed
-during plan revision.
+follow-ups are small current-plan refinements that must be incorporated before
+implementation starts; they may appear only in blocking plan reviews. Future
+follow-ups are independent later work that remains valid after the current
+plan is approved; they are allowed only in approved plan reviews. A concern or
+paraphrase belongs in exactly one current-round list: `blocking_plan_issues`,
+`same_plan_followups`, or `future_followups`. Do not duplicate or reclassify
+the same concern across Same-plan and Future follow-up lists.
+Approved means there are no blocking plan issues, no Same-plan follow-ups, and
+no carried-forward plan items left active for this planning round. If you
+return `<!-- AGENT_PLAN_STATE: blocking -->`, do not use structured Future
+follow-ups; keep all required current-round issues in the main blocking
+content so they are not missed during plan revision.
 Only items listed under `Prior unresolved plan items from earlier rounds` are
 eligible for dispositions in this round. If same-round findings from other
 reviewers appear elsewhere in the issue discussion, treat them as

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -831,6 +831,31 @@ def _dedupe_same_pr_against_blocking(
     )
 
 
+def _dedupe_followups_against(
+    items: tuple[ApprovedFollowup, ...],
+    *authoritative_groups: tuple[ApprovedFollowup, ...],
+) -> tuple[ApprovedFollowup, ...]:
+    authoritative_texts = {
+        normalized
+        for group in authoritative_groups
+        for item in group
+        if (normalized := _normalized_review_item_text(item.text))
+    }
+    if not authoritative_texts:
+        return items
+    return tuple(
+        item for item in items if _normalized_review_item_text(item.text) not in authoritative_texts
+    )
+
+
+def _dedupe_plan_review_items(items: PlanReviewItems) -> PlanReviewItems:
+    same_plan = _dedupe_followups_against(items.same_plan, items.blocking)
+    future = _dedupe_followups_against(items.future, items.blocking, same_plan)
+    if same_plan is items.same_plan and future is items.future:
+        return items
+    return PlanReviewItems(blocking=items.blocking, same_plan=same_plan, future=future)
+
+
 def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | None:
     payload = _extract_structured_pr_review_payload(text)
     if payload is None:
@@ -950,14 +975,17 @@ def parse_structured_plan_review(text: str, *, reviewer: str) -> ParsedPlanRevie
     )
     if state == "blocking" and future_followups:
         raise AgentLoopError("Blocking structured plan reviews may not include future follow-ups.")
-    return _finalize_parsed_plan_review(
-        state=state,
-        summary=summary,
-        items=PlanReviewItems(
+    items = _dedupe_plan_review_items(
+        PlanReviewItems(
             blocking=_structured_followups(blocking_items, reviewer=reviewer),
             same_plan=_structured_followups(same_plan_followups, reviewer=reviewer),
             future=_structured_followups(future_followups, reviewer=reviewer),
-        ),
+        )
+    )
+    return _finalize_parsed_plan_review(
+        state=state,
+        summary=summary,
+        items=items,
         dispositions=dispositions,
     )
 
@@ -1268,10 +1296,12 @@ def parse_plan_review_items(text: str, *, reviewer: str) -> PlanReviewItems:
         empty_item_re=EMPTY_PLAN_SECTION_RE,
         reviewer=reviewer,
     )
-    return PlanReviewItems(
-        blocking=tuple(blocking),
-        same_plan=tuple(same_plan),
-        future=tuple(future),
+    return _dedupe_plan_review_items(
+        PlanReviewItems(
+            blocking=tuple(blocking),
+            same_plan=tuple(same_plan),
+            future=tuple(future),
+        )
     )
 
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -120,6 +120,12 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 ### APPROVED: blocking_items=[], same_pr_followups=[], prior dispositions only "resolved"/"future"
 ### BLOCKING: future_followups=[], prior dispositions MUST NOT use "future"
 
+## DEDUPE RULES (Format B):
+- Same-plan follow-ups and Future follow-ups are mutually exclusive.
+- If the same plan-review concern or paraphrase appears in blocking_plan_issues and same_plan_followups, keep blocking_plan_issues and drop the duplicate same_plan_followups entry.
+- If the same plan-review concern or paraphrase appears in same_plan_followups and future_followups, keep same_plan_followups/current-plan work and drop the duplicate future_followups entry.
+- If the same plan-review concern or paraphrase appears in blocking_plan_issues and future_followups, keep blocking_plan_issues and drop the duplicate future_followups entry.
+
 ## STATE RULES (Format C):
 ### APPROVED: remaining_items=[]
 ### BLOCKING: remaining_items is non-empty

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2631,6 +2631,33 @@ def test_legacy_plan_review_helpers_populate_summary_from_markdown():
     assert [item.text for item in items.same_plan] == ["Add a regression test matrix."]
 
 
+def test_parse_plan_review_items_dedupes_plan_buckets_by_normalized_text():
+    review = """
+    Plan still needs cleanup.
+
+    ### Blocking plan issues
+    - Add `retry` coverage.
+
+    ### Same-plan follow-ups
+    - *add retry coverage!*
+    - Add parser comment.
+
+    ### Future follow-ups
+    - ADD RETRY COVERAGE.
+    - add `parser` comment
+    - Add parser documentation later.
+
+    <!-- AGENT_PLAN_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    items = parse_plan_review_items(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in items.blocking] == ["Add `retry` coverage."]
+    assert [item.text for item in items.same_plan] == ["Add parser comment."]
+    assert [item.text for item in items.future] == ["Add parser documentation later."]
+
+
 def test_parse_structured_pr_review_normalizes_v1_payload_with_footer_contract():
     payload = (
         json.dumps(
@@ -3057,6 +3084,35 @@ def test_parse_structured_plan_review_strips_verdict_and_sections_from_json_summ
 
     assert parsed is not None
     assert parsed.summary == "Need clearer rollback coverage."
+
+
+def test_parse_structured_plan_review_dedupes_same_plan_against_blocking_items():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "blocking",
+                "summary": "Still blocked.",
+                "blocking_plan_issues": ["Add `retry` coverage."],
+                "same_plan_followups": [
+                    "*add retry coverage!*",
+                    "Add retry coverage for timeout handling.",
+                ],
+                "future_followups": [],
+                "prior_plan_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = parse_structured_plan_review(payload, reviewer="OpenAI Codex")
+
+    assert parsed is not None
+    assert [item.text for item in parsed.items.blocking] == ["Add `retry` coverage."]
+    assert [item.text for item in parsed.items.same_plan] == [
+        "Add retry coverage for timeout handling."
+    ]
 
 
 def test_parse_structured_plan_review_rejects_blocking_future_followups():
@@ -3537,8 +3593,13 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
     assert "Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid" in prompt
     assert "Only items listed under `Prior unresolved plan items from earlier rounds`" in prompt
     assert "same-round findings from other\nreviewers appear elsewhere in the issue discussion" in prompt
-    assert "Same-plan\nfollow-ups may appear only in blocking plan reviews" in prompt
-    assert "do not use structured Future follow-ups" in prompt
+    assert "Same-plan\nfollow-ups are small current-plan refinements" in prompt
+    assert "must be incorporated before\nimplementation starts" in prompt
+    assert "they may appear only in blocking plan reviews" in prompt
+    assert "Future\nfollow-ups are independent later work" in prompt
+    assert "A concern or\nparaphrase belongs in exactly one current-round list" in prompt
+    assert "Do not duplicate or reclassify\nthe same concern across Same-plan and Future follow-up lists" in prompt
+    assert "do not use structured Future\nfollow-ups" in prompt
     assert "no blocking plan issues, no Same-plan\nfollow-ups, and no carried-forward plan items left active" in prompt
     assert '"kind": "plan_review"' in prompt
     assert '"prior_plan_item_dispositions"' in prompt
@@ -11350,6 +11411,16 @@ def test_repair_prompt_distinguishes_item_ids_from_requirement_labels():
     assert "addressed_ids" in _REPAIR_PROMPT
     # The prompt must explicitly state item IDs cannot contain spaces
     assert "spaces" in _REPAIR_PROMPT or "DO NOT CONFUSE" in _REPAIR_PROMPT or "NEVER put" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_includes_plan_review_dedupe_guidance():
+    assert "Same-plan follow-ups and Future follow-ups are mutually exclusive" in _REPAIR_PROMPT
+    assert "keep blocking_plan_issues and drop the duplicate same_plan_followups entry" in _REPAIR_PROMPT
+    assert (
+        "keep same_plan_followups/current-plan work and drop the duplicate future_followups entry"
+        in _REPAIR_PROMPT
+    )
+    assert "keep blocking_plan_issues and drop the duplicate future_followups entry" in _REPAIR_PROMPT
 
 
 def test_repair_prompt_includes_skip_trust_in_cli_invocation():


### PR DESCRIPTION
## Summary
- define Same-plan vs Future plan-review follow-ups in reviewer prompts
- dedupe duplicate plan-review items so current-plan buckets win over Future follow-ups
- update repair guidance and regression tests for mutual exclusion

Fixes #205

## Tests
- python -m pytest tests/test_agent_loop.py (failed: python executable not found)
- python3 -m pytest tests/test_agent_loop.py (passed: 519 tests)