### PR TITLE
Clarify empty human requirements follow-ups

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -614,6 +614,7 @@ def _run_validated_agent(
     use_repair: bool = False,
     repair_expected_kind: str | None = None,
     repair_unresolved_item_ids: Sequence[str] | None = None,
+    repair_surfaced_requirement_ids: Sequence[str] | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -743,6 +744,8 @@ def _run_validated_agent(
                     repair_kwargs: dict[str, object] = {"expected_kind": repair_expected_kind}
                     if repair_unresolved_item_ids is not None:
                         repair_kwargs["unresolved_item_ids"] = tuple(repair_unresolved_item_ids)
+                    if repair_surfaced_requirement_ids is not None:
+                        repair_kwargs["surfaced_requirement_ids"] = tuple(repair_surfaced_requirement_ids)
                     repaired = attempt_repair(
                         text,
                         config.gemini_cmd,
@@ -2125,6 +2128,7 @@ def run_pr_loop(
                 use_repair=True,
                 repair_expected_kind="coder_followup",
                 repair_unresolved_item_ids=repair_unresolved_item_ids,
+                repair_surfaced_requirement_ids=coder_human_requirements_context.surfaced_requirement_ids,
             )
             coder_output = coder_response.text
             coder_session_id = coder_response.session_id

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from textwrap import indent
@@ -358,6 +359,12 @@ def _structured_coder_followup_guidance(
     reviewer_name: str,
     human_requirements_context: CoderHumanRequirementsPromptContext,
 ) -> str:
+    example_human_requirement_ids = (
+        list(human_requirements_context.surfaced_requirement_ids[:1])
+        if human_requirements_context.surfaced_requirement_ids
+        else []
+    )
+    example_human_requirement_ids_json = json.dumps(example_human_requirement_ids)
     lines = [
         f"Use this mandatory structured JSON follow-up format so {reviewer_name} and the orchestrator can validate your response deterministically:",
         "",
@@ -371,7 +378,7 @@ def _structured_coder_followup_guidance(
         '  "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},',
         '  "remaining_item_notes": {"item-2": "Deferred because it requires a separate UI change."},',
         '  "human_requirements": {',
-        '    "addressed_ids": ["Requirement 1"],',
+        f'    "addressed_ids": {example_human_requirement_ids_json},',
         '    "checked_discussion_directly": false',
         "  },",
         '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
@@ -383,17 +390,20 @@ def _structured_coder_followup_guidance(
         "Use `addressed_items` and `remaining_items` to classify the unresolved reviewer item IDs shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
         "Use `addressed_item_notes` to summarize how each addressed item was resolved, and use `remaining_item_notes` to give a visible reason for each intentionally deferred remaining item.",
     ]
-    if human_requirements_context.block:
-        if human_requirements_context.surfaced_requirement_ids:
-            surfaced = ", ".join(f"`{item}`" for item in human_requirements_context.surfaced_requirement_ids)
-            lines.append(
-                "In structured replies, set `human_requirements.addressed_ids` to exactly the surfaced signed human requirement IDs you addressed in this prompt: "
-                f"{surfaced}."
-            )
-        elif human_requirements_context.requires_direct_discussion_ack:
-            lines.append(
-                "If the prompt omitted detailed signed human requirements, set `human_requirements.addressed_ids` to `[]` and `human_requirements.checked_discussion_directly` to `true` only after checking the GitHub discussion directly."
-            )
+    if human_requirements_context.surfaced_requirement_ids:
+        surfaced = ", ".join(f"`{item}`" for item in human_requirements_context.surfaced_requirement_ids)
+        lines.append(
+            "In structured replies, set `human_requirements.addressed_ids` to exactly the surfaced signed human requirement IDs you addressed in this prompt: "
+            f"{surfaced}. Only exact surfaced labels such as `Requirement 1` are valid."
+        )
+    elif human_requirements_context.requires_direct_discussion_ack:
+        lines.append(
+            "If the prompt omitted detailed signed human requirements, set `human_requirements.addressed_ids` to `[]` and `human_requirements.checked_discussion_directly` to `true` only after checking the GitHub discussion directly. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`."
+        )
+    else:
+        lines.append(
+            "No signed human requirements are surfaced in this prompt, so structured replies must set `human_requirements.addressed_ids` to `[]`. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`; only exact surfaced signed requirement labels are valid when such labels are actually shown."
+        )
     return "\n".join(lines) + "\n"
 
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -253,7 +253,11 @@ def human_requirements_resolved(text: str) -> bool:
 def _normalize_requirement_label(text: str) -> str:
     match = re.fullmatch(r"\s*Requirement\s+(\d+)\s*", text, re.I)
     if not match:
-        raise AgentLoopError(f"Invalid human requirement label: {text}")
+        raise AgentLoopError(
+            f"Invalid human requirement label: {text}. Only exact surfaced signed labels like "
+            "`Requirement 1` are valid; issue acceptance criteria, reviewer item IDs, reviewer "
+            "comments, and arbitrary labels are not signed human requirements."
+        )
     return f"Requirement {match.group(1)}"
 
 
@@ -319,6 +323,13 @@ def validate_structured_human_requirements_acknowledgement(
     section_present: bool = True,
 ) -> None:
     if not surfaced_requirement_ids and not requires_direct_discussion_ack:
+        if addressed_ids:
+            raise AgentLoopError(
+                "Coder response listed signed human requirement IDs even though no signed human "
+                "requirements were surfaced. Use `human_requirements.addressed_ids: []`; issue "
+                "acceptance criteria, reviewer item IDs, reviewer comments, and arbitrary labels "
+                "are not signed human requirements."
+            )
         return
 
     if not marker_present:

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -33,6 +33,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 
 {coder_followup_required_items_instruction}
 
+{coder_followup_human_requirements_instruction}
+
 ## Valid Format A — PR Review:
 
 {
@@ -118,6 +120,10 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
   NEVER put human requirement labels ("Requirement 1") here — they contain spaces and will fail.
 - human_requirements.addressed_ids -> human REQUIREMENT LABELS like "Requirement 1", "Requirement 2"
   These are different from item IDs and may contain spaces.
+- human_requirements.addressed_ids may contain only exact signed labels surfaced in the original prompt/response context.
+- If no signed human requirement labels are surfaced in the repair context, use "addressed_ids": [].
+- Never convert issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels into signed human requirements.
+- In mixed cases, keep valid surfaced Requirement N labels and drop invalid extras.
 - Every reviewer item ID from the original must appear in EITHER addressed_items OR remaining_items, not both.
 - If a "Required coder follow-up item IDs" block is provided above, every listed ID must appear in exactly one of addressed_items or remaining_items even if the malformed markdown omitted it.
 - Legacy markdown markers like <!-- HUMAN_REQUIREMENTS_ADDRESSED --> and a ### Human requirements section are evidence for human_requirements.addressed_ids and checked_discussion_directly only; they do not classify regular reviewer or orchestrator-injected item-N records.
@@ -280,6 +286,31 @@ Notes:
 - When repairing plan_revision, do not output coder_followup even if the original contains a Human requirements section.
 - If the original plan revision includes <!-- HUMAN_REQUIREMENTS_ADDRESSED --> and a ### Human requirements section, preserve both after the JSON and before <!-- AGENT_PLAN_STATE: blocking -->.
 
+## WORKED EXAMPLE 5 — coder follow-up with no signed human requirements:
+
+Original (malformed): coder_followup includes "Issue #221 acceptance criteria" in human_requirements.addressed_ids, but the repair context has no surfaced signed human requirement labels.
+
+CORRECT repair — keep reviewer items separate and rewrite human_requirements.addressed_ids to []:
+{
+  "schema_version": 1,
+  "kind": "coder_followup",
+  "state": "blocking",
+  "summary": "Updated the implementation and left one reviewer item pending.",
+  "addressed_items": ["item-1"],
+  "remaining_items": ["item-2"],
+  "human_requirements": {
+    "addressed_ids": [],
+    "checked_discussion_directly": false
+  }
+}
+<!-- AGENT_STATE: blocking -->
+-- OpenAI Codex
+
+Notes:
+- Issue acceptance criteria are not signed human requirements.
+- Reviewer items belong in addressed_items / remaining_items, never in human_requirements.addressed_ids.
+- If surfaced signed labels include "Requirement 1" and the malformed response has ["Requirement 1", "Issue #221 acceptance criteria"], keep ["Requirement 1"] and drop "Issue #221 acceptance criteria".
+
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: optional signed human requirements acknowledgement for plan_revision only, then <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
@@ -314,12 +345,34 @@ def _coder_followup_required_items_instruction(
     )
 
 
+def _coder_followup_human_requirements_instruction(
+    expected_kind: str | None,
+    surfaced_requirement_ids: Sequence[str] | None,
+) -> str:
+    if surfaced_requirement_ids is None:
+        return ""
+    if expected_kind != "coder_followup":
+        raise ValueError("surfaced_requirement_ids may only be used for coder_followup repair")
+    rendered_ids = "\n".join(f"- `{item_id}`" for item_id in surfaced_requirement_ids)
+    if not surfaced_requirement_ids:
+        rendered_ids = "- (none)"
+    return (
+        "## Surfaced signed human requirement labels for coder follow-up:\n"
+        f"{rendered_ids}\n"
+        "Only the exact labels above may appear in `human_requirements.addressed_ids`.\n"
+        "When the list is `(none)`, set `human_requirements.addressed_ids` to `[]`. "
+        "Do not use issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, "
+        "summaries, or arbitrary labels as human requirement IDs.\n"
+    )
+
+
 def attempt_repair(
     raw: str,
     gemini_cmd: str,
     *,
     expected_kind: str | None = None,
     unresolved_item_ids: Sequence[str] | None = None,
+    surfaced_requirement_ids: Sequence[str] | None = None,
 ) -> str | None:
     """Call gemini-3.1-flash-lite via the Gemini CLI to reformat a malformed review response.
 
@@ -333,6 +386,10 @@ def attempt_repair(
         expected_kind,
         unresolved_item_ids,
     )
+    coder_followup_human_requirements_instruction = _coder_followup_human_requirements_instruction(
+        expected_kind,
+        surfaced_requirement_ids,
+    )
     expected_kind_instruction = (
         "## Expected response kind:\n"
         f"You MUST repair this response as `{expected_kind}`. Output no other `kind` value.\n"
@@ -343,6 +400,11 @@ def attempt_repair(
     prompt = prompt.replace(
         "{coder_followup_required_items_instruction}",
         coder_followup_required_items_instruction,
+        1,
+    )
+    prompt = prompt.replace(
+        "{coder_followup_human_requirements_instruction}",
+        coder_followup_human_requirements_instruction,
         1,
     )
     prompt = prompt.replace("{raw_response}", raw, 1)

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -154,6 +154,8 @@ def _reconcile_human_requirements_ack_item(
         return list(unresolved_items)
 
     prompt_context = render_coder_human_requirements_prompt_context(human_requirements)
+    if not prompt_context.surfaced_requirement_ids and not prompt_context.requires_direct_discussion_ack:
+        return _clear_human_requirements_ack_item(unresolved_items)
     try:
         structured_followup = validate_structured_coder_followup(coder_output)
         if structured_followup is not None:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4223,6 +4223,123 @@ def test_validate_coder_followup_response_accepts_structured_item_partition():
     assert parsed.remaining_items == ("item-2",)
 
 
+def test_validate_coder_followup_response_rejects_issue_acceptance_criteria_as_human_requirement():
+    response = structured_coder_followup(
+        state="blocking",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Issue #221 acceptance criteria"],
+        reviewer="OpenAI Codex",
+    )
+
+    with pytest.raises(AgentLoopError, match="issue acceptance criteria.*not signed human requirements"):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Add a regression test.",
+                    status="blocking",
+                ),
+            ),
+            human_requirements=(),
+        )
+
+
+def test_validate_coder_followup_response_rejects_requirement_label_when_none_surfaced():
+    response = structured_coder_followup(
+        state="blocking",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Requirement 1"],
+        reviewer="OpenAI Codex",
+    )
+
+    with pytest.raises(AgentLoopError, match="no signed human requirements were surfaced"):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Add a regression test.",
+                    status="blocking",
+                ),
+            ),
+            human_requirements=(),
+        )
+
+
+def test_validate_coder_followup_response_accepts_surfaced_requirement_label():
+    response = structured_coder_followup(
+        state="blocking",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Requirement 1"],
+        reviewer="OpenAI Codex",
+    )
+
+    parsed = _validate_coder_followup_response(
+        response,
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Add a regression test.",
+                status="blocking",
+            ),
+        ),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="PR comment",
+                author="maintainer",
+                created_at="2026-06-02T12:00:00Z",
+                url="https://github.com/OWNER/REPO/pull/1#issuecomment-1",
+                body="Add coverage for the rejected label case.",
+            ),
+        ),
+    )
+
+    assert parsed.human_requirements.addressed_ids == ("Requirement 1",)
+
+
+def test_validate_coder_followup_response_rejects_mixed_valid_and_invalid_requirement_labels():
+    response = structured_coder_followup(
+        state="blocking",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Requirement 1", "Issue #221 acceptance criteria"],
+        reviewer="OpenAI Codex",
+    )
+
+    with pytest.raises(AgentLoopError, match="issue acceptance criteria.*not signed human requirements"):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=(
+                UnresolvedReviewItem(
+                    item_id="item-1",
+                    reviewer="Anthropic Claude",
+                    source_round=1,
+                    text="Add a regression test.",
+                    status="blocking",
+                ),
+            ),
+            human_requirements=(
+                HumanReviewRequirement(
+                    source_type="PR comment",
+                    author="maintainer",
+                    created_at="2026-06-02T12:00:00Z",
+                    url="https://github.com/OWNER/REPO/pull/1#issuecomment-1",
+                    body="Add coverage for the rejected label case.",
+                ),
+            ),
+        )
+
+
 @pytest.mark.parametrize(
     ("addressed_items", "remaining_items", "message"),
     [
@@ -5019,6 +5136,24 @@ def test_issue_and_plan_prompts_surface_signed_human_requirements_before_issue_c
     assert prompt.index("Signed Human Reviewer Requirements") < prompt.index("Issue context from GitHub")
 
 
+def test_followup_prompt_with_no_human_requirements_guides_empty_addressed_ids(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_followup_prompt(
+        222,
+        2,
+        "item-1: Add a regression test.",
+        config,
+        human_requirements=(),
+    )
+
+    assert '"human_requirements": {' in prompt
+    assert '"addressed_ids": []' in prompt
+    assert '"addressed_ids": ["Requirement 1"]' not in prompt
+    assert "No signed human requirements are surfaced in this prompt" in prompt
+    assert "issue acceptance criteria" in prompt
+    assert "reviewer item IDs" in prompt
+
+
 def test_plan_review_prompt_surfaces_signed_issue_requirements_as_approval_critical(tmp_path):
     config = make_config(tmp_path, reviewer=("codex", "gemini"))
     issue_context = IssueContext(
@@ -5606,7 +5741,7 @@ def test_gemini_pre_marker_429_does_not_suppress_structured_review_repair(tmp_pa
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -5650,7 +5785,7 @@ def test_gemini_response_file_repair_ignores_raw_stdout_transient_diagnostics(tm
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_repairs.append(raw)
         return repaired_review
 
@@ -7092,11 +7227,12 @@ def test_blocking_followup_prompt_reinjects_issue_context(tmp_path):
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=[
-            "Fixed review.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: used the absolute URL.\n"
-            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+            structured_coder_followup(
+                state="approved",
+                addressed_items=["item-1"],
+                remaining_items=[],
+                reviewer="Anthropic Claude",
+            )
         ],
     )
     config = make_config(tmp_path)
@@ -10410,7 +10546,7 @@ def test_issue_loop_plan_revision_repair_preserves_signed_human_requirements(tmp
     config = make_config(tmp_path, agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_repairs.append((raw, expected_kind))
         return repaired_revision
 
@@ -10477,7 +10613,7 @@ def test_issue_loop_plan_revision_repair_rejects_wrong_kind_from_human_requireme
     config = make_config(tmp_path, agent_max_retries=0)
     captured_kinds = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_kinds.append(expected_kind)
         return wrong_kind_repair
 
@@ -12121,6 +12257,66 @@ def test_attempt_repair_includes_coder_followup_required_item_ids():
     assert "do not classify regular reviewer or orchestrator-injected item-N records" in prompt
 
 
+def test_attempt_repair_includes_empty_surfaced_requirement_guidance():
+    repaired = structured_coder_followup(
+        state="blocking",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=[],
+        reviewer="Gemini",
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            '"human_requirements":{"addressed_ids":["Issue #221 acceptance criteria"],'
+            '"checked_discussion_directly":false}',
+            "gemini",
+            expected_kind="coder_followup",
+            unresolved_item_ids=["item-1"],
+            surfaced_requirement_ids=[],
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert "Surfaced signed human requirement labels for coder follow-up" in prompt
+    assert "- (none)" in prompt
+    assert "set `human_requirements.addressed_ids` to `[]`" in prompt
+    assert "Issue #221 acceptance criteria" in prompt
+    assert '"addressed_ids": []' in prompt
+
+
+def test_attempt_repair_includes_surfaced_requirement_labels_for_mixed_repairs():
+    repaired = structured_coder_followup(
+        state="blocking",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Requirement 1"],
+        reviewer="Gemini",
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            '"addressed_ids":["Requirement 1","Issue #221 acceptance criteria"]',
+            "gemini",
+            expected_kind="coder_followup",
+            unresolved_item_ids=["item-1"],
+            surfaced_requirement_ids=["Requirement 1"],
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert "`Requirement 1`" in prompt
+    assert "keep [\"Requirement 1\"] and drop \"Issue #221 acceptance criteria\"" in prompt
+
+
 def test_attempt_repair_rejects_unresolved_item_ids_for_non_coder_kind():
     with pytest.raises(ValueError, match="unresolved_item_ids"):
         attempt_repair(
@@ -12180,7 +12376,7 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -12213,7 +12409,7 @@ def test_run_pr_loop_repairs_format_failure_with_5xx_source_line_reference(tmp_p
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -12237,7 +12433,7 @@ def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
 
-    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         assert expected_kind == "pr_review"
         return "still broken output without valid schema"
 
@@ -12293,7 +12489,7 @@ def test_run_pr_loop_uses_repair_pass_on_coder_followup_format_failure(tmp_path)
     captured_repairs = []
     captured_unresolved_item_ids = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
         captured_repairs.append(raw)
         captured_unresolved_item_ids.append(tuple(unresolved_item_ids or ()))
         assert expected_kind == "coder_followup"


### PR DESCRIPTION
## Summary
- Render coder follow-up human requirement examples from the actual surfaced requirement context, using `addressed_ids: []` when none exist.
- Tighten contextual validation and repair guidance so issue acceptance criteria and reviewer item IDs are not treated as signed human requirements.
- Pass surfaced requirement labels into coder follow-up repair and add regression coverage for empty, surfaced, and mixed-label cases.

Fixes #224

## Tests
- python3 -m pytest tests/test_agent_loop.py -k "human_requirements or coder_followup or repair"
- python3 -m pytest