### PR TITLE
Avoid transient false positives in public responses

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import re
 import sys
 from collections.abc import Callable, Sequence
@@ -197,6 +198,26 @@ NEAR_MISS_AGENT_MARKER_RE = re.compile(
     r"(?m)^[ \t]*AGENT_(?:PLAN_)?STATE:[ \t]*(?:approved|blocking)[ \t.]*$",
     re.I,
 )
+PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
+    r"\A\s*(?:=== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ===\s*)+"
+)
+STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
+    {"plan_review", "pr_review", "coder_followup", "plan_revision"}
+)
+PUBLIC_RESPONSE_TRANSIENT_DIAGNOSTIC_RE = re.compile(
+    r"\A\s*(?:\[[^\]]*(?:error|fatal)[^\]]*\]\s*)?"
+    r"(?:"
+    r"invalid stream|empty response|malformed tool call|"
+    r"(?:http|status)\s*[:=]?\s*429\b|429\s+too many requests\b|too many requests\b|"
+    r"rate.?limit(?:ed)?\b|quota\b.{0,40}\b(?:exceeded|exhausted)\b|"
+    r"resource[_-]?exhausted\b|ratelimitexceeded\b|retry[- ]after\b|retry[_-]?delay\b|"
+    r"no capacity available\b|model_capacity_exhausted\b|"
+    r"capacity\b.{0,80}\b(?:unavailable|exceeded|exhausted)\b|"
+    r"(?:gemini|claude|codex|provider|cli)\b.{0,120}"
+    r"(?:429|rate.?limit|resource.?exhausted|no capacity|overloaded)"
+    r")",
+    re.I | re.S,
+)
 
 # Threshold above which a rate-limit reset time causes an immediate exit
 # rather than a silent wait (5 minutes).
@@ -321,18 +342,62 @@ def _is_transient_agent_output(text: str) -> bool:
     )
 
 
+def _decode_public_response_json_prefix(text: str) -> object | None:
+    stripped = text.lstrip()
+    stripped = PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE.sub("", stripped)
+    try:
+        payload, _end = json.JSONDecoder().raw_decode(stripped)
+    except json.JSONDecodeError:
+        return None
+    return payload
+
+
+def _is_error_shaped_json_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    error_keys = {"error", "errors", "code", "status", "message", "type"}
+    return bool(error_keys.intersection(payload))
+
+
+def _is_transient_public_response(text: str, *, repair_expected_kind: str | None = None) -> bool:
+    """Classify extracted public responses without matching transient terms in content."""
+    if NON_RETRYABLE_AGENT_OUTPUT_RE.search(text):
+        return False
+
+    payload = _decode_public_response_json_prefix(text)
+    if isinstance(payload, dict):
+        kind = payload.get("kind")
+        if (
+            kind in STRUCTURED_PUBLIC_RESPONSE_KINDS
+            and (
+                repair_expected_kind is None
+                or repair_expected_kind in STRUCTURED_PUBLIC_RESPONSE_KINDS
+            )
+        ):
+            return False
+        if _is_error_shaped_json_payload(payload):
+            return _is_transient_agent_output(json.dumps(payload, sort_keys=True))
+
+    stripped = text.strip()
+    return bool(PUBLIC_RESPONSE_TRANSIENT_DIAGNOSTIC_RE.search(stripped))
+
+
 def _is_retryable_marker_near_miss(text: str) -> bool:
     return bool(NEAR_MISS_AGENT_MARKER_RE.search(text)) and not bool(
         NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
     )
 
 
-def _failure_category(text: str) -> str:
+def _failure_category(text: str, *, public_response: bool = False) -> str:
     """Classify a failure for logging: helps users decide whether to rerun or fix config/code."""
     if not text.strip():
         return "empty-response"
     if NON_RETRYABLE_AGENT_OUTPUT_RE.search(text):
         return "non-retryable"  # auth/billing — fix configuration
+    if public_response:
+        if _is_transient_public_response(text):
+            return "transient"  # extracted provider diagnostic — rerun may help
+        return "deterministic"  # public response protocol/content issue
     if TRANSIENT_AGENT_OUTPUT_RE.search(text):
         return "transient"  # rate-limit/infra — rerun may help
     return "deterministic"  # no transient signal — may need code fix
@@ -434,6 +499,7 @@ def _run_validated_agent(
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
     last_classification_text = ""
+    last_failure_category = "empty-response"
 
     for attempt in range(1, max_attempts + 1):
         result = run_agent_result(
@@ -465,11 +531,13 @@ def _run_validated_agent(
             classification_text = _agent_failure_classification_text(result, phase="command")
             last_classification_text = classification_text
             should_retry = _is_transient_agent_output(classification_text)
+            last_failure_category = _failure_category(classification_text)
         elif not text.strip():
             last_error = "agent response was empty"
             classification_text = _agent_failure_classification_text(result, phase="empty")
             last_classification_text = classification_text
             should_retry = _is_transient_agent_output(classification_text)
+            last_failure_category = _failure_category(classification_text)
         else:
             try:
                 marker_value = validate(text)
@@ -477,7 +545,16 @@ def _run_validated_agent(
                 last_error = str(exc)
                 classification_text = _agent_failure_classification_text(result, phase="validation")
                 last_classification_text = classification_text
-                public_text_is_transient = _is_transient_agent_output(classification_text)
+                public_text_is_transient = _is_transient_public_response(
+                    classification_text,
+                    repair_expected_kind=repair_expected_kind,
+                )
+                last_failure_category = _failure_category(
+                    classification_text,
+                    public_response=True,
+                )
+                # Marker near-misses are a separate first-attempt nudge for common footer typos;
+                # structured JSON protocol drift still remains repairable when retries are exhausted.
                 should_retry = public_text_is_transient or (
                     attempt == 1 and _is_retryable_marker_near_miss(classification_text)
                 )
@@ -539,7 +616,7 @@ def _run_validated_agent(
                     )
             if attempt < max_attempts:
                 delay = _retry_delay(config, attempt)
-                category = _failure_category(classification_text)
+                category = last_failure_category
                 log(
                     config,
                     f"{agent_name}: {category} failure ({last_error}); "
@@ -556,7 +633,7 @@ def _run_validated_agent(
             reason=last_error,
             result=last_result,
             log_paths=log_paths,
-            category=_failure_category(last_classification_text),
+            category=last_failure_category,
         )
     )
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -42,7 +42,9 @@ from coding_review_agent_loop.orchestrator import (
     _format_reset_duration,
     _failure_category,
     _is_transient_agent_output,
+    _is_transient_public_response,
     _parse_rate_limit_reset_seconds,
+    _run_validated_agent,
 )
 from coding_review_agent_loop.config import (
     default_agent_memory_dir,
@@ -5418,7 +5420,7 @@ def test_pr_loop_retries_gemini_no_capacity(tmp_path):
     assert len(sleep_commands) == 1
 
 
-def test_gemini_transient_text_inside_public_response_suppresses_repair(tmp_path):
+def test_diagnostic_shaped_public_response_remains_transient(tmp_path):
     public_response = (
         f"{PUBLIC_RESPONSE_MARKER}\n"
         "HTTP 429 Too Many Requests: rate limit exceeded.\n"
@@ -5433,6 +5435,233 @@ def test_gemini_transient_text_inside_public_response_suppresses_repair(tmp_path
 
     repair_mock.assert_not_called()
     assert "Failure category: transient" in str(exc_info.value)
+
+
+def test_public_response_error_payload_remains_transient():
+    assert _is_transient_public_response(
+        json.dumps(
+            {
+                "error": {
+                    "code": 429,
+                    "status": "RESOURCE_EXHAUSTED",
+                    "message": "Quota exceeded. Retry-After: 60",
+                }
+            }
+        )
+    )
+
+
+def test_public_response_structured_json_after_known_artifact_is_not_transient():
+    text = (
+        f"{PUBLIC_RESPONSE_MARKER}\n"
+        + structured_pr_review(
+            summary="Wrong structured kind discusses 429, quota, capacity, and transient behavior.",
+            reviewer="Google Gemini",
+        )
+    )
+
+    assert not _is_transient_public_response(text, repair_expected_kind="coder_followup")
+
+
+def test_structured_plan_review_transient_terms_with_trailing_prose_runs_repair(tmp_path):
+    malformed_review = (
+        structured_plan_review(
+            state="approved",
+            summary=(
+                "The plan discusses 429, quota, resource exhausted, timeout, capacity, "
+                "and transient retry handling as domain text."
+            ),
+            reviewer="Google Gemini",
+        )
+        + "\nTrailing prose after the signature should be repaired."
+    )
+    repaired_review = structured_plan_review(
+        state="approved",
+        summary="Plan review repaired.",
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the plan.",
+            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+            validate=lambda text: _validate_plan_review_response(
+                text,
+                reviewer="Google Gemini",
+                unresolved_items=(),
+            ),
+            use_repair=True,
+            repair_expected_kind="plan_review",
+        )
+
+    assert response.text == repaired_review
+    repair_mock.assert_called_once_with(
+        malformed_review,
+        config.gemini_cmd,
+        expected_kind="plan_review",
+    )
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
+def test_structured_pr_review_transient_terms_duplicate_footer_fails_deterministically(tmp_path):
+    malformed_review = (
+        structured_pr_review(
+            state="approved",
+            summary=(
+                "The review covers capacity, timeout, 429, quota, resource-exhausted, "
+                "and transient classifier behavior."
+            ),
+            reviewer="Google Gemini",
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value="still invalid") as repair_mock:
+        with pytest.raises(AgentLoopError) as exc_info:
+            _run_validated_agent(
+                runner,
+                agent="gemini",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                validate=lambda text: _validate_review_response(
+                    text,
+                    reviewer="Google Gemini",
+                    unresolved_items=(),
+                ),
+                use_repair=True,
+                repair_expected_kind="pr_review",
+            )
+
+    repair_mock.assert_called_once_with(
+        malformed_review,
+        config.gemini_cmd,
+        expected_kind="pr_review",
+    )
+    message = str(exc_info.value)
+    assert "Failure category: deterministic" in message
+    assert "Failure category: transient" not in message
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
+def test_structured_coder_followup_transient_terms_before_footer_runs_repair(tmp_path):
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Add timeout regression coverage.",
+            status="blocking",
+        ),
+    )
+    malformed_followup = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "approved",
+                "summary": "Updated timeout and capacity handling without treating prose as transient.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n## Changes made\nMentioned timeout and capacity in prose before the footer.\n"
+        "<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"
+    )
+    repaired_followup = structured_coder_followup(
+        state="approved",
+        summary="Updated timeout and capacity handling.",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        reviewer="Anthropic Claude",
+    )
+    runner = FakeRunner(claude_outputs=[malformed_followup])
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_followup) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Address review feedback.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_coder_followup_response(
+                text,
+                unresolved_items=unresolved_items,
+                human_requirements=(),
+            ),
+            use_repair=True,
+            repair_expected_kind="coder_followup",
+        )
+
+    assert response.text == repaired_followup
+    repair_mock.assert_called_once_with(
+        malformed_followup,
+        config.gemini_cmd,
+        expected_kind="coder_followup",
+    )
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
+def test_structured_plan_revision_transient_terms_before_footer_runs_repair(tmp_path):
+    malformed_revision = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Revise handling for 429, quota, resource exhausted, transient, and timeout.",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": [
+                    "Separate public-response validation from transient raw diagnostics.",
+                    "Keep capacity and quota retry handling for raw provider failures.",
+                ],
+            }
+        )
+        + "\n## Revised plan\nProse before the AGENT_PLAN_STATE footer is invalid.\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    repaired_revision = structured_plan_revision(
+        summary="Revised transient classifier plan.",
+        plan_steps=[
+            "Separate public-response validation from transient raw diagnostics.",
+            "Keep capacity and quota retry handling for raw provider failures.",
+        ],
+        reviewer="Anthropic Claude",
+    )
+    runner = FakeRunner(claude_outputs=[malformed_revision])
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_revision) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Revise the plan.",
+            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+            validate=_validate_plan_revision_response,
+            use_repair=True,
+            repair_expected_kind="plan_revision",
+        )
+
+    assert response.text == repaired_revision
+    repair_mock.assert_called_once_with(
+        malformed_revision,
+        config.gemini_cmd,
+        expected_kind="plan_revision",
+    )
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
 def test_gemini_duplicate_trailing_agent_state_marker_is_repairable(tmp_path):


### PR DESCRIPTION
## Summary
- add a public-response-aware transient classifier for validation failures
- route structured JSON public responses to repair/deterministic failures even when they mention transient-error terms
- keep diagnostic-shaped public responses and raw provider failures retryable

Fixes #223

## Tests
- python3 -m pytest tests/test_agent_loop.py
- python3 -m pytest