### PR TITLE
Add one-shot implementation handoff marker to resume PR review on rerun

### DIFF
--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -24,6 +24,10 @@ PHASE_IMPLEMENTATION_MARKER_RE = re.compile(
     r"<!--\s*AGENT_PLAN_PHASE_IMPLEMENTATION:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
     re.I,
 )
+ONE_SHOT_IMPL_HANDOFF_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_ONE_SHOT_IMPL:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
 ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)(?:\b|$)|#(\d+)\b")
 
 
@@ -81,6 +85,16 @@ class PhaseImplementationHandoffMetadata:
     automation: str
     child_issue_number: int
     child_issue_url: str | None
+
+
+@dataclass(frozen=True)
+class OneShotImplementationHandoffMetadata:
+    parent_issue: int
+    plan_hash: str
+    plan_subject: str
+    mode: str
+    pr_number: int
+    pr_head_sha: str | None
 
 
 def approved_plan_hash(approved_plan: str) -> str:
@@ -601,5 +615,117 @@ def post_decomposition_parent_summary(
             mode=mode,
             plan_hash=plan_hash,
             created=created,
+        ),
+    )
+
+
+def _encode_one_shot_impl_handoff_metadata(
+    metadata: OneShotImplementationHandoffMetadata,
+) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "plan_hash": metadata.plan_hash,
+            "plan_subject": metadata.plan_subject,
+            "mode": metadata.mode,
+            "pr_number": metadata.pr_number,
+            "pr_head_sha": metadata.pr_head_sha,
+        }
+    )
+
+
+def _decode_one_shot_impl_handoff_metadata(encoded: str) -> OneShotImplementationHandoffMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_PLAN_ONE_SHOT_IMPL")
+    try:
+        pr_head_sha = payload.get("pr_head_sha")
+        return OneShotImplementationHandoffMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            plan_hash=str(payload["plan_hash"]),
+            plan_subject=str(payload.get("plan_subject") or ""),
+            mode=str(payload["mode"]),
+            pr_number=int(payload["pr_number"]),
+            pr_head_sha=pr_head_sha if isinstance(pr_head_sha, str) else None,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_PLAN_ONE_SHOT_IMPL payload.") from exc
+
+
+def find_existing_one_shot_impl_handoff(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+    plan_hash: str,
+    mode: str,
+) -> OneShotImplementationHandoffMetadata | None:
+    found: OneShotImplementationHandoffMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in ONE_SHOT_IMPL_HANDOFF_MARKER_RE.finditer(body):
+            metadata = _decode_one_shot_impl_handoff_metadata(match.group("payload"))
+            if (
+                metadata.parent_issue == parent_issue
+                and metadata.plan_hash == plan_hash
+                and metadata.mode == mode
+            ):
+                found = metadata
+    return found
+
+
+def format_one_shot_impl_handoff_comment(
+    *,
+    parent_issue: int,
+    mode: str,
+    plan_hash: str,
+    plan_subject: str,
+    pr_number: int,
+    pr_head_sha: str | None,
+) -> str:
+    metadata = OneShotImplementationHandoffMetadata(
+        parent_issue=parent_issue,
+        plan_hash=plan_hash,
+        plan_subject=plan_subject,
+        mode=mode,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+    )
+    lines = [
+        f"Approved plan for issue #{parent_issue} handed off to PR #{pr_number} for one-shot implementation.",
+        "",
+        f"Mode: {mode}",
+        f"Plan hash: {plan_hash}",
+        f"Plan subject: {plan_subject}",
+        "",
+        "Parent reruns will resume the PR review loop for this PR instead of re-implementing.",
+        "",
+        f"<!-- AGENT_PLAN_ONE_SHOT_IMPL: {_encode_one_shot_impl_handoff_metadata(metadata)} -->",
+        "-- coding-review-agent-loop",
+    ]
+    return "\n".join(lines)
+
+
+def post_one_shot_impl_handoff_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    mode: str,
+    plan_hash: str,
+    plan_subject: str,
+    pr_number: int,
+    pr_head_sha: str | None,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=parent_issue,
+        body=format_one_shot_impl_handoff_comment(
+            parent_issue=parent_issue,
+            mode=mode,
+            plan_hash=plan_hash,
+            plan_subject=plan_subject,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
         ),
     )

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -102,6 +102,34 @@ def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
     return repo
 
 
+def get_pr_state(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> str:
+    """Return the PR state string ('OPEN', 'CLOSED', or 'MERGED').
+
+    Raises AgentLoopError when the state cannot be determined (non-zero exit or
+    absent state field), so the caller can wrap it with issue-level context.
+    """
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            "number,state,url",
+        ],
+        cwd=active_workdir(config),
+    )
+    if result.returncode != 0:
+        raise AgentLoopError(f"Unable to determine state of PR #{pr_number}.")
+    data = json.loads(result.stdout or "{}")
+    state = _optional_str(data.get("state"))
+    if not state:
+        raise AgentLoopError(f"Unable to determine state of PR #{pr_number}.")
+    return state
+
+
 def validate_open_pr(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> None:
     if config.dry_run:
         return

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -26,9 +26,11 @@ from .decomposition import (
     approved_plan_hash,
     create_decomposition_child_issues,
     find_existing_decomposition,
+    find_existing_one_shot_impl_handoff,
     find_existing_phase_implementation_handoff,
     parse_plan_decomposition,
     post_decomposition_parent_summary,
+    post_one_shot_impl_handoff_comment,
     post_phase_implementation_handoff_comment,
 )
 from .errors import AgentLoopError, QuotaResetExceededError, UnknownPriorItemDispositionError
@@ -38,6 +40,7 @@ from .github import (
     get_issue_context,
     get_pr_checks,
     get_pr_review_context,
+    get_pr_state,
     merge_pr,
     post_issue_comment,
     post_pr_comment,
@@ -1069,6 +1072,8 @@ def _implement_approved_issue(
     issue_context: IssueContext,
     coder_session_id: str | None,
     usage_context: RunUsageContext,
+    one_shot_parent_issue: int | None = None,
+    plan_subject: str | None = None,
 ) -> int:
     coder_name = agent_display_name(config.coder)
     sync_coder_base_before_implementation(config, runner)
@@ -1105,6 +1110,18 @@ def _implement_approved_issue(
         pr_number=pr_number,
         issue_number=issue_number,
     )
+    initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
+    if one_shot_parent_issue is not None:
+        post_one_shot_impl_handoff_comment(
+            runner,
+            config=config,
+            parent_issue=one_shot_parent_issue,
+            mode="implement-one-shot",
+            plan_hash=approved_plan_hash(approved_plan),
+            plan_subject=plan_subject or "",
+            pr_number=pr_number,
+            pr_head_sha=initial_pr_context.metadata.head_sha,
+        )
     post_pr_comment(
         runner,
         config=config,
@@ -1116,7 +1133,7 @@ def _implement_approved_issue(
                 role="coder",
                 agent=coder_name,
                 round_number=1,
-                subject=str(get_pr_review_context(runner, config=config, pr_number=pr_number).metadata.head_sha or "unknown"),
+                subject=str(initial_pr_context.metadata.head_sha or "unknown"),
                 prior_items=(),
             ),
         ),
@@ -1704,6 +1721,53 @@ def _run_plan_first_loop(
                 )
 
             if mode == "implement-one-shot":
+                plan_hash = approved_plan_hash(current_plan)
+                plan_subject = _plan_subject(current_plan)
+                existing_handoff = find_existing_one_shot_impl_handoff(
+                    issue_context.comments,
+                    parent_issue=issue_number,
+                    plan_hash=plan_hash,
+                    mode="implement-one-shot",
+                )
+                if existing_handoff is not None:
+                    try:
+                        pr_state = get_pr_state(
+                            runner, config=config, pr_number=existing_handoff.pr_number
+                        )
+                    except AgentLoopError:
+                        raise AgentLoopError(
+                            f"PR #{existing_handoff.pr_number} recorded in the one-shot handoff "
+                            f"for issue #{issue_number} cannot be found in {config.repo}. "
+                            f"Verify the PR exists and rerun "
+                            f"`agent-loop pr {existing_handoff.pr_number}` directly to continue, "
+                            "or remove the handoff comment from the issue and rerun to re-implement."
+                        )
+                    if pr_state == "OPEN":
+                        log(
+                            config,
+                            f"Issue #{issue_number}: resuming PR #{existing_handoff.pr_number} "
+                            "review for already-handed-off plan",
+                        )
+                        validate_pr_references_issue(
+                            runner,
+                            config=config,
+                            pr_number=existing_handoff.pr_number,
+                            issue_number=issue_number,
+                        )
+                        return run_pr_loop(
+                            runner,
+                            pr_number=existing_handoff.pr_number,
+                            config=config,
+                            issue_context=issue_context,
+                            usage_context=usage_context,
+                        )
+                    else:
+                        print(
+                            f"Issue #{issue_number} approved plan was handed off to "
+                            f"PR #{existing_handoff.pr_number}, which is "
+                            f"{pr_state.lower()}. Nothing to resume."
+                        )
+                        return 0
                 return _implement_approved_issue(
                     runner,
                     issue_number=issue_number,
@@ -1713,6 +1777,8 @@ def _run_plan_first_loop(
                     issue_context=issue_context,
                     coder_session_id=coder_session_id,
                     usage_context=usage_context,
+                    one_shot_parent_issue=issue_number,
+                    plan_subject=plan_subject,
                 )
             raise AgentLoopError(f"Unknown plan execution mode: {mode}")
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -60,6 +60,7 @@ from coding_review_agent_loop.decomposition import (
     approved_plan_hash,
     find_existing_phase_implementation_handoff,
     format_decomposition_parent_summary,
+    format_one_shot_impl_handoff_comment,
     format_phase_implementation_handoff_comment,
     parse_plan_decomposition,
 )
@@ -12968,9 +12969,10 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     switch_index = command_index(runner.commands, ["git", "switch", "main"])
     second_claude_index = command_index(runner.commands, ["claude", "--print"], start=first_claude_index + 1)
     assert first_claude_index < fetch_index < switch_index < second_claude_index
-    assert len(runner.comments) == 5
-    assert runner.comments[3].startswith("Implemented approved plan.")
-    assert runner.comments[4].startswith("**Review verdict:** Approved\n\nLGTM.")
+    assert len(runner.comments) == 6
+    assert "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in runner.comments[3]
+    assert runner.comments[4].startswith("Implemented approved plan.")
+    assert runner.comments[5].startswith("**Review verdict:** Approved\n\nLGTM.")
 
 
 def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
@@ -13023,6 +13025,264 @@ def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference
 
     assert "Edit the PR description on GitHub" in str(excinfo.value)
     assert "rerun the orchestrator as `agent-loop pr 77` to continue the review" in str(excinfo.value)
+
+
+def test_issue_loop_plan_first_one_shot_posts_handoff_after_pr_creation(tmp_path):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    runner = FakeRunner(
+        claude_outputs=[
+            plan,
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert (
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+        == 0
+    )
+
+    handoff_comments = [c for c in runner.comments if "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in c]
+    assert len(handoff_comments) == 1
+    assert f"Plan hash: {approved_plan_hash(plan)}" in handoff_comments[0]
+    assert "Plan subject:" in handoff_comments[0]
+    assert "PR #77" in handoff_comments[0]
+
+
+def test_issue_loop_plan_first_one_shot_rerun_resumes_pr_loop(tmp_path):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    handoff = format_one_shot_impl_handoff_comment(
+        parent_issue=56,
+        mode="implement-one-shot",
+        plan_hash=approved_plan_hash(plan),
+        plan_subject=_plan_subject(plan),
+        pr_number=77,
+        pr_head_sha="abc123",
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": handoff},
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True) == 0
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 0
+    assert any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_one_shot_rerun_with_closed_pr_stops(tmp_path, capsys):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    handoff = format_one_shot_impl_handoff_comment(
+        parent_issue=56,
+        mode="implement-one-shot",
+        plan_hash=approved_plan_hash(plan),
+        plan_subject=_plan_subject(plan),
+        pr_number=77,
+        pr_head_sha="abc123",
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": handoff},
+        ],
+        pr_payload={"state": "CLOSED"},
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True) == 0
+
+    output = capsys.readouterr().out
+    assert "PR #77" in output
+    assert "closed" in output
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_one_shot_rerun_hash_mismatch_reimplements(tmp_path):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    old_plan = "Plan:\n- Old approach that was replaced.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    old_handoff = format_one_shot_impl_handoff_comment(
+        parent_issue=56,
+        mode="implement-one-shot",
+        plan_hash=approved_plan_hash(old_plan),
+        plan_subject=_plan_subject(old_plan),
+        pr_number=99,
+        pr_head_sha=None,
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": old_handoff},
+        ],
+        claude_outputs=[
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True) == 0
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 1
+    assert "Approved implementation plan" in claude_calls[0][-1]
+
+
+def test_issue_loop_plan_first_one_shot_rerun_pr_missing_issue_reference(tmp_path):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    handoff = format_one_shot_impl_handoff_comment(
+        parent_issue=56,
+        mode="implement-one-shot",
+        plan_hash=approved_plan_hash(plan),
+        plan_subject=_plan_subject(plan),
+        pr_number=77,
+        pr_head_sha="abc123",
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:02Z", "body": handoff},
+        ],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "No issue reference here.",
+        },
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="does not reference issue #56") as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+
+    assert "Edit the PR description on GitHub" in str(excinfo.value)
+    assert "rerun the orchestrator as `agent-loop pr 77` to continue the review" in str(excinfo.value)
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
 
 def test_is_clarification_request_detects_marker():


### PR DESCRIPTION
## Summary

Fixes #207

When `plan-first` + `implement-one-shot` (or `--implement-after-approval`) creates a PR, the orchestrator now posts an `AGENT_PLAN_ONE_SHOT_IMPL` issue-level marker recording the parent issue, plan hash, plan subject, PR number, and head SHA.

On rerun of the same issue command, the orchestrator detects this marker and:
- **PR still open**: revalidates the PR body still references the parent issue, then resumes `run_pr_loop` directly without re-invoking the coder.
- **PR closed/merged**: prints a clear terminal message and returns 0.
- **PR not found**: raises `AgentLoopError` with explicit recovery instructions.
- **Plan hash mismatch** (plan was revised after the first PR): no match is found, fresh implementation proceeds normally.

The `implement-by-phase` child-issue handoff behavior is unchanged.

## Changes

- `decomposition.py`: New `OneShotImplementationHandoffMetadata` dataclass, `ONE_SHOT_IMPL_HANDOFF_MARKER_RE` regex, encode/decode helpers, `find_existing_one_shot_impl_handoff`, `format_one_shot_impl_handoff_comment`, `post_one_shot_impl_handoff_comment`.
- `github.py`: New `get_pr_state(runner, *, config, pr_number) -> str` that returns the PR state without raising on non-open states (raises only when state is indeterminate).
- `orchestrator.py`: `_implement_approved_issue` accepts `one_shot_parent_issue` / `plan_subject` and posts the handoff after PR validation; `_run_plan_first_loop` detects existing handoff and routes accordingly.

## Test plan

- `test_issue_loop_plan_first_one_shot_posts_handoff_after_pr_creation`: first run posts `<!-- AGENT_PLAN_ONE_SHOT_IMPL: ... -->` with plan hash and subject.
- `test_issue_loop_plan_first_one_shot_rerun_resumes_pr_loop`: rerun with existing handoff + open PR goes directly to PR review loop without invoking the coder.
- `test_issue_loop_plan_first_one_shot_rerun_with_closed_pr_stops`: rerun with closed PR prints message and returns 0.
- `test_issue_loop_plan_first_one_shot_rerun_hash_mismatch_reimplements`: stale handoff with different plan hash is ignored; coder is invoked for fresh implementation.
- `test_issue_loop_plan_first_one_shot_rerun_pr_missing_issue_reference`: rerun with open PR whose body no longer references the issue raises `AgentLoopError` with recovery guidance.
- Updated `test_issue_loop_plan_first_can_implement_after_approval` to account for the new handoff comment in the comments count.

All 630 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)