### PR TITLE
Add cost-aware planning context mode

### DIFF
--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -254,6 +254,15 @@ def build_parser() -> argparse.ArgumentParser:
                 "'fix-and-issue'; default: ignore)."
             ),
         )
+        subparser.add_argument(
+            "--planning-context-mode",
+            choices=("full", "compact"),
+            default="compact",
+            help=(
+                "Planning prompt context mode. Compact uses a cache-aware canonical "
+                "context after the first complete planning round (default: compact)."
+            ),
+        )
 
     issue = subparsers.add_parser("issue", help="Ask the coder to fix an issue, then review it.")
     issue.add_argument("issue_number", type=int)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -287,6 +287,7 @@ def _render_public_plan_review_comment(
     reviewer: str,
     prior_items: Sequence[UnresolvedReviewItem],
     dispositions: Sequence[ReviewItemDisposition],
+    human_requirements_resolved_flag: bool = False,
 ) -> str:
     sections: list[str] = [f"**Review verdict:** {parsed_review.state.title()}"]
     if parsed_review.summary and parsed_review.summary.strip() != "Plan review complete.":
@@ -326,10 +327,15 @@ def _render_public_plan_review_comment(
                 dispositions=dispositions,
             )
         )
-    footer = [
-        f"<!-- AGENT_PLAN_STATE: {parsed_review.state} -->",
-        f"-- {_public_reviewer_name(reviewer)}",
-    ]
+    footer: list[str] = []
+    if human_requirements_resolved_flag:
+        footer.append("<!-- HUMAN_REQUIREMENTS_RESOLVED -->")
+    footer.extend(
+        [
+            f"<!-- AGENT_PLAN_STATE: {parsed_review.state} -->",
+            f"-- {_public_reviewer_name(reviewer)}",
+        ]
+    )
     return "\n\n".join(section for section in sections if section) + (
         ("\n\n" if sections else "") + "\n".join(footer)
     )

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -55,11 +55,14 @@ class AgentLoopConfig:
     refresh_test_profile: bool
     approved_followups: str = "ignore"
     plan_execution_mode: str = "plan-only"
+    planning_context_mode: str = "compact"
     auto_agent_dirs: tuple[AgentName, ...] = ()
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
             object.__setattr__(self, "reviewer", (self.reviewer,))
+        if self.planning_context_mode not in {"full", "compact"}:
+            raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -514,5 +517,6 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         refresh_test_profile=args.refresh_test_profile,
         approved_followups=args.approved_followups,
         plan_execution_mode=getattr(args, "plan_execution_mode", None) or "plan-only",
+        planning_context_mode=getattr(args, "planning_context_mode", None) or "compact",
         auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -50,6 +50,8 @@ from .logging import log, new_run_id, run_usage_summary_path
 from .memory import prepare_agent_memory
 from .migrations import validate_pr_migration_topology
 from .prompts import (
+    CompactPlanTailContext,
+    CompactPriorContext,
     build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
@@ -164,6 +166,7 @@ from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     _apply_unresolved_item_dispositions,
+    _collect_prior_compact_summaries,
     _clear_human_requirements_ack_item,
     _format_same_pr_unresolved_items,
     _format_unresolved_items_for_coder,
@@ -1199,11 +1202,12 @@ def _run_plan_first_loop(
     coder_session_id: str | None = None
     reviewer_session_ids: dict[AgentName, str | None] = {}
     unresolved_items: list[UnresolvedReviewItem] = []
+    compact_prior_summaries: list[str] = []
     approved_future_followups: list[ApprovedFollowup] = []
     next_unresolved_item_number = 1
     resume_state = _resume_plan_round(issue_context.comments, configured_reviewers=configured_reviewers)
     if resume_state is None:
-        log(config, f"Planning issue #{issue_number}: invoking {coder_name}")
+        log(config, f"Planning issue #{issue_number}: invoking {coder_name} (context mode: full)")
         plan_response = _run_validated_agent(
             runner,
             agent=config.coder,
@@ -1240,6 +1244,7 @@ def _run_plan_first_loop(
                     round_number=1,
                     subject=_plan_subject(current_plan),
                     prior_items=(),
+                    compact_prior_summaries=tuple(compact_prior_summaries),
                 ),
             ),
         )
@@ -1248,6 +1253,7 @@ def _run_plan_first_loop(
     else:
         current_plan, resumed_round = resume_state
         unresolved_items = list(resumed_round.prior_items)
+        compact_prior_summaries = list(resumed_round.compact_prior_summaries)
         next_unresolved_item_number = resumed_round.next_unresolved_item_number
         start_round_number = resumed_round.round_number
         log(config, f"Planning issue #{issue_number}: resuming round {start_round_number}")
@@ -1267,6 +1273,17 @@ def _run_plan_first_loop(
             flow="plan",
             current_subject=current_plan_subject,
         )
+        use_compact_context = (
+            config.planning_context_mode == "compact"
+            and round_number >= 2
+            and not round_ledger_incomplete
+        )
+        context_mode = "compact" if use_compact_context else "full"
+        context_reason = " (ledger incomplete)" if (
+            config.planning_context_mode == "compact"
+            and round_number >= 2
+            and round_ledger_incomplete
+        ) else ""
         round_approved_future_followups: list[ApprovedFollowup] = []
         blocking_reviews: list[tuple[str, str]] = []
         all_approved = True
@@ -1296,7 +1313,11 @@ def _run_plan_first_loop(
                 log(config, f"Planning round {round_number}: resuming {reviewer_name}'s completed review")
                 reviewer_new_unresolved_items = list(resumed_record.metadata.new_items)
             else:
-                log(config, f"Planning round {round_number}: {reviewer_name} reviewing issue #{issue_number}")
+                log(
+                    config,
+                    f"Planning round {round_number}: {reviewer_name} reviewing issue #{issue_number} "
+                    f"(context mode: {context_mode}{context_reason})",
+                )
                 review_response = _run_validated_agent(
                     runner,
                     agent=reviewer,
@@ -1310,6 +1331,15 @@ def _run_plan_first_loop(
                         memory=memory,
                         issue_context=issue_context,
                         unresolved_items=prior_unresolved_items,
+                        compact_context=use_compact_context,
+                        compact_prior=CompactPriorContext(tuple(compact_prior_summaries)),
+                        compact_tail=CompactPlanTailContext(
+                            subject=current_plan_subject,
+                            action=(
+                                "Review the current plan for correctness, architecture fit, "
+                                "missing edge cases, test strategy, and ambiguity."
+                            ),
+                        ),
                     ),
                     session_id=reviewer_session_ids.get(reviewer),
                     marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
@@ -1404,6 +1434,7 @@ def _run_plan_first_loop(
                             dispositions=parsed_review.dispositions,
                             new_items=tuple(reviewer_new_unresolved_items),
                             state=review_state,
+                            compact_prior_summaries=tuple(compact_prior_summaries),
                         ),
                     ),
                 )
@@ -1420,6 +1451,14 @@ def _run_plan_first_loop(
             prior_dispositions,
             same_status="same-plan",
             retain_future=False,
+        )
+        compact_prior_summaries.extend(
+            _collect_prior_compact_summaries(
+                prior_unresolved_items,
+                unresolved_items,
+                future_from_prior_items,
+                prior_dispositions,
+            )
         )
         unresolved_items = [*unresolved_items, *round_new_unresolved_items]
         must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-plan"}]
@@ -1544,7 +1583,11 @@ def _run_plan_first_loop(
             )
 
         combined_review = "\n\n".join(f"{name} plan review:\n\n{review}" for name, review in blocking_reviews)
-        log(config, f"Planning round {round_number}: {coder_name} revising the plan")
+        log(
+            config,
+            f"Planning round {round_number}: {coder_name} revising the plan "
+            f"(context mode: {context_mode}{context_reason})",
+        )
         plan_response = _run_validated_agent(
             runner,
             agent=config.coder,
@@ -1558,6 +1601,12 @@ def _run_plan_first_loop(
                 memory,
                 issue_context=issue_context,
                 unresolved_items=must_fix_items,
+                compact_context=use_compact_context,
+                compact_prior=CompactPriorContext(tuple(compact_prior_summaries)),
+                compact_tail=CompactPlanTailContext(
+                    subject=current_plan_subject,
+                    action="Revise the implementation plan to address the blocking plan review.",
+                ),
             ),
             session_id=coder_session_id,
             marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
@@ -1608,6 +1657,7 @@ def _run_plan_first_loop(
                     prior_items=tuple(must_fix_items),
                     canonical_plan=canonical_plan,
                     raw_structured_coder_response=raw_structured_coder_response,
+                    compact_prior_summaries=tuple(compact_prior_summaries),
                 ),
             ),
         )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1286,6 +1286,7 @@ def _run_plan_first_loop(
         ) else ""
         round_approved_future_followups: list[ApprovedFollowup] = []
         blocking_reviews: list[tuple[str, str]] = []
+        approved_review_outputs: list[tuple[str, str]] = []
         all_approved = True
         resumed_by_name = {
             record.metadata.agent: record for record in (current_resume.completed_reviews if current_resume is not None else ())
@@ -1378,6 +1379,8 @@ def _run_plan_first_loop(
             if review_state == "blocking":
                 all_approved = False
                 blocking_reviews.append((reviewer_name, review_output))
+            else:
+                approved_review_outputs.append((reviewer_name, review_output))
             if resumed_record is None:
                 for item in parsed_review.items.blocking:
                     tracked_item = _next_unresolved_item(
@@ -1423,6 +1426,9 @@ def _run_plan_first_loop(
                             reviewer=reviewer_name,
                             prior_items=prior_unresolved_items,
                             dispositions=parsed_review.dispositions,
+                            human_requirements_resolved_flag=human_requirements_resolved(
+                                review_output
+                            ),
                         ),
                         PostedRoundMetadata(
                             flow="plan",
@@ -1465,6 +1471,48 @@ def _run_plan_first_loop(
         approved_future_followups.extend(
             _approved_followup_from_unresolved_item(item) for item in future_from_prior_items
         )
+        if all_approved and not must_fix_items and issue_context.human_requirements:
+            missing_acknowledgements = [
+                reviewer_name
+                for reviewer_name, review_output in approved_review_outputs
+                if not human_requirements_resolved(review_output)
+            ]
+            if missing_acknowledgements:
+                log(
+                    config,
+                    f"Planning round {round_number}: reviewer(s) {', '.join(missing_acknowledgements)} "
+                    "approved without acknowledging signed human requirements; "
+                    "re-injecting as blocking plan item",
+                )
+                synthetic_review = (
+                    "Orchestrator plan review:\n\n"
+                    f"Reviewer(s) {', '.join(missing_acknowledgements)} approved without "
+                    "acknowledging the signed human requirements. Coder must address the "
+                    "human requirements and ensure the reviewer explicitly resolves them "
+                    "before plan approval."
+                )
+                blocking_reviews.append(("Orchestrator", synthetic_review))
+                round_new_unresolved_items.append(
+                    _next_unresolved_item(
+                        item_number=next_unresolved_item_number,
+                        reviewer="Orchestrator",
+                        source_round=round_number,
+                        text=(
+                            f"Reviewer(s) {', '.join(missing_acknowledgements)} approved without "
+                            "acknowledging the signed human requirements. Coder must address the "
+                            "human requirements and ensure the reviewer explicitly resolves them "
+                            "before plan approval."
+                        ),
+                        status="blocking",
+                    )
+                )
+                next_unresolved_item_number += 1
+                unresolved_items = [*unresolved_items, round_new_unresolved_items[-1]]
+                must_fix_items = [
+                    item for item in unresolved_items if item.status in {"blocking", "same-plan"}
+                ]
+                all_approved = False
+
         if all_approved:
             approved_future_followups.extend(round_approved_future_followups)
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -568,6 +568,12 @@ Use this mandatory structured JSON response format:
 <!-- AGENT_PLAN_STATE: approved -->
 -- reviewer signature shown in the volatile tail
 
+If signed human requirements are present in the stable prefix and are fully
+addressed or explicitly resolved, include exactly this marker before the
+`AGENT_PLAN_STATE` footer:
+
+<!-- HUMAN_REQUIREMENTS_RESOLVED -->
+
 Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
 follow-ups are small current-plan refinements that must be incorporated before
 implementation starts; they may appear only in blocking plan reviews. Future

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -28,6 +28,20 @@ class CoderHumanRequirementsPromptContext:
     requires_direct_discussion_ack: bool
 
 
+COMPACT_PLANNING_VOLATILE_TAIL_MARKER = "--- volatile compact planning tail ---"
+
+
+@dataclass(frozen=True)
+class CompactPriorContext:
+    prior_item_summaries: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CompactPlanTailContext:
+    subject: str | None = None
+    action: str | None = None
+
+
 def format_agent_list(agents: Sequence[AgentName]) -> str:
     names = [agent_display_name(agent) for agent in agents]
     if len(names) == 1:
@@ -491,6 +505,169 @@ def _issue_context_block(issue_context: IssueContext | None) -> str:
     )
 
 
+def _compact_issue_context_block(issue_context: IssueContext | None) -> str:
+    if issue_context is None:
+        return ""
+    title = issue_context.title if issue_context.title else "(unknown)"
+    body = issue_context.body if issue_context.body else "(none)"
+    return "\n".join(
+        [
+            "Original GitHub issue context",
+            f"Issue number: {issue_context.number}",
+            "",
+            "Title:",
+            title,
+            "",
+            "Body:",
+            body,
+            "",
+            "Raw prior issue comments are omitted in compact planning context. Durable reviewer findings must appear in the active unresolved ledger or the append-only compact prior ledger below.",
+            "",
+        ]
+    )
+
+
+def _compact_prior_ledger_block(compact_prior: CompactPriorContext | None) -> str:
+    summaries = compact_prior.prior_item_summaries if compact_prior is not None else ()
+    if not summaries:
+        return "Append-only compact prior item ledger\n\n(none)\n"
+    return (
+        "Append-only compact prior item ledger\n\n"
+        + "\n\n".join(summaries)
+        + "\n"
+    )
+
+
+def _canonical_plan_ledger_rules() -> str:
+    return """Canonical compact planning ledger rules
+
+- Treat active prior unresolved plan items as approval-critical until explicitly dispositioned.
+- Treat append-only compact prior ledger entries as the canonical history for prior blocking and same-plan concerns that left the active ledger.
+- Do not reinterpret, reorder, or rewrite prior compact ledger entries; append only new resolved or future-follow-up summaries after later review rounds.
+- Future follow-ups are relevant in compact mode only when elevated, referenced, or preserved in the compact prior ledger.
+"""
+
+
+def _plan_review_schema_and_rules() -> str:
+    return """Plan review response protocol
+
+Use this mandatory structured JSON response format:
+
+{
+  "schema_version": 1,
+  "kind": "plan_review",
+  "state": "approved",
+  "summary": "Plan looks good.",
+  "blocking_plan_issues": [],
+  "same_plan_followups": [],
+  "future_followups": ["Consider a later cleanup pass."],
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved", "note": "Covered by the revised tests."}
+  ]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- reviewer signature shown in the volatile tail
+
+Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
+follow-ups are small current-plan refinements that must be incorporated before
+implementation starts; they may appear only in blocking plan reviews. Future
+follow-ups are independent later work that remains valid after the current
+plan is approved; they are allowed only in approved plan reviews. A concern or
+paraphrase belongs in exactly one current-round list: `blocking_plan_issues`,
+`same_plan_followups`, or `future_followups`. Do not duplicate or reclassify
+the same concern across Same-plan and Future follow-up lists.
+Approved means there are no blocking plan issues, no Same-plan follow-ups, and
+no carried-forward plan items left active for this planning round. If you
+return `<!-- AGENT_PLAN_STATE: blocking -->`, do not use structured Future
+follow-ups; keep all required current-round issues in the main blocking
+content so they are not missed during plan revision.
+Only items listed under `Prior unresolved plan items from earlier rounds` are
+eligible for dispositions in this round. If same-round findings from other
+reviewers appear elsewhere in the issue discussion, treat them as
+informational only and do not disposition them until a later round carries
+them forward explicitly.
+Structured responses must start with one top-level JSON object, place the
+`AGENT_PLAN_STATE` footer immediately after that payload, and end with only
+your standalone signature. Do not include prose or code fences before the JSON
+object.
+"""
+
+
+def _plan_revision_schema_and_rules() -> str:
+    return """Plan revision response protocol
+
+Revise the plan item by item instead of replying only with free-form prose. If
+prior unresolved plan items are listed in the stable prefix, include this exact
+section in your response and address each item ID exactly once:
+
+### Prior plan review item dispositions
+- [item-id] resolved: brief explanation of how the revised plan addresses it
+- [item-id] still blocking: brief explanation if you cannot resolve it yet
+- [item-id] same-plan: brief explanation of the remaining current-plan refinement
+- [item-id] future: brief explanation only if a reviewer explicitly asked to move it to future work
+
+Then provide the revised implementation plan with concrete file areas, edge
+cases, and tests. Use `same-plan`, never `same-pr`, when describing plan-only
+current-round refinements.
+
+Use this mandatory structured JSON response format:
+
+{
+  "schema_version": 1,
+  "kind": "plan_revision",
+  "state": "blocking",
+  "summary": "Updated the plan to cover parser hard-fail behavior and resume state reconstruction.",
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-3", "disposition": "resolved", "note": "Added the carry-forward metadata step."}
+  ],
+  "plan_steps": [
+    "Update `src/coding_review_agent_loop/protocol.py` to hard-fail invalid structured plan payloads after JSON-prefix detection.",
+    "Normalize structured plan rendering and metadata-backed resume behavior in `src/coding_review_agent_loop/orchestrator.py`.",
+    "Extend prompts and targeted tests for structured planning flows."
+  ]
+}
+<!-- AGENT_PLAN_STATE: blocking -->
+-- coder signature shown in the volatile tail
+
+The orchestrator will normalize structured plan revisions into canonical
+markdown for stored plan state, reviewer prompts, subject hashing, and resume.
+Your response must start with exactly one top-level JSON object, with no prose
+or code fences before it. Put the `AGENT_PLAN_STATE` footer immediately after
+the JSON, make the footer state match the JSON state, and include only your
+standalone signature after the footer.
+"""
+
+
+def _compact_plan_stable_prefix(
+    *,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None,
+    issue_context: IssueContext | None,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    compact_prior: CompactPriorContext | None,
+    human_requirements_block: str,
+    human_requirements_guidance: str,
+    response_protocol: str,
+) -> str:
+    return "\n".join(
+        part.rstrip()
+        for part in (
+            "Compact cache-aware planning context",
+            f"Repository: {config.repo}",
+            _scratch_file_guidance(),
+            response_protocol,
+            _memory_block(memory),
+            _compact_issue_context_block(issue_context),
+            human_requirements_block,
+            human_requirements_guidance,
+            _canonical_plan_ledger_rules(),
+            _format_unresolved_plan_items(unresolved_items) or "Prior unresolved plan items from earlier rounds\n\n(none)\n",
+            _compact_prior_ledger_block(compact_prior),
+        )
+        if part
+    ) + "\n"
+
+
 def _issue_human_requirements_block(
     issue_context: IssueContext | None,
     *,
@@ -631,7 +808,23 @@ def build_plan_review_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     unresolved_items: Sequence[UnresolvedReviewItem] = (),
+    compact_context: bool = False,
+    compact_prior: CompactPriorContext | None = None,
+    compact_tail: CompactPlanTailContext | None = None,
 ) -> str:
+    if compact_context:
+        return _build_compact_plan_review_prompt(
+            issue_number,
+            round_number,
+            plan,
+            config,
+            reviewer=reviewer,
+            memory=memory,
+            issue_context=issue_context,
+            unresolved_items=unresolved_items,
+            compact_prior=compact_prior,
+            compact_tail=compact_tail,
+        )
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
     reviewer_group = format_agent_list(reviewers(config))
@@ -736,6 +929,100 @@ object. Always sign your response:
 """
 
 
+def _build_compact_plan_review_prompt(
+    issue_number: int,
+    round_number: int,
+    plan: str,
+    config: AgentLoopConfig,
+    *,
+    reviewer: AgentName,
+    memory: AgentMemoryContext | None,
+    issue_context: IssueContext | None,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    compact_prior: CompactPriorContext | None,
+    compact_tail: CompactPlanTailContext | None,
+) -> str:
+    coder_name = agent_display_name(config.coder)
+    reviewer_name = agent_display_name(reviewer)
+    reviewer_signature = agent_signature(reviewer)
+    reviewer_group = format_agent_list(reviewers(config))
+    human_requirements_block = _issue_human_requirements_block(
+        issue_context,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before approving the plan.",
+    )
+    human_requirements_guidance = _human_requirements_review_guidance(
+        issue_context.human_requirements if issue_context is not None else (),
+        requirement_label="signed human issue requirements",
+    )
+    if unresolved_items:
+        unresolved_items_guidance = """Because prior unresolved plan items exist, include this exact section in your review:
+
+### Prior unresolved plan item dispositions
+
+Use one bullet per listed item and cover every item exactly once. Allowed forms:
+- [item-id] resolved
+- [item-id] still blocking
+- [item-id] same-plan
+- [item-id] future follow-up: brief reason
+
+Only use `future follow-up` when returning `approved`. If a current-plan item still needs to be fixed before implementation starts, keep it as `still blocking` or `same-plan` instead of downgrading it.
+For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later plan changes, or now belongs back in same-plan/blocking work.
+Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
+"""
+    else:
+        unresolved_items_guidance = ""
+    stable_prefix = _compact_plan_stable_prefix(
+        config=config,
+        memory=memory,
+        issue_context=issue_context,
+        unresolved_items=unresolved_items,
+        compact_prior=compact_prior,
+        human_requirements_block=human_requirements_block,
+        human_requirements_guidance=(
+            "Signed human issue requirements are approval-critical issue constraints for this plan review.\n"
+            f"{human_requirements_guidance}"
+        ),
+        response_protocol=_plan_review_schema_and_rules() + "\n" + unresolved_items_guidance,
+    )
+    subject_line = f"Current plan subject: {compact_tail.subject}" if compact_tail and compact_tail.subject else "Current plan subject: (unknown)"
+    action = (
+        compact_tail.action
+        if compact_tail and compact_tail.action
+        else "Review the current plan for correctness, architecture fit, missing edge cases, test strategy, and ambiguity."
+    )
+    return f"""{stable_prefix}
+{COMPACT_PLANNING_VOLATILE_TAIL_MARKER}
+
+GitHub issue #{issue_number}
+Planning round: {round_number}
+Role: reviewer
+Reviewer: {reviewer_name}
+Coder: {coder_name}
+{subject_line}
+Action for this call: {action}
+
+Current implementation plan from {coder_name}:
+
+{plan}
+
+All configured reviewers ({reviewer_group}) must approve in the same planning
+round before implementation can proceed. End your final response with exactly
+one planning marker:
+
+<!-- AGENT_PLAN_STATE: approved -->
+
+or:
+
+<!-- AGENT_PLAN_STATE: blocking -->
+
+Use approved only if there are no blocking plan issues, no Same-plan
+follow-ups, and no carried-forward plan items left active for this planning
+round. Always sign your response:
+-- {reviewer_signature}
+"""
+
+
 def build_plan_decomposition_prompt(
     issue_number: int,
     approved_plan: str,
@@ -809,7 +1096,23 @@ def build_plan_revision_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     unresolved_items: Sequence[UnresolvedReviewItem] = (),
+    compact_context: bool = False,
+    compact_prior: CompactPriorContext | None = None,
+    compact_tail: CompactPlanTailContext | None = None,
 ) -> str:
+    if compact_context:
+        return _build_compact_plan_revision_prompt(
+            issue_number,
+            round_number,
+            previous_plan,
+            review,
+            config,
+            memory=memory,
+            issue_context=issue_context,
+            unresolved_items=unresolved_items,
+            compact_prior=compact_prior,
+            compact_tail=compact_tail,
+        )
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder)
     unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
@@ -883,6 +1186,76 @@ standalone signature after the footer.
 
 This is planning round {round_number}. End your final response with exactly one
 planning marker:
+
+<!-- AGENT_PLAN_STATE: blocking -->
+
+Use blocking to hand the revised plan back to {reviewer_name}. Sign the response as:
+-- {coder_signature}
+"""
+
+
+def _build_compact_plan_revision_prompt(
+    issue_number: int,
+    round_number: int,
+    previous_plan: str,
+    review: str,
+    config: AgentLoopConfig,
+    *,
+    memory: AgentMemoryContext | None,
+    issue_context: IssueContext | None,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    compact_prior: CompactPriorContext | None,
+    compact_tail: CompactPlanTailContext | None,
+) -> str:
+    reviewer_name = format_agent_list(reviewers(config))
+    coder_signature = agent_signature(config.coder)
+    human_requirements_context = _issue_human_requirements_prompt_context(
+        issue_context,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+    stable_prefix = _compact_plan_stable_prefix(
+        config=config,
+        memory=memory,
+        issue_context=issue_context,
+        unresolved_items=unresolved_items,
+        compact_prior=compact_prior,
+        human_requirements_block=human_requirements_context.block,
+        human_requirements_guidance=_coder_human_requirements_guidance(
+            human_requirements_context,
+            requirement_label="planning requirements",
+            surfaced_requirement_instruction=(
+                "Each bullet must explain how the revised plan covers that item or what remains risky or blocked."
+            ),
+        ),
+        response_protocol=_plan_revision_schema_and_rules(),
+    )
+    subject_line = f"Current plan subject: {compact_tail.subject}" if compact_tail and compact_tail.subject else "Current plan subject: (unknown)"
+    action = (
+        compact_tail.action
+        if compact_tail and compact_tail.action
+        else "Revise the implementation plan to address the blocking plan review."
+    )
+    return f"""{stable_prefix}
+{COMPACT_PLANNING_VOLATILE_TAIL_MARKER}
+
+GitHub issue #{issue_number}
+Planning round: {round_number}
+Role: coder
+Coder: {agent_display_name(config.coder)}
+Reviewers: {reviewer_name}
+{subject_line}
+Action for this call: {action}
+
+Previous implementation plan:
+
+{previous_plan}
+
+Blocking plan review payload:
+
+{review}
+
+End your final response with exactly one planning marker:
 
 <!-- AGENT_PLAN_STATE: blocking -->
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -672,6 +672,11 @@ def _extract_structured_plan_review_payload(text: str) -> dict[str, object] | No
     if extracted is None:
         return None
     payload, trailing = extracted
+    trailing = trailing.lstrip()
+    if HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing):
+        marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(trailing)
+        assert marker_match is not None
+        trailing = trailing[marker_match.end() :]
     return _consume_structured_footer_and_signature(
         payload=payload,
         trailing=trailing,

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -35,6 +35,7 @@ class PostedRoundMetadata:
     state: str | None = None
     canonical_plan: str | None = None
     raw_structured_coder_response: str | None = None
+    compact_prior_summaries: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -58,6 +59,7 @@ class ResumedReviewRound:
     completed_reviews: tuple[PostedRoundRecord, ...]
     next_unresolved_item_number: int
     ledger_may_be_incomplete: bool = False
+    compact_prior_summaries: tuple[str, ...] = ()
 
 
 def _serialize_unresolved_item(item: UnresolvedReviewItem) -> dict[str, object]:
@@ -121,6 +123,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "state": metadata.state,
         "canonical_plan": metadata.canonical_plan,
         "raw_structured_coder_response": metadata.raw_structured_coder_response,
+        "compact_prior_summaries": list(metadata.compact_prior_summaries),
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -153,6 +156,9 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
                 str(payload["raw_structured_coder_response"])
                 if payload.get("raw_structured_coder_response") is not None
                 else None
+            ),
+            compact_prior_summaries=tuple(
+                str(summary) for summary in payload.get("compact_prior_summaries", [])
             ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
@@ -337,6 +343,11 @@ def _resume_pr_round(
         )
         + 1,
         ledger_may_be_incomplete=ledger_may_be_incomplete,
+        compact_prior_summaries=(
+            latest_coder_record.metadata.compact_prior_summaries
+            if latest_coder_record is not None
+            else ()
+        ),
     )
 
 
@@ -386,5 +397,6 @@ def _resume_plan_round(
             )
             + 1,
             ledger_may_be_incomplete=ledger_may_be_incomplete,
+            compact_prior_summaries=latest_coder_record.metadata.compact_prior_summaries,
         ),
     )

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -344,6 +344,46 @@ def _apply_unresolved_item_dispositions(
     return next_unresolved, future_items
 
 
+def _collect_prior_compact_summaries(
+    prior_items: Sequence[UnresolvedReviewItem],
+    remaining_items: Sequence[UnresolvedReviewItem],
+    future_from_prior: Sequence[UnresolvedReviewItem],
+    dispositions_by_item: dict[str, list[ReviewItemDisposition]],
+) -> tuple[str, ...]:
+    """Render append-only summaries for prior items that just left the active ledger."""
+    remaining_ids = {item.item_id for item in remaining_items}
+    future_ids = {item.item_id for item in future_from_prior}
+    summaries: list[str] = []
+    for item in sorted(prior_items, key=lambda prior: prior.item_id):
+        if item.item_id in remaining_ids:
+            continue
+        dispositions = dispositions_by_item.get(item.item_id, [])
+        if not dispositions:
+            continue
+        label = "future follow-up" if item.item_id in future_ids else "resolved"
+        lines = [
+            f"[{item.item_id}] {label}: {item.reviewer} {item.source_status or item.status} item from round {item.source_round}",
+            "Original item text:",
+            item.text,
+        ]
+        notes = list(item.notes)
+        for disposition in sorted(
+            dispositions,
+            key=lambda disposition: (disposition.reviewer, disposition.item_id, disposition.disposition, disposition.note or ""),
+        ):
+            if disposition.note:
+                note = f"{disposition.reviewer}: {disposition.disposition}: {disposition.note}"
+            else:
+                note = f"{disposition.reviewer}: {disposition.disposition}"
+            if note not in notes:
+                notes.append(note)
+        if notes:
+            lines.append("Disposition updates:")
+            lines.extend(f"- {note}" for note in notes)
+        summaries.append("\n".join(lines))
+    return tuple(summaries)
+
+
 def _validate_plan_review_response(
     text: str,
     *,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -105,6 +105,9 @@ from coding_review_agent_loop.orchestrator import (
     render_canonical_plan_steps,
 )
 from coding_review_agent_loop.prompts import (
+    COMPACT_PLANNING_VOLATILE_TAIL_MARKER,
+    CompactPlanTailContext,
+    CompactPriorContext,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
     build_followup_prompt,
@@ -3913,6 +3916,237 @@ def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositio
     assert "normalize structured plan revisions into canonical\nmarkdown for stored plan state" in prompt
     assert "Use this mandatory structured JSON response format" in prompt
     assert "fall back to markdown" not in prompt.lower()
+
+
+def _compact_issue_context() -> IssueContext:
+    return IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Add compact planning context",
+        body="Original acceptance criteria: preserve requirements and known reproductions.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="reviewer",
+                created_at="2026-06-01T00:00:00Z",
+                body="UNRELATED RAW PRIOR COMMENT PROSE should not be replayed in compact mode.",
+            ),
+            IssueComment(
+                author="reviewer",
+                created_at="2026-06-01T00:05:00Z",
+                body="Unrelated future-only comment that was never elevated.",
+            ),
+        ),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue comment",
+                author="wwind123",
+                created_at="2026-06-04T06:47:03Z",
+                url="https://github.com/OWNER/REPO/issues/56#issuecomment-1",
+                body="Compact mode must use a stable prefix and volatile tail.",
+            ),
+        ),
+    )
+
+
+def test_config_and_cli_default_to_compact_planning_context(tmp_path):
+    assert make_config(tmp_path).planning_context_mode == "compact"
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+    assert config_from_args(args, FakeRunner()).planning_context_mode == "compact"
+
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--planning-context-mode",
+        "full",
+    ])
+    assert config_from_args(args, FakeRunner()).planning_context_mode == "full"
+
+    with pytest.raises(AgentLoopError):
+        make_config(tmp_path, planning_context_mode="invalid")
+    with pytest.raises(SystemExit):
+        parser.parse_args(["task", "Fix", "--planning-context-mode", "invalid"])
+
+
+def test_compact_plan_review_prompt_preserves_canonical_context_and_omits_raw_prose(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    long_reproduction = "Known reproduction: " + ("run plan loop after idle gap. " * 80)
+    prompt = build_plan_review_prompt(
+        56,
+        2,
+        "Current plan payload.",
+        config,
+        reviewer="codex",
+        memory=None,
+        issue_context=_compact_issue_context(),
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="OpenAI Codex",
+                source_round=1,
+                text=long_reproduction,
+                status="blocking",
+            ),
+        ),
+        compact_context=True,
+        compact_prior=CompactPriorContext(
+            (
+                "[item-2] resolved: Google Gemini same-plan item from round 1\n"
+                "Original item text:\nPrior resolved item full text.\n"
+                "Disposition updates:\n- Google Gemini: resolved: covered by tests.",
+                "[item-3] future follow-up: OpenAI Codex blocking item from round 1\n"
+                "Original item text:\nPrior future item text.",
+            )
+        ),
+        compact_tail=CompactPlanTailContext(subject="subject-a", action="Review action."),
+    )
+
+    prefix, tail = prompt.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
+    assert "Original acceptance criteria: preserve requirements" in prefix
+    assert "Compact mode must use a stable prefix and volatile tail." in prefix
+    assert "Known reproduction: run plan loop after idle gap." in prefix
+    assert "run plan loop after idle gap. run plan loop after idle gap. run plan loop after idle gap." in prefix
+    assert "[item-2] resolved" in prefix
+    assert "Prior resolved item full text." in prefix
+    assert "[item-3] future follow-up" in prefix
+    assert "UNRELATED RAW PRIOR COMMENT PROSE" not in prompt
+    assert "Unrelated future-only comment that was never elevated." not in prompt
+    assert "Current plan payload." in tail
+    assert "Planning round: 2" in tail
+    assert "subject-a" in tail
+
+
+def test_compact_plan_revision_prompt_preserves_context_and_omits_raw_prose(tmp_path):
+    config = make_config(tmp_path)
+    prompt = build_plan_revision_prompt(
+        56,
+        2,
+        "Previous plan payload.",
+        "Blocking review payload.",
+        config,
+        memory=None,
+        issue_context=_compact_issue_context(),
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-4",
+                reviewer="OpenAI Codex",
+                source_round=1,
+                text="Known reproduction: resume after subject change drops resolved item.",
+                status="same-plan",
+            ),
+        ),
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-5] resolved: stable old item text",)),
+        compact_tail=CompactPlanTailContext(subject="subject-b", action="Revision action."),
+    )
+
+    prefix, tail = prompt.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
+    assert "Original acceptance criteria: preserve requirements" in prefix
+    assert "Compact mode must use a stable prefix and volatile tail." in prefix
+    assert "Known reproduction: resume after subject change" in prefix
+    assert "[item-5] resolved: stable old item text" in prefix
+    assert "UNRELATED RAW PRIOR COMMENT PROSE" not in prompt
+    assert "Previous plan payload." in tail
+    assert "Blocking review payload." in tail
+    assert "Planning round: 2" in tail
+    assert "subject-b" in tail
+
+
+def test_full_plan_prompt_still_includes_raw_issue_comments(tmp_path):
+    config = make_config(tmp_path)
+    prompt = build_plan_review_prompt(
+        56,
+        2,
+        "Current plan payload.",
+        config,
+        reviewer="codex",
+        issue_context=_compact_issue_context(),
+    )
+
+    assert "UNRELATED RAW PRIOR COMMENT PROSE" in prompt
+
+
+def test_compact_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp_path):
+    config = make_config(tmp_path)
+    issue_context = _compact_issue_context()
+    first = build_plan_review_prompt(
+        56,
+        2,
+        "Plan tail A.",
+        config,
+        reviewer="codex",
+        issue_context=issue_context,
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
+        compact_tail=CompactPlanTailContext(subject="subject-a", action="Review A."),
+    )
+    second = build_plan_review_prompt(
+        56,
+        3,
+        "Plan tail B.",
+        config,
+        reviewer="codex",
+        issue_context=issue_context,
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
+        compact_tail=CompactPlanTailContext(subject="subject-b", action="Review B."),
+    )
+
+    first_prefix, first_tail = first.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
+    second_prefix, second_tail = second.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
+    assert first_prefix.encode() == second_prefix.encode()
+    assert first_tail != second_tail
+    for volatile in ("Planning round: 2", "Plan tail A.", "subject-a", "Review A."):
+        assert volatile not in first_prefix
+        assert volatile in first_tail
+
+
+def test_compact_revision_prompt_stable_prefix_is_byte_identical_across_rounds(tmp_path):
+    config = make_config(tmp_path)
+    issue_context = _compact_issue_context()
+    first = build_plan_revision_prompt(
+        56,
+        2,
+        "Previous plan A.",
+        "Review A.",
+        config,
+        issue_context=issue_context,
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
+        compact_tail=CompactPlanTailContext(subject="subject-a", action="Revision A."),
+    )
+    second = build_plan_revision_prompt(
+        56,
+        3,
+        "Previous plan B.",
+        "Review B.",
+        config,
+        issue_context=issue_context,
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
+        compact_tail=CompactPlanTailContext(subject="subject-b", action="Revision B."),
+    )
+
+    first_prefix, first_tail = first.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
+    second_prefix, second_tail = second.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
+    assert first_prefix.encode() == second_prefix.encode()
+    assert first_tail != second_tail
+    for volatile in ("Planning round: 2", "Previous plan A.", "Review A.", "subject-a", "Revision A."):
+        assert volatile not in first_prefix
+        assert volatile in first_tail
 
 
 def test_render_canonical_plan_steps_numbers_items():
@@ -11339,6 +11573,132 @@ def test_issue_loop_plan_first_does_not_expose_same_round_item_ids_to_later_revi
     assert "### New tracked unresolved items" not in runner.comments[1]
 
 
+def test_issue_loop_plan_first_uses_compact_context_after_round_one(tmp_path, capsys):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(
+                summary="Resolve item one.",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Covered."}
+                ],
+                plan_steps=["Revised plan after round one."],
+            ),
+            structured_plan_revision(
+                summary="Resolve item two.",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-2", "disposition": "resolved", "note": "Covered."}
+                ],
+                plan_steps=["Revised plan after round two."],
+            ),
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                blocking_plan_issues=["Round one issue."],
+            ),
+            structured_plan_review(
+                state="blocking",
+                blocking_plan_issues=["Round two issue."],
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Covered."}
+                ],
+            ),
+            structured_plan_review(
+                state="approved",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-2", "disposition": "resolved", "note": "Covered."}
+                ],
+            ),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer=("codex",),
+        max_rounds=3,
+        quiet=False,
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"])]
+    round_one_review = next(prompt for prompt in prompts if "planning round 1" in prompt)
+    round_two_review = next(prompt for prompt in prompts if "Planning round: 2" in prompt and "Role: reviewer" in prompt)
+    round_two_revision = next(prompt for prompt in prompts if "Planning round: 2" in prompt and "Role: coder" in prompt)
+    assert COMPACT_PLANNING_VOLATILE_TAIL_MARKER not in round_one_review
+    assert COMPACT_PLANNING_VOLATILE_TAIL_MARKER in round_two_review
+    assert COMPACT_PLANNING_VOLATILE_TAIL_MARKER in round_two_revision
+
+    captured = capsys.readouterr()
+    assert "Planning issue #56: invoking Claude (context mode: full)" in captured.err
+    assert "Planning round 2: Codex reviewing issue #56 (context mode: compact)" in captured.err
+    assert "Planning round 2: Claude revising the plan (context mode: compact)" in captured.err
+
+
+def test_issue_loop_plan_first_uses_full_context_when_plan_ledger_incomplete(tmp_path, capsys):
+    old_plan = "Old plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    new_plan = "New plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    old_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Old subject item that could be missed.",
+        status="blocking",
+        source_status="blocking",
+    )
+    old_reviewer_comment = _attach_round_metadata(
+        structured_plan_review(
+            state="blocking",
+            blocking_plan_issues=["Old subject item that could be missed."],
+        ),
+        PostedRoundMetadata(
+            flow="plan",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject=_plan_subject(old_plan),
+            new_items=(old_item,),
+            state="blocking",
+        ),
+    )
+    latest_coder_comment = _attach_round_metadata(
+        new_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=_plan_subject(new_plan),
+            prior_items=(),
+        ),
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:00:00Z", "body": old_reviewer_comment},
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:10:00Z", "body": latest_coder_comment},
+        ],
+        codex_outputs=[structured_plan_review(state="approved")],
+    )
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer=("codex",),
+        quiet=False,
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    review_prompt = [
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:2] == ["codex", "exec"] and "planning round 2" in cmd[-1]
+    ][0]
+    assert COMPACT_PLANNING_VOLATILE_TAIL_MARKER not in review_prompt
+    captured = capsys.readouterr()
+    assert "Planning round 2: Codex reviewing issue #56 (context mode: full (ledger incomplete))" in captured.err
+
+
 def test_issue_loop_plan_first_resumes_with_only_missing_reviewer_for_current_plan(tmp_path):
     current_plan = "Revised plan.\n- Add state reconstruction.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
     coder_comment = _attach_round_metadata(
@@ -11616,6 +11976,84 @@ def test_round_metadata_round_trip_preserves_canonical_plan():
     )
 
     assert _decode_round_metadata(_encode_round_metadata(metadata)).canonical_plan == metadata.canonical_plan
+
+
+def test_round_metadata_round_trip_preserves_compact_prior_summaries():
+    metadata = PostedRoundMetadata(
+        flow="plan",
+        role="coder",
+        agent="Claude",
+        round_number=2,
+        subject="abc",
+        compact_prior_summaries=("[item-1] resolved: full prior text",),
+    )
+
+    decoded = _decode_round_metadata(_encode_round_metadata(metadata))
+
+    assert decoded.compact_prior_summaries == metadata.compact_prior_summaries
+
+
+def test_decode_old_round_metadata_defaults_compact_prior_summaries_to_empty():
+    payload = {
+        "flow": "plan",
+        "role": "coder",
+        "agent": "Claude",
+        "round_number": 2,
+        "subject": "abc",
+        "prior_items": [],
+        "dispositions": [],
+        "new_items": [],
+        "state": None,
+        "canonical_plan": None,
+        "raw_structured_coder_response": None,
+    }
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+
+    assert _decode_round_metadata(encoded).compact_prior_summaries == ()
+
+
+def test_resume_plan_round_restores_compact_prior_summaries_across_subject_change():
+    old_plan = "Old plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    new_plan = "New plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    old_subject = _plan_subject(old_plan)
+    new_subject = _plan_subject(new_plan)
+    old_summary = "[item-1] resolved: old-subject resolved summary"
+    old_coder_comment = _attach_round_metadata(
+        old_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject=old_subject,
+            compact_prior_summaries=(old_summary,),
+        ),
+    )
+    new_coder_comment = _attach_round_metadata(
+        new_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=3,
+            subject=new_subject,
+            compact_prior_summaries=(old_summary,),
+        ),
+    )
+
+    resumed = _resume_plan_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-20T09:00:00Z", body=old_coder_comment),
+            IssueComment(author="bot", created_at="2026-05-20T09:10:00Z", body=new_coder_comment),
+        ],
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    _current_plan, state = resumed
+    assert state.compact_prior_summaries == (old_summary,)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -76,6 +76,7 @@ from coding_review_agent_loop.followups import (
     MAX_APPROVED_FOLLOWUP_ISSUES,
     reconcile_approved_followups,
 )
+from coding_review_agent_loop.memory import AgentMemoryContext
 from coding_review_agent_loop.migrations import MigrationValidationResult, validate_pr_migration_topology
 from coding_review_agent_loop.orchestrator import (
     ITEM_SUMMARY_LIMIT,
@@ -342,6 +343,7 @@ class FakeRunner(Runner):
                     for item in parse_plan_item_dispositions(output, reviewer="OpenAI Codex")
                 ],
                 reviewer=signature,
+                human_requirements_resolved="<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in output,
             )
         if '"kind": "plan_revision"' in prompt and "<!-- AGENT_PLAN_STATE:" in output:
             return structured_plan_revision(
@@ -715,6 +717,7 @@ def structured_plan_review(
     future_followups: list[str] | None = None,
     prior_plan_item_dispositions: list[dict[str, str]] | None = None,
     reviewer: str = "OpenAI Codex",
+    human_requirements_resolved: bool = False,
 ) -> str:
     return (
         json.dumps(
@@ -729,6 +732,7 @@ def structured_plan_review(
                 "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
             }
         )
+        + ("\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->" if human_requirements_resolved else "")
         + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n-- {reviewer}"
     )
 
@@ -3949,6 +3953,19 @@ def _compact_issue_context() -> IssueContext:
     )
 
 
+def _compact_memory_context(tmp_path: Path) -> AgentMemoryContext:
+    return AgentMemoryContext(
+        memory_dir=tmp_path / "memory",
+        current_commit="abc123",
+        last_analyzed_commit="def456",
+        changed_files=("src/coding_review_agent_loop/prompts.py",),
+        repo_summary="Repo memory summary for compact prefix.",
+        architecture_map=None,
+        test_profile="Run `python -m pytest`.",
+        toolchain=None,
+    )
+
+
 def test_config_and_cli_default_to_compact_planning_context(tmp_path):
     assert make_config(tmp_path).planning_context_mode == "compact"
 
@@ -4082,13 +4099,23 @@ def test_full_plan_prompt_still_includes_raw_issue_comments(tmp_path):
 def test_compact_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp_path):
     config = make_config(tmp_path)
     issue_context = _compact_issue_context()
+    memory = _compact_memory_context(tmp_path)
+    unresolved_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Active ledger item remains approval-critical.",
+        status="blocking",
+    )
     first = build_plan_review_prompt(
         56,
         2,
         "Plan tail A.",
         config,
         reviewer="codex",
+        memory=memory,
         issue_context=issue_context,
+        unresolved_items=(unresolved_item,),
         compact_context=True,
         compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
         compact_tail=CompactPlanTailContext(subject="subject-a", action="Review A."),
@@ -4099,7 +4126,9 @@ def test_compact_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp
         "Plan tail B.",
         config,
         reviewer="codex",
+        memory=memory,
         issue_context=issue_context,
+        unresolved_items=(unresolved_item,),
         compact_context=True,
         compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
         compact_tail=CompactPlanTailContext(subject="subject-b", action="Review B."),
@@ -4109,6 +4138,14 @@ def test_compact_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp
     second_prefix, second_tail = second.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
     assert first_prefix.encode() == second_prefix.encode()
     assert first_tail != second_tail
+    assert "Plan review response protocol" in first_prefix
+    assert '"kind": "plan_review"' in first_prefix
+    assert "Repo memory summary for compact prefix." in first_prefix
+    assert "Original acceptance criteria: preserve requirements" in first_prefix
+    assert "Compact mode must use a stable prefix and volatile tail." in first_prefix
+    assert "Active ledger item remains approval-critical." in first_prefix
+    assert "[item-1] resolved: unchanged" in first_prefix
+    assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in first_prefix
     for volatile in ("Planning round: 2", "Plan tail A.", "subject-a", "Review A."):
         assert volatile not in first_prefix
         assert volatile in first_tail
@@ -4117,13 +4154,23 @@ def test_compact_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp
 def test_compact_revision_prompt_stable_prefix_is_byte_identical_across_rounds(tmp_path):
     config = make_config(tmp_path)
     issue_context = _compact_issue_context()
+    memory = _compact_memory_context(tmp_path)
+    unresolved_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Active revision ledger item remains approval-critical.",
+        status="same-plan",
+    )
     first = build_plan_revision_prompt(
         56,
         2,
         "Previous plan A.",
         "Review A.",
         config,
+        memory=memory,
         issue_context=issue_context,
+        unresolved_items=(unresolved_item,),
         compact_context=True,
         compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
         compact_tail=CompactPlanTailContext(subject="subject-a", action="Revision A."),
@@ -4134,7 +4181,9 @@ def test_compact_revision_prompt_stable_prefix_is_byte_identical_across_rounds(t
         "Previous plan B.",
         "Review B.",
         config,
+        memory=memory,
         issue_context=issue_context,
+        unresolved_items=(unresolved_item,),
         compact_context=True,
         compact_prior=CompactPriorContext(("[item-1] resolved: unchanged",)),
         compact_tail=CompactPlanTailContext(subject="subject-b", action="Revision B."),
@@ -4144,9 +4193,33 @@ def test_compact_revision_prompt_stable_prefix_is_byte_identical_across_rounds(t
     second_prefix, second_tail = second.split(COMPACT_PLANNING_VOLATILE_TAIL_MARKER, 1)
     assert first_prefix.encode() == second_prefix.encode()
     assert first_tail != second_tail
+    assert "Plan revision response protocol" in first_prefix
+    assert '"kind": "plan_revision"' in first_prefix
+    assert "Repo memory summary for compact prefix." in first_prefix
+    assert "Original acceptance criteria: preserve requirements" in first_prefix
+    assert "Compact mode must use a stable prefix and volatile tail." in first_prefix
+    assert "Active revision ledger item remains approval-critical." in first_prefix
+    assert "[item-1] resolved: unchanged" in first_prefix
     for volatile in ("Planning round: 2", "Previous plan A.", "Review A.", "subject-a", "Revision A."):
         assert volatile not in first_prefix
         assert volatile in first_tail
+
+
+def test_structured_plan_review_preserves_human_requirements_resolution_marker():
+    review = structured_plan_review(human_requirements_resolved=True)
+
+    assert _extract_structured_plan_review_payload(review) is not None
+    parsed = parse_plan_review(review, reviewer="OpenAI Codex")
+    public = _render_public_plan_review_comment(
+        parsed,
+        reviewer="OpenAI Codex",
+        prior_items=(),
+        dispositions=(),
+        human_requirements_resolved_flag=True,
+    )
+
+    assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in public
+    assert public.index("<!-- HUMAN_REQUIREMENTS_RESOLVED -->") < public.index("<!-- AGENT_PLAN_STATE: approved -->")
 
 
 def test_render_canonical_plan_steps_numbers_items():
@@ -11109,7 +11182,7 @@ def test_issue_loop_plan_first_accepts_initial_plan_human_requirements_acknowled
             "- Requirement 1: the plan keeps the public API unchanged.\n"
             "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
         ],
-        codex_outputs=[structured_plan_review(summary="Plan looks sound.")],
+        codex_outputs=[structured_plan_review(summary="Plan looks sound.", human_requirements_resolved=True)],
     )
     config = make_config(tmp_path)
 
@@ -11250,6 +11323,7 @@ def test_issue_loop_plan_revision_accepts_human_requirements_acknowledgement(tmp
             structured_plan_review(
                 summary="Plan looks sound.",
                 prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                human_requirements_resolved=True,
             ),
         ],
     )
@@ -11315,6 +11389,7 @@ def test_issue_loop_plan_revision_repair_preserves_signed_human_requirements(tmp
             structured_plan_review(
                 summary="Plan looks sound.",
                 prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                human_requirements_resolved=True,
             ),
         ],
     )
@@ -11634,6 +11709,62 @@ def test_issue_loop_plan_first_uses_compact_context_after_round_one(tmp_path, ca
     assert "Planning issue #56: invoking Claude (context mode: full)" in captured.err
     assert "Planning round 2: Codex reviewing issue #56 (context mode: compact)" in captured.err
     assert "Planning round 2: Claude revising the plan (context mode: compact)" in captured.err
+
+
+def test_issue_loop_plan_first_requires_reviewer_human_requirements_resolution(tmp_path, capsys):
+    runner = FakeRunner(
+        issue_payload={
+            "body": "Keep compact context cache-aware.\n\n-- Human Reviewer",
+        },
+        claude_outputs=[
+            "Initial plan covers cache-aware compact context.\n"
+            "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+            "### Human requirements\n"
+            "- Requirement 1: The plan keeps compact context cache-aware.\n"
+            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(
+                summary="Revised plan requires explicit reviewer acknowledgement.",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Reviewer must acknowledge."}
+                ],
+                plan_steps=["Keep the compact context cache-aware and require reviewer acknowledgement."],
+                human_requirements=(
+                    "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+                    "### Human requirements\n"
+                    "- Requirement 1: The revised plan covers the cache-aware compact context requirement."
+                ),
+            ),
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_plan_review(
+                state="approved",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Acknowledged."}
+                ],
+                human_requirements_resolved=True,
+            ),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer=("codex",),
+        max_rounds=2,
+        plan_execution_mode="plan-only",
+        quiet=False,
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert "Approved plan:" in runner.comments[-1]
+    assert any(
+        "approved without acknowledging the signed human requirements" in comment
+        for comment in runner.comments
+    )
+    assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in runner.comments[-2]
+    captured = capsys.readouterr()
+    assert "approved without acknowledging signed human requirements" in captured.err
 
 
 def test_issue_loop_plan_first_uses_full_context_when_plan_ledger_incomplete(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- default plan-first planning context mode to compact while retaining a full-context override
- add cache-aware compact plan review/revision prompts with stable prefix, append-only prior ledger, and volatile tail
- persist compact prior summaries in round metadata and resume them from the latest plan coder record

Fixes #240

## Tests
- python3 -m pytest tests/test_agent_loop.py