### PR TITLE
Handle Claude session-limit reset times

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import re
 import sys
+import zoneinfo
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
@@ -265,6 +266,15 @@ _RESET_IN_RE = re.compile(
 _ISO_TIMESTAMP_RE = re.compile(
     r"(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)"
 )
+# Parse Claude Code session-limit messages such as
+# "resets 1:30am (America/Los_Angeles)".
+_ABSOLUTE_RESET_TIME_RE = re.compile(
+    r"\brese(?:t|ts)(?:\s+at)?\s+"
+    r"(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*"
+    r"(?P<ampm>a\.?m\.?|p\.?m\.?)\s*"
+    r"\((?P<timezone>[A-Za-z0-9_./+-]+)\)",
+    re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -275,7 +285,55 @@ class ValidatedAgentResponse:
     usage: UsageMetadata | None = None
 
 
-def _parse_rate_limit_reset_seconds(text: str) -> int | None:
+def _parse_absolute_reset_seconds(
+    text: str,
+    *,
+    now_utc: datetime.datetime | None = None,
+) -> int | None:
+    m = _ABSOLUTE_RESET_TIME_RE.search(text)
+    if not m:
+        return None
+
+    try:
+        tz = zoneinfo.ZoneInfo(m.group("timezone"))
+    except zoneinfo.ZoneInfoNotFoundError:
+        return None
+
+    if now_utc is None:
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+    elif now_utc.tzinfo is None:
+        now_utc = now_utc.replace(tzinfo=datetime.timezone.utc)
+    else:
+        now_utc = now_utc.astimezone(datetime.timezone.utc)
+
+    hour = int(m.group("hour"))
+    minute = int(m.group("minute") or 0)
+    ampm = m.group("ampm").lower().replace(".", "")
+    if not 1 <= hour <= 12 or not 0 <= minute <= 59:
+        return None
+    if ampm == "am":
+        hour = 0 if hour == 12 else hour
+    else:
+        hour = 12 if hour == 12 else hour + 12
+
+    now_local = now_utc.astimezone(tz)
+    reset_local = now_local.replace(
+        hour=hour,
+        minute=minute,
+        second=0,
+        microsecond=0,
+    )
+    if reset_local <= now_local:
+        reset_local += datetime.timedelta(days=1)
+
+    return int((reset_local.astimezone(datetime.timezone.utc) - now_utc).total_seconds())
+
+
+def _parse_rate_limit_reset_seconds(
+    text: str,
+    *,
+    now_utc: datetime.datetime | None = None,
+) -> int | None:
     """Extract the reset wait time in seconds from a rate-limit error message.
 
     Returns None if the reset time cannot be reliably parsed.
@@ -309,11 +367,20 @@ def _parse_rate_limit_reset_seconds(text: str) -> int | None:
             if not ts_str.endswith("Z"):
                 ts_str += "Z"
             ts = datetime.datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-            delta = int((ts - datetime.datetime.now(datetime.timezone.utc)).total_seconds())
+            base_now = now_utc or datetime.datetime.now(datetime.timezone.utc)
+            if base_now.tzinfo is None:
+                base_now = base_now.replace(tzinfo=datetime.timezone.utc)
+            else:
+                base_now = base_now.astimezone(datetime.timezone.utc)
+            delta = int((ts - base_now).total_seconds())
             if delta > 0:
                 return delta
         except (ValueError, OverflowError):
             pass
+
+    reset_secs = _parse_absolute_reset_seconds(text, now_utc=now_utc)
+    if reset_secs is not None:
+        return reset_secs
 
     return None
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import json
 import re
 import subprocess
@@ -6,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import coding_review_agent_loop.orchestrator as orchestrator
 from coding_review_agent_loop.agents.claude import (
     BACKEND as CLAUDE_BACKEND,
     _normalize_claude_usage,
@@ -6431,6 +6433,37 @@ def test_pr_loop_exits_immediately_on_long_reset_rate_limit(tmp_path):
     assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
+def test_pr_loop_exits_immediately_on_claude_session_limit_reset(tmp_path, monkeypatch):
+    class FixedDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed = cls(2026, 6, 3, 5, 33, 48, tzinfo=datetime.timezone.utc)
+            if tz is None:
+                return fixed.replace(tzinfo=None)
+            return fixed.astimezone(tz)
+
+    monkeypatch.setattr(orchestrator.datetime, "datetime", FixedDateTime)
+    session_limit_output = json.dumps(
+        {
+            "type": "result",
+            "is_error": True,
+            "api_error_status": 429,
+            "result": "You've hit your session limit · resets 1:30am (America/Los_Angeles)",
+        }
+    )
+    runner = FakeRunner(claude_outputs=[(session_limit_output, 1)])
+    config = make_config(tmp_path, reviewer="claude")
+
+    with pytest.raises(QuotaResetExceededError) as exc_info:
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    message = str(exc_info.value)
+    assert "Claude quota exhausted" in message
+    assert "2h 56m" in message
+    assert "Rerun when quota resets" in message
+    assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
 def test_pr_loop_retries_on_short_reset_rate_limit(tmp_path):
     # "Retry-After: 60" → 60 s reset ≤ 300 s threshold → retry automatically.
     rate_limit_output = "HTTP 429: rate limit exceeded. Retry-After: 60"
@@ -6468,6 +6501,13 @@ def test_pr_loop_retries_on_rate_limit_without_reset_time(tmp_path):
 ])
 def test_parse_rate_limit_reset_seconds(text, expected_secs):
     assert _parse_rate_limit_reset_seconds(text) == expected_secs
+
+
+def test_parse_rate_limit_reset_seconds_claude_absolute_time():
+    now = datetime.datetime(2026, 6, 3, 5, 33, 48, tzinfo=datetime.timezone.utc)
+    text = "You've hit your session limit · resets 1:30am (America/Los_Angeles)"
+
+    assert _parse_rate_limit_reset_seconds(text, now_utc=now) == 10572
 
 
 @pytest.mark.parametrize("text", [


### PR DESCRIPTION
## Summary
- parse Claude Code session-limit messages like `resets 1:30am (America/Los_Angeles)`
- convert the next reset wall-clock time into seconds so the existing quota-reset exit path fires
- add coverage that Claude 429/session-limit output exits immediately instead of sleeping/retrying

## Tests
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile src/coding_review_agent_loop/orchestrator.py tests/test_agent_loop.py`
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -k 'quota_reset or rate_limit_reset or claude_session_limit'`
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py`