### PR TITLE
Handle structured response recovery mismatches

### DIFF
--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -91,6 +91,11 @@ The orchestrator will post only that file's contents when it exists and is
 non-empty. Keep internal tool narration, planning notes, diagnostics, and
 scratch output out of that file. Include the required AGENT_STATE / AGENT_PR /
 AGENT_CLARIFY markers in the file, as requested above.
+
+For structured responses, the file must start directly with {{, contain exactly
+one structured JSON object, then the required footer marker and signature. Do
+not put the stdout filtering marker, headings, prose, or markdown code fences in
+the response file.
 """
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -66,6 +66,7 @@ from .prompts import (
 from .protocol import (
     ParsedPlanReview,
     ParsedReview,
+    PUBLIC_RESPONSE_MARKER,
     ReviewItemDisposition,
     StructuredCoderFollowup,
     StructuredPlanRevision,
@@ -79,6 +80,7 @@ from .protocol import (
     parse_structured_plan_review,
     parse_pr_number,
     review_freeform_summary_text,
+    normalize_response_file_structured_text,
     validate_human_requirements_acknowledgement,
     validate_structured_plan_revision,
 )
@@ -203,6 +205,10 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
     {"plan_review", "pr_review", "coder_followup", "plan_revision"}
+)
+STRUCTURED_FENCE_RE = re.compile(
+    r"```(?:json)?[ \t]*\n(?P<body>\s*\{.*?\}\s*)```",
+    re.I | re.S,
 )
 PUBLIC_RESPONSE_TRANSIENT_DIAGNOSTIC_RE = re.compile(
     r"\A\s*(?:\[[^\]]*(?:error|fatal)[^\]]*\]\s*)?"
@@ -403,6 +409,121 @@ def _failure_category(text: str, *, public_response: bool = False) -> str:
     return "deterministic"  # no transient signal — may need code fix
 
 
+def _response_file_structured_status(text: str) -> str:
+    normalized, status = normalize_response_file_structured_text(text)
+    if status is not None:
+        return status
+    if normalized.lstrip().startswith("{"):
+        return "structured-prefix"
+    if normalized.lstrip().startswith("```"):
+        return "fenced-or-markdown"
+    return "markdown-or-prose"
+
+
+def _candidate_source_texts(result: AgentResult) -> list[tuple[str, str]]:
+    sources: list[tuple[str, str]] = []
+    if result.message_text:
+        sources.append(("message_text", result.message_text))
+    if result.raw_output:
+        raw = result.raw_output
+        if PUBLIC_RESPONSE_MARKER in raw:
+            sources.append(("stdout_marker", raw.rsplit(PUBLIC_RESPONSE_MARKER, 1)[1].lstrip()))
+        sources.append(("raw_output", raw))
+    seen: set[tuple[str, str]] = set()
+    unique: list[tuple[str, str]] = []
+    for source, text in sources:
+        key = (source, text)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append((source, text))
+    return unique
+
+
+def _unfence_structured_json_blocks(text: str) -> str:
+    return STRUCTURED_FENCE_RE.sub(lambda match: match.group("body").strip(), text)
+
+
+def _structured_response_candidates(text: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    decoder = json.JSONDecoder()
+    for variant in (text, _unfence_structured_json_blocks(text)):
+        for match in re.finditer(r"\{", variant):
+            start = match.start()
+            try:
+                payload, end = decoder.raw_decode(variant[start:])
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            absolute_end = start + end
+            trailing = variant[absolute_end:]
+            for signature in re.finditer(r"(?m)^--\s+\S[^\n]*(?:\n)?", trailing):
+                candidate = variant[start : absolute_end + signature.end()]
+                if candidate not in seen:
+                    seen.add(candidate)
+                    candidates.append(candidate)
+                break
+    return candidates
+
+
+def _recover_valid_structured_candidate(
+    result: AgentResult,
+    *,
+    validate: Callable[[str], object],
+    expected_kind: str | None,
+    config: AgentLoopConfig,
+    agent_name: str,
+) -> tuple[str, object] | None:
+    if expected_kind not in STRUCTURED_PUBLIC_RESPONSE_KINDS:
+        return None
+    valid: list[tuple[str, str, object]] = []
+    invalid_count = 0
+    for source, text in _candidate_source_texts(result):
+        for candidate in _structured_response_candidates(text):
+            try:
+                marker_value = validate(candidate)
+            except AgentLoopError:
+                invalid_count += 1
+                continue
+            valid.append((source, candidate, marker_value))
+    unique_valid: list[tuple[str, str, object]] = []
+    seen_candidates: set[str] = set()
+    for item in valid:
+        if item[1] in seen_candidates:
+            continue
+        seen_candidates.add(item[1])
+        unique_valid.append(item)
+    if len(unique_valid) == 1:
+        source, candidate, marker_value = unique_valid[0]
+        log(
+            config,
+            f"{agent_name}: public response file was not structured; recovered valid "
+            f"{expected_kind} from {source}",
+        )
+        return candidate, marker_value
+    if len(unique_valid) > 1:
+        log(
+            config,
+            f"{agent_name}: refused stdout/result recovery because multiple structured "
+            f"{expected_kind} candidates were present",
+        )
+    elif invalid_count:
+        log(
+            config,
+            f"{agent_name}: stdout/result contained structured-looking output, but no "
+            f"candidate passed {expected_kind} validation",
+        )
+    else:
+        log(
+            config,
+            f"{agent_name}: stdout/result did not contain a recoverable structured "
+            f"{expected_kind} response",
+        )
+    return None
+
+
 def _retry_delay(config: AgentLoopConfig, retry_index: int) -> int:
     delays = config.agent_retry_backoff_seconds
     if not delays:
@@ -492,6 +613,7 @@ def _run_validated_agent(
     usage_context: RunUsageContext | None = None,
     use_repair: bool = False,
     repair_expected_kind: str | None = None,
+    repair_unresolved_item_ids: Sequence[str] | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -539,6 +661,16 @@ def _run_validated_agent(
             should_retry = _is_transient_agent_output(classification_text)
             last_failure_category = _failure_category(classification_text)
         else:
+            response_file_pre_status = (
+                _response_file_structured_status(result.response_file_text)
+                if result.response_file_text
+                else None
+            )
+            if response_file_pre_status == "leading-public-response-marker-recovered":
+                log(
+                    config,
+                    f"{agent_name}: response file contained stdout filtering marker and was recovered",
+                )
             try:
                 marker_value = validate(text)
             except AgentLoopError as exc:
@@ -568,12 +700,53 @@ def _run_validated_agent(
                         config,
                         f"{agent_name}: transient diagnostics were present outside the public response",
                     )
+                response_file_status = None
+                if result.response_file_text:
+                    response_file_status = response_file_pre_status
+                    if response_file_status == "leading-public-response-marker-not-recoverable":
+                        log(
+                            config,
+                            f"{agent_name}: response file contained stdout filtering marker but "
+                            "the remainder was not recoverable",
+                        )
+                    elif response_file_status in {"markdown-or-prose", "fenced-or-markdown"}:
+                        log(
+                            config,
+                            f"{agent_name}: public response file was not structured "
+                            f"({response_file_status})",
+                        )
+                response_file_not_structured = response_file_status in {
+                    "leading-public-response-marker-not-recoverable",
+                    "markdown-or-prose",
+                    "fenced-or-markdown",
+                }
+                if result.response_file_text and response_file_not_structured:
+                    recovered = _recover_valid_structured_candidate(
+                        result,
+                        validate=validate,
+                        expected_kind=repair_expected_kind,
+                        config=config,
+                        agent_name=agent_name,
+                    )
+                    if recovered is not None:
+                        recovered_text, marker_value = recovered
+                        if usage_record is not None:
+                            usage_record.validation_status = "validated"
+                        return ValidatedAgentResponse(
+                            text=recovered_text,
+                            session_id=result.session_id,
+                            marker_value=marker_value,
+                            usage=usage,
+                        )
                 if use_repair and not public_text_is_transient:
                     log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
+                    repair_kwargs: dict[str, object] = {"expected_kind": repair_expected_kind}
+                    if repair_unresolved_item_ids is not None:
+                        repair_kwargs["unresolved_item_ids"] = tuple(repair_unresolved_item_ids)
                     repaired = attempt_repair(
                         text,
                         config.gemini_cmd,
-                        expected_kind=repair_expected_kind,
+                        **repair_kwargs,
                     )
                     if repaired is not None:
                         try:
@@ -1931,6 +2104,11 @@ def run_pr_loop(
                     human_requirements_context=coder_human_requirements_context,
                 )
             log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
+            repair_unresolved_item_ids = tuple(
+                item.item_id
+                for item in unresolved_items
+                if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+            )
             coder_response = _run_validated_agent(
                 runner,
                 agent=config.coder,
@@ -1946,6 +2124,7 @@ def run_pr_loop(
                 usage_context=usage_context,
                 use_repair=True,
                 repair_expected_kind="coder_followup",
+                repair_unresolved_item_ids=repair_unresolved_item_ids,
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -376,7 +376,7 @@ def _structured_coder_followup_guidance(
         "}",
         "",
         "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `tests_run` is optional.",
-        "Your response must begin with exactly one top-level JSON object and must not include prose or code fences before or between the JSON and footer.",
+        "Your response and public response file must start directly with `{`, contain exactly one top-level JSON object, and must not include stdout filtering markers, prose, headings, or code fences before or between the JSON and footer.",
         "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->`, then only your standalone signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
         "Use `addressed_items` and `remaining_items` to classify the unresolved reviewer item IDs shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
     ]

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 
 from .errors import AgentLoopError
 
+PUBLIC_RESPONSE_MARKER = "=== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ==="
+
 HUMAN_REQUIREMENTS_ADDRESSED_MARKER = "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->"
 HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK = (
     "checked the relevant GitHub discussion directly before responding"
@@ -532,6 +534,23 @@ def _extract_structured_response_object(text: str) -> dict[str, object] | None:
     return payload
 
 
+def normalize_response_file_structured_text(text: str) -> tuple[str, str | None]:
+    """Recover a public-response stdout marker only when it leaked at the front.
+
+    The public response file is already authoritative, so the stdout filtering
+    marker is invalid there.  This helper is intentionally narrow: it only strips
+    a leading marker after whitespace when the remaining body begins like the
+    required structured response.
+    """
+    stripped = text.lstrip()
+    if not stripped.startswith(PUBLIC_RESPONSE_MARKER):
+        return text, None
+    remainder = stripped[len(PUBLIC_RESPONSE_MARKER) :].lstrip()
+    if remainder.startswith("{"):
+        return remainder, "leading-public-response-marker-recovered"
+    return text, "leading-public-response-marker-not-recoverable"
+
+
 def _extract_json_object_prefix(text: str) -> tuple[dict[str, object], str] | None:
     stripped = text.lstrip()
     if not stripped.startswith("{"):
@@ -597,6 +616,7 @@ def _consume_structured_footer_and_signature(
 
 
 def _extract_structured_pr_review_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
     extracted = _extract_json_object_prefix(text)
     if extracted is None:
         return None
@@ -617,6 +637,7 @@ def _extract_structured_pr_review_payload(text: str) -> dict[str, object] | None
 
 
 def _extract_structured_plan_review_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
     extracted = _extract_json_object_prefix(text)
     if extracted is None:
         return None
@@ -631,6 +652,7 @@ def _extract_structured_plan_review_payload(text: str) -> dict[str, object] | No
 
 
 def _extract_structured_plan_revision_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
     extracted = _extract_json_object_prefix(text)
     if extracted is None:
         return None
@@ -646,6 +668,7 @@ def _extract_structured_plan_revision_payload(text: str) -> dict[str, object] | 
 
 
 def _extract_structured_coder_followup_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
     extracted = _extract_json_object_prefix(text)
     if extracted is None:
         return None

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Sequence
 
 from .agents.gemini import _parse_gemini_payload
 
@@ -29,6 +30,8 @@ _REPAIR_PROMPT = """\
 You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, or coder follow-up that failed strict schema validation. Extract its intent and reformat it into one of these four valid formats.
 
 {expected_kind_instruction}
+
+{coder_followup_required_items_instruction}
 
 ## Valid Format A — PR Review:
 
@@ -114,6 +117,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 - human_requirements.addressed_ids -> human REQUIREMENT LABELS like "Requirement 1", "Requirement 2"
   These are different from item IDs and may contain spaces.
 - Every reviewer item ID from the original must appear in EITHER addressed_items OR remaining_items, not both.
+- If a "Required coder follow-up item IDs" block is provided above, every listed ID must appear in exactly one of addressed_items or remaining_items even if the malformed markdown omitted it.
+- Legacy markdown markers like <!-- HUMAN_REQUIREMENTS_ADDRESSED --> and a ### Human requirements section are evidence for human_requirements.addressed_ids and checked_discussion_directly only; they do not classify regular reviewer or orchestrator-injected item-N records.
 - Do NOT include human requirement labels in addressed_items or remaining_items.
 
 ## STATE RULES (Format A/B):
@@ -288,7 +293,32 @@ _REPAIR_MODEL = "gemini-3.1-flash-lite"
 _SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision"}
 
 
-def attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+def _coder_followup_required_items_instruction(
+    expected_kind: str | None,
+    unresolved_item_ids: Sequence[str] | None,
+) -> str:
+    if unresolved_item_ids is None:
+        return ""
+    if expected_kind != "coder_followup":
+        raise ValueError("unresolved_item_ids may only be used for coder_followup repair")
+    rendered_ids = "\n".join(f"- `{item_id}`" for item_id in unresolved_item_ids)
+    return (
+        "## Required coder follow-up item IDs:\n"
+        "The repaired coder_followup must classify every ID below in exactly one of "
+        "`addressed_items` or `remaining_items`, even if the malformed response does "
+        "not mention the ID:\n"
+        f"{rendered_ids or '- (none)'}\n"
+        "Do not put human requirement labels such as `Requirement 1` in these arrays.\n"
+    )
+
+
+def attempt_repair(
+    raw: str,
+    gemini_cmd: str,
+    *,
+    expected_kind: str | None = None,
+    unresolved_item_ids: Sequence[str] | None = None,
+) -> str | None:
     """Call gemini-3.1-flash-lite via the Gemini CLI to reformat a malformed review response.
 
     Uses the same CLI invocation path as the reviewer so no extra auth is needed.
@@ -297,6 +327,10 @@ def attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = Non
     """
     if expected_kind is not None and expected_kind not in _SUPPORTED_EXPECTED_KINDS:
         raise ValueError(f"Unsupported expected repair kind: {expected_kind}")
+    coder_followup_required_items_instruction = _coder_followup_required_items_instruction(
+        expected_kind,
+        unresolved_item_ids,
+    )
     expected_kind_instruction = (
         "## Expected response kind:\n"
         f"You MUST repair this response as `{expected_kind}`. Output no other `kind` value.\n"
@@ -304,6 +338,11 @@ def attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = Non
         else "## Expected response kind:\nNo expected response kind was provided; choose from the format-selection rules.\n"
     )
     prompt = _REPAIR_PROMPT.replace("{expected_kind_instruction}", expected_kind_instruction, 1)
+    prompt = prompt.replace(
+        "{coder_followup_required_items_instruction}",
+        coder_followup_required_items_instruction,
+        1,
+    )
     prompt = prompt.replace("{raw_response}", raw, 1)
     try:
         result = subprocess.run(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -120,8 +120,11 @@ from coding_review_agent_loop.prompts import (
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
     _expect_string_list,
+    _extract_structured_coder_followup_payload,
     _extract_structured_plan_review_payload,
     _extract_structured_plan_revision_payload,
+    _extract_structured_pr_review_payload,
+    normalize_response_file_structured_text,
     parse_approved_followups,
     parse_human_requirements_acknowledgement,
     parse_pr_review,
@@ -3399,6 +3402,61 @@ def test_extract_structured_plan_review_payload_rejects_embedded_json_markdown()
     assert _extract_structured_plan_review_payload(review) is None
 
 
+@pytest.mark.parametrize(
+    ("builder", "extractor"),
+    [
+        (lambda: structured_plan_review(reviewer="Google Gemini"), _extract_structured_plan_review_payload),
+        (lambda: structured_pr_review(reviewer="Google Gemini"), _extract_structured_pr_review_payload),
+        (lambda: structured_coder_followup(reviewer="Anthropic Claude"), _extract_structured_coder_followup_payload),
+        (lambda: structured_plan_revision(reviewer="Anthropic Claude"), _extract_structured_plan_revision_payload),
+    ],
+)
+def test_structured_extractors_recover_leading_public_response_marker(builder, extractor):
+    text = f"\n\n{PUBLIC_RESPONSE_MARKER}\n{builder()}"
+
+    payload = extractor(text)
+
+    assert payload is not None
+
+
+def test_response_file_marker_normalization_reports_unrecoverable_marker():
+    text = f"{PUBLIC_RESPONSE_MARKER}\n### Review\nLooks good."
+
+    normalized, status = normalize_response_file_structured_text(text)
+
+    assert normalized == text
+    assert status == "leading-public-response-marker-not-recoverable"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "approved",
+                "summary": PUBLIC_RESPONSE_MARKER,
+                "blocking_plan_issues": [],
+                "same_plan_followups": [],
+                "future_followups": [],
+                "prior_plan_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini",
+        "Some prose first.\n"
+        + PUBLIC_RESPONSE_MARKER
+        + "\n"
+        + structured_plan_review(reviewer="Google Gemini"),
+    ],
+)
+def test_response_file_marker_not_stripped_inside_json_or_mid_prose(text):
+    normalized, status = normalize_response_file_structured_text(text)
+
+    assert normalized == text
+    assert status is None
+
+
 def test_extract_structured_plan_review_payload_rejects_footer_state_mismatch():
     payload = json.dumps(
         {
@@ -3993,6 +4051,38 @@ def test_validate_coder_followup_response_rejects_marker_only_markdown():
         _validate_coder_followup_response(
             "Updated the PR.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
             unresolved_items=(),
+            human_requirements=(),
+        )
+
+
+def test_validate_coder_followup_response_requires_regular_synthetic_human_requirement_item():
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-8",
+            reviewer="Orchestrator",
+            source_round=4,
+            text="Reviewers approved without acknowledging signed human requirements.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id=HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=4,
+            text="Internal human requirements acknowledgement pseudo-item.",
+            status="blocking",
+        ),
+    )
+    response = structured_coder_followup(
+        state="approved",
+        addressed_items=[],
+        remaining_items=[],
+        reviewer="Anthropic Claude",
+    )
+
+    with pytest.raises(AgentLoopError, match="item-8"):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=unresolved_items,
             human_requirements=(),
         )
 
@@ -5284,7 +5374,7 @@ def test_gemini_pre_marker_429_does_not_suppress_structured_review_repair(tmp_pa
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -5328,7 +5418,7 @@ def test_gemini_response_file_repair_ignores_raw_stdout_transient_diagnostics(tm
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_repairs.append(raw)
         return repaired_review
 
@@ -5612,6 +5702,186 @@ def test_structured_coder_followup_transient_terms_before_footer_runs_repair(tmp
         expected_kind="coder_followup",
     )
     assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
+def test_run_validated_agent_recovers_coder_followup_from_message_text_when_response_file_markdown(tmp_path):
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-8",
+            reviewer="Orchestrator",
+            source_round=4,
+            text="Acknowledge signed human requirements.",
+            status="blocking",
+        ),
+    )
+    valid_followup = structured_coder_followup(
+        state="approved",
+        summary="Acknowledged the signed human requirements.",
+        addressed_items=["item-8"],
+        remaining_items=[],
+        reviewer="OpenAI Codex",
+    )
+    markdown_response_file = (
+        "### Human requirements\n\n"
+        "Acknowledged.\n\n"
+        "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"
+        "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+    )
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": valid_followup, "stdout": "diagnostic output"}],
+        public_response_outputs=[{"text": markdown_response_file}],
+    )
+    config = make_config(tmp_path, coder="codex", agent_max_retries=0)
+
+    response = _run_validated_agent(
+        runner,
+        agent="codex",
+        config=config,
+        prompt="Address feedback.",
+        marker_description="<!-- AGENT_STATE: approved|blocking -->",
+        validate=lambda text: _validate_coder_followup_response(
+            text,
+            unresolved_items=unresolved_items,
+            human_requirements=(),
+        ),
+        repair_expected_kind="coder_followup",
+    )
+
+    assert response.text == valid_followup
+    assert response.marker_value.addressed_items == ("item-8",)
+
+
+def test_run_validated_agent_recovers_fenced_coder_followup_from_raw_stdout(tmp_path):
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Fix the bug.",
+            status="blocking",
+        ),
+    )
+    valid_followup = structured_coder_followup(
+        state="approved",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        reviewer="OpenAI Codex",
+    )
+    json_part, footer = valid_followup.split("\n<!-- AGENT_STATE:", 1)
+    fenced_stdout = f"tool diagnostic\n```json\n{json_part}\n```\n<!-- AGENT_STATE:{footer}"
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": "legacy markdown", "stdout": fenced_stdout}],
+        public_response_outputs=[{"text": "### Update\nFixed it.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"}],
+    )
+    config = make_config(tmp_path, coder="codex", agent_max_retries=0)
+
+    response = _run_validated_agent(
+        runner,
+        agent="codex",
+        config=config,
+        prompt="Address feedback.",
+        marker_description="<!-- AGENT_STATE: approved|blocking -->",
+        validate=lambda text: _validate_coder_followup_response(
+            text,
+            unresolved_items=unresolved_items,
+            human_requirements=(),
+        ),
+        repair_expected_kind="coder_followup",
+    )
+
+    assert response.text == valid_followup
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        structured_pr_review(reviewer="OpenAI Codex"),
+        "diagnostic output without a structured response",
+    ],
+)
+def test_run_validated_agent_refuses_unrecoverable_stdout_when_response_file_markdown(tmp_path, stdout):
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": "legacy markdown", "stdout": stdout}],
+        public_response_outputs=[{"text": "### Update\nFixed it.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"}],
+    )
+    config = make_config(tmp_path, coder="codex", agent_max_retries=0)
+
+    with pytest.raises(AgentLoopError, match="No review result was recorded"):
+        _run_validated_agent(
+            runner,
+            agent="codex",
+            config=config,
+            prompt="Address feedback.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_coder_followup_response(
+                text,
+                unresolved_items=(),
+                human_requirements=(),
+            ),
+            repair_expected_kind="coder_followup",
+        )
+
+
+def test_run_validated_agent_refuses_multiple_stdout_structured_candidates(tmp_path):
+    first = structured_coder_followup(
+        state="approved",
+        summary="First candidate.",
+        reviewer="OpenAI Codex",
+    )
+    second = structured_coder_followup(
+        state="approved",
+        summary="Second candidate.",
+        reviewer="OpenAI Codex",
+    )
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": "legacy markdown", "stdout": first + "\n\n" + second}],
+        public_response_outputs=[{"text": "### Update\nFixed it.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"}],
+    )
+    config = make_config(tmp_path, coder="codex", agent_max_retries=0)
+
+    with pytest.raises(AgentLoopError, match="No review result was recorded"):
+        _run_validated_agent(
+            runner,
+            agent="codex",
+            config=config,
+            prompt="Address feedback.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_coder_followup_response(
+                text,
+                unresolved_items=(),
+                human_requirements=(),
+            ),
+            repair_expected_kind="coder_followup",
+        )
+
+
+def test_run_validated_agent_keeps_valid_response_file_authoritative_over_noisy_stdout(tmp_path):
+    valid_followup = structured_coder_followup(
+        state="approved",
+        summary="Response file wins.",
+        reviewer="OpenAI Codex",
+    )
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": "ignored message", "stdout": "unrelated noisy diagnostics"}],
+        public_response_outputs=[{"text": valid_followup}],
+    )
+    config = make_config(tmp_path, coder="codex", agent_max_retries=0)
+
+    response = _run_validated_agent(
+        runner,
+        agent="codex",
+        config=config,
+        prompt="Address feedback.",
+        marker_description="<!-- AGENT_STATE: approved|blocking -->",
+        validate=lambda text: _validate_coder_followup_response(
+            text,
+            unresolved_items=(),
+            human_requirements=(),
+        ),
+        repair_expected_kind="coder_followup",
+    )
+
+    assert response.text == valid_followup
 
 
 def test_structured_plan_revision_transient_terms_before_footer_runs_repair(tmp_path):
@@ -9904,7 +10174,7 @@ def test_issue_loop_plan_revision_repair_preserves_signed_human_requirements(tmp
     config = make_config(tmp_path, agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_repairs.append((raw, expected_kind))
         return repaired_revision
 
@@ -9971,7 +10241,7 @@ def test_issue_loop_plan_revision_repair_rejects_wrong_kind_from_human_requireme
     config = make_config(tmp_path, agent_max_retries=0)
     captured_kinds = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_kinds.append(expected_kind)
         return wrong_kind_repair
 
@@ -11586,6 +11856,45 @@ def test_attempt_repair_includes_expected_kind_instruction():
     assert "Output no other `kind` value" in prompt
 
 
+def test_attempt_repair_includes_coder_followup_required_item_ids():
+    repaired = structured_coder_followup(
+        state="approved",
+        addressed_items=["item-8"],
+        remaining_items=[],
+        reviewer="Gemini",
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            "### Human requirements\nAcknowledged.\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->",
+            "gemini",
+            expected_kind="coder_followup",
+            unresolved_item_ids=["item-8"],
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert "Required coder follow-up item IDs" in prompt
+    assert "`item-8`" in prompt
+    assert "exactly one of `addressed_items` or `remaining_items`" in prompt
+    assert "HUMAN_REQUIREMENTS_ADDRESSED" in prompt
+    assert "do not classify regular reviewer or orchestrator-injected item-N records" in prompt
+
+
+def test_attempt_repair_rejects_unresolved_item_ids_for_non_coder_kind():
+    with pytest.raises(ValueError, match="unresolved_item_ids"):
+        attempt_repair(
+            "malformed plan review",
+            "gemini",
+            expected_kind="plan_review",
+            unresolved_item_ids=["item-1"],
+        )
+
+
 def test_attempt_repair_handles_json_wrapped_cli_output():
     repaired_text = (
         '{"schema_version":1,"kind":"pr_review","state":"approved","summary":"OK",'
@@ -11635,7 +11944,7 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -11668,7 +11977,7 @@ def test_run_pr_loop_repairs_format_failure_with_5xx_source_line_reference(tmp_p
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -11692,7 +12001,7 @@ def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
 
-    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         assert expected_kind == "pr_review"
         return "still broken output without valid schema"
 
@@ -11746,9 +12055,11 @@ def test_run_pr_loop_uses_repair_pass_on_coder_followup_format_failure(tmp_path)
     config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2, agent_max_retries=0)
 
     captured_repairs = []
+    captured_unresolved_item_ids = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
         captured_repairs.append(raw)
+        captured_unresolved_item_ids.append(tuple(unresolved_item_ids or ()))
         assert expected_kind == "coder_followup"
         return repaired_followup
 
@@ -11758,6 +12069,7 @@ def test_run_pr_loop_uses_repair_pass_on_coder_followup_format_failure(tmp_path)
     assert result == 0
     assert len(captured_repairs) == 1
     assert "pr_review" in captured_repairs[0]
+    assert captured_unresolved_item_ids == [("item-1",)]
 
 
 def test_run_pr_loop_falls_back_to_error_when_coder_followup_repair_also_fails(tmp_path):


### PR DESCRIPTION
## Summary
- recover leading public-response marker leakage for structured response files
- recover exactly one valid structured stdout/result candidate when a non-structured response file fails validation
- thread unresolved coder follow-up item IDs into repair and strengthen response-file instructions

Fixes #217

## Tests
- python3 -m pytest tests/test_agent_loop.py -q
- python3 -m pytest -q