### PR TITLE
Repair unknown prior item dispositions

### DIFF
--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -6,6 +6,7 @@ import json
 import re
 from collections.abc import Sequence
 
+from .errors import AgentLoopError
 from .agents.registry import agent_display_name, agent_signature
 from .protocol import (
     ANY_HEADING_RE,
@@ -96,7 +97,12 @@ def _render_prior_dispositions_section(
     item_by_id = {item.item_id: item for item in prior_items}
     lines = [heading]
     for disposition in dispositions:
-        item = item_by_id[disposition.item_id]
+        item = item_by_id.get(disposition.item_id)
+        if item is None:
+            raise AgentLoopError(
+                f"Renderer encountered unknown prior item ID {disposition.item_id!r}; "
+                f"allowed IDs: {sorted(item_by_id)}"
+            )
         lines.append(
             f"- [{disposition.item_id}] {_format_unresolved_item_label(item)}"
             f" -> {_render_disposition_status(disposition)}"

--- a/src/coding_review_agent_loop/errors.py
+++ b/src/coding_review_agent_loop/errors.py
@@ -7,6 +7,27 @@ class AgentLoopError(RuntimeError):
     """Raised for expected orchestration failures."""
 
 
+class UnknownPriorItemDispositionError(AgentLoopError):
+    """Raised when an agent dispositions a non-carried prior item ID."""
+
+    def __init__(
+        self,
+        *,
+        unknown_ids: tuple[str, ...],
+        allowed_ids: tuple[str, ...],
+        same_round_description: str,
+    ) -> None:
+        self.unknown_ids = tuple(unknown_ids)
+        self.allowed_ids = tuple(allowed_ids)
+        self.same_round_description = same_round_description
+        message = (
+            f"Unknown prior-item disposition ID(s) {sorted(unknown_ids)!r}; "
+            f"allowed carried prior IDs: {sorted(allowed_ids) or '(none)'}; "
+            f"{same_round_description}"
+        )
+        super().__init__(message)
+
+
 class QuotaResetExceededError(AgentLoopError):
     """Raised when a rate-limit reset time exceeds the auto-retry threshold.
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -31,7 +31,7 @@ from .decomposition import (
     post_decomposition_parent_summary,
     post_phase_implementation_handoff_comment,
 )
-from .errors import AgentLoopError, QuotaResetExceededError
+from .errors import AgentLoopError, QuotaResetExceededError, UnknownPriorItemDispositionError
 from .github import (
     IssueContext,
     PullRequestReviewContext,
@@ -682,6 +682,8 @@ def _run_validated_agent(
     repair_expected_kind: str | None = None,
     repair_unresolved_item_ids: Sequence[str] | None = None,
     repair_surfaced_requirement_ids: Sequence[str] | None = None,
+    repair_allowed_prior_item_ids: Sequence[str] | None = None,
+    ledger_incomplete: bool = False,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -806,13 +808,26 @@ def _run_validated_agent(
                             marker_value=marker_value,
                             usage=usage,
                         )
-                if use_repair and not public_text_is_transient:
+                if (
+                    use_repair
+                    and not public_text_is_transient
+                    and not (
+                        isinstance(exc, UnknownPriorItemDispositionError)
+                        and ledger_incomplete
+                    )
+                ):
                     log(config, f"{agent_name}: schema validation failed ({exc}); attempting repair pass")
                     repair_kwargs: dict[str, object] = {"expected_kind": repair_expected_kind}
                     if repair_unresolved_item_ids is not None:
                         repair_kwargs["unresolved_item_ids"] = tuple(repair_unresolved_item_ids)
                     if repair_surfaced_requirement_ids is not None:
                         repair_kwargs["surfaced_requirement_ids"] = tuple(repair_surfaced_requirement_ids)
+                    if isinstance(exc, UnknownPriorItemDispositionError):
+                        repair_kwargs["allowed_prior_item_ids"] = exc.allowed_ids
+                        repair_kwargs["unknown_prior_item_ids"] = exc.unknown_ids
+                        repair_kwargs["same_round_context"] = exc.same_round_description
+                    elif repair_allowed_prior_item_ids is not None:
+                        repair_kwargs["allowed_prior_item_ids"] = tuple(repair_allowed_prior_item_ids)
                     repaired = attempt_repair(
                         text,
                         config.gemini_cmd,
@@ -828,7 +843,16 @@ def _run_validated_agent(
                                 f"{agent_name}: repair pass produced invalid output ({repair_exc})",
                             )
                         else:
-                            log(config, f"{agent_name}: repair pass recovered malformed response")
+                            if isinstance(exc, UnknownPriorItemDispositionError):
+                                removed = ", ".join(sorted(exc.unknown_ids))
+                                allowed = ", ".join(sorted(exc.allowed_ids)) or "(none)"
+                                log(
+                                    config,
+                                    f"{agent_name}: repair pass removed unknown prior-item "
+                                    f"disposition ID(s) {removed}; allowed carried prior IDs: {allowed}",
+                                )
+                            else:
+                                log(config, f"{agent_name}: repair pass recovered malformed response")
                             if usage_record is not None:
                                 usage_record.validation_status = "validated"
                             return ValidatedAgentResponse(
@@ -934,9 +958,27 @@ def _merge_human_requirements(
     return tuple(sorted(combined, key=lambda requirement: requirement.created_at or ""))
 
 
-def _validate_plan_revision_response(text: str) -> StructuredPlanRevision | str:
+def _validate_plan_revision_response(
+    text: str,
+    *,
+    unresolved_items: Sequence[UnresolvedReviewItem] = (),
+) -> StructuredPlanRevision | str:
     parsed = validate_structured_plan_revision(text)
     if parsed is not None:
+        allowed_ids = {item.item_id for item in unresolved_items}
+        unknown = {
+            disposition.item_id
+            for disposition in parsed.prior_plan_item_dispositions
+        } - allowed_ids
+        if unknown:
+            raise UnknownPriorItemDispositionError(
+                unknown_ids=tuple(sorted(unknown)),
+                allowed_ids=tuple(sorted(allowed_ids)),
+                same_round_description=(
+                    "Same-round findings are informational only and must not be "
+                    "dispositioned as prior carried items."
+                ),
+            )
         return parsed
     raise AgentLoopError("Plan revision did not use the required structured format.")
 
@@ -975,6 +1017,30 @@ def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
     if has_same_plan:
         return "blocking with same-plan follow-ups"
     return "blocking with blocking plan issues"
+
+
+def _round_ledger_may_be_incomplete(
+    *,
+    current_resume: ResumedReviewRound | None,
+    prior_unresolved_items: Sequence[UnresolvedReviewItem],
+    comments: Sequence[object],
+    flow: str,
+    current_subject: str,
+) -> bool:
+    same_subject_incomplete = (
+        current_resume.ledger_may_be_incomplete
+        if current_resume is not None
+        else False
+    )
+    if prior_unresolved_items:
+        return same_subject_incomplete
+    records = _extract_round_metadata_records(comments, flow=flow)
+    cross_subject_incomplete = any(
+        record.metadata.new_items
+        for record in records
+        if record.metadata.subject != current_subject
+    )
+    return same_subject_incomplete or cross_subject_incomplete
 
 
 def _implement_approved_issue(
@@ -1193,6 +1259,14 @@ def _run_plan_first_loop(
             item.item_id: [] for item in prior_unresolved_items
         }
         round_new_unresolved_items: list[UnresolvedReviewItem] = []
+        current_plan_subject = _plan_subject(current_plan)
+        round_ledger_incomplete = _round_ledger_may_be_incomplete(
+            current_resume=current_resume,
+            prior_unresolved_items=prior_unresolved_items,
+            comments=issue_context.comments,
+            flow="plan",
+            current_subject=current_plan_subject,
+        )
         round_approved_future_followups: list[ApprovedFollowup] = []
         blocking_reviews: list[tuple[str, str]] = []
         all_approved = True
@@ -1243,10 +1317,13 @@ def _run_plan_first_loop(
                         text,
                         reviewer=reviewer_name,
                         unresolved_items=items,
+                        current_round_items=round_new_unresolved_items,
                     ),
                     usage_context=usage_context,
                     use_repair=True,
                     repair_expected_kind="plan_review",
+                    repair_allowed_prior_item_ids=tuple(item.item_id for item in prior_unresolved_items),
+                    ledger_incomplete=round_ledger_incomplete,
                 )
                 review_output = review_response.text
                 reviewer_session_ids[reviewer] = review_response.session_id
@@ -1265,7 +1342,7 @@ def _run_plan_first_loop(
                     disposition,
                     flow="plan",
                     round_number=round_number,
-                    subject=_plan_subject(current_plan),
+                    subject=current_plan_subject,
                     reviewer_name=reviewer_name,
                 )
             if review_state == "blocking":
@@ -1484,9 +1561,12 @@ def _run_plan_first_loop(
             ),
             session_id=coder_session_id,
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
-            validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
+            validate=lambda text, human_requirements=issue_context.human_requirements, items=tuple(must_fix_items): _validate_response_with_human_requirements(
                 text,
-                marker_validator=_validate_plan_revision_response,
+                marker_validator=lambda revised_text: _validate_plan_revision_response(
+                    revised_text,
+                    unresolved_items=items,
+                ),
                 human_requirements=human_requirements,
                 requirement_scope="planning requirements",
                 full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
@@ -1494,6 +1574,8 @@ def _run_plan_first_loop(
             usage_context=usage_context,
             use_repair=True,
             repair_expected_kind="plan_revision",
+            repair_allowed_prior_item_ids=tuple(item.item_id for item in must_fix_items),
+            ledger_incomplete=round_ledger_incomplete,
         )
         canonical_plan: str | None = None
         public_comment = plan_response.text
@@ -1817,6 +1899,14 @@ def run_pr_loop(
                 item.item_id: [] for item in prior_unresolved_items
             }
             round_new_unresolved_items: list[UnresolvedReviewItem] = []
+            current_pr_subject = str(pr_metadata.head_sha or "unknown")
+            round_ledger_incomplete = _round_ledger_may_be_incomplete(
+                current_resume=current_resume,
+                prior_unresolved_items=prior_unresolved_items,
+                comments=pr_comments,
+                flow="pr",
+                current_subject=current_pr_subject,
+            )
             approved_review_outputs: list[tuple[str, str]] = []
             pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
             resumed_by_name = {
@@ -1863,10 +1953,13 @@ def run_pr_loop(
                             text,
                             reviewer=reviewer_name,
                             unresolved_items=items,
+                            current_round_items=round_new_unresolved_items,
                         ),
                         usage_context=usage_context,
                         use_repair=True,
                         repair_expected_kind="pr_review",
+                        repair_allowed_prior_item_ids=tuple(item.item_id for item in prior_unresolved_items),
+                        ledger_incomplete=round_ledger_incomplete,
                     )
                     review_output = review_response.text
                     reviewer_session_ids[reviewer] = review_response.session_id
@@ -1881,7 +1974,7 @@ def run_pr_loop(
                         disposition,
                         flow="pr",
                         round_number=round_number,
-                        subject=str(pr_metadata.head_sha or "unknown"),
+                        subject=current_pr_subject,
                         reviewer_name=reviewer_name,
                     )
                 blocking_summary = parsed_review.summary
@@ -1959,7 +2052,7 @@ def run_pr_loop(
                                     role="reviewer",
                                     agent=reviewer_name,
                                     round_number=round_number,
-                                    subject=str(pr_metadata.head_sha or "unknown"),
+                                    subject=current_pr_subject,
                                     prior_items=prior_unresolved_items,
                                     dispositions=parsed_review.dispositions,
                                     new_items=tuple(reviewer_new_unresolved_items),
@@ -2004,7 +2097,7 @@ def run_pr_loop(
                                 role="reviewer",
                                 agent=reviewer_name,
                                 round_number=round_number,
-                                subject=str(pr_metadata.head_sha or "unknown"),
+                                    subject=current_pr_subject,
                                 prior_items=prior_unresolved_items,
                                 dispositions=parsed_review.dispositions,
                                 new_items=tuple(reviewer_new_unresolved_items),

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -16,6 +16,10 @@ from .agents.gemini import _parse_gemini_payload
 
 _logger = logging.getLogger(__name__)
 
+# v12 prompt — adds explicit prior-item disposition repair context:
+#   - lists carried prior IDs that may be dispositioned
+#   - lists unknown prior-item disposition IDs that must be removed
+#   - reminds agents that same-round findings are informational only
 # v11 prompt — constrains repair to the caller's expected response kind when supplied
 # and preserves signed human-requirements acknowledgements on plan revisions:
 #   - expected_kind prevents plan_revision repair from drifting into coder_followup
@@ -34,6 +38,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 {coder_followup_required_items_instruction}
 
 {coder_followup_human_requirements_instruction}
+
+{prior_item_dispositions_instruction}
 
 ## Valid Format A — PR Review:
 
@@ -366,6 +372,33 @@ def _coder_followup_human_requirements_instruction(
     )
 
 
+def _repair_prior_item_ids_instruction(
+    allowed_prior_item_ids: Sequence[str] | None,
+    unknown_prior_item_ids: Sequence[str] | None,
+    same_round_context: str | None,
+) -> str:
+    if (
+        allowed_prior_item_ids is None
+        and unknown_prior_item_ids is None
+        and same_round_context is None
+    ):
+        return ""
+    allowed = ", ".join(sorted(allowed_prior_item_ids or ())) or "(none)"
+    unknown = ", ".join(sorted(unknown_prior_item_ids or ())) or "(none)"
+    context = (
+        same_round_context
+        or "Same-round findings are informational only and must not be dispositioned as prior carried items."
+    )
+    return (
+        "## Prior item disposition repair:\n"
+        "Same-round findings are informational only and must not be dispositioned as prior carried items.\n"
+        f"Allowed carried prior item IDs: {allowed}\n"
+        f"Unknown prior item disposition IDs to remove: {unknown}\n"
+        f"Context: {context}\n"
+        "Preserve valid dispositions for allowed IDs. Remove only unknown prior-item disposition entries.\n"
+    )
+
+
 def attempt_repair(
     raw: str,
     gemini_cmd: str,
@@ -373,6 +406,9 @@ def attempt_repair(
     expected_kind: str | None = None,
     unresolved_item_ids: Sequence[str] | None = None,
     surfaced_requirement_ids: Sequence[str] | None = None,
+    allowed_prior_item_ids: Sequence[str] | None = None,
+    unknown_prior_item_ids: Sequence[str] | None = None,
+    same_round_context: str | None = None,
 ) -> str | None:
     """Call gemini-3.1-flash-lite via the Gemini CLI to reformat a malformed review response.
 
@@ -390,6 +426,11 @@ def attempt_repair(
         expected_kind,
         surfaced_requirement_ids,
     )
+    prior_item_dispositions_instruction = _repair_prior_item_ids_instruction(
+        allowed_prior_item_ids,
+        unknown_prior_item_ids,
+        same_round_context,
+    )
     expected_kind_instruction = (
         "## Expected response kind:\n"
         f"You MUST repair this response as `{expected_kind}`. Output no other `kind` value.\n"
@@ -405,6 +446,11 @@ def attempt_repair(
     prompt = prompt.replace(
         "{coder_followup_human_requirements_instruction}",
         coder_followup_human_requirements_instruction,
+        1,
+    )
+    prompt = prompt.replace(
+        "{prior_item_dispositions_instruction}",
+        prior_item_dispositions_instruction,
         1,
     )
     prompt = prompt.replace("{raw_response}", raw, 1)

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -57,6 +57,7 @@ class ResumedReviewRound:
     coder_output: str | None
     completed_reviews: tuple[PostedRoundRecord, ...]
     next_unresolved_item_number: int
+    ledger_may_be_incomplete: bool = False
 
 
 def _serialize_unresolved_item(item: UnresolvedReviewItem) -> dict[str, object]:
@@ -312,6 +313,15 @@ def _resume_pr_round(
         return None
     prior_items = anchor_metadata.prior_items
     round_number = anchor_metadata.round_number
+    ledger_may_be_incomplete = (
+        len(anchor_metadata.prior_items) == 0
+        and any(
+            record.metadata.new_items
+            for record in records
+            if record.metadata.subject == anchor_metadata.subject
+            and record.metadata.round_number < anchor_metadata.round_number
+        )
+    )
     return ResumedReviewRound(
         round_number=round_number,
         prior_items=prior_items,
@@ -326,6 +336,7 @@ def _resume_pr_round(
             [record for record in records if record.metadata.subject == head_sha]
         )
         + 1,
+        ledger_may_be_incomplete=ledger_may_be_incomplete,
     )
 
 
@@ -347,6 +358,15 @@ def _resume_plan_round(
     anchor_metadata = selection.anchor_record.metadata
     current_plan = latest_coder_record.metadata.canonical_plan or latest_coder_record.body
     coder_output = latest_coder_record.metadata.raw_structured_coder_response or current_plan
+    ledger_may_be_incomplete = (
+        len(anchor_metadata.prior_items) == 0
+        and any(
+            record.metadata.new_items
+            for record in records
+            if record.metadata.subject == anchor_metadata.subject
+            and record.metadata.round_number < anchor_metadata.round_number
+        )
+    )
     reviewer_records: dict[str, PostedRoundRecord] = {}
     configured_reviewer_names = {agent_display_name(agent) for agent in configured_reviewers}
     for record in current_round_records:
@@ -365,5 +385,6 @@ def _resume_plan_round(
                 [record for record in records if record.metadata.subject == anchor_metadata.subject]
             )
             + 1,
+            ledger_may_be_incomplete=ledger_may_be_incomplete,
         ),
     )

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 
-from .errors import AgentLoopError
+from .errors import AgentLoopError, UnknownPriorItemDispositionError
 from .prompts import render_coder_human_requirements_prompt_context
 from .protocol import (
     ParsedPlanReview,
@@ -73,15 +73,49 @@ def _next_unresolved_item(
     )
 
 
+def _same_round_prior_disposition_description(
+    unknown: Sequence[str],
+    current_round_items: Sequence[UnresolvedReviewItem],
+) -> str:
+    same_round_ids = {item.item_id for item in current_round_items}
+    same_round_description = (
+        "Same-round findings are informational only and must not be dispositioned "
+        "as prior carried items."
+    )
+    same_round_matches = [item_id for item_id in unknown if item_id in same_round_ids]
+    if same_round_matches:
+        same_round_description += (
+            " Unknown ID(s) matching same-round findings: "
+            + ", ".join(same_round_matches)
+            + "."
+        )
+    return same_round_description
+
+
+def _raise_unknown_prior_item_disposition(
+    unknown: Sequence[str],
+    *,
+    allowed_ids: Sequence[str],
+    current_round_items: Sequence[UnresolvedReviewItem],
+) -> None:
+    raise UnknownPriorItemDispositionError(
+        unknown_ids=tuple(sorted(unknown)),
+        allowed_ids=tuple(sorted(allowed_ids)),
+        same_round_description=_same_round_prior_disposition_description(
+            tuple(sorted(unknown)),
+            current_round_items,
+        ),
+    )
+
+
 def _validate_review_response(
     text: str,
     *,
     reviewer: str,
     unresolved_items: Sequence[UnresolvedReviewItem],
+    current_round_items: Sequence[UnresolvedReviewItem] = (),
 ) -> ParsedReview:
     parsed = parse_pr_review(text, reviewer=reviewer)
-    if not unresolved_items:
-        return parsed
 
     unresolved_by_id = {item.item_id: item for item in unresolved_items}
     dispositions = _maybe_fill_resolved_dispositions_from_prose(
@@ -89,6 +123,8 @@ def _validate_review_response(
         reviewer=reviewer,
         unresolved_items=unresolved_items,
     )
+    if not dispositions and not unresolved_items:
+        return parsed
     disposition_ids = [item.item_id for item in dispositions]
     duplicates = sorted({item_id for item_id in disposition_ids if disposition_ids.count(item_id) > 1})
     if duplicates:
@@ -97,14 +133,17 @@ def _validate_review_response(
         )
     unknown = sorted(set(disposition_ids) - set(unresolved_by_id))
     if unknown:
-        raise AgentLoopError(
-            "Review referenced unknown prior unresolved item IDs: " + ", ".join(unknown)
+        _raise_unknown_prior_item_disposition(
+            unknown,
+            allowed_ids=tuple(unresolved_by_id),
+            current_round_items=current_round_items,
         )
-    missing = sorted(set(unresolved_by_id) - set(disposition_ids))
-    if missing:
-        raise AgentLoopError(
-            "Review did not evaluate all prior unresolved items: " + ", ".join(missing)
-        )
+    if unresolved_items:
+        missing = sorted(set(unresolved_by_id) - set(disposition_ids))
+        if missing:
+            raise AgentLoopError(
+                "Review did not evaluate all prior unresolved items: " + ", ".join(missing)
+            )
     return ParsedReview(
         state=parsed.state,
         summary=parsed.summary,
@@ -310,10 +349,9 @@ def _validate_plan_review_response(
     *,
     reviewer: str,
     unresolved_items: Sequence[UnresolvedReviewItem],
+    current_round_items: Sequence[UnresolvedReviewItem] = (),
 ) -> ParsedPlanReview:
     parsed = parse_plan_review(text, reviewer=reviewer)
-    if not unresolved_items:
-        return parsed
 
     unresolved_by_id = {item.item_id: item for item in unresolved_items}
     dispositions = _maybe_fill_resolved_dispositions_from_prose(
@@ -321,6 +359,8 @@ def _validate_plan_review_response(
         reviewer=reviewer,
         unresolved_items=unresolved_items,
     )
+    if not dispositions and not unresolved_items:
+        return parsed
     disposition_ids = [item.item_id for item in dispositions]
     duplicates = sorted({item_id for item_id in disposition_ids if disposition_ids.count(item_id) > 1})
     if duplicates:
@@ -330,16 +370,18 @@ def _validate_plan_review_response(
         )
     unknown = sorted(set(disposition_ids) - set(unresolved_by_id))
     if unknown:
-        raise AgentLoopError(
-            "Plan review referenced unknown prior unresolved plan item IDs: "
-            + ", ".join(unknown)
+        _raise_unknown_prior_item_disposition(
+            unknown,
+            allowed_ids=tuple(unresolved_by_id),
+            current_round_items=current_round_items,
         )
-    missing = sorted(set(unresolved_by_id) - set(disposition_ids))
-    if missing:
-        raise AgentLoopError(
-            "Plan review did not evaluate all prior unresolved plan items: "
-            + ", ".join(missing)
-        )
+    if unresolved_items:
+        missing = sorted(set(unresolved_by_id) - set(disposition_ids))
+        if missing:
+            raise AgentLoopError(
+                "Plan review did not evaluate all prior unresolved plan items: "
+                + ", ".join(missing)
+            )
     return ParsedPlanReview(
         state=parsed.state,
         summary=parsed.summary,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -39,7 +39,7 @@ from coding_review_agent_loop.cli import (
     run_pr_loop,
     run_task_loop,
 )
-from coding_review_agent_loop.errors import QuotaResetExceededError
+from coding_review_agent_loop.errors import QuotaResetExceededError, UnknownPriorItemDispositionError
 from coding_review_agent_loop.orchestrator import (
     _format_reset_duration,
     _failure_category,
@@ -2204,7 +2204,7 @@ def test_validate_plan_review_response_rejects_unknown_item_ids():
         prior_plan_item_dispositions=[{"item_id": "item-9", "disposition": "resolved"}],
     )
 
-    with pytest.raises(AgentLoopError, match="unknown prior unresolved plan item IDs: item-9"):
+    with pytest.raises(UnknownPriorItemDispositionError, match="item-9"):
         _validate_plan_review_response(
             review,
             reviewer="OpenAI Codex",
@@ -2218,6 +2218,63 @@ def test_validate_plan_review_response_rejects_unknown_item_ids():
                 ),
             ),
         )
+
+
+def test_validate_plan_review_response_rejects_unknown_item_with_empty_prior_ledger():
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+    )
+
+    with pytest.raises(UnknownPriorItemDispositionError) as exc_info:
+        _validate_plan_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(),
+        )
+
+    assert exc_info.value.unknown_ids == ("item-1",)
+    assert exc_info.value.allowed_ids == ()
+    assert "Same-round findings are informational only" in exc_info.value.same_round_description
+
+
+def test_unknown_prior_item_disposition_error_message_includes_ids():
+    exc = UnknownPriorItemDispositionError(
+        unknown_ids=("item-15",),
+        allowed_ids=("item-12", "item-17"),
+        same_round_description="Same-round findings are informational only.",
+    )
+
+    message = str(exc)
+    assert "item-15" in message
+    assert "item-12" in message
+    assert "item-17" in message
+
+
+def test_validate_plan_review_response_describes_same_round_unknown_item():
+    review = structured_plan_review(
+        state="approved",
+        summary="Looks good now.",
+        prior_plan_item_dispositions=[{"item_id": "item-2", "disposition": "resolved"}],
+    )
+    current_round_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="Google Gemini",
+        source_round=2,
+        text="Same-round finding.",
+        status="same-plan",
+    )
+
+    with pytest.raises(UnknownPriorItemDispositionError) as exc_info:
+        _validate_plan_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(),
+            current_round_items=(current_round_item,),
+        )
+
+    assert "item-2" in exc_info.value.same_round_description
 
 
 def test_validate_plan_review_response_accepts_structured_resolved_dispositions():
@@ -2453,6 +2510,25 @@ def test_validate_review_response_accepts_structured_resolved_dispositions():
         ("item-1", "resolved"),
         ("item-2", "resolved"),
     ]
+
+
+def test_validate_review_response_rejects_unknown_item_with_empty_prior_ledger():
+    review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+    )
+
+    with pytest.raises(UnknownPriorItemDispositionError) as exc_info:
+        _validate_review_response(
+            review,
+            reviewer="OpenAI Codex",
+            unresolved_items=(),
+        )
+
+    assert exc_info.value.unknown_ids == ("item-1",)
+    assert exc_info.value.allowed_ids == ()
+    assert "Same-round findings are informational only" in exc_info.value.same_round_description
 
 
 def test_validate_review_response_rejects_ambiguous_blanket_prose():
@@ -3426,6 +3502,50 @@ def test_validate_plan_revision_response_rejects_marker_only_markdown():
         _validate_plan_revision_response(
             "Revised plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex"
         )
+
+
+def test_validate_plan_revision_response_rejects_unknown_prior_disposition():
+    revision = structured_plan_revision(
+        prior_plan_item_dispositions=[
+            {"item_id": "item-15", "disposition": "resolved"},
+        ],
+    )
+    active_item = UnresolvedReviewItem(
+        item_id="item-12",
+        reviewer="Google Gemini",
+        source_round=5,
+        text="Active must-fix item.",
+        status="blocking",
+    )
+
+    with pytest.raises(UnknownPriorItemDispositionError) as exc_info:
+        _validate_plan_revision_response(revision, unresolved_items=(active_item,))
+
+    assert exc_info.value.unknown_ids == ("item-15",)
+    assert exc_info.value.allowed_ids == ("item-12",)
+
+
+def test_render_canonical_plan_revision_rejects_unknown_prior_disposition_without_keyerror():
+    revision = validate_structured_plan_revision(
+        structured_plan_revision(
+            prior_plan_item_dispositions=[
+                {"item_id": "item-15", "disposition": "resolved"},
+            ],
+        )
+    )
+    assert revision is not None
+    active_item = UnresolvedReviewItem(
+        item_id="item-12",
+        reviewer="Google Gemini",
+        source_round=5,
+        text="Active must-fix item.",
+        status="blocking",
+    )
+
+    with pytest.raises(AgentLoopError, match="Renderer encountered unknown prior item ID") as exc_info:
+        render_canonical_plan_revision(revision, prior_items=(active_item,))
+
+    assert not isinstance(exc_info.value, KeyError)
 
 
 @pytest.mark.parametrize(
@@ -5743,7 +5863,7 @@ def test_gemini_pre_marker_429_does_not_suppress_structured_review_repair(tmp_pa
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -5787,7 +5907,7 @@ def test_gemini_response_file_repair_ignores_raw_stdout_transient_diagnostics(tm
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_repairs.append(raw)
         return repaired_review
 
@@ -6303,6 +6423,246 @@ def test_structured_plan_revision_transient_terms_before_footer_runs_repair(tmp_
     assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
+def test_run_validated_agent_repairs_unknown_prior_item_disposition_when_ledger_complete(tmp_path):
+    malformed_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        reviewer="Google Gemini",
+    )
+    repaired_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[],
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_review_response(
+                text,
+                reviewer="Google Gemini",
+                unresolved_items=(),
+            ),
+            use_repair=True,
+            repair_expected_kind="pr_review",
+            repair_allowed_prior_item_ids=(),
+            ledger_incomplete=False,
+    )
+
+    assert response.text == repaired_review
+    repair_mock.assert_called_once()
+    assert repair_mock.call_args.args == (malformed_review, config.gemini_cmd)
+    assert repair_mock.call_args.kwargs["expected_kind"] == "pr_review"
+    assert repair_mock.call_args.kwargs["allowed_prior_item_ids"] == ()
+    assert repair_mock.call_args.kwargs["unknown_prior_item_ids"] == ("item-1",)
+    assert "Same-round findings are informational only" in repair_mock.call_args.kwargs["same_round_context"]
+
+
+def test_run_validated_agent_skips_unknown_prior_item_repair_when_ledger_incomplete(tmp_path):
+    malformed_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        with pytest.raises(AgentLoopError) as exc_info:
+            _run_validated_agent(
+                runner,
+                agent="gemini",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                validate=lambda text: _validate_review_response(
+                    text,
+                    reviewer="Google Gemini",
+                    unresolved_items=(),
+                ),
+                use_repair=True,
+                repair_expected_kind="pr_review",
+                repair_allowed_prior_item_ids=(),
+                ledger_incomplete=True,
+            )
+
+    repair_mock.assert_not_called()
+    assert "item-1" in str(exc_info.value)
+
+
+def test_run_validated_agent_rejects_repair_that_invents_prior_item_id(tmp_path):
+    malformed_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        reviewer="Google Gemini",
+    )
+    repaired_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[{"item_id": "item-2", "disposition": "resolved"}],
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review):
+        with pytest.raises(AgentLoopError) as exc_info:
+            _run_validated_agent(
+                runner,
+                agent="gemini",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                validate=lambda text: _validate_review_response(
+                    text,
+                    reviewer="Google Gemini",
+                    unresolved_items=(),
+                ),
+                use_repair=True,
+                repair_expected_kind="pr_review",
+                repair_allowed_prior_item_ids=(),
+            )
+
+    assert "item-2" in str(exc_info.value)
+
+
+def test_run_validated_agent_preserves_valid_disposition_when_repair_removes_unknown(tmp_path):
+    carried_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Keep this prior item.",
+        status="blocking",
+    )
+    malformed_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[
+            {"item_id": "item-1", "disposition": "resolved"},
+            {"item_id": "item-9", "disposition": "resolved"},
+        ],
+        reviewer="Google Gemini",
+    )
+    repaired_review = structured_pr_review(
+        state="approved",
+        summary="LGTM.",
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_review_response(
+                text,
+                reviewer="Google Gemini",
+                unresolved_items=(carried_item,),
+            ),
+            use_repair=True,
+            repair_expected_kind="pr_review",
+            repair_allowed_prior_item_ids=("item-1",),
+        )
+
+    assert response.marker_value.dispositions[0].item_id == "item-1"
+    assert repair_mock.call_args.kwargs["allowed_prior_item_ids"] == ("item-1",)
+    assert repair_mock.call_args.kwargs["unknown_prior_item_ids"] == ("item-9",)
+
+
+def test_run_validated_agent_repairs_unknown_plan_revision_prior_disposition(tmp_path):
+    active_item = UnresolvedReviewItem(
+        item_id="item-12",
+        reviewer="Google Gemini",
+        source_round=5,
+        text="Active must-fix item.",
+        status="blocking",
+    )
+    malformed_revision = structured_plan_revision(
+        prior_plan_item_dispositions=[
+            {"item_id": "item-15", "disposition": "resolved"},
+        ],
+    )
+    repaired_revision = structured_plan_revision(prior_plan_item_dispositions=[])
+    runner = FakeRunner(claude_outputs=[malformed_revision])
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_revision) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Revise the plan.",
+            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+            validate=lambda text: _validate_plan_revision_response(
+                text,
+                unresolved_items=(active_item,),
+            ),
+            use_repair=True,
+            repair_expected_kind="plan_revision",
+            repair_allowed_prior_item_ids=("item-12",),
+            ledger_incomplete=False,
+        )
+
+    assert response.text == repaired_revision
+    assert repair_mock.call_args.kwargs["allowed_prior_item_ids"] == ("item-12",)
+    assert repair_mock.call_args.kwargs["unknown_prior_item_ids"] == ("item-15",)
+
+
+def test_run_validated_agent_plan_revision_unknown_prior_disposition_fails_when_ledger_incomplete(tmp_path):
+    active_item = UnresolvedReviewItem(
+        item_id="item-12",
+        reviewer="Google Gemini",
+        source_round=5,
+        text="Active must-fix item.",
+        status="blocking",
+    )
+    malformed_revision = structured_plan_revision(
+        prior_plan_item_dispositions=[
+            {"item_id": "item-15", "disposition": "resolved"},
+            {"item_id": "item-18", "disposition": "resolved"},
+        ],
+    )
+    runner = FakeRunner(claude_outputs=[malformed_revision])
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        with pytest.raises(AgentLoopError) as exc_info:
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Revise the plan.",
+                marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                validate=lambda text: _validate_plan_revision_response(
+                    text,
+                    unresolved_items=(active_item,),
+                ),
+                use_repair=True,
+                repair_expected_kind="plan_revision",
+                repair_allowed_prior_item_ids=("item-12",),
+                ledger_incomplete=True,
+            )
+
+    repair_mock.assert_not_called()
+    assert "item-15" in str(exc_info.value)
+    assert "item-18" in str(exc_info.value)
+
+
 def test_gemini_duplicate_trailing_agent_state_marker_is_repairable(tmp_path):
     malformed_public_review = (
         structured_pr_review(
@@ -6328,6 +6688,7 @@ def test_gemini_duplicate_trailing_agent_state_marker_is_repairable(tmp_path):
         malformed_public_review,
         config.gemini_cmd,
         expected_kind="pr_review",
+        allowed_prior_item_ids=(),
     )
     assert any("Duplicate marker repaired." in comment for comment in runner.comments)
 
@@ -8789,6 +9150,146 @@ def test_resume_pr_round_prefers_structured_coder_followup_metadata():
     assert '"kind": "coder_followup"' not in _strip_round_metadata(coder_comment)
 
 
+def test_resume_pr_round_marks_empty_ledger_incomplete_after_same_subject_prior_new_items():
+    prior_new_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Prior same-head item.",
+        status="blocking",
+    )
+    prior_review_comment = _attach_round_metadata(
+        "Prior review.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject="abc123",
+            prior_items=(),
+            new_items=(prior_new_item,),
+            state="blocking",
+        ),
+    )
+    current_coder_comment = _attach_round_metadata(
+        "Current coder output.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="abc123",
+            prior_items=(),
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=prior_review_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=current_coder_comment),
+        ],
+        head_sha="abc123",
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    assert resumed.ledger_may_be_incomplete is True
+
+
+def test_resume_pr_round_does_not_mark_ledger_incomplete_for_cross_subject_prior_new_items():
+    prior_new_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Prior other-head item.",
+        status="blocking",
+    )
+    prior_review_comment = _attach_round_metadata(
+        "Prior review.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+            new_items=(prior_new_item,),
+            state="blocking",
+        ),
+    )
+    current_coder_comment = _attach_round_metadata(
+        "Current coder output.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=1,
+            subject="new-sha",
+            prior_items=(),
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=prior_review_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=current_coder_comment),
+        ],
+        head_sha="new-sha",
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    assert resumed.ledger_may_be_incomplete is False
+
+
+def test_resume_plan_round_marks_empty_ledger_incomplete_after_same_subject_prior_new_items():
+    plan = "Plan text."
+    subject = _plan_subject(plan)
+    prior_new_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Prior same-plan item.",
+        status="blocking",
+    )
+    prior_review_comment = _attach_round_metadata(
+        "Prior plan review.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="plan",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject=subject,
+            prior_items=(),
+            new_items=(prior_new_item,),
+            state="blocking",
+        ),
+    )
+    current_coder_comment = _attach_round_metadata(
+        plan + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=subject,
+            prior_items=(),
+            canonical_plan=plan,
+        ),
+    )
+
+    resumed = _resume_plan_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=prior_review_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=current_coder_comment),
+        ],
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    assert resumed[1].ledger_may_be_incomplete is True
+
+
 def test_resume_pr_round_prefers_latest_metadata_ledger_for_same_head_replay():
     stale_item = UnresolvedReviewItem(
         item_id="item-3",
@@ -10586,7 +11087,7 @@ def test_issue_loop_plan_revision_repair_preserves_signed_human_requirements(tmp
     config = make_config(tmp_path, agent_max_retries=0)
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_repairs.append((raw, expected_kind))
         return repaired_revision
 
@@ -10653,7 +11154,7 @@ def test_issue_loop_plan_revision_repair_rejects_wrong_kind_from_human_requireme
     config = make_config(tmp_path, agent_max_retries=0)
     captured_kinds = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_kinds.append(expected_kind)
         return wrong_kind_repair
 
@@ -12268,6 +12769,31 @@ def test_attempt_repair_includes_expected_kind_instruction():
     assert "Output no other `kind` value" in prompt
 
 
+def test_attempt_repair_includes_prior_item_disposition_repair_context():
+    repaired = structured_plan_revision(prior_plan_item_dispositions=[])
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            "malformed plan revision",
+            "gemini",
+            expected_kind="plan_revision",
+            allowed_prior_item_ids=["item-12"],
+            unknown_prior_item_ids=["item-15", "item-18"],
+            same_round_context="Same-round findings are informational only.",
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert "Prior item disposition repair" in prompt
+    assert "Allowed carried prior item IDs: item-12" in prompt
+    assert "Unknown prior item disposition IDs to remove: item-15, item-18" in prompt
+    assert "Same-round findings are informational only" in prompt
+
+
 def test_attempt_repair_includes_coder_followup_required_item_ids():
     repaired = structured_coder_followup(
         state="approved",
@@ -12416,7 +12942,7 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -12449,7 +12975,7 @@ def test_run_pr_loop_repairs_format_failure_with_5xx_source_line_reference(tmp_p
 
     captured_repairs = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_repairs.append(raw)
         assert expected_kind == "pr_review"
         return repaired_review
@@ -12473,7 +12999,7 @@ def test_run_pr_loop_falls_back_to_error_when_repair_also_fails(tmp_path):
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", agent_max_retries=0)
 
-    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair_fails(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         assert expected_kind == "pr_review"
         return "still broken output without valid schema"
 
@@ -12529,7 +13055,7 @@ def test_run_pr_loop_uses_repair_pass_on_coder_followup_format_failure(tmp_path)
     captured_repairs = []
     captured_unresolved_item_ids = []
 
-    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None) -> str | None:
+    def fake_attempt_repair(raw: str, gemini_cmd: str, *, expected_kind: str | None = None, unresolved_item_ids=None, surfaced_requirement_ids=None, allowed_prior_item_ids=None, unknown_prior_item_ids=None, same_round_context=None) -> str | None:
         captured_repairs.append(raw)
         captured_unresolved_item_ids.append(tuple(unresolved_item_ids or ()))
         assert expected_kind == "coder_followup"


### PR DESCRIPTION
Fixes #234

## Summary
- add a structured unknown prior-item disposition error with deterministic messages
- route complete-ledger unknown dispositions through repair with explicit allowed/removed IDs
- fail fast when resume metadata indicates the ledger may be incomplete
- guard prior-disposition rendering against stale IDs, including plan revisions

## Tests
- python3 -m pytest