### PR TITLE
Allow Gemini repair after internal retry diagnostics

### DIFF
--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -15,11 +15,14 @@ if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
 AgentName = Literal["claude", "codex", "gemini"]
+AgentTextSource = Literal["response_file", "stdout_marker", "stdout"]
 
 
 @dataclass(frozen=True)
 class AgentResult:
     text: str
+    raw_output: str = ""
+    text_source: AgentTextSource = "stdout"
     response_file_text: str | None = None
     message_text: str | None = None
     session_id: str | None = None

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -100,6 +100,8 @@ class ClaudeBackend:
         response_file_text = read_public_response_file(response_path)
         return AgentResult(
             text=response_file_text or message_text,
+            raw_output=result.stdout,
+            text_source="response_file" if response_file_text is not None else "stdout",
             response_file_text=response_file_text,
             message_text=message_text,
             session_id=new_session_id,

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -132,6 +132,8 @@ class CodexBackend:
             log(config, f"Codex finished; log: {log_path}")
             return AgentResult(
                 text=result.stdout,
+                raw_output=result.stdout,
+                text_source="stdout",
                 message_text=result.stdout,
                 log_path=log_path,
                 returncode=result.returncode,
@@ -164,6 +166,8 @@ class CodexBackend:
             log(config, f"Codex finished; log: {log_path}")
             return AgentResult(
                 text=response_file_text or message_text,
+                raw_output=result.stdout,
+                text_source="response_file" if response_file_text is not None else "stdout",
                 response_file_text=response_file_text,
                 message_text=message_text,
                 log_path=log_path,

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from .base import (
     AgentName,
     AgentResult,
+    AgentTextSource,
     public_response_path,
     read_public_response_file,
     with_public_response_file_instruction,
@@ -43,29 +44,29 @@ until you are done with all internal reasoning, tool use, and review work.
 """
 
 
-def _strip_public_response_marker(raw: str) -> str:
+def _strip_public_response_marker(raw: str) -> tuple[str, bool]:
     if PUBLIC_RESPONSE_MARKER not in raw:
-        return raw
-    return raw.rsplit(PUBLIC_RESPONSE_MARKER, 1)[1].lstrip("\n")
+        return raw, False
+    return raw.rsplit(PUBLIC_RESPONSE_MARKER, 1)[1].lstrip("\n"), True
 
 
-def _strip_gemini_preamble(raw: str) -> str:
+def _strip_gemini_preamble(raw: str) -> tuple[str, AgentTextSource]:
     """Drop Gemini CLI diagnostics that can appear before the final response."""
-    marker_stripped = _strip_public_response_marker(raw)
-    if marker_stripped != raw:
-        return marker_stripped
+    marker_stripped, used_marker = _strip_public_response_marker(raw)
+    if used_marker:
+        return marker_stripped, "stdout_marker"
 
     marker_matches = [*STATE_RE.finditer(raw), *PLAN_STATE_RE.finditer(raw), *CLARIFY_RE.finditer(raw)]
     if not marker_matches:
-        return raw
+        return raw, "stdout"
 
     public_end = max(match.start() for match in marker_matches)
     separator = "\n---\n"
     separator_at = raw.find(separator, 0, public_end)
     if separator_at == -1:
-        return raw
+        return raw, "stdout"
 
-    return raw[separator_at + len(separator) :].lstrip("\n")
+    return raw[separator_at + len(separator) :].lstrip("\n"), "stdout"
 
 def _normalize_gemini_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
@@ -98,8 +99,8 @@ def _normalize_gemini_usage(payload: object) -> UsageMetadata | None:
 
 def _parse_gemini_payload(
     raw: str,
-) -> tuple[str, str | None, UsageMetadata | None, object | None]:
-    """Extract (text, session_id, usage, raw_usage) from Gemini output."""
+) -> tuple[str, str | None, UsageMetadata | None, object | None, AgentTextSource]:
+    """Extract (text, session_id, usage, raw_usage, text_source) from Gemini output."""
     try:
         data = json.loads(raw)
         if isinstance(data, dict):
@@ -108,15 +109,18 @@ def _parse_gemini_payload(
                 text = raw
             session_id = data.get("session_id")
             raw_usage = first_present(data, "stats", "usage", "usageMetadata")
+            message_text, text_source = _strip_gemini_preamble(text)
             return (
-                _strip_gemini_preamble(text),
+                message_text,
                 session_id if isinstance(session_id, str) else None,
                 _normalize_gemini_usage(raw_usage),
                 raw_usage,
+                text_source,
             )
     except (json.JSONDecodeError, ValueError):
         pass
-    return _strip_gemini_preamble(raw), None, None, None
+    message_text, text_source = _strip_gemini_preamble(raw)
+    return message_text, None, None, None, text_source
 
 
 def _gemini_public_response_root(gemini_dir: Path) -> Path:
@@ -187,10 +191,12 @@ class GeminiBackend:
             check=False,
         )
         log(config, f"Gemini finished; log: {log_path}")
-        message_text, new_session_id, usage, raw_usage = _parse_gemini_payload(result.stdout)
+        message_text, new_session_id, usage, raw_usage, message_source = _parse_gemini_payload(result.stdout)
         response_file_text = read_public_response_file(response_path)
         return AgentResult(
             text=response_file_text or message_text,
+            raw_output=result.stdout,
+            text_source="response_file" if response_file_text is not None else message_source,
             response_file_text=response_file_text,
             message_text=message_text,
             session_id=new_session_id,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -382,8 +382,6 @@ def _agent_failure_classification_text(
     """Choose the text that matches the failure being classified."""
     if phase in {"command", "empty"}:
         return result.raw_output or result.text
-    if result.text_source in {"response_file", "stdout_marker"}:
-        return result.text
     return result.text
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -374,6 +374,19 @@ def _format_invalid_agent_response_error(
     )
 
 
+def _agent_failure_classification_text(
+    result: AgentResult,
+    *,
+    phase: str,
+) -> str:
+    """Choose the text that matches the failure being classified."""
+    if phase in {"command", "empty"}:
+        return result.raw_output or result.text
+    if result.text_source in {"response_file", "stdout_marker"}:
+        return result.text
+    return result.text
+
+
 def _new_usage_context(config: AgentLoopConfig) -> RunUsageContext:
     run_id = new_run_id()
     return RunUsageContext(run_id=run_id, summary_path=run_usage_summary_path(config, run_id))
@@ -422,6 +435,7 @@ def _run_validated_agent(
     max_attempts = config.agent_max_retries + 1
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
+    last_classification_text = ""
 
     for attempt in range(1, max_attempts + 1):
         result = run_agent_result(
@@ -450,19 +464,36 @@ def _run_validated_agent(
         should_retry = False
         if result.returncode != 0:
             last_error = f"agent command exited with {result.returncode}"
-            should_retry = _is_transient_agent_output(text)
+            classification_text = _agent_failure_classification_text(result, phase="command")
+            last_classification_text = classification_text
+            should_retry = _is_transient_agent_output(classification_text)
         elif not text.strip():
             last_error = "agent response was empty"
-            should_retry = _is_transient_agent_output(text)
+            classification_text = _agent_failure_classification_text(result, phase="empty")
+            last_classification_text = classification_text
+            should_retry = _is_transient_agent_output(classification_text)
         else:
             try:
                 marker_value = validate(text)
             except AgentLoopError as exc:
                 last_error = str(exc)
-                should_retry = _is_transient_agent_output(text) or (
-                    attempt == 1 and _is_retryable_marker_near_miss(text)
+                classification_text = _agent_failure_classification_text(result, phase="validation")
+                last_classification_text = classification_text
+                public_text_is_transient = _is_transient_agent_output(classification_text)
+                should_retry = public_text_is_transient or (
+                    attempt == 1 and _is_retryable_marker_near_miss(classification_text)
                 )
-                if use_repair and not _is_transient_agent_output(text):
+                if (
+                    result.raw_output
+                    and result.raw_output != classification_text
+                    and _is_transient_agent_output(result.raw_output)
+                    and not public_text_is_transient
+                ):
+                    log(
+                        config,
+                        f"{agent_name}: transient diagnostics were present outside the public response",
+                    )
+                if use_repair and not public_text_is_transient:
                     log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
                     repaired = attempt_repair(
                         text,
@@ -499,8 +530,8 @@ def _run_validated_agent(
                 )
 
         if should_retry:
-            if _QUOTA_RATE_LIMIT_RE.search(text):
-                reset_secs = _parse_rate_limit_reset_seconds(text)
+            if _QUOTA_RATE_LIMIT_RE.search(classification_text):
+                reset_secs = _parse_rate_limit_reset_seconds(classification_text)
                 if reset_secs is not None and reset_secs > LONG_RESET_THRESHOLD_SECONDS:
                     duration_str = _format_reset_duration(reset_secs)
                     at_str = _format_reset_at_utc(reset_secs)
@@ -510,7 +541,7 @@ def _run_validated_agent(
                     )
             if attempt < max_attempts:
                 delay = _retry_delay(config, attempt)
-                category = _failure_category(text)
+                category = _failure_category(classification_text)
                 log(
                     config,
                     f"{agent_name}: {category} failure ({last_error}); "
@@ -527,7 +558,7 @@ def _run_validated_agent(
             reason=last_error,
             result=last_result,
             log_paths=log_paths,
-            category=_failure_category(text),
+            category=_failure_category(last_classification_text),
         )
     )
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -318,5 +318,5 @@ def attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = Non
     if result.returncode != 0:
         _logger.debug("repair pass CLI exited with code %d", result.returncode)
         return None
-    text, _, _, _ = _parse_gemini_payload(result.stdout.strip())
+    text, _, _, _, _ = _parse_gemini_payload(result.stdout.strip())
     return text or None

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -390,7 +390,9 @@ class FakeRunner(Runner):
         response_path = Path(match.group(1))
         response_path.parent.mkdir(parents=True, exist_ok=True)
         response = self.public_response_outputs.pop(0)
-        if isinstance(response, str):
+        if isinstance(response, dict):
+            response = response.get("text", "")
+        elif isinstance(response, str):
             response = self._normalize_legacy_agent_output(response, prompt)
         response_path.write_text(response, encoding="utf-8")
 
@@ -437,8 +439,16 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
         if cmd[:1] == ["gemini"]:
-            output, returncode = self._next_agent_output(self.gemini_outputs)
-            if isinstance(output, str):
+            output = self._next_agent_output(self.gemini_outputs)
+            explicit_stdout = False
+            if isinstance(output, dict):
+                stdout = output.get("stdout", "")
+                returncode = output.get("returncode", 0)
+                explicit_stdout = True
+            else:
+                stdout, returncode = output
+            output = stdout
+            if isinstance(output, str) and not explicit_stdout:
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
@@ -1070,7 +1080,7 @@ def test_parse_gemini_output_extracts_json_response():
         "response": "Reviewed.\n<!-- AGENT_STATE: approved -->",
         "session_id": "gemini-session-1",
     })
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text == "Reviewed.\n<!-- AGENT_STATE: approved -->"
     assert sid == "gemini-session-1"
     assert usage is None
@@ -1078,7 +1088,7 @@ def test_parse_gemini_output_extracts_json_response():
 
 
 def test_parse_gemini_output_falls_back_on_plain_text():
-    text, sid, usage, raw_usage = _parse_gemini_payload("plain response")
+    text, sid, usage, raw_usage, source = _parse_gemini_payload("plain response")
     assert text == "plain response"
     assert sid is None
     assert usage is None
@@ -1087,7 +1097,7 @@ def test_parse_gemini_output_falls_back_on_plain_text():
 
 def test_parse_gemini_output_falls_back_on_non_string_response():
     raw = json.dumps({"response": 42, "session_id": "gemini-session-1"})
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text == raw
     assert sid == "gemini-session-1"
     assert usage is None
@@ -1108,7 +1118,7 @@ No blocking findings.
 
 -- Google Gemini
 """
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text.startswith("## Review")
     assert "True color" not in text
     assert "YOLO mode" not in text
@@ -1128,7 +1138,7 @@ intermediate draft
 Final answer.
 <!-- AGENT_STATE: approved -->
 """
-    text, _sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, _sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text == "Final answer.\n<!-- AGENT_STATE: approved -->\n"
     assert usage is None
     assert raw_usage is None
@@ -1139,7 +1149,7 @@ def test_parse_gemini_json_response_strips_public_response_marker():
         "response": f"diagnostic\n{PUBLIC_RESPONSE_MARKER}\nReviewed.\n<!-- AGENT_STATE: approved -->",
         "session_id": "gemini-session-1",
     })
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text == "Reviewed.\n<!-- AGENT_STATE: approved -->"
     assert sid == "gemini-session-1"
     assert usage is None
@@ -1167,7 +1177,7 @@ Looks good.
 
 -- Google Gemini
 """
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text.startswith("## Code Review")
     assert "_GaxiosError" not in text
     assert "YOLO mode" not in text
@@ -1192,7 +1202,7 @@ Looks like a solid approach.
 
 -- Google Gemini
 """
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text.startswith("## Plan Review")
     assert "YOLO mode" not in text
     assert "<!-- AGENT_PLAN_STATE: approved -->" in text
@@ -1217,7 +1227,7 @@ Still looks good.
 
 <!-- AGENT_STATE: approved -->
 """
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text.startswith("## Summary")
     assert "YOLO mode" not in text
     assert "## Details" in text
@@ -1236,7 +1246,7 @@ I need to ask a question.
     Which endpoint should I update?
 <!-- AGENT_CLARIFY -->
 """
-    text, sid, usage, raw_usage = _parse_gemini_payload(raw)
+    text, sid, usage, raw_usage, source = _parse_gemini_payload(raw)
     assert text.startswith("    Which endpoint")
     assert "True color" not in text
     assert "<!-- AGENT_CLARIFY -->" in text
@@ -5240,6 +5250,94 @@ def test_gemini_public_response_file_resolves_worktree_git_dir(tmp_path):
     assert str(config.gemini_dir / ".git" / "agent-loop") not in gemini_call[2]
 
 
+def test_gemini_pre_marker_429_does_not_suppress_structured_review_repair(tmp_path):
+    malformed_public_review = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Found one issue.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\nProse between JSON and footer should be repaired.\n"
+        "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    )
+    raw_stdout = (
+        "Attempt 1 failed with status 429. Retrying with backoff... "
+        "No capacity available for model gemini-3-flash-preview on the server.\n"
+        f"{PUBLIC_RESPONSE_MARKER}\n"
+        f"{malformed_public_review}"
+    )
+    repaired_review = structured_pr_review(
+        state="approved",
+        summary="Review passed after repair.",
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[{"stdout": raw_stdout}])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+    captured_repairs = []
+
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+        captured_repairs.append(raw)
+        assert expected_kind == "pr_review"
+        return repaired_review
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
+        assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert captured_repairs == [malformed_public_review]
+    assert "429" not in captured_repairs[0]
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+    assert any("Review passed after repair." in comment for comment in runner.comments)
+
+
+def test_gemini_response_file_repair_ignores_raw_stdout_transient_diagnostics(tmp_path):
+    malformed_public_review = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Found one issue.",
+                "blocking_items": ["Approved reviews cannot have blocking items."],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    )
+    repaired_review = structured_pr_review(
+        state="approved",
+        summary="Response file review passed after repair.",
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(
+        gemini_outputs=[
+            {"stdout": "Attempt 1 failed with status 429. No capacity available, then recovered."}
+        ],
+        public_response_outputs=[{"text": malformed_public_review}],
+    )
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+    captured_repairs = []
+
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+        captured_repairs.append(raw)
+        return repaired_review
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
+        assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert captured_repairs == [malformed_public_review]
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+    assert any("Response file review passed after repair." in comment for comment in runner.comments)
+
+
 def test_pr_loop_exhausted_transient_retry_reports_attempt_logs(tmp_path):
     diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
     runner = FakeRunner(gemini_outputs=[(diagnostic, 1), (diagnostic, 1), (diagnostic, 1)])
@@ -5250,6 +5348,7 @@ def test_pr_loop_exhausted_transient_retry_reports_attempt_logs(tmp_path):
 
     message = str(exc_info.value)
     assert "No review result was recorded" in message
+    assert "Failure category: transient" in message
     assert "Attempt logs:" in message
     assert "gemini.log" in message
     assert runner.comments == []
@@ -5317,6 +5416,86 @@ def test_pr_loop_retries_gemini_no_capacity(tmp_path):
     assert runner.comments == [f"**Review verdict:** Approved\n\n{valid}"]
     sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
     assert len(sleep_commands) == 1
+
+
+def test_gemini_transient_text_inside_public_response_suppresses_repair(tmp_path):
+    public_response = (
+        f"{PUBLIC_RESPONSE_MARKER}\n"
+        "HTTP 429 Too Many Requests: rate limit exceeded.\n"
+        "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    )
+    runner = FakeRunner(gemini_outputs=[{"stdout": public_response}])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        with pytest.raises(AgentLoopError) as exc_info:
+            run_pr_loop(runner, pr_number=77, config=config)
+
+    repair_mock.assert_not_called()
+    assert "Failure category: transient" in str(exc_info.value)
+
+
+def test_gemini_duplicate_trailing_agent_state_marker_is_repairable(tmp_path):
+    malformed_public_review = (
+        structured_pr_review(
+            state="approved",
+            summary="Found one issue.",
+            reviewer="Google Gemini",
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+    raw_stdout = f"{PUBLIC_RESPONSE_MARKER}\n{malformed_public_review}"
+    repaired_review = structured_pr_review(
+        state="approved",
+        summary="Duplicate marker repaired.",
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[{"stdout": raw_stdout}])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review) as repair_mock:
+        assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    repair_mock.assert_called_once_with(
+        malformed_public_review,
+        config.gemini_cmd,
+        expected_kind="pr_review",
+    )
+    assert any("Duplicate marker repaired." in comment for comment in runner.comments)
+
+
+def test_gemini_pre_marker_429_malformed_public_response_fails_deterministically(tmp_path):
+    malformed_public_review = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Found one issue.",
+                "blocking_items": [],
+                "same_pr_followups": [],
+                "future_followups": [],
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\nExtra prose before the footer.\n"
+        "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+    )
+    raw_stdout = (
+        "Attempt 1 failed with status 429. No capacity available for model gemini.\n"
+        f"{PUBLIC_RESPONSE_MARKER}\n"
+        f"{malformed_public_review}"
+    )
+    runner = FakeRunner(gemini_outputs=[{"stdout": raw_stdout}])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value="still invalid"):
+        with pytest.raises(AgentLoopError) as exc_info:
+            run_pr_loop(runner, pr_number=77, config=config)
+
+    message = str(exc_info.value)
+    assert "Failure category: deterministic" in message
+    assert "Failure category: transient" not in message
 
 
 def test_pr_loop_does_not_retry_billing_credit_exhaustion(tmp_path):


### PR DESCRIPTION
## Summary

- track raw agent stdout separately from extracted public response text
- classify validation failures using extracted response text for response files and Gemini stdout markers
- keep raw-output transient retry behavior when no public response exists
- add Gemini regressions for pre-marker 429 diagnostics, response-file repair, in-response transient text, duplicate footer markers, and final failure category

Fixes #221

## Tests

- python3 -m pytest tests/test_agent_loop.py
