### PR TITLE
Recover unrecorded PR head advances

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ remain earlier in the issue or PR thread, while newer orchestrator-rendered
 comments carry `AGENT_LOOP_META`. When metadata exists for the current head or
 plan subject, resume reconstruction uses that metadata-backed ledger and ignores
 stale visible item IDs from older heads, superseded plans, or replayed rounds.
+If a PR head advances but no current-head coder metadata was recorded, the PR
+loop recovers from metadata-backed active `blocking` and `same-pr` items on the
+latest recorded head and routes them through a coder follow-up before reviewers
+run again.
 
 Structured JSON is also the preferred coder format for follow-up and plan
 revision rounds. Coder follow-up responses use `kind: "coder_followup"` with

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -506,6 +506,10 @@ markdown comments, newer orchestrator-rendered comments, or both. When
 `AGENT_LOOP_META` exists for the current PR head or plan subject, resume uses
 that metadata-backed ledger and ignores stale visible item IDs from older heads,
 superseded plans, or replayed rounds.
+If the PR head advanced without a current-head coder metadata comment, resume
+uses metadata-backed active `blocking` and `same-pr` items from the latest
+recorded head and sends them to the coder for a structured follow-up before
+reviewers run again.
 
 Reviewer responses should use structured JSON first. A PR review starts with:
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2205,7 +2205,17 @@ def run_pr_loop(
             resumed_by_name = {
                 record.metadata.agent: record for record in (current_resume.completed_reviews if current_resume is not None else ())
             }
-            for reviewer in configured_reviewers:
+            skip_reviewers_for_recovery = bool(
+                current_resume is not None and current_resume.unrecorded_head_advance
+            )
+            if skip_reviewers_for_recovery:
+                log(
+                    config,
+                    f"Round {round_number}: PR head advanced to {current_pr_subject} "
+                    "without current-head coder metadata; routing recovered prior items "
+                    f"through {coder_name} before review",
+                )
+            for reviewer in (() if skip_reviewers_for_recovery else configured_reviewers):
                 reviewer_name = agent_display_name(reviewer)
                 resumed_record = resumed_by_name.get(reviewer_name)
                 if resumed_record is not None:

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -18,6 +18,7 @@ from .protocol import (
     ReviewItemDisposition,
     UnresolvedReviewItem,
 )
+from .unresolved_items import _apply_unresolved_item_dispositions
 
 ROUND_RESUME_MARKER_RE = re.compile(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", re.I)
 
@@ -60,6 +61,7 @@ class ResumedReviewRound:
     next_unresolved_item_number: int
     ledger_may_be_incomplete: bool = False
     compact_prior_summaries: tuple[str, ...] = ()
+    unrecorded_head_advance: bool = False
 
 
 def _serialize_unresolved_item(item: UnresolvedReviewItem) -> dict[str, object]:
@@ -280,6 +282,125 @@ def _max_unresolved_item_number_from_records(records: Sequence[PostedRoundRecord
     return max_number
 
 
+def _active_pr_items(items: Sequence[UnresolvedReviewItem]) -> list[UnresolvedReviewItem]:
+    return [item for item in items if item.status in {"blocking", "same-pr"}]
+
+
+def _append_active_pr_new_items(
+    active_items: list[UnresolvedReviewItem],
+    records: Sequence[PostedRoundRecord],
+) -> None:
+    seen_item_ids = {item.item_id for item in active_items}
+    for record in records:
+        for item in record.metadata.new_items:
+            if item.status not in {"blocking", "same-pr"} or item.item_id in seen_item_ids:
+                continue
+            active_items.append(item)
+            seen_item_ids.add(item.item_id)
+
+
+def _aggregate_record_dispositions(
+    records: Sequence[PostedRoundRecord],
+) -> dict[str, list[ReviewItemDisposition]]:
+    dispositions_by_item: dict[str, list[ReviewItemDisposition]] = {}
+    for record in records:
+        for disposition in record.metadata.dispositions:
+            dispositions_by_item.setdefault(disposition.item_id, []).append(disposition)
+    return dispositions_by_item
+
+
+def _recover_unrecorded_pr_head_advance(
+    records: Sequence[PostedRoundRecord],
+    *,
+    head_sha: str,
+) -> ResumedReviewRound | None:
+    prior_records = [record for record in records if record.metadata.subject != head_sha]
+    if not prior_records:
+        return None
+    latest_prior_subject = prior_records[-1].metadata.subject
+    selection = _select_current_round_records(records, subject=latest_prior_subject)
+    if selection is None:
+        return None
+
+    current_round_records = selection.current_round_records
+    anchor_metadata = selection.anchor_record.metadata
+    latest_coder_record = next(
+        (
+            record
+            for record in reversed(current_round_records)
+            if record.metadata.role == "coder"
+        ),
+        None,
+    )
+    reviewer_records_after_coder = tuple(
+        record
+        for record in current_round_records
+        if record.metadata.role == "reviewer"
+        and (latest_coder_record is None or record.index > latest_coder_record.index)
+    )
+    all_reviewer_records = tuple(
+        record for record in current_round_records if record.metadata.role == "reviewer"
+    )
+
+    if latest_coder_record is not None and not reviewer_records_after_coder:
+        round_number = latest_coder_record.metadata.round_number
+        recovered_items = _active_pr_items(latest_coder_record.metadata.prior_items)
+        coder_output = latest_coder_record.metadata.raw_structured_coder_response or latest_coder_record.body
+        compact_prior_summaries = latest_coder_record.metadata.compact_prior_summaries
+    elif latest_coder_record is not None:
+        round_number = latest_coder_record.metadata.round_number
+        recovered_items, _future_items = _apply_unresolved_item_dispositions(
+            latest_coder_record.metadata.prior_items,
+            _aggregate_record_dispositions(reviewer_records_after_coder),
+            retain_future=False,
+        )
+        recovered_items = _active_pr_items(recovered_items)
+        _append_active_pr_new_items(recovered_items, reviewer_records_after_coder)
+        coder_output = latest_coder_record.metadata.raw_structured_coder_response or latest_coder_record.body
+        compact_prior_summaries = latest_coder_record.metadata.compact_prior_summaries
+    elif all_reviewer_records:
+        round_number = anchor_metadata.round_number
+        recovered_items, _future_items = _apply_unresolved_item_dispositions(
+            anchor_metadata.prior_items,
+            _aggregate_record_dispositions(all_reviewer_records),
+            retain_future=False,
+        )
+        recovered_items = _active_pr_items(recovered_items)
+        _append_active_pr_new_items(recovered_items, all_reviewer_records)
+        coder_output = None
+        compact_prior_summaries = ()
+    else:
+        return None
+
+    if not recovered_items:
+        return None
+
+    return ResumedReviewRound(
+        round_number=round_number,
+        prior_items=tuple(recovered_items),
+        coder_output=coder_output,
+        completed_reviews=(),
+        next_unresolved_item_number=_max_unresolved_item_number_from_records(records) + 1,
+        ledger_may_be_incomplete=True,
+        compact_prior_summaries=compact_prior_summaries,
+        unrecorded_head_advance=True,
+    )
+
+
+def _latest_prior_pr_subject_is_coherent(records: Sequence[PostedRoundRecord], *, head_sha: str) -> bool:
+    prior_records = [record for record in records if record.metadata.subject != head_sha]
+    if not prior_records:
+        return True
+    latest_prior_subject = prior_records[-1].metadata.subject
+    selection = _select_current_round_records(records, subject=latest_prior_subject)
+    if selection is None:
+        return False
+    return any(
+        record.metadata.role in {"coder", "reviewer"}
+        for record in selection.current_round_records
+    )
+
+
 def _plan_subject(text: str) -> str:
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
 
@@ -297,7 +418,19 @@ def _resume_pr_round(
         return None
     selection = _select_current_round_records(records, subject=head_sha)
     if selection is None:
-        return None
+        recovered = _recover_unrecorded_pr_head_advance(records, head_sha=head_sha)
+        if recovered is not None:
+            return recovered
+        if _latest_prior_pr_subject_is_coherent(records, head_sha=head_sha):
+            return None
+        latest_prior_subject = records[-1].metadata.subject
+        raise AgentLoopError(
+            "PR head advanced without a recorded coder follow-up and the metadata-backed "
+            "handoff could not be recovered safely. "
+            f"Current head: {head_sha}. Latest recorded metadata subject: {latest_prior_subject}. "
+            "Rerun after posting a valid structured coder follow-up for the current head "
+            "or repair the metadata-backed handoff."
+        )
     current_round_records = selection.current_round_records
     anchor_metadata = selection.anchor_record.metadata
     latest_coder_record = next(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9795,6 +9795,242 @@ def test_resume_pr_round_does_not_mark_ledger_incomplete_for_cross_subject_prior
     assert resumed.ledger_may_be_incomplete is False
 
 
+def test_resume_pr_round_recovers_unrecorded_head_advance_reviewer_new_item():
+    active_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="Google Gemini",
+        source_round=1,
+        text="Fix the regression before merge.",
+        status="blocking",
+    )
+    coder_comment = _attach_round_metadata(
+        "Initial PR handoff.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+        ),
+    )
+    review_comment = _attach_round_metadata(
+        "Blocked.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Gemini",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+            new_items=(active_item,),
+            state="blocking",
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=review_comment),
+        ],
+        head_sha="new-sha",
+        configured_reviewers=("gemini",),
+    )
+
+    assert resumed is not None
+    assert resumed.unrecorded_head_advance is True
+    assert resumed.ledger_may_be_incomplete is True
+    assert resumed.round_number == 1
+    assert resumed.completed_reviews == ()
+    assert [item.item_id for item in resumed.prior_items] == ["item-2"]
+    assert resumed.next_unresolved_item_number == 3
+
+
+def test_resume_pr_round_recovers_coder_only_unrecorded_head_advance():
+    carried_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Still needs a targeted test.",
+        status="same-pr",
+    )
+    future_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Document this later.",
+        status="future",
+    )
+    coder_comment = _attach_round_metadata(
+        "Addressed prior feedback.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=2,
+            subject="old-sha",
+            prior_items=(carried_item, future_item),
+            compact_prior_summaries=("Older summary.",),
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=coder_comment)],
+        head_sha="new-sha",
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    assert resumed.unrecorded_head_advance is True
+    assert resumed.round_number == 2
+    assert [item.item_id for item in resumed.prior_items] == ["item-1"]
+    assert resumed.compact_prior_summaries == ("Older summary.",)
+
+
+def test_resume_pr_round_recovers_reviewer_only_with_aggregated_dispositions():
+    prior_blocking = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Fix the flaky test.",
+        status="blocking",
+    )
+    prior_same_pr = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="Google Gemini",
+        source_round=1,
+        text="Tighten the docs.",
+        status="same-pr",
+    )
+    future_new_item = UnresolvedReviewItem(
+        item_id="item-3",
+        reviewer="OpenAI Codex",
+        source_round=2,
+        text="Follow up in another PR.",
+        status="future",
+    )
+    active_new_item = UnresolvedReviewItem(
+        item_id="item-4",
+        reviewer="Google Gemini",
+        source_round=2,
+        text="Add one same-PR assertion.",
+        status="same-pr",
+    )
+    codex_resolution = ReviewItemDisposition(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        disposition="resolved",
+        note=None,
+    )
+    gemini_same_pr = ReviewItemDisposition(
+        item_id="item-2",
+        reviewer="Google Gemini",
+        disposition="same-pr",
+        note="Still needed before merge.",
+    )
+    codex_comment = _attach_round_metadata(
+        "Codex review.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=2,
+            subject="old-sha",
+            prior_items=(prior_blocking, prior_same_pr),
+            dispositions=(codex_resolution,),
+            new_items=(future_new_item,),
+            state="approved",
+        ),
+    )
+    gemini_comment = _attach_round_metadata(
+        "Gemini review.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Gemini",
+            round_number=2,
+            subject="old-sha",
+            prior_items=(prior_blocking, prior_same_pr),
+            dispositions=(gemini_same_pr,),
+            new_items=(active_new_item,),
+            state="blocking",
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=codex_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=gemini_comment),
+        ],
+        head_sha="new-sha",
+        configured_reviewers=("codex", "gemini"),
+    )
+
+    assert resumed is not None
+    assert resumed.unrecorded_head_advance is True
+    assert [item.item_id for item in resumed.prior_items] == ["item-2", "item-4"]
+    assert resumed.prior_items[0].status == "same-pr"
+    assert "Still needed before merge." in resumed.prior_items[0].text
+
+
+def test_resume_pr_round_ignores_unrecorded_head_advance_with_no_active_items():
+    future_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Future cleanup.",
+        status="future",
+    )
+    review_comment = _attach_round_metadata(
+        "Approved with future follow-up.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+            new_items=(future_item,),
+            state="approved",
+        ),
+    )
+
+    assert (
+        _resume_pr_round(
+            [IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=review_comment)],
+            head_sha="new-sha",
+            configured_reviewers=("codex",),
+        )
+        is None
+    )
+
+
+def test_resume_pr_round_fails_early_for_incoherent_unrecorded_head_advance():
+    bad_comment = _attach_round_metadata(
+        "Bad metadata.\n<!-- AGENT_STATE: blocking -->\n-- Bot",
+        PostedRoundMetadata(
+            flow="pr",
+            role="observer",
+            agent="Bot",
+            round_number=1,
+            subject="old-sha",
+        ),
+    )
+
+    with pytest.raises(
+        AgentLoopError,
+        match=(
+            "PR head advanced without a recorded coder follow-up.*"
+            "Current head: new-sha.*Latest recorded metadata subject: old-sha"
+        ),
+    ):
+        _resume_pr_round(
+            [IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=bad_comment)],
+            head_sha="new-sha",
+            configured_reviewers=("codex",),
+        )
+
+
 def test_resume_plan_round_marks_empty_ledger_incomplete_after_same_subject_prior_new_items():
     plan = "Plan text."
     subject = _plan_subject(plan)
@@ -10029,6 +10265,138 @@ def test_pr_loop_resume_hybrid_history_prefers_metadata_ledger_over_legacy_markd
     assert "[item-1]" in gemini_prompt
     assert "Add a regression test before merge." in gemini_prompt
     assert "Keep the legacy fallback path." not in gemini_prompt
+
+
+def test_pr_loop_routes_unrecorded_head_advance_through_coder_before_reviewers(tmp_path):
+    old_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="Google Gemini",
+        source_round=1,
+        text="Preserve the metadata-backed unresolved item on rerun.",
+        status="blocking",
+    )
+    old_coder_comment = _attach_round_metadata(
+        "Opened the PR.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent="Claude",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+        ),
+    )
+    old_review_comment = _attach_round_metadata(
+        "Blocked.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Gemini",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+            new_items=(old_item,),
+            state="blocking",
+        ),
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_coder_followup(
+                summary="Addressed the recovered prior item.",
+                addressed_items=["item-2"],
+                tests_run=["python -m pytest tests/test_agent_loop.py -k unrecorded_head"],
+            )
+        ],
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Recovered item is resolved.",
+                prior_item_dispositions=[
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+            )
+        ],
+        pr_payload={
+            "headRefOid": "new-sha",
+            "comments": [
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:00:00Z", "body": old_coder_comment},
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:01:00Z", "body": old_review_comment},
+            ],
+        },
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    first_coder = command_index(runner.commands, ["claude"])
+    first_reviewer = command_index(runner.commands, ["codex", "exec"])
+    assert first_coder < first_reviewer
+    reviewer_prompt = runner.commands[first_reviewer][0][-1]
+    assert "[item-2]" in reviewer_prompt
+    assert "Preserve the metadata-backed unresolved item on rerun." in reviewer_prompt
+    posted_coder_comment = next(
+        comment["body"]
+        for comment in runner.pr_payload["comments"]
+        if "## Coder follow-up" in comment["body"]
+    )
+    match = re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", posted_coder_comment)
+    assert match is not None
+    metadata = _decode_round_metadata(match.group("payload"))
+    assert metadata.subject == "new-sha"
+    assert metadata.round_number == 2
+    assert [item.item_id for item in metadata.prior_items] == ["item-2"]
+
+
+def test_pr_loop_unrecorded_head_advance_prevents_empty_ledger_unknown_item_abort(tmp_path):
+    old_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="Google Gemini",
+        source_round=1,
+        text="Carry this item instead of starting an empty ledger.",
+        status="blocking",
+    )
+    old_review_comment = _attach_round_metadata(
+        "Blocked.\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="pr",
+            role="reviewer",
+            agent="Gemini",
+            round_number=1,
+            subject="old-sha",
+            prior_items=(),
+            new_items=(old_item,),
+            state="blocking",
+        ),
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_coder_followup(
+                summary="Classified the recovered item.",
+                addressed_items=["item-2"],
+            )
+        ],
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Old item is resolved.",
+                prior_item_dispositions=[
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+            )
+        ],
+        pr_payload={
+            "headRefOid": "new-sha",
+            "comments": [
+                {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:01:00Z", "body": old_review_comment},
+            ],
+        },
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert runner.claude_outputs == []
+    assert runner.codex_outputs == []
+    assert not any("unknown item" in comment.lower() for comment in runner.comments)
 
 
 def test_reconcile_human_requirements_ack_item_accepts_stored_structured_coder_followup():


### PR DESCRIPTION
## Summary
- recover metadata-backed active PR items when the head advanced without current-head coder metadata
- route recovered items through the coder follow-up path before reviewers run
- document the recovery behavior and add focused regression coverage

Fixes #225

## Tests
- python3 -m pytest tests/test_agent_loop.py -k "resume_pr_round or unrecorded_head or coder_followup"
- python3 -m pytest