### PR TITLE
Add compact PR review context mode

### DIFF
--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -263,6 +263,16 @@ def build_parser() -> argparse.ArgumentParser:
                 "context after the first complete planning round (default: compact)."
             ),
         )
+        subparser.add_argument(
+            "--pr-review-context-mode",
+            choices=("full", "compact"),
+            default="full",
+            help=(
+                "PR review prompt context mode. Compact omits raw prior PR-review "
+                "transcript from round 2 onward, sending only a structured summary "
+                "(default: full)."
+            ),
+        )
 
     issue = subparsers.add_parser("issue", help="Ask the coder to fix an issue, then review it.")
     issue.add_argument("issue_number", type=int)

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -56,6 +56,7 @@ class AgentLoopConfig:
     approved_followups: str = "ignore"
     plan_execution_mode: str = "plan-only"
     planning_context_mode: str = "compact"
+    pr_review_context_mode: str = "full"
     auto_agent_dirs: tuple[AgentName, ...] = ()
 
     def __post_init__(self) -> None:
@@ -63,6 +64,8 @@ class AgentLoopConfig:
             object.__setattr__(self, "reviewer", (self.reviewer,))
         if self.planning_context_mode not in {"full", "compact"}:
             raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")
+        if self.pr_review_context_mode not in {"full", "compact"}:
+            raise AgentLoopError("--pr-review-context-mode must be either 'full' or 'compact'.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -518,5 +521,6 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         approved_followups=args.approved_followups,
         plan_execution_mode=getattr(args, "plan_execution_mode", None) or "plan-only",
         planning_context_mode=getattr(args, "planning_context_mode", None) or "compact",
+        pr_review_context_mode=getattr(args, "pr_review_context_mode", None) or "full",
         auto_agent_dirs=auto_agent_dirs,
     )

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -29,6 +29,7 @@ class PullRequestMetadata:
     base_branch: str | None
     head_sha: str | None
     url: str | None
+    body: str | None = None
 
 
 @dataclass(frozen=True)
@@ -85,7 +86,7 @@ class PullRequestChecks:
     branch_protection_note: str | None = None
 
 
-PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url"
+PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url,body"
 PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
 ISSUE_REFERENCE_RE_TEMPLATE = r"(?:#%d\b|/issues/%d\b)"
 
@@ -170,6 +171,7 @@ def _parse_pr_metadata(
         base_branch=_optional_str(data.get("baseRefName")),
         head_sha=_optional_str(data.get("headRefOid")),
         url=_optional_str(data.get("url")),
+        body=_optional_str(data.get("body")),
     )
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -52,6 +52,7 @@ from .migrations import validate_pr_migration_topology
 from .prompts import (
     CompactPlanTailContext,
     CompactPriorContext,
+    CompactPrReviewTailContext,
     build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
@@ -85,6 +86,7 @@ from .protocol import (
     review_freeform_summary_text,
     normalize_response_file_structured_text,
     validate_human_requirements_acknowledgement,
+    validate_structured_coder_followup,
     validate_structured_plan_revision,
 )
 from .protocol import ApprovedFollowup, parse_review
@@ -2015,6 +2017,26 @@ def run_task_loop(
             _persist_usage_summary(config, usage_context)
 
 
+def _extract_structured_coder_summary(text: str | None) -> str | None:
+    if not text:
+        return None
+    try:
+        parsed = validate_structured_coder_followup(text)
+        return parsed.summary if parsed else None
+    except AgentLoopError:
+        return None
+
+
+def _extract_structured_coder_tests_run(text: str | None) -> tuple[str, ...] | None:
+    if not text:
+        return None
+    try:
+        parsed = validate_structured_coder_followup(text)
+        return parsed.tests_run if parsed else None
+    except AgentLoopError:
+        return None
+
+
 def run_pr_loop(
     runner: Runner,
     *,
@@ -2038,6 +2060,7 @@ def run_pr_loop(
         reviewer_session_ids: dict[AgentName, str | None] = {}
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
+        pr_compact_prior_summaries: list[str] = []
         latest_coder_output: str | None = None
         next_unresolved_item_number = 1
         start_round_number = 1
@@ -2055,6 +2078,7 @@ def run_pr_loop(
         )
         if resumed_round is not None:
             unresolved_items = list(resumed_round.prior_items)
+            pr_compact_prior_summaries = list(resumed_round.compact_prior_summaries)
             latest_coder_output = resumed_round.coder_output
             next_unresolved_item_number = resumed_round.next_unresolved_item_number
             start_round_number = resumed_round.round_number
@@ -2095,6 +2119,21 @@ def run_pr_loop(
                 flow="pr",
                 current_subject=current_pr_subject,
             )
+            use_compact_pr_context = (
+                config.pr_review_context_mode == "compact"
+                and round_number >= 2
+                and not round_ledger_incomplete
+            )
+            compact_coder_summary = (
+                _extract_structured_coder_summary(latest_coder_output)
+                if use_compact_pr_context
+                else None
+            )
+            compact_coder_tests_run = (
+                _extract_structured_coder_tests_run(latest_coder_output)
+                if use_compact_pr_context
+                else None
+            )
             approved_review_outputs: list[tuple[str, str]] = []
             pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
             resumed_by_name = {
@@ -2117,8 +2156,21 @@ def run_pr_loop(
                     reviewer_new_unresolved_items = list(resumed_record.metadata.new_items)
                     log(config, f"Round {round_number}: resuming {reviewer_name}'s completed review")
                 else:
-                    log(config, f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number}")
+                    context_mode = "compact" if use_compact_pr_context else "full"
+                    log(
+                        config,
+                        f"Round {round_number}: {reviewer_name} reviewing PR #{pr_number} "
+                        f"(context mode: {context_mode})",
+                    )
                     sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
+                    compact_tail = (
+                        CompactPrReviewTailContext(
+                            head_sha=pr_metadata.head_sha,
+                            round_number=round_number,
+                        )
+                        if use_compact_pr_context
+                        else None
+                    )
                     review_response = _run_validated_agent(
                         runner,
                         agent=reviewer,
@@ -2134,8 +2186,17 @@ def run_pr_loop(
                             issue_context=issue_context,
                             human_requirements=human_requirements,
                             unresolved_items=prior_unresolved_items,
+                            compact_context=use_compact_pr_context,
+                            compact_prior=(
+                                CompactPriorContext(tuple(pr_compact_prior_summaries))
+                                if use_compact_pr_context
+                                else None
+                            ),
+                            compact_tail=compact_tail,
+                            compact_coder_summary=compact_coder_summary,
+                            compact_coder_tests_run=compact_coder_tests_run,
                         ),
-                        session_id=reviewer_session_ids.get(reviewer),
+                        session_id=None if use_compact_pr_context else reviewer_session_ids.get(reviewer),
                         marker_description="<!-- AGENT_STATE: approved|blocking -->",
                         validate=lambda text, reviewer_name=reviewer_name, items=prior_unresolved_items: _validate_review_response(
                             text,
@@ -2296,14 +2357,30 @@ def run_pr_loop(
                 else:
                     round_new_unresolved_items.extend(reviewer_new_unresolved_items)
 
-            unresolved_items, _future_items = _apply_unresolved_item_dispositions(
-                prior_unresolved_items,
-                prior_dispositions,
-            )
+            if use_compact_pr_context:
+                unresolved_items, future_from_prior_items = _apply_unresolved_item_dispositions(
+                    prior_unresolved_items,
+                    prior_dispositions,
+                    retain_future=False,
+                )
+                pr_compact_prior_summaries.extend(
+                    _collect_prior_compact_summaries(
+                        prior_unresolved_items,
+                        unresolved_items,
+                        future_from_prior_items,
+                        prior_dispositions,
+                    )
+                )
+            else:
+                unresolved_items, _future_items = _apply_unresolved_item_dispositions(
+                    prior_unresolved_items,
+                    prior_dispositions,
+                )
+                future_from_prior_items = []
             unresolved_items = [*unresolved_items, *round_new_unresolved_items]
             future_followups = [
                 _approved_followup_from_unresolved_item(item)
-                for item in unresolved_items
+                for item in [*unresolved_items, *future_from_prior_items]
                 if item.status == "future"
             ]
             must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
@@ -2591,6 +2668,7 @@ def run_pr_loop(
                         subject=str(updated_pr_context.metadata.head_sha or "unknown"),
                         prior_items=tuple(unresolved_items),
                         raw_structured_coder_response=raw_structured_coder_response,
+                        compact_prior_summaries=tuple(pr_compact_prior_summaries),
                     ),
                 ),
             )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -29,6 +29,7 @@ class CoderHumanRequirementsPromptContext:
 
 
 COMPACT_PLANNING_VOLATILE_TAIL_MARKER = "--- volatile compact planning tail ---"
+COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER = "--- volatile compact pr-review tail ---"
 
 
 @dataclass(frozen=True)
@@ -39,6 +40,13 @@ class CompactPriorContext:
 @dataclass(frozen=True)
 class CompactPlanTailContext:
     subject: str | None = None
+    action: str | None = None
+
+
+@dataclass(frozen=True)
+class CompactPrReviewTailContext:
+    head_sha: str | None = None
+    round_number: int | None = None
     action: str | None = None
 
 
@@ -1394,6 +1402,305 @@ Sign your response as:
 """
 
 
+def _compact_pr_review_issue_context_block(
+    issue_context: IssueContext | None,
+    pr_body: str | None,
+) -> str:
+    lines = ["Original PR context"]
+    if pr_body:
+        lines.extend(["", "PR body:", pr_body])
+    if issue_context is not None:
+        title = issue_context.title if issue_context.title else "(unknown)"
+        body = issue_context.body if issue_context.body else "(none)"
+        lines.extend(
+            [
+                "",
+                f"Linked GitHub issue #{issue_context.number}",
+                "",
+                "Issue title:",
+                title,
+                "",
+                "Issue body:",
+                body,
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "Raw prior PR-review comments are omitted in compact PR review context. "
+            "Durable reviewer findings must appear in the active unresolved ledger or "
+            "the append-only compact prior ledger below.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _canonical_pr_review_ledger_rules() -> str:
+    return """Canonical compact PR review ledger rules
+
+- Treat active prior unresolved review items as approval-critical until explicitly dispositioned.
+- Treat append-only compact prior ledger entries as the canonical history for prior blocking and same-PR concerns that left the active ledger.
+- Do not reinterpret, reorder, or rewrite prior compact ledger entries; append only new resolved or future-follow-up summaries after later review rounds.
+- Future follow-ups are relevant in compact mode only when elevated, referenced, or preserved in the compact prior ledger.
+"""
+
+
+def _compact_coder_followup_block(
+    summary: str | None,
+    tests_run: Sequence[str] | None,
+) -> str:
+    if not summary and not tests_run:
+        return ""
+    lines = ["Latest coder follow-up summary"]
+    if summary:
+        lines.extend(["", summary])
+    if tests_run:
+        lines.extend(["", "Tests run:"] + [f"- {t}" for t in tests_run])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _compact_pr_review_stable_prefix(
+    *,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None,
+    pr_metadata: PullRequestMetadata,
+    issue_context: IssueContext | None,
+    human_requirements: Sequence[HumanReviewRequirement] | None,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    compact_prior: CompactPriorContext | None,
+    compact_coder_summary: str | None,
+    compact_coder_tests_run: Sequence[str] | None,
+    unresolved_items_guidance: str,
+    followup_guidance: str,
+    human_requirements_guidance: str,
+) -> str:
+    reviewer_group = format_agent_list(reviewers(config))
+    coder_name = agent_display_name(config.coder)
+    response_schema = f"""Use this mandatory structured PR review format. Start your response with
+exactly one top-level JSON object and no prose or code fences before it:
+
+{{
+  "schema_version": 1,
+  "kind": "pr_review",
+  "state": "approved" | "blocking",
+  "summary": "short reviewer summary",
+  "blocking_items": ["render-only blocking bullet", "..."],
+  "same_pr_followups": ["same-PR fix still required", "..."],
+  "future_followups": ["future work after approval", "..."],
+  "prior_item_dispositions": [
+    {{"item_id": "item-1", "disposition": "resolved"}},
+    {{"item_id": "item-2", "disposition": "future", "note": "brief reason"}}
+  ]
+}}
+
+`blocking_items` and `same_pr_followups` must be mutually exclusive: a single
+concern belongs in exactly one list. Put merge-blocking defects, missing
+requirements, regressions, security issues, and consistency gaps in
+`blocking_items`; put only small Same-PR cleanup that is not itself the reason
+the PR is blocked in `same_pr_followups`.
+
+After the JSON object, include only:
+1. optional `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`
+2. required `<!-- AGENT_STATE: approved -->` or `<!-- AGENT_STATE: blocking -->`
+3. your standalone signature line (shown in volatile tail)
+
+Do not include any extra prose, headings, bullets, or fenced blocks before or
+after that structured response. The footer AGENT_STATE must match the JSON
+`state`.
+
+Use approved only if there are no blocking issues, no Same-PR follow-ups, and
+no carried-forward unresolved items left active for this round.
+Only items listed under `Prior unresolved review items from earlier rounds`
+are eligible for dispositions in this round. If same-round findings from
+other reviewers appear elsewhere in the PR discussion, treat them as
+informational only and do not disposition them until a later round carries
+them forward explicitly.
+All configured reviewers ({reviewer_group}) must approve in the same round for
+the pull request to be considered approved.
+Focus on correctness, security, test coverage, and maintainability. Review the
+full diff and any existing PR discussion. Do not make code changes in this
+review step; report blocking findings if {coder_name} needs to fix anything.
+Treat the GitHub PR checks block in the volatile tail as authoritative for current CI state.
+Do not say or imply that tests passed globally unless the GitHub PR checks
+state is `passing` or `no_checks`. If only a local subset passed while GitHub
+checks are `failing`, `pending`, or `unavailable`, say that explicitly.
+When the PR changes files under `alembic/versions/`, verify migration topology:
+new revisions should descend from the current head unless the PR intentionally
+adds a merge migration.
+"""
+    non_future_items = [item for item in unresolved_items if item.status != "future"]
+    return "\n".join(
+        part.rstrip()
+        for part in (
+            "Compact cache-aware PR review context",
+            f"Repository: {config.repo}",
+            _scratch_file_guidance(),
+            response_schema,
+            unresolved_items_guidance,
+            followup_guidance,
+            human_requirements_guidance,
+            _memory_block(memory),
+            _compact_pr_review_issue_context_block(issue_context, pr_metadata.body),
+            _human_requirements_block(human_requirements),
+            _canonical_pr_review_ledger_rules(),
+            _format_unresolved_review_items(non_future_items)
+            or "Prior unresolved review items from earlier rounds\n\n(none)\n",
+            _compact_coder_followup_block(compact_coder_summary, compact_coder_tests_run),
+            _compact_prior_ledger_block(compact_prior),
+        )
+        if part
+    ) + "\n"
+
+
+def _build_compact_pr_review_prompt(
+    pr_number: int,
+    round_number: int,
+    config: AgentLoopConfig,
+    *,
+    reviewer: AgentName,
+    pr_metadata: PullRequestMetadata,
+    pr_checks: PullRequestChecks | None,
+    memory: AgentMemoryContext | None,
+    issue_context: IssueContext | None,
+    human_requirements: Sequence[HumanReviewRequirement] | None,
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    compact_prior: CompactPriorContext | None,
+    compact_coder_summary: str | None,
+    compact_coder_tests_run: Sequence[str] | None,
+    compact_tail: CompactPrReviewTailContext | None,
+) -> str:
+    reviewer_name = agent_display_name(reviewer)
+    reviewer_signature = agent_signature(reviewer)
+    checks_block = f"{format_pr_checks(pr_checks)}\n" if pr_checks is not None else ""
+    human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
+    non_future_items = [item for item in unresolved_items if item.status != "future"]
+    if non_future_items:
+        unresolved_items_guidance = """Because prior unresolved items exist, include this exact section in your review:
+
+### Prior unresolved item dispositions
+
+Use one bullet per listed item and cover every item exactly once. Allowed forms:
+- [item-id] resolved
+- [item-id] still blocking
+- [item-id] same-pr
+- [item-id] future follow-up: brief reason
+
+Only use `future follow-up` when returning `approved`. If an item should still be fixed before merge, keep it as `still blocking` or `same-pr` instead of downgrading it.
+For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later commits, or now belongs back in same-PR/blocking work.
+Contradictory forms like `same-pr: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
+"""
+    else:
+        unresolved_items_guidance = ""
+    coder_name = agent_display_name(config.coder)
+    if config.approved_followups == "ignore":
+        followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
+Non-blocking follow-ups sections in approved reviews; this run is configured to
+ignore approved-review follow-up sections. Mark the review blocking instead
+when cleanup should be fixed before merge.
+"""
+    elif config.approved_followups.startswith("fix-and-"):
+        followup_guidance = f"""For small, localized, low-risk cleanup that must still be fixed in this PR
+before merge, return `<!-- AGENT_STATE: blocking -->` and list those items
+under this exact heading:
+
+### Same-PR follow-ups
+
+Use Same-PR follow-ups only for narrow current-PR cleanup in files already
+touched by this PR or directly adjacent code. Do not use this section for
+larger redesigns, broad refactors, or independent future work.
+Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
+`blocking_items` for defects, missing requirements, regressions, security
+issues, or consistency gaps that make the PR not merge-ready. Use
+`same_pr_followups` only for small localized cleanup that should be handled in
+this PR but is not itself the reason the PR is blocked.
+Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
+follow-up remains, including a carried-forward prior item that stays
+`still blocking` or `same-pr`, the review is not approved yet.
+
+If the PR is otherwise fully complete for this round but you notice substantial
+work that is better handled separately in a future issue or PR, list at most
+three highest-value items under this exact heading:
+
+### Future follow-ups
+
+Approved means there are no blocking issues, no Same-PR follow-ups, and no
+carried-forward prior unresolved items left active for this round.
+Same-PR follow-ups will be sent back to {coder_name} and require another review
+round before final approval. Do not put trivial style nits in either follow-up
+section. If you return `<!-- AGENT_STATE: blocking -->`, do not use structured
+Future follow-ups; keep all required current-round work in the blocking review
+so it is not missed during revision.
+"""
+    else:
+        followup_guidance = """If you approve but notice substantial work that is better handled separately in
+a future issue or PR, list at most three highest-value items under this exact
+heading:
+
+### Future follow-ups
+
+Do not use the Same-PR follow-ups section in this mode; mark the review blocking
+instead when small or local cleanup should be fixed before merge.
+The legacy heading `### Non-blocking follow-ups` is still accepted as future
+follow-ups for compatibility, but prefer `### Future follow-ups`.
+"""
+    stable_prefix = _compact_pr_review_stable_prefix(
+        config=config,
+        memory=memory,
+        pr_metadata=pr_metadata,
+        issue_context=issue_context,
+        human_requirements=human_requirements,
+        unresolved_items=unresolved_items,
+        compact_prior=compact_prior,
+        compact_coder_summary=compact_coder_summary,
+        compact_coder_tests_run=compact_coder_tests_run,
+        unresolved_items_guidance=unresolved_items_guidance,
+        followup_guidance=followup_guidance,
+        human_requirements_guidance=human_requirements_guidance,
+    )
+    head_sha = (compact_tail.head_sha if compact_tail else None) or pr_metadata.head_sha or "(unknown)"
+    volatile_round = (compact_tail.round_number if compact_tail else None) or round_number
+    action = (
+        compact_tail.action if compact_tail and compact_tail.action else None
+    ) or "Review the current PR diff for correctness, security, test coverage, and maintainability."
+    title = pr_metadata.title or "(unknown)"
+    head_branch = pr_metadata.head_branch or "(unknown)"
+    base_branch = pr_metadata.base_branch or "(unknown)"
+    url_line = f"- URL: {pr_metadata.url}\n" if pr_metadata.url else ""
+    return f"""{stable_prefix}
+{COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER}
+
+PR #{pr_number} in {config.repo} (round {volatile_round})
+- Title: {title}
+- Head branch: {head_branch}
+- Base branch: {base_branch}
+- Head SHA: {head_sha}
+{url_line}
+Use the Head SHA above as authoritative for this review round. If local files do not match that SHA, refresh/fetch the checkout before reviewing. Do not report findings based on untracked files unless those files are present in the PR diff.
+
+{checks_block}Suggested commands:
+- {config.gh_cmd} pr view {pr_metadata.number} --repo {pr_metadata.repo} --json title,body,headRefName,baseRefName,headRefOid,comments,reviews
+- {config.gh_cmd} pr diff {pr_number} --repo {config.repo}
+
+If a shell/tool command requires confirmation in non-interactive mode, do not retry repeatedly. Use the PR metadata above and the suggested GitHub CLI commands, or produce a blocking review explaining the limitation.
+
+Reviewer: {reviewer_name}
+Action for this call: {action}
+
+End your final response with exactly one marker:
+
+<!-- AGENT_STATE: approved -->
+
+or:
+
+<!-- AGENT_STATE: blocking -->
+
+Use blocking only for issues that should prevent merge. Always sign your response:
+-- {reviewer_signature}
+"""
+
+
 def build_review_prompt(
     pr_number: int,
     round_number: int,
@@ -1406,6 +1713,11 @@ def build_review_prompt(
     issue_context: IssueContext | None = None,
     human_requirements: Sequence[HumanReviewRequirement] | None = None,
     unresolved_items: Sequence[UnresolvedReviewItem] | None = None,
+    compact_context: bool = False,
+    compact_prior: CompactPriorContext | None = None,
+    compact_tail: CompactPrReviewTailContext | None = None,
+    compact_coder_summary: str | None = None,
+    compact_coder_tests_run: Sequence[str] | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_signature = agent_signature(reviewer)
@@ -1419,6 +1731,23 @@ def build_review_prompt(
         head_sha=None,
         url=None,
     )
+    if compact_context:
+        return _build_compact_pr_review_prompt(
+            pr_number,
+            round_number,
+            config,
+            reviewer=reviewer,
+            pr_metadata=metadata,
+            pr_checks=pr_checks,
+            memory=memory,
+            issue_context=issue_context,
+            human_requirements=human_requirements,
+            unresolved_items=unresolved_items or [],
+            compact_prior=compact_prior,
+            compact_coder_summary=compact_coder_summary,
+            compact_coder_tests_run=compact_coder_tests_run,
+            compact_tail=compact_tail,
+        )
     title = metadata.title or "(unknown)"
     head_branch = metadata.head_branch or "(unknown)"
     base_branch = metadata.base_branch or "(unknown)"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -107,7 +107,9 @@ from coding_review_agent_loop.orchestrator import (
 )
 from coding_review_agent_loop.prompts import (
     COMPACT_PLANNING_VOLATILE_TAIL_MARKER,
+    COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER,
     CompactPlanTailContext,
+    CompactPrReviewTailContext,
     CompactPriorContext,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
@@ -772,6 +774,7 @@ def structured_coder_followup(
     remaining_item_notes: dict[str, str] | None = None,
     human_requirement_ids: list[str] | None = None,
     checked_discussion_directly: bool = False,
+    tests_run: list[str] | None = None,
     reviewer: str = "Anthropic Claude",
 ) -> str:
     return (
@@ -789,6 +792,7 @@ def structured_coder_followup(
                     "addressed_ids": human_requirement_ids or [],
                     "checked_discussion_directly": checked_discussion_directly,
                 },
+                **({"tests_run": tests_run} if tests_run is not None else {}),
             }
         )
         + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
@@ -4094,6 +4098,185 @@ def test_full_plan_prompt_still_includes_raw_issue_comments(tmp_path):
     )
 
     assert "UNRELATED RAW PRIOR COMMENT PROSE" in prompt
+
+
+def _compact_pr_issue_context() -> IssueContext:
+    return IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Linked issue title",
+        body="Linked issue body with durable requirements.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="reviewer",
+                created_at="2026-06-01T00:00:00Z",
+                body="UNRELATED RAW PRIOR PR REVIEW HISTORY should not be replayed.",
+            ),
+        ),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="PR comment",
+                author="wwind123",
+                created_at="2026-06-04T10:00:00Z",
+                url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+                body="Compact PR mode must preserve human requirements.",
+            ),
+        ),
+    )
+
+
+def _compact_pr_metadata() -> PullRequestMetadata:
+    return PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Compact PR context",
+        head_branch="feature/context",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/77",
+        body="PR body with author intent and scope.",
+    )
+
+
+def test_config_and_cli_default_to_full_pr_review_context(tmp_path):
+    assert make_config(tmp_path).pr_review_context_mode == "full"
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--pr-review-context-mode",
+        "compact",
+    ])
+    assert config_from_args(args, FakeRunner()).pr_review_context_mode == "compact"
+
+    with pytest.raises(AgentLoopError):
+        make_config(tmp_path, pr_review_context_mode="invalid")
+    with pytest.raises(SystemExit):
+        parser.parse_args(["pr", "77", "--pr-review-context-mode", "invalid"])
+
+
+def test_compact_pr_review_prompt_preserves_context_and_omits_raw_history(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    issue_context = _compact_pr_issue_context()
+    prompt = build_review_prompt(
+        77,
+        2,
+        config,
+        reviewer="codex",
+        pr_metadata=_compact_pr_metadata(),
+        pr_checks=None,
+        memory=_compact_memory_context(tmp_path),
+        issue_context=issue_context,
+        human_requirements=issue_context.human_requirements,
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="OpenAI Codex",
+                source_round=1,
+                text="Active blocking issue remains important.",
+                status="blocking",
+            ),
+            UnresolvedReviewItem(
+                item_id="item-2",
+                reviewer="Google Gemini",
+                source_round=1,
+                text="Active same-PR cleanup remains important.",
+                status="same-pr",
+            ),
+            UnresolvedReviewItem(
+                item_id="item-3",
+                reviewer="OpenAI Codex",
+                source_round=1,
+                text="Unrelated future-only item should not stay active in compact prompt.",
+                status="future",
+            ),
+        ),
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-4] resolved: old resolved item",)),
+        compact_coder_summary="Coder says the compact mode wiring is complete.",
+        compact_coder_tests_run=("python -m pytest tests/test_agent_loop.py -k compact_pr",),
+        compact_tail=CompactPrReviewTailContext(
+            head_sha="abc123",
+            round_number=2,
+            action="Review compact PR context mode.",
+        ),
+    )
+
+    prefix, tail = prompt.split(COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER, 1)
+    assert "PR body with author intent and scope." in prefix
+    assert "Linked issue body with durable requirements." in prefix
+    assert "Compact PR mode must preserve human requirements." in prefix
+    assert "Repo memory summary for compact prefix." in prefix
+    assert "Active blocking issue remains important." in prefix
+    assert "Active same-PR cleanup remains important." in prefix
+    assert "Unrelated future-only item should not stay active" not in prefix
+    assert "UNRELATED RAW PRIOR PR REVIEW HISTORY" not in prompt
+    assert "[item-4] resolved: old resolved item" in prefix
+    assert "Coder says the compact mode wiring is complete." in prefix
+    assert "python -m pytest tests/test_agent_loop.py -k compact_pr" in prefix
+    assert "Review compact PR context mode." in tail
+    assert "Head SHA: abc123" in tail
+    assert "gh pr diff 77 --repo OWNER/REPO" in tail
+
+
+def test_compact_pr_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp_path):
+    config = make_config(tmp_path)
+    metadata = _compact_pr_metadata()
+    issue_context = _compact_pr_issue_context()
+    unresolved_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Active PR item remains approval-critical.",
+        status="blocking",
+    )
+    first = build_review_prompt(
+        77,
+        2,
+        config,
+        reviewer="codex",
+        pr_metadata=metadata,
+        memory=_compact_memory_context(tmp_path),
+        issue_context=issue_context,
+        human_requirements=issue_context.human_requirements,
+        unresolved_items=(unresolved_item,),
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-9] resolved: unchanged",)),
+        compact_coder_summary="Stable coder summary.",
+        compact_coder_tests_run=("pytest -k stable",),
+        compact_tail=CompactPrReviewTailContext(head_sha="abc123", round_number=2, action="Review A."),
+    )
+    second = build_review_prompt(
+        77,
+        3,
+        config,
+        reviewer="codex",
+        pr_metadata=metadata,
+        memory=_compact_memory_context(tmp_path),
+        issue_context=issue_context,
+        human_requirements=issue_context.human_requirements,
+        unresolved_items=(unresolved_item,),
+        compact_context=True,
+        compact_prior=CompactPriorContext(("[item-9] resolved: unchanged",)),
+        compact_coder_summary="Stable coder summary.",
+        compact_coder_tests_run=("pytest -k stable",),
+        compact_tail=CompactPrReviewTailContext(head_sha="def456", round_number=3, action="Review B."),
+    )
+
+    first_prefix, first_tail = first.split(COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER, 1)
+    second_prefix, second_tail = second.split(COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER, 1)
+    assert first_prefix.encode() == second_prefix.encode()
+    assert first_tail != second_tail
+    assert "Active PR item remains approval-critical." in first_prefix
+    assert "Stable coder summary." in first_prefix
+    assert "PR body with author intent and scope." in first_prefix
+    for volatile in ("round 2", "Head SHA: abc123", "Review A."):
+        assert volatile not in first_prefix
+        assert volatile in first_tail
 
 
 def test_compact_review_prompt_stable_prefix_is_byte_identical_across_rounds(tmp_path):
@@ -8305,7 +8488,7 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
         if cmd[:3] == ["gh", "pr", "view"]
         and "--json" in cmd
         and cmd[cmd.index("--json") + 1]
-        == "number,title,headRefName,baseRefName,headRefOid,url,comments,reviews"
+        == "number,title,headRefName,baseRefName,headRefOid,url,body,comments,reviews"
     ]
     assert len(metadata_fetches) == 1
     assert ["pytest", "tests/test_agent_loop.py"] in commands
@@ -9080,7 +9263,7 @@ def test_pr_loop_reruns_all_reviewers_when_any_reviewer_blocks(tmp_path):
         if cmd[:3] == ["gh", "pr", "view"]
         and "--json" in cmd
         and cmd[cmd.index("--json") + 1]
-        == "number,title,headRefName,baseRefName,headRefOid,url,comments,reviews"
+        == "number,title,headRefName,baseRefName,headRefOid,url,body,comments,reviews"
     ]
     assert len(metadata_fetches) == 2
 
@@ -9245,6 +9428,68 @@ def test_pr_loop_carries_new_future_followups_into_later_reviewer_prompts(tmp_pa
     summary = runner.comments[-1]
     assert summary.startswith("Approved-review future follow-ups for PR #77:")
     assert "Document cache cleanup behavior." in summary
+
+
+def test_pr_loop_compact_review_mode_uses_fresh_sessions_and_compact_prior_ledger(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Codex approves with future work.\n\n"
+            "### Future follow-ups\n"
+            "- Document cache cleanup behavior.\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "Codex approves final pass."
+            + prior_item_dispositions(
+                "[item-1] future follow-up: still future work",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Claude still blocks.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Claude approves final pass."
+            + prior_item_dispositions(
+                "[item-1] future follow-up: still future work",
+                "[item-2] resolved",
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        gemini_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Implemented blocker and ran focused tests.",
+                addressed_items=["item-1", "item-2"],
+                remaining_items=[],
+                tests_run=["python -m pytest tests/test_agent_loop.py -k compact_pr"],
+                reviewer="Google Gemini",
+            )
+        ],
+        pr_payload={"body": "PR body used by compact review mode."},
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        approved_followups="summarize",
+        max_rounds=2,
+        pr_review_context_mode="compact",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    codex_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(codex_prompts) == 2
+    second_codex_prompt = codex_prompts[1]
+    assert COMPACT_PR_REVIEW_VOLATILE_TAIL_MARKER in second_codex_prompt
+    assert "PR body used by compact review mode." in second_codex_prompt
+    assert "Implemented blocker and ran focused tests." in second_codex_prompt
+    assert "python -m pytest tests/test_agent_loop.py -k compact_pr" in second_codex_prompt
+    assert "Document cache cleanup behavior." not in second_codex_prompt
+    assert "[item-1] future" not in second_codex_prompt
+    assert "Claude still blocks." in second_codex_prompt
+    assert not any("--resume" in cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+
+    assert runner.comments[-1].startswith("Approved-review future follow-ups for PR #77:")
+    assert "Document cache cleanup behavior." in runner.comments[-1]
 
 
 def test_pr_loop_carries_prior_item_notes_without_creating_duplicate_blocker_items(tmp_path):


### PR DESCRIPTION
## Summary

- Salvages and completes the interrupted Claude implementation for issue #244.
- Adds `--pr-review-context-mode {full,compact}` with default `full`.
- Fetches/stores PR body and includes it in compact PR review context.
- Adds a compact PR review prompt with stable prefix / volatile tail, compact prior ledger, human requirements, latest coder summary/tests, PR identity, checks, and suggested diff commands.
- In compact PR review rounds, starts fresh reviewer sessions to avoid replaying raw prior session transcript.
- Omits unrelated future-only items from the active compact prompt while still preserving elevated/referenced future work for approved follow-up publication.

Fixes #244

## Tests

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile src/coding_review_agent_loop/cli.py src/coding_review_agent_loop/config.py src/coding_review_agent_loop/github.py src/coding_review_agent_loop/orchestrator.py src/coding_review_agent_loop/prompts.py tests/test_agent_loop.py`
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -k "compact_pr_review or pr_loop_compact_review_mode or default_to_full_pr_review_context or compact_plan_review_prompt_preserves_canonical_context"` (5 passed)
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -k "pr_loop_carries_new_future_followups_into_later_reviewer_prompts or pr_loop_fix_and_summarize_sends_same_pr_followups_to_coder_then_rereviews or pr_loop_fix_and_summarize_uses_only_final_round_future_followups or parse_structured_pr_review_rejects_future_followups_in_blocking_reviews"` (4 passed)
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py` (625 passed)
