### PR TITLE
Expand coder follow-up item context

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,9 @@ stale visible item IDs from older heads, superseded plans, or replayed rounds.
 Structured JSON is also the preferred coder format for follow-up and plan
 revision rounds. Coder follow-up responses use `kind: "coder_followup"` with
 `state`, `summary`, `addressed_items`, `remaining_items`,
-`human_requirements`, and optional `tests_run`; every carried reviewer item ID
-must appear exactly once in either `addressed_items` or `remaining_items`.
+`human_requirements`, optional `addressed_item_notes` / `remaining_item_notes`,
+and optional `tests_run`; every carried reviewer item ID must appear exactly
+once in either `addressed_items` or `remaining_items`.
 Plan-revision responses use `kind: "plan_revision"` with `state: "blocking"`,
 `summary`, `prior_plan_item_dispositions`, and `plan_steps`. Structured
 responses must start with one top-level JSON object, place the matching

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -542,6 +542,8 @@ response must classify every carried reviewer item exactly once:
   "summary": "Implemented the requested fix.",
   "addressed_items": ["item-1"],
   "remaining_items": [],
+  "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},
+  "remaining_item_notes": {},
   "human_requirements": {
     "addressed_ids": [],
     "checked_discussion_directly": false

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -333,17 +333,48 @@ def _render_public_coder_followup_comment(
     parsed_followup: StructuredCoderFollowup,
     *,
     signature: str,
+    prior_items: Sequence[UnresolvedReviewItem] = (),
 ) -> str:
-    addressed_items = (
-        [f"- {item_id}" for item_id in parsed_followup.addressed_items]
-        if parsed_followup.addressed_items
-        else ["- None."]
-    )
-    remaining_items = (
-        [f"- {item_id}" for item_id in parsed_followup.remaining_items]
-        if parsed_followup.remaining_items
-        else ["- None."]
-    )
+    item_by_id = {item.item_id: item for item in prior_items}
+
+    def render_item(item_id: str, *, note_label: str, note: str | None, placeholder: str | None) -> list[str]:
+        item = item_by_id.get(item_id)
+        if item is None:
+            lines = [f"- {item_id}: Item context unavailable in current round metadata."]
+        else:
+            lines = [f"- {item_id}: {_format_unresolved_item_label(item)}"]
+        if note:
+            lines.append(f"  - {note_label}: {note}")
+        elif placeholder:
+            lines.append(f"  - {note_label}: {placeholder}")
+        return lines
+
+    addressed_items: list[str] = []
+    for item_id in parsed_followup.addressed_items:
+        addressed_items.extend(
+            render_item(
+                item_id,
+                note_label="Resolution",
+                note=parsed_followup.addressed_item_notes.get(item_id),
+                placeholder=None,
+            )
+        )
+    if not addressed_items:
+        addressed_items = ["- None."]
+
+    remaining_items: list[str] = []
+    for item_id in parsed_followup.remaining_items:
+        remaining_items.extend(
+            render_item(
+                item_id,
+                note_label="Reason",
+                note=parsed_followup.remaining_item_notes.get(item_id),
+                placeholder="No reason provided by coder.",
+            )
+        )
+    if not remaining_items:
+        remaining_items = ["- None."]
+
     sections = [
         "## Coder follow-up",
         parsed_followup.summary.strip(),

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2136,6 +2136,7 @@ def run_pr_loop(
                 public_comment = _render_public_coder_followup_comment(
                     coder_response.marker_value,
                     signature=agent_signature(config.coder),
+                    prior_items=tuple(unresolved_items),
                 )
 
             unresolved_items = _reconcile_human_requirements_ack_item(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -368,6 +368,8 @@ def _structured_coder_followup_guidance(
         '  "summary": "Implemented the requested fix and left one reviewer item for follow-up.",',
         '  "addressed_items": ["item-1"],',
         '  "remaining_items": ["item-2"],',
+        '  "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},',
+        '  "remaining_item_notes": {"item-2": "Deferred because it requires a separate UI change."},',
         '  "human_requirements": {',
         '    "addressed_ids": ["Requirement 1"],',
         '    "checked_discussion_directly": false',
@@ -375,10 +377,11 @@ def _structured_coder_followup_guidance(
         '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
         "}",
         "",
-        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `tests_run` is optional.",
+        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `addressed_item_notes`, `remaining_item_notes`, and `tests_run` are optional.",
         "Your response and public response file must start directly with `{`, contain exactly one top-level JSON object, and must not include stdout filtering markers, prose, headings, or code fences before or between the JSON and footer.",
         "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->`, then only your standalone signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
         "Use `addressed_items` and `remaining_items` to classify the unresolved reviewer item IDs shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
+        "Use `addressed_item_notes` to summarize how each addressed item was resolved, and use `remaining_item_notes` to give a visible reason for each intentionally deferred remaining item.",
     ]
     if human_requirements_context.block:
         if human_requirements_context.surfaced_requirement_ids:

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -181,6 +181,8 @@ class StructuredCoderFollowup:
     addressed_items: tuple[str, ...]
     remaining_items: tuple[str, ...]
     human_requirements: StructuredHumanRequirementsPayload
+    addressed_item_notes: dict[str, str]
+    remaining_item_notes: dict[str, str]
     tests_run: tuple[str, ...] | None = None
 
 
@@ -506,6 +508,23 @@ def _expect_item_id_list(value: object, *, context: str) -> tuple[str, ...]:
         _expect_item_id(item, context=f"{context} item at index {index}")
         for index, item in enumerate(value)
     )
+
+
+def _expect_item_note_map(
+    value: object,
+    *,
+    context: str,
+    allowed_item_ids: set[str],
+    allowed_context: str,
+) -> dict[str, str]:
+    note_payload = _expect_object(value, context=context)
+    rendered: dict[str, str] = {}
+    for raw_item_id, raw_note in note_payload.items():
+        item_id = _expect_item_id(raw_item_id, context=f"{context} key")
+        if item_id not in allowed_item_ids:
+            raise AgentLoopError(f"{context} key `{item_id}` is not listed in {allowed_context}.")
+        rendered[item_id] = _expect_non_empty_string(raw_note, context=f"{context}.{item_id}")
+    return rendered
 
 
 def _expect_requirement_id_list(value: object, *, context: str) -> tuple[str, ...]:
@@ -1033,7 +1052,7 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
             "remaining_items",
             "human_requirements",
         },
-        optional={"tests_run"},
+        optional={"addressed_item_notes", "remaining_item_notes", "tests_run"},
     )
     human_requirements_payload = _expect_object(
         payload["human_requirements"],
@@ -1054,19 +1073,33 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
         if tests_run_value is not None
         else None
     )
+    addressed_items = _expect_item_id_list(
+        payload["addressed_items"],
+        context="coder_followup.addressed_items",
+    )
+    remaining_items = _expect_item_id_list(
+        payload["remaining_items"],
+        context="coder_followup.remaining_items",
+    )
+    addressed_item_notes = _expect_item_note_map(
+        payload.get("addressed_item_notes", {}),
+        context="coder_followup.addressed_item_notes",
+        allowed_item_ids=set(addressed_items),
+        allowed_context="coder_followup.addressed_items",
+    )
+    remaining_item_notes = _expect_item_note_map(
+        payload.get("remaining_item_notes", {}),
+        context="coder_followup.remaining_item_notes",
+        allowed_item_ids=set(remaining_items),
+        allowed_context="coder_followup.remaining_items",
+    )
     return StructuredCoderFollowup(
         schema_version=1,
         kind="coder_followup",
         state=_expect_state(payload["state"], context="coder_followup.state"),
         summary=_expect_non_empty_string(payload["summary"], context="coder_followup.summary"),
-        addressed_items=_expect_item_id_list(
-            payload["addressed_items"],
-            context="coder_followup.addressed_items",
-        ),
-        remaining_items=_expect_item_id_list(
-            payload["remaining_items"],
-            context="coder_followup.remaining_items",
-        ),
+        addressed_items=addressed_items,
+        remaining_items=remaining_items,
         human_requirements=StructuredHumanRequirementsPayload(
             addressed_ids=_expect_requirement_id_list(
                 human_requirements_payload["addressed_ids"],
@@ -1077,6 +1110,8 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
                 context="coder_followup.human_requirements.checked_discussion_directly",
             ),
         ),
+        addressed_item_notes=addressed_item_notes,
+        remaining_item_notes=remaining_item_notes,
         tests_run=tests_run,
     )
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -77,6 +77,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
   "summary": "<short summary>",
   "addressed_items": ["item-1"],
   "remaining_items": ["item-2"],
+  "addressed_item_notes": {"item-1": "<how it was resolved>"},
+  "remaining_item_notes": {"item-2": "<why it remains>"},
   "human_requirements": {
     "addressed_ids": ["Requirement 1"],
     "checked_discussion_directly": false

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -759,6 +759,8 @@ def structured_coder_followup(
     summary: str = "Updated the PR.",
     addressed_items: list[str] | None = None,
     remaining_items: list[str] | None = None,
+    addressed_item_notes: dict[str, str] | None = None,
+    remaining_item_notes: dict[str, str] | None = None,
     human_requirement_ids: list[str] | None = None,
     checked_discussion_directly: bool = False,
     reviewer: str = "Anthropic Claude",
@@ -772,6 +774,8 @@ def structured_coder_followup(
                 "summary": summary,
                 "addressed_items": addressed_items or [],
                 "remaining_items": remaining_items or [],
+                "addressed_item_notes": addressed_item_notes or {},
+                "remaining_item_notes": remaining_item_notes or {},
                 "human_requirements": {
                     "addressed_ids": human_requirement_ids or [],
                     "checked_discussion_directly": checked_discussion_directly,
@@ -3177,6 +3181,87 @@ def test_validate_structured_coder_followup_accepts_v1_payload():
     assert parsed.addressed_items == ("item-1",)
     assert parsed.remaining_items == ("item-2",)
     assert parsed.human_requirements.addressed_ids == ("Requirement 1",)
+    assert parsed.addressed_item_notes == {}
+    assert parsed.remaining_item_notes == {}
+
+
+def test_validate_structured_coder_followup_accepts_optional_item_notes():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Addressed the parser; deferred the docs.",
+                "addressed_items": ["item-1"],
+                "remaining_items": ["item-2"],
+                "addressed_item_notes": {"item-1": "Added parsing coverage."},
+                "remaining_item_notes": {"item-2": "Deferred until the docs owner weighs in."},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = validate_structured_coder_followup(payload)
+
+    assert parsed is not None
+    assert parsed.addressed_item_notes == {"item-1": "Added parsing coverage."}
+    assert parsed.remaining_item_notes == {
+        "item-2": "Deferred until the docs owner weighs in."
+    }
+
+
+def test_validate_structured_coder_followup_rejects_note_for_unlisted_item():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Addressed one item.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "addressed_item_notes": {"item-2": "This note is stale."},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="item-2.*not listed in coder_followup.addressed_items"):
+        validate_structured_coder_followup(payload)
+
+
+@pytest.mark.parametrize("bad_note", ["", "   ", 5, None])
+def test_validate_structured_coder_followup_rejects_invalid_note_values(bad_note):
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Addressed one item.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "addressed_item_notes": {"item-1": bad_note},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="coder_followup.addressed_item_notes.item-1"):
+        validate_structured_coder_followup(payload)
 
 
 def test_validate_structured_coder_followup_returns_none_when_no_structured_candidate_exists():
@@ -3776,6 +3861,10 @@ def test_render_public_coder_followup_comment():
                 "summary": "Added the requested regression test.",
                 "addressed_items": ["item-1", "item-2"],
                 "remaining_items": [],
+                "addressed_item_notes": {
+                    "item-1": "Added coverage for the parser.",
+                    "item-2": "Updated the helper.",
+                },
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,
@@ -3788,15 +3877,37 @@ def test_render_public_coder_followup_comment():
         + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
     )
     assert parsed is not None
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Add a regression test before merge.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="Google Gemini",
+            source_round=2,
+            text="Rename the shared helper.",
+            status="same-pr",
+        ),
+    )
 
-    rendered = _render_public_coder_followup_comment(parsed, signature="Anthropic Claude")
+    rendered = _render_public_coder_followup_comment(
+        parsed,
+        signature="Anthropic Claude",
+        prior_items=prior_items,
+    )
 
     assert rendered == (
         "## Coder follow-up\n\n"
         "Added the requested regression test.\n\n"
         "### Addressed items\n"
-        "- item-1\n"
-        "- item-2\n\n"
+        "- item-1: Blocking issue from OpenAI Codex, round 1: Add a regression test before merge.\n"
+        "  - Resolution: Added coverage for the parser.\n"
+        "- item-2: Same-PR follow-up from Google Gemini, round 2: Rename the shared helper.\n"
+        "  - Resolution: Updated the helper.\n\n"
         "### Remaining items\n"
         "- None.\n\n"
         "### Tests run\n"
@@ -3832,7 +3943,128 @@ def test_render_public_coder_followup_comment():
     )
     assert "### Tests run" not in rendered_without_tests
     assert "### Addressed items\n- None." in rendered_without_tests
-    assert "### Remaining items\n- item-3" in rendered_without_tests
+    assert (
+        "### Remaining items\n"
+        "- item-3: Item context unavailable in current round metadata.\n"
+        "  - Reason: No reason provided by coder."
+    ) in rendered_without_tests
+
+
+def test_render_public_coder_followup_comment_expands_carried_items_with_notes_and_placeholders():
+    parsed = validate_structured_coder_followup(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Fixed the blocker and deferred the follow-up.",
+                "addressed_items": ["item-1"],
+                "remaining_items": ["item-2"],
+                "addressed_item_notes": {"item-1": "Restored the missing validation branch."},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    assert parsed is not None
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=2,
+            text="  - Preserve structured coder follow-up metadata.\n\nExtra context should be summarized.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="Google Gemini",
+            source_round=3,
+            text="Move the rendering helper into a shared module.",
+            status="same-pr",
+        ),
+    )
+
+    rendered = _render_public_coder_followup_comment(
+        parsed,
+        signature="Anthropic Claude",
+        prior_items=prior_items,
+    )
+
+    assert (
+        "- item-1: Blocking issue from OpenAI Codex, round 2: "
+        "Preserve structured coder follow-up metadata."
+    ) in rendered
+    assert "  - Resolution: Restored the missing validation branch." in rendered
+    assert (
+        "- item-2: Same-PR follow-up from Google Gemini, round 3: "
+        "Move the rendering helper into a shared module."
+    ) in rendered
+    assert "  - Reason: No reason provided by coder." in rendered
+
+
+def test_render_public_coder_followup_comment_expands_pr_220_remaining_items():
+    parsed = validate_structured_coder_followup(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Hardened markdown stripping; two follow-ups remain.",
+                "addressed_items": ["item-3", "item-4"],
+                "remaining_items": ["item-5", "item-6"],
+                "remaining_item_notes": {
+                    "item-5": "Deferred because URL canonicalization needs product confirmation.",
+                    "item-6": "Deferred because the helper move should be isolated from this fix.",
+                },
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    assert parsed is not None
+    prior_items = (
+        UnresolvedReviewItem(
+            item_id="item-5",
+            reviewer="Google Gemini",
+            source_round=3,
+            text=(
+                "Update `server/static/index.html` and `server/static/landing.html` to use "
+                "relative paths for `og:image` and `og:url` if possible."
+            ),
+            status="same-pr",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-6",
+            reviewer="Google Gemini",
+            source_round=3,
+            text=(
+                "Deduplicate `_strip_markdown` helper logic between `server/app.py` and "
+                "`core/orchestrator.py` by moving it to `core/utils.py`."
+            ),
+            status="same-pr",
+        ),
+    )
+
+    rendered = _render_public_coder_followup_comment(
+        parsed,
+        signature="Anthropic Claude",
+        prior_items=prior_items,
+    )
+
+    assert "- item-5: Same-PR follow-up from Google Gemini, round 3:" in rendered
+    assert "relative paths" in rendered
+    assert "  - Reason: Deferred because URL canonicalization needs product confirmation." in rendered
+    assert "- item-6: Same-PR follow-up from Google Gemini, round 3:" in rendered
+    assert "Deduplicate `_strip_markdown` helper logic" in rendered
+    assert "  - Reason: Deferred because the helper move should be isolated from this fix." in rendered
+    assert "\n- item-5\n" not in rendered
+    assert "\n- item-6\n" not in rendered
 
 
 def test_render_public_plan_review_comment_normalizes_sections():
@@ -6258,6 +6490,9 @@ def test_pr_loop_accepts_structured_coder_followup_in_pr_round(tmp_path):
                     "summary": "Added the requested regression test.",
                     "addressed_items": ["item-1"],
                     "remaining_items": [],
+                    "addressed_item_notes": {
+                        "item-1": "Added the structured coder follow-up regression case."
+                    },
                     "human_requirements": {
                         "addressed_ids": [],
                         "checked_discussion_directly": False,
@@ -6284,7 +6519,8 @@ def test_pr_loop_accepts_structured_coder_followup_in_pr_round(tmp_path):
     assert len(followup_comments) == 1
     visible_followup = _strip_round_metadata(followup_comments[0])
     assert "Added the requested regression test." in visible_followup
-    assert "### Addressed items\n- item-1" in visible_followup
+    assert "### Addressed items\n- item-1: Blocking issue from OpenAI Codex" in visible_followup
+    assert "  - Resolution: Added the structured coder follow-up regression case." in visible_followup
     assert "### Remaining items\n- None." in visible_followup
     assert (
         "### Tests run\n- pytest tests/test_agent_loop.py -k structured_coder_followup"


### PR DESCRIPTION
## Summary
- add optional addressed/remaining item note maps to structured coder follow-up validation
- expand public addressed/remaining item sections with prior-item context and visible notes/placeholders
- pass the unresolved item ledger through the PR-loop renderer and cover the issue #220 shape in tests

## Tests
- python3 -m pytest tests/test_agent_loop.py -k "coder_followup or structured_coder_followup"
- python3 -m pytest

Fixes #220