### PR TITLE
Repair approved reviews with active prior dispositions

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1547,6 +1547,17 @@ def _run_plan_first_loop(
                                     round_new_unresolved_items.append(new_item)
                                     unresolved_items = [*unresolved_items, new_item]
                                     next_unresolved_item_number += 1
+                                for item in repaired_parsed.items.same_plan:
+                                    new_item = _next_unresolved_item(
+                                        item_number=next_unresolved_item_number,
+                                        reviewer=item.reviewer,
+                                        source_round=round_number,
+                                        text=item.text,
+                                        status="same-plan",
+                                    )
+                                    round_new_unresolved_items.append(new_item)
+                                    unresolved_items = [*unresolved_items, new_item]
+                                    next_unresolved_item_number += 1
                                 all_approved = False
                                 must_fix_items = [
                                     item for item in unresolved_items
@@ -2358,6 +2369,17 @@ def run_pr_loop(
                                                 source_round=round_number,
                                                 text=item.text,
                                                 status="blocking",
+                                            )
+                                            round_new_unresolved_items.append(new_item)
+                                            unresolved_items.append(new_item)
+                                            next_unresolved_item_number += 1
+                                        for item in repaired_parsed.followups.same_pr:
+                                            new_item = _next_unresolved_item(
+                                                item_number=next_unresolved_item_number,
+                                                reviewer=item.reviewer,
+                                                source_round=round_number,
+                                                text=item.text,
+                                                status="same-pr",
                                             )
                                             round_new_unresolved_items.append(new_item)
                                             unresolved_items.append(new_item)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -961,6 +961,17 @@ def _merge_human_requirements(
     return tuple(sorted(combined, key=lambda requirement: requirement.created_at or ""))
 
 
+def _surfaced_reviewer_requirement_ids(
+    human_requirements: Sequence,
+    *,
+    requirement_scope: str,
+) -> tuple[str, ...]:
+    return render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope=requirement_scope,
+    ).surfaced_requirement_ids
+
+
 def _validate_plan_revision_response(
     text: str,
     *,
@@ -1478,40 +1489,108 @@ def _run_plan_first_loop(
                 if not human_requirements_resolved(review_output)
             ]
             if missing_acknowledgements:
-                log(
-                    config,
-                    f"Planning round {round_number}: reviewer(s) {', '.join(missing_acknowledgements)} "
-                    "approved without acknowledging signed human requirements; "
-                    "re-injecting as blocking plan item",
+                hr_ids = _surfaced_reviewer_requirement_ids(
+                    issue_context.human_requirements,
+                    requirement_scope="planning requirements",
                 )
-                synthetic_review = (
-                    "Orchestrator plan review:\n\n"
-                    f"Reviewer(s) {', '.join(missing_acknowledgements)} approved without "
-                    "acknowledging the signed human requirements. Coder must address the "
-                    "human requirements and ensure the reviewer explicitly resolves them "
-                    "before plan approval."
-                )
-                blocking_reviews.append(("Orchestrator", synthetic_review))
-                round_new_unresolved_items.append(
-                    _next_unresolved_item(
-                        item_number=next_unresolved_item_number,
-                        reviewer="Orchestrator",
-                        source_round=round_number,
-                        text=(
-                            f"Reviewer(s) {', '.join(missing_acknowledgements)} approved without "
-                            "acknowledging the signed human requirements. Coder must address the "
-                            "human requirements and ensure the reviewer explicitly resolves them "
-                            "before plan approval."
-                        ),
-                        status="blocking",
+                still_missing = []
+                for reviewer_name, review_output in approved_review_outputs:
+                    if human_requirements_resolved(review_output):
+                        continue
+                    log(
+                        config,
+                        f"Planning round {round_number}: {reviewer_name} approved without "
+                        "HUMAN_REQUIREMENTS_RESOLVED; attempting repair",
                     )
-                )
-                next_unresolved_item_number += 1
-                unresolved_items = [*unresolved_items, round_new_unresolved_items[-1]]
-                must_fix_items = [
-                    item for item in unresolved_items if item.status in {"blocking", "same-plan"}
-                ]
-                all_approved = False
+                    repaired_text = attempt_repair(
+                        review_output,
+                        config.gemini_cmd,
+                        expected_kind="plan_review",
+                        reviewer_requirement_ids=hr_ids,
+                        allowed_prior_item_ids=tuple(
+                            item.item_id for item in prior_unresolved_items
+                        ),
+                    )
+                    if repaired_text is not None:
+                        try:
+                            repaired_parsed = _validate_plan_review_response(
+                                repaired_text,
+                                reviewer=reviewer_name,
+                                unresolved_items=prior_unresolved_items,
+                                current_round_items=round_new_unresolved_items,
+                            )
+                            if (
+                                repaired_parsed.state == "approved"
+                                and human_requirements_resolved(repaired_text)
+                            ):
+                                log(
+                                    config,
+                                    f"Planning round {round_number}: repair recovered "
+                                    f"HUMAN_REQUIREMENTS_RESOLVED for {reviewer_name}",
+                                )
+                                continue
+                            if repaired_parsed.state == "blocking":
+                                log(
+                                    config,
+                                    f"Planning round {round_number}: repair returned blocking for "
+                                    f"{reviewer_name}; treating as reviewer blocking",
+                                )
+                                blocking_reviews.append((reviewer_name, repaired_text))
+                                for item in repaired_parsed.items.blocking:
+                                    new_item = _next_unresolved_item(
+                                        item_number=next_unresolved_item_number,
+                                        reviewer=item.reviewer,
+                                        source_round=round_number,
+                                        text=item.text,
+                                        status="blocking",
+                                    )
+                                    round_new_unresolved_items.append(new_item)
+                                    unresolved_items = [*unresolved_items, new_item]
+                                    next_unresolved_item_number += 1
+                                all_approved = False
+                                must_fix_items = [
+                                    item for item in unresolved_items
+                                    if item.status in {"blocking", "same-plan"}
+                                ]
+                                continue
+                        except AgentLoopError:
+                            pass
+                    still_missing.append(reviewer_name)
+                if still_missing:
+                    log(
+                        config,
+                        f"Planning round {round_number}: reviewer(s) {', '.join(still_missing)} "
+                        "approved without acknowledging signed human requirements; "
+                        "re-injecting as blocking plan item",
+                    )
+                    synthetic_review = (
+                        "Orchestrator plan review:\n\n"
+                        f"Reviewer(s) {', '.join(still_missing)} approved without "
+                        "acknowledging the signed human requirements. Coder must address the "
+                        "human requirements and ensure the reviewer explicitly resolves them "
+                        "before plan approval."
+                    )
+                    blocking_reviews.append(("Orchestrator", synthetic_review))
+                    round_new_unresolved_items.append(
+                        _next_unresolved_item(
+                            item_number=next_unresolved_item_number,
+                            reviewer="Orchestrator",
+                            source_round=round_number,
+                            text=(
+                                f"Reviewer(s) {', '.join(still_missing)} approved without "
+                                "acknowledging the signed human requirements. Coder must address the "
+                                "human requirements and ensure the reviewer explicitly resolves them "
+                                "before plan approval."
+                            ),
+                            status="blocking",
+                        )
+                    )
+                    next_unresolved_item_number += 1
+                    unresolved_items = [*unresolved_items, round_new_unresolved_items[-1]]
+                    must_fix_items = [
+                        item for item in unresolved_items if item.status in {"blocking", "same-plan"}
+                    ]
+                    all_approved = False
 
         if all_approved:
             approved_future_followups.extend(round_approved_future_followups)
@@ -2226,30 +2305,97 @@ def run_pr_loop(
                         if not human_requirements_resolved(review_output)
                     ]
                     if missing_acknowledgements:
-                        log(
-                            config,
-                            f"Round {round_number}: reviewer(s) {', '.join(missing_acknowledgements)} "
-                            "approved without acknowledging signed human requirements; "
-                            "re-injecting as blocking item",
+                        hr_ids = _surfaced_reviewer_requirement_ids(
+                            human_requirements,
+                            requirement_scope="PR requirements",
                         )
-                        unresolved_items.append(
-                            _next_unresolved_item(
-                                item_number=next_unresolved_item_number,
-                                reviewer="Orchestrator",
-                                source_round=round_number,
-                                text=(
-                                    f"Reviewer(s) {', '.join(missing_acknowledgements)} approved without "
-                                    "acknowledging the signed human requirements. Coder must address the "
-                                    "human requirements and ensure the reviewer explicitly resolves them "
-                                    "before approval."
-                                ),
-                                status="blocking",
+                        still_missing = []
+                        for reviewer_name, review_output in approved_review_outputs:
+                            if human_requirements_resolved(review_output):
+                                continue
+                            log(
+                                config,
+                                f"Round {round_number}: {reviewer_name} approved without "
+                                "HUMAN_REQUIREMENTS_RESOLVED; attempting repair",
                             )
-                        )
-                        next_unresolved_item_number += 1
-                        must_fix_items = [
-                            item for item in unresolved_items if item.status in {"blocking", "same-pr"}
-                        ]
+                            repaired_text = attempt_repair(
+                                review_output,
+                                config.gemini_cmd,
+                                expected_kind="pr_review",
+                                reviewer_requirement_ids=hr_ids,
+                                allowed_prior_item_ids=tuple(
+                                    item.item_id for item in prior_unresolved_items
+                                ),
+                            )
+                            if repaired_text is not None:
+                                try:
+                                    repaired_parsed = _validate_review_response(
+                                        repaired_text,
+                                        reviewer=reviewer_name,
+                                        unresolved_items=prior_unresolved_items,
+                                        current_round_items=round_new_unresolved_items,
+                                    )
+                                    if (
+                                        repaired_parsed.state == "approved"
+                                        and human_requirements_resolved(repaired_text)
+                                    ):
+                                        log(
+                                            config,
+                                            f"Round {round_number}: repair recovered "
+                                            f"HUMAN_REQUIREMENTS_RESOLVED for {reviewer_name}",
+                                        )
+                                        continue
+                                    if repaired_parsed.state == "blocking":
+                                        log(
+                                            config,
+                                            f"Round {round_number}: repair returned blocking for "
+                                            f"{reviewer_name}; treating as reviewer blocking",
+                                        )
+                                        for item in repaired_parsed.blocking_items:
+                                            new_item = _next_unresolved_item(
+                                                item_number=next_unresolved_item_number,
+                                                reviewer=item.reviewer,
+                                                source_round=round_number,
+                                                text=item.text,
+                                                status="blocking",
+                                            )
+                                            round_new_unresolved_items.append(new_item)
+                                            unresolved_items.append(new_item)
+                                            next_unresolved_item_number += 1
+                                        all_approved = False
+                                        must_fix_items = [
+                                            item for item in unresolved_items
+                                            if item.status in {"blocking", "same-pr"}
+                                        ]
+                                        continue
+                                except AgentLoopError:
+                                    pass
+                            still_missing.append(reviewer_name)
+                        if still_missing:
+                            log(
+                                config,
+                                f"Round {round_number}: reviewer(s) {', '.join(still_missing)} "
+                                "approved without acknowledging signed human requirements; "
+                                "re-injecting as blocking item",
+                            )
+                            unresolved_items.append(
+                                _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer="Orchestrator",
+                                    source_round=round_number,
+                                    text=(
+                                        f"Reviewer(s) {', '.join(still_missing)} approved without "
+                                        "acknowledging the signed human requirements. Coder must address the "
+                                        "human requirements and ensure the reviewer explicitly resolves them "
+                                        "before approval."
+                                    ),
+                                    status="blocking",
+                                )
+                            )
+                            next_unresolved_item_number += 1
+                            must_fix_items = [
+                                item for item in unresolved_items if item.status in {"blocking", "same-pr"}
+                            ]
                 sync_coder_pr_before_validation(config, runner, pr_number, pr_metadata)
                 migration_validation = validate_pr_migration_topology(
                     runner,

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -485,7 +485,10 @@ Only genuinely independent later work should remain in future_followups on an ap
 
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
-2. After }: optional signed human requirements acknowledgement for plan_revision only, then <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
+2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,
+   place that marker immediately after the JSON and before the AGENT_STATE/AGENT_PLAN_STATE footer.
+   For `plan_revision`, place the optional signed human requirements acknowledgement before the footer.
+   Then: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
 3. JSON "state" matches X. Then: -- Agent Name. STOP. Nothing else.
 
 Output ONLY the repaired response. No explanations.

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -16,6 +16,13 @@ from .agents.gemini import _parse_gemini_payload
 
 _logger = logging.getLogger(__name__)
 
+# v13 prompt — adds repair guidance for human-requirements marker, active approved dispositions,
+# blocking+future dispositions, approved+current-plan future_followups, and same-round confusion:
+#   - _reviewer_human_requirements_instruction for pr_review/plan_review missing HUMAN_REQUIREMENTS_RESOLVED
+#   - STATE RULES updated: blocking reviews must explicitly disposition ALL allowed prior items; future forbidden
+#   - Worked Example 2 updated: shows explicit non-future disposition instead of omission
+#   - New state rules for approved+active dispositions, blocking+future, approved+current-plan future_followups
+#   - New Examples 6-12 covering all new repair scenarios
 # v12 prompt — adds explicit prior-item disposition repair context:
 #   - lists carried prior IDs that may be dispositioned
 #   - lists unknown prior-item disposition IDs that must be removed
@@ -38,6 +45,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 {coder_followup_required_items_instruction}
 
 {coder_followup_human_requirements_instruction}
+
+{reviewer_human_requirements_instruction}
 
 {prior_item_dispositions_instruction}
 
@@ -136,8 +145,22 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 - Do NOT include human requirement labels in addressed_items or remaining_items.
 
 ## STATE RULES (Format A/B):
-### APPROVED: blocking_items=[], same_pr_followups=[], prior dispositions only "resolved"/"future"
-### BLOCKING: future_followups=[], prior dispositions MUST NOT use "future"
+### APPROVED: blocking_items=[], same_pr_followups=[], prior dispositions only "resolved" or "future"
+### APPROVED + active same-pr/same-plan/blocking prior dispositions:
+  - If the note clearly says the current PR/plan already covers the item: change disposition to "resolved"
+  - If the item is genuinely still open: change state to "blocking" and keep the active disposition
+  - Never return "approved" with active same-pr, same-plan, or blocking prior dispositions
+### APPROVED with future_followups that are actually current-plan/PR concerns:
+  - Evaluate each entry in future_followups — genuinely deferred independent work may stay
+  - If any entry is actually required for the current plan/PR to be correct (not independent future work):
+    move it to blocking_plan_issues/blocking_items and change state to "blocking"
+  - Only genuinely independent later work may remain in future_followups on an approved review
+### BLOCKING: future_followups=[], ALL prior items in the allowed list must appear in prior_item_dispositions
+  - No item may be omitted, including items that were "future" in a prior round
+  - "future" disposition is forbidden in blocking reviews
+  - Only "blocking"/"same-pr"/"same-plan"/"resolved" are valid prior dispositions in blocking reviews
+### Invalid enum values: "still blocking" → "blocking", "still same-pr" → "same-pr",
+  "still same-plan" → "same-plan" — normalize without dropping any other items
 
 ## DEDUPE RULES (Format B):
 - Same-plan follow-ups and Future follow-ups are mutually exclusive.
@@ -179,9 +202,10 @@ The future item ("Consider improving contrast ratio") is DISCARDED. It can be ra
 
 ## WORKED EXAMPLE 2 — prior item already filed as "future", now in a blocking review:
 
-Original (malformed): blocking review, prior item-1 was already "future" in a previous round.
+Original (malformed): blocking review, prior item-1 was already "future" in a previous round,
+but item-1 is in the allowed carried prior item IDs list.
 
-CORRECT repair: OMIT item-1 from prior_item_dispositions entirely. Do not include it at all.
+CORRECT repair: include item-1 explicitly with a valid non-future disposition. Never omit it.
 {
   "schema_version": 1, "kind": "pr_review", "state": "blocking",
   "summary": "...",
@@ -189,13 +213,16 @@ CORRECT repair: OMIT item-1 from prior_item_dispositions entirely. Do not includ
   "same_pr_followups": ["Fix the CLI flag in error message"],
   "future_followups": [],
   "prior_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved", "note": "No longer relevant given current changes"},
     {"item_id": "item-2", "disposition": "same-pr", "note": "CLI flag still wrong"}
   ]
 }
 <!-- AGENT_STATE: blocking -->
 -- Reviewer
 
-item-1 is omitted because it was already "future" — it stays future without needing to be re-dispositioned.
+item-1 must appear because all allowed prior items must be explicitly dispositioned in blocking reviews.
+"future" is forbidden in blocking reviews. Use "resolved" if no longer relevant, "blocking" if it must
+be fixed now, or "same-pr"/"same-plan" if it still needs attention.
 
 ## WORKED EXAMPLE 3 — coder follow-up with JSON wrapped in fences and human requirements:
 
@@ -317,6 +344,145 @@ Notes:
 - Reviewer items belong in addressed_items / remaining_items, never in human_requirements.addressed_ids.
 - If surfaced signed labels include "Requirement 1" and the malformed response has ["Requirement 1", "Issue #221 acceptance criteria"], keep ["Requirement 1"] and drop "Issue #221 acceptance criteria".
 
+## WORKED EXAMPLE 6 — approved plan_review with same-plan disposition whose note says plan covers it:
+
+Original (malformed): approved plan_review, item-13 has disposition "same-plan" but note says "Plan now covers this".
+
+CORRECT repair: change disposition to "resolved", keep state "approved".
+{
+  "schema_version": 1, "kind": "plan_review", "state": "approved",
+  "summary": "...",
+  "blocking_plan_issues": [], "same_plan_followups": [], "future_followups": [],
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-13", "disposition": "resolved", "note": "Plan now covers this"}
+  ]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Reviewer
+
+## WORKED EXAMPLE 7 — approved plan_review with same-plan disposition, note says work remains:
+
+Original (malformed): approved plan_review, item-14 has disposition "same-plan" and note says work remains.
+
+CORRECT repair: change state to "blocking", keep the same-plan disposition.
+{
+  "schema_version": 1, "kind": "plan_review", "state": "blocking",
+  "summary": "...",
+  "blocking_plan_issues": [],
+  "same_plan_followups": [],
+  "future_followups": [],
+  "prior_plan_item_dispositions": [
+    {"item_id": "item-14", "disposition": "same-plan", "note": "Test count still not updated"}
+  ]
+}
+<!-- AGENT_PLAN_STATE: blocking -->
+-- Reviewer
+
+## WORKED EXAMPLE 8 — blocking pr_review with future_followups and a formerly-future allowed prior item:
+
+Original (malformed): blocking pr_review, has future_followups, prior item-1 was previously "future"
+and is in the allowed prior item IDs.
+
+CORRECT repair: remove future_followups, include item-1 with explicit non-future disposition.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": ["Fix the memory leak"],
+  "same_pr_followups": [],
+  "future_followups": [],
+  "prior_item_dispositions": [
+    {"item_id": "item-1", "disposition": "resolved", "note": "No longer applicable"},
+    {"item_id": "item-2", "disposition": "blocking", "note": "Memory leak is still present"}
+  ]
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+item-1 must appear explicitly; omitting it would fail validation.
+The future_followup entry is discarded; it can be raised again in a later round.
+
+## WORKED EXAMPLE 9 — "still blocking" invalid enum, all other items preserved:
+
+Original (malformed): pr_review with disposition "still blocking" instead of "blocking".
+
+CORRECT repair: normalize "still blocking" → "blocking"; preserve all other items unchanged.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": [],
+  "same_pr_followups": [],
+  "future_followups": [],
+  "prior_item_dispositions": [
+    {"item_id": "item-1", "disposition": "blocking", "note": "Still needs attention"},
+    {"item_id": "item-2", "disposition": "resolved"}
+  ]
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+Only the enum value is changed; no other items are dropped.
+
+## WORKED EXAMPLE 10 — approved review missing HUMAN_REQUIREMENTS_RESOLVED, requirements satisfied:
+
+Original (malformed): approved pr_review with all requirements satisfied but missing the marker.
+The repair context surfaced: Requirement 1.
+
+CORRECT repair: keep state "approved", add <!-- HUMAN_REQUIREMENTS_RESOLVED --> after the JSON.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "approved",
+  "summary": "...",
+  "blocking_items": [], "same_pr_followups": [], "future_followups": [],
+  "prior_item_dispositions": []
+}
+<!-- HUMAN_REQUIREMENTS_RESOLVED -->
+<!-- AGENT_STATE: approved -->
+-- Reviewer
+
+## WORKED EXAMPLE 11 — approved review missing HUMAN_REQUIREMENTS_RESOLVED, requirement unresolved:
+
+Original (malformed): approved pr_review but Requirement 1 is not satisfied by the current PR.
+The repair context surfaced: Requirement 1.
+
+CORRECT repair: change state to "blocking", add a concrete blocking_item naming the requirement.
+{
+  "schema_version": 1, "kind": "pr_review", "state": "blocking",
+  "summary": "...",
+  "blocking_items": ["Requirement 1 is not satisfied: the PR must use absolute URLs as required."],
+  "same_pr_followups": [],
+  "future_followups": [],
+  "prior_item_dispositions": []
+}
+<!-- AGENT_STATE: blocking -->
+-- Reviewer
+
+Do NOT add <!-- HUMAN_REQUIREMENTS_RESOLVED --> when blocking.
+
+## WORKED EXAMPLE 12 — approved plan_review with same-round item in prior_plan_item_dispositions
+and current-plan concerns in future_followups:
+
+Original (malformed): approved plan_review with prior_plan_item_dispositions containing item-1
+(which is a same-round finding, not a carried prior item — allowed_prior_item_ids is empty),
+and future_followups containing current-plan validation details that are not genuinely deferred.
+
+CORRECT repair: remove the invalid same-round disposition, promote current-plan concerns to
+blocking_plan_issues, change state to "blocking".
+{
+  "schema_version": 1, "kind": "plan_review", "state": "blocking",
+  "summary": "...",
+  "blocking_plan_issues": [
+    "The repair examples and validators for already-future prior items must be reconciled."
+  ],
+  "same_plan_followups": [],
+  "future_followups": [],
+  "prior_plan_item_dispositions": []
+}
+<!-- AGENT_PLAN_STATE: blocking -->
+-- Reviewer
+
+item-1 is removed because it was a same-round finding, not an eligible carried prior item.
+The future_followups entry is moved to blocking_plan_issues because it concerns current-plan correctness.
+Only genuinely independent later work should remain in future_followups on an approved review.
+
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: optional signed human requirements acknowledgement for plan_revision only, then <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
@@ -372,6 +538,32 @@ def _coder_followup_human_requirements_instruction(
     )
 
 
+def _reviewer_human_requirements_instruction(
+    expected_kind: str | None,
+    reviewer_requirement_ids: Sequence[str] | None,
+) -> str:
+    if reviewer_requirement_ids is None:
+        return ""
+    if expected_kind not in {"pr_review", "plan_review"}:
+        raise ValueError("reviewer_requirement_ids may only be used for pr_review or plan_review repair")
+    rendered_ids = "\n".join(f"- `{req_id}`" for req_id in reviewer_requirement_ids)
+    if not reviewer_requirement_ids:
+        rendered_ids = "- (none)"
+    state_marker = "AGENT_STATE" if expected_kind == "pr_review" else "AGENT_PLAN_STATE"
+    blocking_field = "blocking_items" if expected_kind == "pr_review" else "blocking_plan_issues"
+    return (
+        "## Signed human requirements missing acknowledgement:\n"
+        "This approved review is missing <!-- HUMAN_REQUIREMENTS_RESOLVED -->.\n"
+        f"Surfaced signed human requirements:\n{rendered_ids}\n"
+        "For each listed requirement, confirm whether the current plan/PR satisfies it.\n"
+        "If ALL requirements are satisfied: keep state `approved` and add "
+        f"`<!-- HUMAN_REQUIREMENTS_RESOLVED -->` after the JSON and before the `<!-- {state_marker}: approved -->` footer.\n"
+        "If ANY requirement is NOT satisfied: change state to `blocking` and add a concrete "
+        f"`{blocking_field}` entry naming the unresolved requirement. "
+        "Do NOT add `<!-- HUMAN_REQUIREMENTS_RESOLVED -->` when blocking.\n"
+    )
+
+
 def _repair_prior_item_ids_instruction(
     allowed_prior_item_ids: Sequence[str] | None,
     unknown_prior_item_ids: Sequence[str] | None,
@@ -406,6 +598,7 @@ def attempt_repair(
     expected_kind: str | None = None,
     unresolved_item_ids: Sequence[str] | None = None,
     surfaced_requirement_ids: Sequence[str] | None = None,
+    reviewer_requirement_ids: Sequence[str] | None = None,
     allowed_prior_item_ids: Sequence[str] | None = None,
     unknown_prior_item_ids: Sequence[str] | None = None,
     same_round_context: str | None = None,
@@ -425,6 +618,10 @@ def attempt_repair(
     coder_followup_human_requirements_instruction = _coder_followup_human_requirements_instruction(
         expected_kind,
         surfaced_requirement_ids,
+    )
+    reviewer_human_requirements_instr = _reviewer_human_requirements_instruction(
+        expected_kind,
+        reviewer_requirement_ids,
     )
     prior_item_dispositions_instruction = _repair_prior_item_ids_instruction(
         allowed_prior_item_ids,
@@ -446,6 +643,11 @@ def attempt_repair(
     prompt = prompt.replace(
         "{coder_followup_human_requirements_instruction}",
         coder_followup_human_requirements_instruction,
+        1,
+    )
+    prompt = prompt.replace(
+        "{reviewer_human_requirements_instruction}",
+        reviewer_human_requirements_instr,
         1,
     )
     prompt = prompt.replace(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -13756,3 +13756,574 @@ def test_repair_prompt_does_not_suggest_ack_pseudo_item_in_addressed_items():
     # any mention of it in an addressed_items context will teach Gemini to produce
     # responses that the validator rejects.
     assert HUMAN_REQUIREMENTS_ACK_ITEM_ID not in _REPAIR_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# New tests for issue #246: repair approved reviews with active prior dispositions
+# ---------------------------------------------------------------------------
+
+from coding_review_agent_loop.repair import (
+    _reviewer_human_requirements_instruction,
+)
+from coding_review_agent_loop.orchestrator import _surfaced_reviewer_requirement_ids
+
+
+# --- repair.py prompt content tests ---
+
+def test_repair_prompt_blocking_state_rules_require_explicit_prior_dispositions():
+    """STATE RULES for BLOCKING must prohibit omitting allowed prior items."""
+    assert "ALL prior items in the allowed list must appear in prior_item_dispositions" in _REPAIR_PROMPT
+    assert "No item may be omitted" in _REPAIR_PROMPT or "no item may be omitted" in _REPAIR_PROMPT.lower()
+    assert '"future" is forbidden in blocking reviews' in _REPAIR_PROMPT or "future\" is forbidden in blocking" in _REPAIR_PROMPT
+
+
+def test_repair_example_2_no_longer_says_omit():
+    """Worked Example 2 must not instruct omission of formerly-future prior items."""
+    assert "OMIT item-1 from prior_item_dispositions entirely" not in _REPAIR_PROMPT
+    assert "WORKED EXAMPLE 2" in _REPAIR_PROMPT
+    assert "must appear" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_includes_approved_plus_active_disposition_rules():
+    """STATE RULES must cover approved + active same-pr/same-plan/blocking dispositions."""
+    assert "APPROVED + active same-pr/same-plan/blocking prior dispositions" in _REPAIR_PROMPT
+    assert 'change disposition to "resolved"' in _REPAIR_PROMPT
+
+
+def test_repair_prompt_includes_approved_future_followups_current_plan_rule():
+    """STATE RULES must cover approved reviews with current-plan concerns in future_followups."""
+    assert "future_followups that are actually current-plan" in _REPAIR_PROMPT or \
+           "future_followups" in _REPAIR_PROMPT and "required for the current plan" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_includes_worked_example_6_to_12():
+    """Examples 6-12 must be present."""
+    for n in range(6, 13):
+        assert f"WORKED EXAMPLE {n}" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_example_12_same_round_confusion_case():
+    """Example 12 must describe the same-round disposition confusion with future_followups."""
+    assert "WORKED EXAMPLE 12" in _REPAIR_PROMPT
+    assert "same-round" in _REPAIR_PROMPT.lower() or "same-round finding" in _REPAIR_PROMPT.lower()
+    assert "future_followups" in _REPAIR_PROMPT
+
+
+# --- _reviewer_human_requirements_instruction tests ---
+
+def test_reviewer_human_requirements_instruction_pr_review():
+    result = _reviewer_human_requirements_instruction("pr_review", ["Requirement 1", "Requirement 2"])
+    assert "HUMAN_REQUIREMENTS_RESOLVED" in result
+    assert "Requirement 1" in result
+    assert "Requirement 2" in result
+    assert "AGENT_STATE" in result
+    assert "blocking_items" in result
+
+
+def test_reviewer_human_requirements_instruction_plan_review():
+    result = _reviewer_human_requirements_instruction("plan_review", ["Requirement 1"])
+    assert "HUMAN_REQUIREMENTS_RESOLVED" in result
+    assert "Requirement 1" in result
+    assert "AGENT_PLAN_STATE" in result
+    assert "blocking_plan_issues" in result
+
+
+def test_reviewer_human_requirements_instruction_empty_ids():
+    result = _reviewer_human_requirements_instruction("pr_review", [])
+    assert "(none)" in result
+    assert "HUMAN_REQUIREMENTS_RESOLVED" in result
+
+
+def test_reviewer_human_requirements_instruction_returns_empty_for_none():
+    assert _reviewer_human_requirements_instruction("pr_review", None) == ""
+    assert _reviewer_human_requirements_instruction("plan_review", None) == ""
+
+
+def test_reviewer_human_requirements_instruction_rejects_coder_kind():
+    with pytest.raises(ValueError, match="reviewer_requirement_ids"):
+        _reviewer_human_requirements_instruction("coder_followup", ["Requirement 1"])
+
+
+def test_attempt_repair_includes_reviewer_requirement_instruction():
+    """attempt_repair passes reviewer_requirement_ids into the prompt for pr_review."""
+    repaired = structured_pr_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=True,
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        attempt_repair(
+            "malformed review",
+            "gemini",
+            expected_kind="pr_review",
+            reviewer_requirement_ids=["Requirement 1", "Requirement 2"],
+        )
+
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert "Requirement 1" in prompt
+    assert "Requirement 2" in prompt
+    assert "HUMAN_REQUIREMENTS_RESOLVED" in prompt
+    assert "AGENT_STATE" in prompt
+
+
+def test_attempt_repair_reviewer_requirement_ids_not_included_for_plan_revision():
+    """reviewer_requirement_ids raises for non pr_review/plan_review kinds."""
+    with pytest.raises(ValueError, match="reviewer_requirement_ids"):
+        attempt_repair(
+            "malformed plan revision",
+            "gemini",
+            expected_kind="plan_revision",
+            reviewer_requirement_ids=["Requirement 1"],
+        )
+
+
+# --- _surfaced_reviewer_requirement_ids tests ---
+
+def test_surfaced_reviewer_requirement_ids_pr_uses_merged_requirements():
+    """PR loop helper returns IDs using PR requirements scope."""
+    hr = (
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="maintainer",
+            created_at="2026-01-01T00:00:00Z",
+            url="https://example.com/1",
+            body="Use absolute URLs.",
+        ),
+    )
+    ids = _surfaced_reviewer_requirement_ids(hr, requirement_scope="PR requirements")
+    assert ids == ("Requirement 1",)
+
+
+def test_surfaced_reviewer_requirement_ids_plan_uses_issue_requirements():
+    """Plan loop helper returns IDs using planning requirements scope."""
+    hr = (
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="maintainer",
+            created_at="2026-01-01T00:00:00Z",
+            url="https://example.com/1",
+            body="Add regression tests.",
+        ),
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="maintainer",
+            created_at="2026-01-02T00:00:00Z",
+            url="https://example.com/2",
+            body="Keep backward compatibility.",
+        ),
+    )
+    ids = _surfaced_reviewer_requirement_ids(hr, requirement_scope="planning requirements")
+    assert "Requirement 1" in ids
+    assert "Requirement 2" in ids
+
+
+def test_surfaced_reviewer_requirement_ids_empty_for_no_requirements():
+    ids = _surfaced_reviewer_requirement_ids([], requirement_scope="PR requirements")
+    assert ids == ()
+
+
+# --- PR loop repair-first tests ---
+
+def _pr_payload_with_human_requirement():
+    return {
+        "number": 77,
+        "state": "OPEN",
+        "url": "https://github.com/OWNER/REPO/pull/77",
+        "title": "Improve review prompt context",
+        "headRefName": "feature/review-context",
+        "baseRefName": "main",
+        "headRefOid": "abc123",
+        "comments": [
+            {
+                "author": {"login": "maintainer"},
+                "createdAt": "2026-05-18T10:00:00Z",
+                "url": "https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                "body": "Please use the absolute URL.\n\n-- Human Reviewer",
+            }
+        ],
+        "reviews": [],
+    }
+
+
+def test_pr_loop_repair_missing_hr_marker_recovers_approved(tmp_path):
+    """When repair returns approved + HUMAN_REQUIREMENTS_RESOLVED, no synthetic item is injected."""
+    approved_without_marker = structured_pr_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    repaired_with_marker = structured_pr_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=True,
+    )
+    runner = FakeRunner(
+        codex_outputs=[approved_without_marker],
+        pr_payload=_pr_payload_with_human_requirement(),
+    )
+    config = make_config(tmp_path, max_rounds=1)
+
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, reviewer_requirement_ids=None, **kwargs):
+        assert expected_kind == "pr_review"
+        assert reviewer_requirement_ids == ("Requirement 1",)
+        return repaired_with_marker
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert claude_calls == [], "Coder should not be woken when repair recovers the marker"
+
+
+def test_pr_loop_repair_missing_hr_marker_returns_blocking_not_synthetic(tmp_path):
+    """When repair returns valid blocking, treat as reviewer blocking — no synthetic item."""
+    approved_without_marker = structured_pr_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    repaired_blocking = structured_pr_review(
+        state="blocking",
+        summary="Requirement 1 not satisfied: absolute URL missing.",
+        blocking_items=["Requirement 1 not satisfied: absolute URL missing."],
+        reviewer="OpenAI Codex",
+    )
+    # Round 2: coder addresses item-1 (the repaired blocking item) + acks human requirements
+    coder_response = structured_coder_followup(
+        state="approved",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Requirement 1"],
+        reviewer="Anthropic Claude",
+    )
+    runner = FakeRunner(
+        claude_outputs=[coder_response],
+        codex_outputs=[
+            approved_without_marker,
+            structured_pr_review(
+                state="approved",
+                reviewer="OpenAI Codex",
+                human_requirements_resolved=True,
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        pr_payload=_pr_payload_with_human_requirement(),
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    pr_review_repair_calls = []
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, reviewer_requirement_ids=None, **kwargs):
+        if expected_kind == "pr_review" and reviewer_requirement_ids is not None:
+            pr_review_repair_calls.append(raw)
+            return repaired_blocking
+        return None  # don't interfere with coder_followup repair
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    assert pr_review_repair_calls, "Repair should have been attempted for the reviewer"
+    # The repaired blocking item text should appear in a coder prompt
+    claude_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert any("absolute URL missing" in p for p in claude_prompts), \
+        "Repaired blocking item should appear in coder prompt"
+    # There should be no synthetic Orchestrator item text
+    assert not any("Orchestrator" in p and "acknowledging the signed human requirements" in p
+                   for p in claude_prompts), \
+        "Synthetic orchestrator item must not appear when repair returned valid blocking"
+
+
+def test_pr_loop_repair_missing_hr_marker_failure_uses_synthetic(tmp_path):
+    """When repair fails (returns None), synthetic blocking item is injected."""
+    approved_without_marker = structured_pr_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    runner = FakeRunner(
+        codex_outputs=[approved_without_marker],
+        pr_payload=_pr_payload_with_human_requirement(),
+    )
+    config = make_config(tmp_path, max_rounds=1)
+
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, **kwargs):
+        return None  # repair fails
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+
+
+# --- Plan loop repair-first tests ---
+
+def _issue_with_human_requirement():
+    return {
+        "author": {"login": "maintainer"},
+        "createdAt": "2026-05-17T08:00:00Z",
+        "body": "Keep the public API unchanged.\n\n-- Human Reviewer",
+    }
+
+
+def test_plan_loop_repair_missing_hr_marker_recovers_approved(tmp_path):
+    """Plan loop: repair returning approved+marker suppresses synthetic."""
+    plan = (
+        "Initial plan.\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: keep the public API unchanged.\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    approved_without_marker = structured_plan_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    repaired_with_marker = structured_plan_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=True,
+    )
+    runner = FakeRunner(
+        issue_payload=_issue_with_human_requirement(),
+        claude_outputs=[plan],
+        codex_outputs=[approved_without_marker],
+    )
+    config = make_config(tmp_path)
+
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, reviewer_requirement_ids=None, **kwargs):
+        assert expected_kind == "plan_review"
+        assert reviewer_requirement_ids == ("Requirement 1",)
+        return repaired_with_marker
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    # No second claude call needed (no synthetic blocking item)
+    plan_revision_calls = [
+        cmd for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and runner.claude_outputs == []
+    ]
+    # Verify plan approved comment was posted
+    assert any("Approved plan:" in comment for comment in runner.comments)
+
+
+def test_plan_loop_repair_missing_hr_marker_returns_blocking_not_synthetic(tmp_path):
+    """Plan loop: repair returning blocking is treated as reviewer's blocking, not synthetic."""
+    plan = (
+        "Initial plan.\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: keep the public API unchanged.\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    approved_without_marker = structured_plan_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    repaired_blocking = structured_plan_review(
+        state="blocking",
+        summary="Requirement 1 not satisfied: plan changes the public API.",
+        blocking_plan_issues=["Requirement 1 not satisfied: plan changes the public API."],
+        reviewer="OpenAI Codex",
+    )
+    revision = structured_plan_revision(
+        summary="Revised plan preserving the public API.",
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        human_requirements=(
+            "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves the public API.\n"
+        ),
+    )
+    runner = FakeRunner(
+        issue_payload=_issue_with_human_requirement(),
+        claude_outputs=[plan, revision],
+        codex_outputs=[
+            approved_without_marker,
+            structured_plan_review(
+                summary="Plan looks sound.",
+                human_requirements_resolved=True,
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=3)
+
+    call_count = [0]
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, reviewer_requirement_ids=None, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return repaired_blocking
+        return None  # subsequent calls not needed
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    # Confirm the repaired blocking item text reached the coder
+    claude_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert any("plan changes the public API" in p for p in claude_prompts), \
+        "Repaired blocking item text must appear in coder prompt"
+    # No synthetic orchestrator text
+    assert not any("Orchestrator" in p and "acknowledging the signed human requirements" in p
+                   for p in claude_prompts), \
+        "Synthetic orchestrator item must not appear when repair returned valid blocking"
+
+
+def test_plan_loop_repair_missing_hr_marker_failure_uses_synthetic(tmp_path):
+    """Plan loop: when repair fails, synthetic blocking item is injected."""
+    plan = (
+        "Initial plan.\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: keep the public API unchanged.\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    approved_without_marker = structured_plan_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    revision = structured_plan_revision(
+        summary="Revised plan.",
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        human_requirements=(
+            "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves the public API.\n"
+        ),
+    )
+    runner = FakeRunner(
+        issue_payload=_issue_with_human_requirement(),
+        claude_outputs=[plan, revision],
+        codex_outputs=[
+            approved_without_marker,
+            structured_plan_review(
+                summary="Plan looks sound.",
+                human_requirements_resolved=True,
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=3)
+
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, **kwargs):
+        return None  # repair fails
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    # The synthetic item must have been injected (coder was woken with it)
+    claude_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert any("acknowledging the signed human requirements" in p for p in claude_prompts), \
+        "Synthetic item must appear in coder prompt when repair fails"
+
+
+# --- Protocol regression tests ---
+
+def test_parse_pr_review_rejects_approved_with_same_pr_active_disposition():
+    """Approved PR review with active same-pr disposition must fail validation."""
+    malformed = structured_pr_review(
+        state="approved",
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "same-pr", "note": "Still needed"}],
+    )
+    with pytest.raises(AgentLoopError, match="Approved reviews must be fully complete"):
+        parse_pr_review(malformed, reviewer="OpenAI Codex")
+
+
+def test_parse_plan_review_rejects_blocking_with_future_disposition_on_prior_item():
+    """Blocking plan review with future prior disposition must fail validation."""
+    malformed = structured_plan_review(
+        state="blocking",
+        blocking_plan_issues=["Something is wrong."],
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "future"}],
+    )
+    with pytest.raises(AgentLoopError, match="[Ff]uture"):
+        parse_plan_review(malformed, reviewer="OpenAI Codex")
+
+
+def test_repair_blocking_formerly_future_prior_item_explicit_disposition():
+    """Repair of blocking review with formerly-future prior item produces explicit non-future disposition."""
+    malformed = (
+        json.dumps({
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "blocking",
+            "summary": "Fix the memory leak.",
+            "blocking_items": ["Fix the memory leak"],
+            "same_pr_followups": [],
+            "future_followups": [],
+            "prior_item_dispositions": [
+                {"item_id": "item-1", "disposition": "future"},
+            ],
+        })
+        + "\n<!-- AGENT_STATE: blocking -->\n-- Reviewer"
+    )
+    repaired = structured_pr_review(
+        state="blocking",
+        blocking_items=["Fix the memory leak"],
+        prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        reviewer="Reviewer",
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            malformed,
+            "gemini",
+            expected_kind="pr_review",
+            allowed_prior_item_ids=["item-1"],
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    # Verify the prompt contains the guidance about explicitly dispositioning prior items
+    assert "must appear in prior_item_dispositions" in prompt or "prior_item_dispositions" in prompt
+    assert "item-1" in prompt
+
+
+def test_repair_same_round_disposition_confusion_promotes_to_blocking():
+    """Repair prompt instructs removing same-round dispositions and promoting current concerns."""
+    malformed = structured_plan_review(
+        state="approved",
+        future_followups=["Reconcile repair examples and validators."],
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+    )
+    repaired = structured_plan_review(
+        state="blocking",
+        blocking_plan_issues=["Reconcile repair examples and validators."],
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        result = attempt_repair(
+            malformed,
+            "gemini",
+            expected_kind="plan_review",
+            allowed_prior_item_ids=[],
+            unknown_prior_item_ids=["item-1"],
+            same_round_context="item-1 matches a same-round finding, not a carried prior item.",
+        )
+
+    assert result == repaired
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    # The same-round context should appear in the prompt
+    assert "same-round finding" in prompt
+    # The guidance about future_followups promoting to blocking should be in STATE RULES
+    assert "future_followups" in prompt

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -14327,3 +14327,123 @@ def test_repair_same_round_disposition_confusion_promotes_to_blocking():
     assert "same-round finding" in prompt
     # The guidance about future_followups promoting to blocking should be in STATE RULES
     assert "future_followups" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Round 2 follow-up tests: same-pr/same-plan followup recording and FORMAT fix
+# ---------------------------------------------------------------------------
+
+def test_repair_prompt_format_rule_allows_human_requirements_resolved_for_pr_plan_review():
+    """FORMAT rule must permit HUMAN_REQUIREMENTS_RESOLVED for pr_review/plan_review, not just plan_revision."""
+    assert "pr_review" in _REPAIR_PROMPT or "HUMAN_REQUIREMENTS_RESOLVED" in _REPAIR_PROMPT
+    # Ensure the FORMAT rule no longer says "plan_revision only"
+    assert "for plan_revision only" not in _REPAIR_PROMPT
+
+
+def test_pr_loop_repair_blocking_records_same_pr_followups(tmp_path):
+    """When repair returns blocking with same_pr_followups, those are recorded as same-pr items."""
+    approved_without_marker = structured_pr_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    repaired_blocking = structured_pr_review(
+        state="blocking",
+        same_pr_followups=["Fix the error message formatting."],
+        reviewer="OpenAI Codex",
+    )
+    # Coder addresses item-1 (same-pr followup)
+    coder_response = structured_coder_followup(
+        state="approved",
+        addressed_items=["item-1"],
+        remaining_items=[],
+        human_requirement_ids=["Requirement 1"],
+        reviewer="Anthropic Claude",
+    )
+    runner = FakeRunner(
+        claude_outputs=[coder_response],
+        codex_outputs=[
+            approved_without_marker,
+            structured_pr_review(
+                state="approved",
+                reviewer="OpenAI Codex",
+                human_requirements_resolved=True,
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        pr_payload=_pr_payload_with_human_requirement(),
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, reviewer_requirement_ids=None, **kwargs):
+        if expected_kind == "pr_review" and reviewer_requirement_ids is not None:
+            return repaired_blocking
+        return None
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    # The same-pr followup text must appear in the coder's prompt
+    claude_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert any("error message formatting" in p for p in claude_prompts), \
+        "Same-PR followup from repaired review must appear in coder prompt"
+
+
+def test_plan_loop_repair_blocking_records_same_plan_followups(tmp_path):
+    """When repair returns blocking with same_plan_followups, those are recorded as same-plan items."""
+    plan = (
+        "Initial plan.\n"
+        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: keep the public API unchanged.\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    approved_without_marker = structured_plan_review(
+        state="approved",
+        reviewer="OpenAI Codex",
+        human_requirements_resolved=False,
+    )
+    repaired_blocking = structured_plan_review(
+        state="blocking",
+        same_plan_followups=["Add a regression test for the parser edge case."],
+        reviewer="OpenAI Codex",
+    )
+    revision = structured_plan_revision(
+        summary="Revised plan with regression test.",
+        prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+        human_requirements=(
+            "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"
+            "### Human requirements\n"
+            "- Requirement 1: the plan preserves the public API.\n"
+        ),
+    )
+    runner = FakeRunner(
+        issue_payload=_issue_with_human_requirement(),
+        claude_outputs=[plan, revision],
+        codex_outputs=[
+            approved_without_marker,
+            structured_plan_review(
+                summary="Plan looks sound.",
+                human_requirements_resolved=True,
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=3)
+
+    call_count = [0]
+    def fake_repair(raw, gemini_cmd, *, expected_kind=None, reviewer_requirement_ids=None, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1 and expected_kind == "plan_review":
+            return repaired_blocking
+        return None
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_repair):
+        result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    # The same-plan followup text must appear in the coder's prompt
+    claude_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert any("regression test for the parser" in p for p in claude_prompts), \
+        "Same-plan followup from repaired review must appear in coder prompt"


### PR DESCRIPTION
Fixes #246

## Summary

- **`repair.py` (v13)**: Adds `_reviewer_human_requirements_instruction` helper for `pr_review`/`plan_review` repair when `HUMAN_REQUIREMENTS_RESOLVED` is missing. Fixes the STATE RULES: blocking reviews must now explicitly disposition all allowed prior items (including formerly-future ones) — the previous "OMIT item-1" instruction in Example 2 was wrong because validators require all prior items to be present. Adds new state rules for: approved+active dispositions, blocking+future, and approved reviews with current-plan concerns in `future_followups` (Requirement 2). Adds Examples 6-12. Bumps to v13.

- **`orchestrator.py`**: Adds `_surfaced_reviewer_requirement_ids(human_requirements, *, requirement_scope)` helper called with correct scope at each site (PR loop uses merged requirements + `"PR requirements"`, plan loop uses `issue_context.human_requirements` + `"planning requirements"`). Replaces the direct synthetic blocking injection in both `run_pr_loop` and `_run_plan_first_loop` with repair-first logic: attempt repair for each approved reviewer missing `HUMAN_REQUIREMENTS_RESOLVED`; if repair returns `approved+marker` → count as resolved (no synthetic); if repair returns valid `blocking` → treat as the reviewer's own blocking outcome (record its items, wake coder); inject synthetic only when repair fails or produces invalid output.

- **`tests/test_agent_loop.py`**: 26 new tests covering all new code paths.

## Test plan

- [x] All 618 tests pass locally (`python -m pytest tests/test_agent_loop.py -q`)
- [x] New tests cover: repair-first in PR loop (approved recovery, blocking outcome, failure fallback), repair-first in plan loop (same three), `_surfaced_reviewer_requirement_ids` scoping, prompt content assertions, protocol regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)