### PR TITLE
Address lightweight future review notes

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -47,6 +47,9 @@ flowchart LR
     Protocol --> RoundState
     Repair --> Protocol
 
+    %% The orchestrator owns repair invocation: it catches validation failures,
+    %% calls repair.py, then re-runs Protocol validation on the repaired output.
+
     Registry --> Claude[Claude backend<br/>claude]
     Registry --> Codex[Codex backend<br/>codex exec]
     Registry --> Gemini[Gemini backend<br/>gemini --prompt]
@@ -73,6 +76,8 @@ flowchart LR
     GitHub --> RoundState
     Followups --> GitHubOps
 ```
+
+The orchestrator owns the repair pass: it catches structured-response validation failures, invokes `repair.py`, and then sends the repaired output back through protocol validation before anything is posted.
 
 At runtime, the orchestrator drives one of three entrypoints:
 

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -15,15 +15,12 @@ from .base import (
     with_public_response_file_instruction,
 )
 from ..logging import agent_log_path, log
-from ..protocol import CLARIFY_RE, PLAN_STATE_RE, STATE_RE
+from ..protocol import CLARIFY_RE, PLAN_STATE_RE, PUBLIC_RESPONSE_MARKER, STATE_RE
 from ..runner import Runner
 from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
-
-
-PUBLIC_RESPONSE_MARKER = "=== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ==="
 
 
 def _with_public_response_marker_instruction(prompt: str) -> str:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -219,7 +219,8 @@ NEAR_MISS_AGENT_MARKER_RE = re.compile(
     re.I,
 )
 PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
-    r"\A\s*(?:=== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ===\s*)+"
+    r"\A\s*(?:={3,}\s*AGENT_LOOP_PUBLIC_RESPONSE_BELOW\s*={3,}\s*)+",
+    re.I,
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
     {"plan_review", "pr_review", "coder_followup", "plan_revision"}
@@ -479,14 +480,19 @@ def _is_retryable_marker_near_miss(text: str) -> bool:
     )
 
 
-def _failure_category(text: str, *, public_response: bool = False) -> str:
+def _failure_category(
+    text: str,
+    *,
+    public_response: bool = False,
+    repair_expected_kind: str | None = None,
+) -> str:
     """Classify a failure for logging: helps users decide whether to rerun or fix config/code."""
     if not text.strip():
         return "empty-response"
     if NON_RETRYABLE_AGENT_OUTPUT_RE.search(text):
         return "non-retryable"  # auth/billing — fix configuration
     if public_response:
-        if _is_transient_public_response(text):
+        if _is_transient_public_response(text, repair_expected_kind=repair_expected_kind):
             return "transient"  # extracted provider diagnostic — rerun may help
         return "deterministic"  # public response protocol/content issue
     if TRANSIENT_AGENT_OUTPUT_RE.search(text):
@@ -894,13 +900,14 @@ def _run_validated_agent(
                 if result.response_file_text
                 else None
             )
-            if response_file_pre_status == "leading-public-response-marker-recovered":
-                log(
-                    config,
-                    f"{agent_name}: response file contained stdout filtering marker and was recovered",
-                )
             try:
                 marker_value = validate(text)
+                if response_file_pre_status == "leading-public-response-marker-recovered":
+                    log(
+                        config,
+                        f"{agent_name}: response file contained stdout filtering marker and "
+                        "validated after stripping it",
+                    )
             except AgentLoopError as exc:
                 last_error = str(exc)
                 classification_text = _agent_failure_classification_text(result, phase="validation")
@@ -912,6 +919,7 @@ def _run_validated_agent(
                 last_failure_category = _failure_category(
                     classification_text,
                     public_response=True,
+                    repair_expected_kind=repair_expected_kind,
                 )
                 # Marker near-misses are a separate first-attempt nudge for common footer typos;
                 # structured JSON protocol drift still remains repairable when retries are exhausted.

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -235,6 +235,10 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 
 ## Valid Format D — Plan Revision:
 
+When the malformed plan_revision did not include a signed human requirements
+acknowledgement, omit the `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` marker and
+the `### Human requirements` section from Format D.
+
 {
   "schema_version": 1,
   "kind": "plan_revision",
@@ -722,10 +726,9 @@ def _repair_prior_item_ids_instruction(
     )
     return (
         "## Prior item disposition repair:\n"
-        "Same-round findings are informational only and must not be dispositioned as prior carried items.\n"
+        f"{context}\n"
         f"Allowed carried prior item IDs: {allowed}\n"
         f"Unknown prior item disposition IDs to remove: {unknown}\n"
-        f"Context: {context}\n"
         "Preserve valid dispositions for allowed IDs. Remove only unknown prior-item disposition entries.\n"
     )
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -42,6 +42,7 @@ from coding_review_agent_loop.cli import (
 )
 from coding_review_agent_loop.errors import QuotaResetExceededError, UnknownPriorItemDispositionError
 from coding_review_agent_loop.orchestrator import (
+    _decode_public_response_json_prefix,
     _format_reset_duration,
     _failure_category,
     _is_transient_agent_output,
@@ -3885,6 +3886,37 @@ def test_response_file_marker_normalization_reports_unrecoverable_marker():
 
     assert normalized == text
     assert status == "leading-public-response-marker-not-recoverable"
+
+
+def test_public_response_json_prefix_strips_marker_variants():
+    text = "==== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ====\n" + json.dumps(
+        {"error": {"status": 429, "message": "quota exceeded"}}
+    )
+
+    payload = _decode_public_response_json_prefix(text)
+
+    assert payload == {"error": {"status": 429, "message": "quota exceeded"}}
+    assert _is_transient_public_response(text)
+
+
+def test_failure_category_threads_public_response_expected_kind():
+    text = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_review",
+            "message": "quota exceeded",
+        }
+    )
+
+    assert _failure_category(text, public_response=True) == "deterministic"
+    assert (
+        _failure_category(
+            text,
+            public_response=True,
+            repair_expected_kind="future_structured_kind",
+        )
+        == "transient"
+    )
 
 
 @pytest.mark.parametrize(
@@ -15333,6 +15365,11 @@ def test_attempt_repair_includes_expected_kind_instruction():
     assert "Output no other `kind` value" in prompt
 
 
+def test_attempt_repair_format_d_marks_human_requirements_optional():
+    assert "omit the `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` marker" in _REPAIR_PROMPT
+    assert "the `### Human requirements` section from Format D" in _REPAIR_PROMPT
+
+
 def test_attempt_repair_includes_prior_item_disposition_repair_context():
     repaired = structured_plan_revision(prior_plan_item_dispositions=[])
     mock_result = MagicMock()
@@ -15356,6 +15393,26 @@ def test_attempt_repair_includes_prior_item_disposition_repair_context():
     assert "Allowed carried prior item IDs: item-12" in prompt
     assert "Unknown prior item disposition IDs to remove: item-15, item-18" in prompt
     assert "Same-round findings are informational only" in prompt
+
+
+def test_attempt_repair_prior_item_disposition_context_is_not_duplicated():
+    repaired = structured_plan_revision(prior_plan_item_dispositions=[])
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = repaired
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=mock_result) as mock_run:
+        attempt_repair(
+            "malformed plan revision",
+            "gemini",
+            expected_kind="plan_revision",
+            same_round_context="item-1 matches a same-round finding, not a carried prior item.",
+        )
+
+    cmd = mock_run.call_args.args[0]
+    prompt = cmd[cmd.index("--prompt") + 1]
+    assert prompt.count("item-1 matches a same-round finding") == 1
+    assert "Context: item-1 matches a same-round finding" not in prompt
 
 
 def test_attempt_repair_includes_coder_followup_required_item_ids():
@@ -15454,6 +15511,16 @@ def test_attempt_repair_rejects_unresolved_item_ids_for_non_coder_kind():
             "gemini",
             expected_kind="plan_review",
             unresolved_item_ids=["item-1"],
+        )
+
+
+def test_attempt_repair_rejects_surfaced_requirement_ids_for_non_coder_kind():
+    with pytest.raises(ValueError, match="surfaced_requirement_ids"):
+        attempt_repair(
+            "malformed plan review",
+            "gemini",
+            expected_kind="plan_review",
+            surfaced_requirement_ids=["Requirement 1"],
         )
 
 


### PR DESCRIPTION
## Summary

- Clarify repair-pass ownership in local agent-loop docs.
- Consolidate Gemini public-response marker use through protocol.py and tolerate marker variants when decoding public-response JSON prefixes.
- Thread repair_expected_kind through public-response failure-category classification.
- Defer stdout-marker recovery success logging until stripped response validation succeeds.
- Clarify repair prompt Format D human-requirements markers as conditional and remove duplicated same-round prior-item repair context.
- Add focused regression tests for the repair/public-response cleanup cases.

Closes #210
Closes #213
Closes #227
Closes #228
Closes #230
Closes #231
Closes #236
Closes #243

## Tests

- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile src/coding_review_agent_loop/agents/gemini.py src/coding_review_agent_loop/orchestrator.py src/coding_review_agent_loop/repair.py tests/test_agent_loop.py
- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py -k "public_response_json_prefix or failure_category_threads or attempt_repair_format_d or prior_item_disposition_context_is_not_duplicated or surfaced_requirement_ids_for_non_coder" (5 passed)
- /home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest tests/test_agent_loop.py (642 passed)
