### PR TITLE
File plan follow-ups before implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,14 @@ When earlier plan issues remain open, reviewers must also include
 `### Prior unresolved plan item dispositions` and disposition every carried item
 exactly once with `resolved`, `still blocking`, `same-plan`, or `future
 follow-up`. `Future follow-ups` are accepted only in approved plan reviews and
-are summarized with the final approved plan instead of reopening planning. By
-default the loop posts the approved plan summary and stops; add
+are reconciled with the final approved plan instead of reopening planning. If
+`--approved-followups=issue` or `fix-and-issue` is enabled and implementation
+will continue after approval, those plan-stage future follow-ups are filed as
+separate issues before implementation starts. Otherwise they are summarized in
+the planning-complete comment with an explicit note that they are not carried
+into PR review. Planning `item-*` IDs visible in issue history are not PR prior
+review items unless they are repeated in the active PR unresolved-item ledger.
+By default the loop posts the approved plan summary and stops; add
 `--implement-after-approval` to continue into the normal PR flow:
 
 ```bash
@@ -343,7 +349,9 @@ skipped by the cap.
 Plan reviews follow the same rule: approved plan reviews may include Future
 follow-ups only. Blocking plan issues, Same-plan follow-ups, or carried-forward
 plan items left `still blocking` or `same-plan` keep the planning round
-unapproved.
+unapproved. Plan-stage future follow-up issues are filed before implementation
+begins in issue-filing modes; PR-stage approved-review future follow-up issues
+are filed after final PR approval.
 
 By default, `--approved-followups=ignore` asks reviewers not to include
 approved-review follow-up sections. Reviewers should mark the review blocking

--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ follow-up`. `Future follow-ups` are accepted only in approved plan reviews and
 are reconciled with the final approved plan instead of reopening planning. If
 `--approved-followups=issue` or `fix-and-issue` is enabled and implementation
 will continue after approval, those plan-stage future follow-ups are filed as
-separate issues before implementation starts. Otherwise they are summarized in
-the planning-complete comment with an explicit note that they are not carried
-into PR review. Planning `item-*` IDs visible in issue history are not PR prior
-review items unless they are repeated in the active PR unresolved-item ledger.
-By default the loop posts the approved plan summary and stops; add
+separate issues before implementation starts. If implementation continues but
+issue filing is disabled, they are summarized in the planning-complete comment
+with an explicit note that they are not carried into PR review. Planning
+`item-*` IDs visible in issue history are not PR prior review items unless they
+are repeated in the active PR unresolved-item ledger. By default the loop posts
+the approved plan summary and stops without filing follow-up issues; add
 `--implement-after-approval` to continue into the normal PR flow:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -196,10 +196,15 @@ If earlier blocking or same-plan items are still open, reviewers must also add
 `### Prior unresolved plan item dispositions` and disposition every carried
 item exactly once. Use `same-plan` for required current-plan refinements,
 reserve `future follow-up` for approved plan reviews only, and expect approved
-future follow-ups to be summarized with the final approved plan instead of
-reopening planning. By default the loop posts an approved consensus summary to
-the issue and stops. Add `--implement-after-approval` to continue into the
-normal implementation and PR review loop using the approved plan:
+future follow-ups to be reconciled with the final approved plan instead of
+reopening planning. In `--approved-followups=issue` and `fix-and-issue` modes,
+plan-stage future follow-ups are filed as separate issues before implementation
+starts; otherwise they are summarized inline with a note that they are not
+carried into PR review. Planning `item-*` IDs visible in issue history are not
+PR prior review items unless they appear in the active PR unresolved-item
+ledger. By default the loop posts an approved consensus summary to the issue
+and stops. Add `--implement-after-approval` to continue into the normal
+implementation and PR review loop using the approved plan:
 
 ```bash
 agent-loop issue 56 --repo OWNER/REPO --plan-first --implement-after-approval
@@ -676,6 +681,11 @@ be fixed before merge.
 - `issue`: create GitHub issues for up to three future follow-ups, then comment with the created issue links.
 - `fix-and-summarize`: send same-PR follow-ups to the coder for another review round, then summarize future follow-ups after final approval.
 - `fix-and-issue`: send same-PR follow-ups to the coder for another review round, then create issues for future follow-ups after final approval and comment with the created issue links.
+
+For plan-first runs that continue into implementation, issue-filing modes apply
+twice at different lifecycle points: planning-stage future follow-ups are filed
+before implementation begins, while PR-stage approved-review future follow-ups
+are filed only after final PR approval.
 
 Bullets and prose paragraphs inside the `Same-PR follow-ups`, `Future follow-ups`,
 and legacy `Non-blocking follow-ups` sections are parsed; each section ends at

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -198,12 +198,14 @@ item exactly once. Use `same-plan` for required current-plan refinements,
 reserve `future follow-up` for approved plan reviews only, and expect approved
 future follow-ups to be reconciled with the final approved plan instead of
 reopening planning. In `--approved-followups=issue` and `fix-and-issue` modes,
-plan-stage future follow-ups are filed as separate issues before implementation
-starts; otherwise they are summarized inline with a note that they are not
-carried into PR review. Planning `item-*` IDs visible in issue history are not
-PR prior review items unless they appear in the active PR unresolved-item
-ledger. By default the loop posts an approved consensus summary to the issue
-and stops. Add `--implement-after-approval` to continue into the normal
+when implementation will continue after approval, plan-stage future follow-ups
+are filed as separate issues before implementation starts. If implementation
+continues but issue filing is disabled, they are summarized inline with a note
+that they are not carried into PR review. Planning `item-*` IDs visible in issue
+history are not PR prior review items unless they appear in the active PR
+unresolved-item ledger. By default the loop posts an approved consensus summary
+to the issue and stops without filing follow-up issues. Add
+`--implement-after-approval` to continue into the normal
 implementation and PR review loop using the approved plan:
 
 ```bash

--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .config import AgentLoopConfig
-from .github import create_issue, post_pr_comment
+from .github import create_issue, post_issue_comment, post_pr_comment
 from .logging import log
 from .protocol import ApprovedFollowup, UnresolvedReviewItem
 from .runner import Runner
@@ -16,6 +16,10 @@ from .runner import Runner
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
 APPROVED_FOLLOWUP_MARKER_RE = re.compile(
     r"<!--\s*AGENT_APPROVED_FOLLOWUPS:\s*pr=(?P<pr>\d+)\s+head=(?P<head>\S+)\s+mode=(?P<mode>[a-z-]+)\s*-->",
+    re.I,
+)
+PLAN_APPROVED_FOLLOWUP_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_APPROVED_FOLLOWUPS:\s*issue=(?P<issue>\d+)\s+plan=(?P<plan>\S+)\s+mode=(?P<mode>[a-z-]+)\s*-->",
     re.I,
 )
 FOLLOWUP_UPDATE_SPLIT_RE = re.compile(r"\n{2,}Update from ", re.I)
@@ -39,6 +43,38 @@ class GroupedApprovedFollowup:
 class ApprovedFollowupReconciliation:
     groups: tuple[GroupedApprovedFollowup, ...]
     selected_groups: tuple[GroupedApprovedFollowup, ...]
+    skipped_by_cap: int
+    deduplicated_count: int
+
+
+@dataclass(frozen=True)
+class PlanApprovedFollowupSource:
+    item_id: str | None
+    reviewer: str
+    source_round: int | None
+    text: str
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlanGroupedApprovedFollowup:
+    text: str
+    items: tuple[ApprovedFollowup, ...]
+    sources: tuple[PlanApprovedFollowupSource, ...]
+
+    @property
+    def reviewers(self) -> tuple[str, ...]:
+        reviewers: list[str] = []
+        for source in self.sources:
+            if source.reviewer not in reviewers:
+                reviewers.append(source.reviewer)
+        return tuple(reviewers)
+
+
+@dataclass(frozen=True)
+class PlanApprovedFollowupReconciliation:
+    groups: tuple[PlanGroupedApprovedFollowup, ...]
+    selected_groups: tuple[PlanGroupedApprovedFollowup, ...]
     skipped_by_cap: int
     deduplicated_count: int
 
@@ -208,6 +244,25 @@ def _approved_followup_from_unresolved_item(item: UnresolvedReviewItem) -> Appro
     return ApprovedFollowup(reviewer=item.reviewer, text=text)
 
 
+def _plan_followup_source_from_unresolved_item(item: UnresolvedReviewItem) -> PlanApprovedFollowupSource:
+    return PlanApprovedFollowupSource(
+        item_id=item.item_id,
+        reviewer=item.reviewer,
+        source_round=item.source_round,
+        text=item.text,
+        notes=tuple(item.notes),
+    )
+
+
+def _approved_followup_from_plan_source(source: PlanApprovedFollowupSource) -> ApprovedFollowup:
+    text = source.text
+    for note in source.notes:
+        update_line = f"Update from {note}"
+        if update_line not in text:
+            text = f"{text.rstrip()}\n\n{update_line}"
+    return ApprovedFollowup(reviewer=source.reviewer, text=text)
+
+
 def reconcile_approved_followups(
     followups: Sequence[ApprovedFollowup],
     *,
@@ -240,6 +295,37 @@ def reconcile_approved_followups(
         selected_groups=selected_groups,
         skipped_by_cap=max(0, len(grouped) - len(selected_groups)),
         deduplicated_count=len(followups) - len(grouped),
+    )
+
+
+def reconcile_plan_approved_followups(
+    sources: Sequence[PlanApprovedFollowupSource],
+    *,
+    issue_limit: int = MAX_APPROVED_FOLLOWUP_ISSUES,
+) -> PlanApprovedFollowupReconciliation:
+    source_by_projection_id: dict[int, PlanApprovedFollowupSource] = {}
+    projections: list[ApprovedFollowup] = []
+    for source in sources:
+        projection = _approved_followup_from_plan_source(source)
+        projections.append(projection)
+        source_by_projection_id[id(projection)] = source
+
+    reconciliation = reconcile_approved_followups(projections, issue_limit=issue_limit)
+
+    def plan_group(group: GroupedApprovedFollowup) -> PlanGroupedApprovedFollowup:
+        return PlanGroupedApprovedFollowup(
+            text=group.text,
+            items=group.items,
+            sources=tuple(source_by_projection_id[id(item)] for item in group.items),
+        )
+
+    groups = tuple(plan_group(group) for group in reconciliation.groups)
+    selected_groups = tuple(plan_group(group) for group in reconciliation.selected_groups)
+    return PlanApprovedFollowupReconciliation(
+        groups=groups,
+        selected_groups=selected_groups,
+        skipped_by_cap=reconciliation.skipped_by_cap,
+        deduplicated_count=reconciliation.deduplicated_count,
     )
 
 
@@ -323,6 +409,53 @@ def _has_approved_followups_marker(
     return False
 
 
+def _plan_approved_followups_marker(issue_number: int, plan_hash: str, mode: str) -> str:
+    return f"<!-- AGENT_PLAN_APPROVED_FOLLOWUPS: issue={issue_number} plan={plan_hash} mode={mode} -->"
+
+
+def _append_plan_approved_followups_marker(
+    body: str,
+    *,
+    issue_number: int,
+    plan_hash: str,
+    mode: str,
+) -> str:
+    footer = "\n-- coding-review-agent-loop"
+    prefix, found, _suffix = body.rpartition(footer)
+    if not found:
+        return body
+    prefix = prefix.rstrip()
+    return "\n".join(
+        [
+            prefix,
+            "",
+            _plan_approved_followups_marker(issue_number, plan_hash, mode),
+            "-- coding-review-agent-loop",
+        ]
+    )
+
+
+def _has_plan_approved_followups_marker(
+    comments: Sequence[object],
+    *,
+    issue_number: int,
+    plan_hash: str,
+    mode: str,
+) -> bool:
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in PLAN_APPROVED_FOLLOWUP_MARKER_RE.finditer(body):
+            if (
+                int(match.group("issue")) == issue_number
+                and match.group("plan") == plan_hash
+                and match.group("mode").lower() == mode.lower()
+            ):
+                return True
+    return False
+
+
 def _followup_issue_title(followup: ApprovedFollowup) -> str:
     text = " ".join(_followup_main_text(followup.text).split())
     title = f"Follow up future review note: {text}"
@@ -380,6 +513,97 @@ def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> s
         ]
     )
     return "\n".join(lines)
+
+
+def _plan_followup_issue_title(followup: PlanGroupedApprovedFollowup) -> str:
+    text = " ".join(_followup_main_text(followup.text).split())
+    title = f"Follow up future plan-review note: {text}"
+    return title[:120]
+
+
+def _plan_source_label(source: PlanApprovedFollowupSource) -> str:
+    parts: list[str] = []
+    if source.item_id:
+        parts.append(source.item_id)
+    if source.source_round is not None:
+        parts.append(f"round {source.source_round}")
+    parts.append(source.reviewer)
+    return ", ".join(parts)
+
+
+def _plan_followup_issue_body(
+    *,
+    issue_number: int,
+    plan_hash: str,
+    plan_subject: str,
+    followup: PlanGroupedApprovedFollowup,
+) -> str:
+    reviewers = followup.reviewers
+    rounds = sorted({source.source_round for source in followup.sources if source.source_round is not None})
+    item_ids = [source.item_id for source in followup.sources if source.item_id]
+    lines = [
+        f"Future follow-up from approved planning for issue #{issue_number}.",
+        "",
+        "Source context:",
+        f"- Parent issue: #{issue_number}",
+        f"- Approved plan subject: {plan_subject}",
+        f"- Approved plan hash: {plan_hash}",
+    ]
+    if rounds:
+        lines.append("- Planning round(s): " + ", ".join(str(round_number) for round_number in rounds))
+    if len(reviewers) == 1:
+        lines.append(f"- Reviewer: {reviewers[0]}")
+    else:
+        lines.append("- Reviewers: " + ", ".join(reviewers))
+    if item_ids:
+        lines.append("- Original plan item ID(s): " + ", ".join(item_ids))
+    lines.extend(
+        [
+            "",
+            "Canonical follow-up:",
+            f"- {_followup_main_text(followup.text)}",
+            "",
+            "Original reviewer notes:",
+        ]
+    )
+    for source in followup.sources:
+        lines.append(f"- {_plan_source_label(source)}: {source.text}")
+        for note in source.notes:
+            lines.append(f"  - Update from {note}")
+    lines.extend(
+        [
+            "",
+            "This was approved as future work during planning. It is outside the current "
+            "implementation scope and is not a PR-review prior item.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _create_plan_approved_followup_issues(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    plan_hash: str,
+    plan_subject: str,
+    reconciliation: PlanApprovedFollowupReconciliation,
+) -> list[str]:
+    issue_urls: list[str] = []
+    for followup in reconciliation.selected_groups:
+        issue_url = create_issue(
+            runner,
+            config=config,
+            title=_plan_followup_issue_title(followup),
+            body=_plan_followup_issue_body(
+                issue_number=issue_number,
+                plan_hash=plan_hash,
+                plan_subject=plan_subject,
+                followup=followup,
+            ),
+        )
+        issue_urls.append(issue_url or "Created issue URL unavailable from GitHub CLI output.")
+    return issue_urls
 
 
 def _create_approved_followup_issues(
@@ -534,7 +758,10 @@ def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
 def _format_plan_approval_summary_with_followups(
     issue_number: int,
     approved_plan: str,
-    future_followups: Sequence[ApprovedFollowup],
+    *,
+    reconciliation: PlanApprovedFollowupReconciliation | None = None,
+    issue_urls: Sequence[str] = (),
+    filing_enabled: bool = False,
 ) -> str:
     lines = [
         f"Planning complete for issue #{issue_number}.",
@@ -545,8 +772,113 @@ def _format_plan_approval_summary_with_followups(
         "",
         approved_plan,
     ]
-    if future_followups:
-        lines.extend(["", "Approved plan future follow-ups:", ""])
-        lines.extend(f"- {followup.text} ({followup.reviewer})" for followup in future_followups)
+    if reconciliation is not None and reconciliation.selected_groups:
+        if filing_enabled:
+            lines.extend(["", "Filed future follow-up issues:", ""])
+            unique_issue_urls = list(dict.fromkeys(issue_urls))
+            lines.extend(f"- {issue_url}" for issue_url in unique_issue_urls)
+            lines.extend(
+                [
+                    "",
+                    (
+                        f"Reconciliation: {len(reconciliation.selected_groups)} filed, "
+                        f"{reconciliation.deduplicated_count} deduplicated, "
+                        f"{reconciliation.skipped_by_cap} skipped by cap."
+                    ),
+                ]
+            )
+        else:
+            lines.extend(["", "Approved plan future follow-ups:", ""])
+            for followup in reconciliation.selected_groups:
+                reviewers = ", ".join(followup.reviewers)
+                lines.append(f"- {_followup_main_text(followup.text)} ({reviewers})")
+                for source in followup.sources:
+                    for note in source.notes:
+                        lines.append(f"  - Update from {note}")
+            lines.extend(
+                [
+                    "",
+                    (
+                        f"Reconciliation: {len(reconciliation.selected_groups)} summarized, "
+                        f"{reconciliation.deduplicated_count} deduplicated, "
+                        f"{reconciliation.skipped_by_cap} skipped by cap."
+                    ),
+                ]
+            )
+        lines.extend(
+            [
+                "",
+                "These planning-stage future follow-ups are future work outside the current "
+                "implementation scope. They are not carried into PR review and their plan "
+                "item IDs are not PR prior review items.",
+            ]
+        )
     lines.extend(["", "-- coding-review-agent-loop"])
     return "\n".join(lines)
+
+
+def _publish_plan_approved_followups(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    approved_plan: str,
+    plan_hash: str,
+    plan_subject: str,
+    issue_comments: Sequence[object],
+    sources: Sequence[PlanApprovedFollowupSource],
+) -> bool:
+    filing_enabled = config.approved_followups in ("issue", "fix-and-issue")
+    mode = "issue" if filing_enabled else "summarize"
+    if _has_plan_approved_followups_marker(
+        issue_comments,
+        issue_number=issue_number,
+        plan_hash=plan_hash,
+        mode=mode,
+    ):
+        log(
+            config,
+            f"Planning future follow-ups already recorded for issue #{issue_number} "
+            f"plan {plan_hash} ({mode})",
+        )
+        return False
+
+    reconciliation = (
+        reconcile_plan_approved_followups(sources, issue_limit=MAX_APPROVED_FOLLOWUP_ISSUES)
+        if sources
+        else None
+    )
+    issue_urls: list[str] = []
+    if reconciliation is not None and reconciliation.selected_groups:
+        log(
+            config,
+            f"Planning future follow-up reconciliation for issue #{issue_number}: "
+            f"{len(reconciliation.selected_groups)} selected, "
+            f"{reconciliation.deduplicated_count} deduplicated, "
+            f"{reconciliation.skipped_by_cap} skipped by cap",
+        )
+        if filing_enabled:
+            issue_urls = _create_plan_approved_followup_issues(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                plan_hash=plan_hash,
+                plan_subject=plan_subject,
+                reconciliation=reconciliation,
+            )
+
+    body = _format_plan_approval_summary_with_followups(
+        issue_number,
+        approved_plan,
+        reconciliation=reconciliation,
+        issue_urls=issue_urls,
+        filing_enabled=filing_enabled,
+    )
+    body = _append_plan_approved_followups_marker(
+        body,
+        issue_number=issue_number,
+        plan_hash=plan_hash,
+        mode=mode,
+    )
+    post_issue_comment(runner, config=config, issue_number=issue_number, body=body)
+    return True

--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -827,8 +827,9 @@ def _publish_plan_approved_followups(
     plan_subject: str,
     issue_comments: Sequence[object],
     sources: Sequence[PlanApprovedFollowupSource],
+    allow_issue_filing: bool = True,
 ) -> bool:
-    filing_enabled = config.approved_followups in ("issue", "fix-and-issue")
+    filing_enabled = allow_issue_filing and config.approved_followups in ("issue", "fix-and-issue")
     mode = "issue" if filing_enabled else "summarize"
     if _has_plan_approved_followups_marker(
         issue_comments,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -92,7 +92,7 @@ from .protocol import (
     validate_structured_coder_followup,
     validate_structured_plan_revision,
 )
-from .protocol import ApprovedFollowup, parse_review
+from .protocol import parse_review
 from .repair import attempt_repair
 from .runner import Runner
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
@@ -1632,6 +1632,9 @@ def _run_plan_first_loop(
         if all_approved and not must_fix_items:
             plan_hash = approved_plan_hash(current_plan)
             plan_subject = _plan_subject(current_plan)
+            mode = config.plan_execution_mode
+            if implement_after_approval:
+                mode = "implement-one-shot"
             _publish_plan_approved_followups(
                 runner,
                 config=config,
@@ -1641,10 +1644,8 @@ def _run_plan_first_loop(
                 plan_subject=plan_subject,
                 issue_comments=issue_context.comments,
                 sources=approved_future_followup_sources,
+                allow_issue_filing=mode != "plan-only",
             )
-            mode = config.plan_execution_mode
-            if implement_after_approval:
-                mode = "implement-one-shot"
             if mode == "plan-only":
                 print(
                     f"Issue #{issue_number} plan approved by {format_agent_list(configured_reviewers)}."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -129,6 +129,7 @@ from .followups import (
     APPROVED_FOLLOWUP_MARKER_RE,
     GroupedApprovedFollowup,
     MAX_APPROVED_FOLLOWUP_ISSUES,
+    PlanApprovedFollowupSource,
     _append_approved_followups_marker,
     _approved_followup_from_unresolved_item,
     _approved_followups_marker,
@@ -139,9 +140,10 @@ from .followups import (
     _followup_issue_title,
     _format_approved_followup_summary,
     _format_created_followup_issue_summary,
-    _format_plan_approval_summary_with_followups,
     _format_same_pr_followups,
     _has_approved_followups_marker,
+    _plan_followup_source_from_unresolved_item,
+    _publish_plan_approved_followups,
     _normalize_followup_key,
     _publish_approved_followups,
 )
@@ -1233,7 +1235,7 @@ def _run_plan_first_loop(
     reviewer_session_ids: dict[AgentName, str | None] = {}
     unresolved_items: list[UnresolvedReviewItem] = []
     compact_prior_summaries: list[str] = []
-    approved_future_followups: list[ApprovedFollowup] = []
+    approved_future_followup_sources: list[PlanApprovedFollowupSource] = []
     next_unresolved_item_number = 1
     resume_state = _resume_plan_round(issue_context.comments, configured_reviewers=configured_reviewers)
     if resume_state is None:
@@ -1314,7 +1316,7 @@ def _run_plan_first_loop(
             and round_number >= 2
             and round_ledger_incomplete
         ) else ""
-        round_approved_future_followups: list[ApprovedFollowup] = []
+        round_approved_future_followup_sources: list[PlanApprovedFollowupSource] = []
         blocking_reviews: list[tuple[str, str]] = []
         approved_review_outputs: list[tuple[str, str]] = []
         all_approved = True
@@ -1445,7 +1447,9 @@ def _run_plan_first_loop(
                     round_new_unresolved_items.append(tracked_item)
                     reviewer_new_unresolved_items.append(tracked_item)
                     next_unresolved_item_number += 1
-                    round_approved_future_followups.append(item)
+                    round_approved_future_followup_sources.append(
+                        _plan_followup_source_from_unresolved_item(tracked_item)
+                    )
                 post_issue_comment(
                     runner,
                     config=config,
@@ -1476,8 +1480,8 @@ def _run_plan_first_loop(
                 )
             else:
                 round_new_unresolved_items.extend(reviewer_new_unresolved_items)
-                round_approved_future_followups.extend(
-                    _approved_followup_from_unresolved_item(item)
+                round_approved_future_followup_sources.extend(
+                    _plan_followup_source_from_unresolved_item(item)
                     for item in reviewer_new_unresolved_items
                     if item.status == "future"
                 )
@@ -1498,8 +1502,8 @@ def _run_plan_first_loop(
         )
         unresolved_items = [*unresolved_items, *round_new_unresolved_items]
         must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-plan"}]
-        approved_future_followups.extend(
-            _approved_followup_from_unresolved_item(item) for item in future_from_prior_items
+        approved_future_followup_sources.extend(
+            _plan_followup_source_from_unresolved_item(item) for item in future_from_prior_items
         )
         if all_approved and not must_fix_items and issue_context.human_requirements:
             missing_acknowledgements = [
@@ -1623,18 +1627,20 @@ def _run_plan_first_loop(
                     all_approved = False
 
         if all_approved:
-            approved_future_followups.extend(round_approved_future_followups)
+            approved_future_followup_sources.extend(round_approved_future_followup_sources)
 
         if all_approved and not must_fix_items:
-            post_issue_comment(
+            plan_hash = approved_plan_hash(current_plan)
+            plan_subject = _plan_subject(current_plan)
+            _publish_plan_approved_followups(
                 runner,
                 config=config,
                 issue_number=issue_number,
-                body=_format_plan_approval_summary_with_followups(
-                    issue_number,
-                    current_plan,
-                    approved_future_followups,
-                ),
+                approved_plan=current_plan,
+                plan_hash=plan_hash,
+                plan_subject=plan_subject,
+                issue_comments=issue_context.comments,
+                sources=approved_future_followup_sources,
             )
             mode = config.plan_execution_mode
             if implement_after_approval:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1644,7 +1644,7 @@ def _run_plan_first_loop(
                 plan_subject=plan_subject,
                 issue_comments=issue_context.comments,
                 sources=approved_future_followup_sources,
-                allow_issue_filing=mode != "plan-only",
+                allow_issue_filing=mode in {"implement-one-shot", "implement-by-phase"},
             )
             if mode == "plan-only":
                 print(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1517,6 +1517,12 @@ are eligible for dispositions in this round. If same-round findings from
 other reviewers appear elsewhere in the PR discussion, treat them as
 informational only and do not disposition them until a later round carries
 them forward explicitly.
+Item IDs visible only in `issue_context`, issue history, or planning comments
+are informational only. This includes planning-stage `item-*` IDs and approved
+plan future follow-ups, which are tracked separately. Do not include those IDs
+in `prior_item_dispositions` or `prior_plan_item_dispositions` unless they are
+also listed in the active `Prior unresolved review items from earlier rounds`
+section above.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.
 Focus on correctness, security, test coverage, and maintainability. Review the
@@ -1868,6 +1874,12 @@ are eligible for dispositions in this round. If same-round findings from
 other reviewers appear elsewhere in the PR discussion, treat them as
 informational only and do not disposition them until a later round carries
 them forward explicitly.
+Item IDs visible only in `issue_context`, issue history, or planning comments
+are informational only. This includes planning-stage `item-*` IDs and approved
+plan future follow-ups, which are tracked separately. Do not include those IDs
+in `prior_item_dispositions` or `prior_plan_item_dispositions` unless they are
+also listed in the active `Prior unresolved review items from earlier rounds`
+section above.
 {unresolved_items_guidance}
 {followup_guidance}
 Use blocking only for issues that should prevent merge.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12875,6 +12875,214 @@ def test_issue_loop_plan_first_approved_future_followups_are_summarized_without_
     assert "Approved plan future follow-ups:" in runner.comments[-1]
     assert "document parser helper reuse separately" in runner.comments[-1]
     assert "Add a later cleanup to dedupe shared prompt rendering." in runner.comments[-1]
+    assert "not carried into PR review" in runner.comments[-1]
+    assert "not PR prior review items" in runner.comments[-1]
+
+
+def test_issue_loop_plan_first_files_approved_future_followups_before_implementation(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="approved",
+                future_followups=["Add a later cleanup to dedupe shared prompt rendering."],
+            ),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/99"],
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == (
+        "Follow up future plan-review note: Add a later cleanup to dedupe shared prompt rendering."
+    )
+    issue_body = runner.issues[0]["body"]
+    assert "Parent issue: #56" in issue_body
+    assert "Approved plan hash:" in issue_body
+    assert "Planning round(s): 1" in issue_body
+    assert "Original plan item ID(s): item-1" in issue_body
+    assert "Codex" in issue_body
+    assert "outside the current implementation scope" in issue_body
+    assert "not a PR-review prior item" in issue_body
+    summary = runner.comments[2]
+    assert summary.startswith("Planning complete for issue #56.")
+    assert "Filed future follow-up issues:" in summary
+    assert "https://github.com/OWNER/REPO/issues/99" in summary
+    assert "Approved plan future follow-ups:" not in summary
+    assert "<!-- AGENT_PLAN_APPROVED_FOLLOWUPS:" in summary
+
+    issue_create_index = command_index(runner.commands, ["gh", "issue", "create"])
+    second_claude_index = command_index(
+        runner.commands,
+        ["claude", "--print"],
+        start=command_index(runner.commands, ["claude", "--print"]) + 1,
+    )
+    assert issue_create_index < second_claude_index
+
+
+def test_issue_loop_plan_first_ignore_mode_keeps_pr_prior_ledger_clean(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="approved",
+                future_followups=["Track a separate planning cleanup later."],
+            ),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+    )
+    config = make_config(tmp_path, approved_followups="ignore")
+
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
+
+    assert runner.issues == []
+    planning_summary = runner.comments[2]
+    assert "Approved plan future follow-ups:" in planning_summary
+    assert "Track a separate planning cleanup later." in planning_summary
+    assert "not carried into PR review" in planning_summary
+    pr_review_prompt = [
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:2] == ["codex", "exec"] and '"kind": "pr_review"' in cmd[-1]
+    ][0]
+    assert "Only items listed under `Prior unresolved review items from earlier rounds`" in pr_review_prompt
+    assert "Track a separate planning cleanup later." not in pr_review_prompt
+    assert "planning-stage `item-*` IDs and approved\nplan future follow-ups" in pr_review_prompt
+    assert "prior_plan_item_dispositions" in pr_review_prompt
+
+
+def test_issue_loop_plan_first_deduplicates_plan_followup_issues_across_reviewers(tmp_path):
+    runner = FakeRunner(
+        gemini_outputs=[
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Google Gemini",
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="approved",
+                future_followups=[
+                    "**Remote validation**: Validate explicit workdir git remotes against the target repo.",
+                ],
+            ),
+        ],
+        claude_outputs=[
+            structured_plan_review(
+                state="approved",
+                future_followups=[
+                    "**Remote validation**: Validate explicit workdir git remotes against the target repo.",
+                ],
+                reviewer="Anthropic Claude",
+            ),
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/99"],
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        approved_followups="issue",
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(runner.issues) == 1
+    body = runner.issues[0]["body"]
+    assert "Reviewers: Codex, Claude" in body
+    assert "Original plan item ID(s): item-1, item-2" in body
+    assert body.count("**Remote validation**") == 3
+    assert "Reconciliation: 1 filed, 1 deduplicated, 0 skipped by cap." in runner.comments[-1]
+
+
+def test_issue_loop_plan_first_plan_followup_marker_prevents_duplicate_issue_creation(tmp_path):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan_hash = approved_plan_hash(plan)
+    future_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="Codex",
+        source_round=1,
+        text="Add a later cleanup to dedupe shared prompt rendering.",
+        status="future",
+        source_status="future",
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    structured_plan_review(
+                        state="approved",
+                        future_followups=["Add a later cleanup to dedupe shared prompt rendering."],
+                    ),
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        new_items=(future_item,),
+                        state="approved",
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:02Z",
+                "body": (
+                    "Planning complete for issue #56.\n\n"
+                    "<!-- AGENT_PLAN_APPROVED_FOLLOWUPS: "
+                    f"issue=56 plan={plan_hash} mode=issue -->\n"
+                    "-- coding-review-agent-loop"
+                ),
+            },
+        ],
+    )
+    config = make_config(tmp_path, approved_followups="issue")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.issues == []
+    assert runner.comments == []
 
 
 def test_issue_loop_plan_first_decompose_only_creates_child_issues(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12885,6 +12885,55 @@ def test_issue_loop_plan_first_plan_only_does_not_publish_approved_future_follow
     assert "mode=summarize" in summary
 
 
+def test_issue_loop_plan_first_decompose_only_summarizes_instead_of_filing_plan_followups(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Split the implementation into phases.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            plan_decomposition_json(
+                {
+                    "title": "Schema helpers",
+                    "scope": "Add parser dataclasses and tests.",
+                    "non_goals": "No live orchestrator switch.",
+                    "dependency_notes": "First phase; no dependencies.",
+                    "rollout_risk": "low - internal only.",
+                    "validation": "Run python -m pytest tests/test_agent_loop.py.",
+                    "parent_context": "Approved plan slice: add schema helpers and preserve behavior.",
+                    "automation": "agent-pr",
+                    "depends_on": [],
+                }
+            ),
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="approved",
+                future_followups=["Add a later cleanup to dedupe shared prompt rendering."],
+            ),
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/101"],
+    )
+    config = make_config(
+        tmp_path,
+        approved_followups="issue",
+        plan_execution_mode="decompose-only",
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "Phase 1: Schema helpers (from #56)"
+    assert not any(
+        issue["title"].startswith("Follow up future plan-review note:")
+        for issue in runner.issues
+    )
+    planning_summary = runner.comments[2]
+    assert planning_summary.startswith("Planning complete for issue #56.")
+    assert "Approved plan future follow-ups:" in planning_summary
+    assert "Add a later cleanup to dedupe shared prompt rendering." in planning_summary
+    assert "Filed future follow-up issues:" not in planning_summary
+    assert "mode=summarize" in planning_summary
+    assert "mode=issue" not in planning_summary
+
+
 def test_issue_loop_plan_first_files_approved_future_followups_before_implementation(tmp_path):
     runner = FakeRunner(
         claude_outputs=[

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12854,7 +12854,7 @@ def test_issue_loop_plan_first_rejects_contradictory_disposition_before_extra_re
     assert len(claude_calls) == 2
 
 
-def test_issue_loop_plan_first_approved_future_followups_are_summarized_without_reopening(tmp_path):
+def test_issue_loop_plan_first_plan_only_does_not_publish_approved_future_followups(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
             "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
@@ -12872,11 +12872,17 @@ def test_issue_loop_plan_first_approved_future_followups_are_summarized_without_
 
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
 
-    assert "Approved plan future follow-ups:" in runner.comments[-1]
-    assert "document parser helper reuse separately" in runner.comments[-1]
-    assert "Add a later cleanup to dedupe shared prompt rendering." in runner.comments[-1]
-    assert "not carried into PR review" in runner.comments[-1]
-    assert "not PR prior review items" in runner.comments[-1]
+    assert runner.issues == []
+    summary = runner.comments[-1]
+    assert summary.startswith("Planning complete for issue #56.")
+    assert "Approved plan future follow-ups:" in summary
+    assert "document parser helper reuse separately" in summary
+    assert "Add a later cleanup to dedupe shared prompt rendering." in summary
+    assert "not carried into PR review" in summary
+    assert "not PR prior review items" in summary
+    assert "Filed future follow-up issues:" not in summary
+    assert "<!-- AGENT_PLAN_APPROVED_FOLLOWUPS:" in summary
+    assert "mode=summarize" in summary
 
 
 def test_issue_loop_plan_first_files_approved_future_followups_before_implementation(tmp_path):
@@ -12982,6 +12988,7 @@ def test_issue_loop_plan_first_deduplicates_plan_followup_issues_across_reviewer
     runner = FakeRunner(
         gemini_outputs=[
             "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Google Gemini",
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Google Gemini",
         ],
         codex_outputs=[
             structured_plan_review(
@@ -12990,6 +12997,7 @@ def test_issue_loop_plan_first_deduplicates_plan_followup_issues_across_reviewer
                     "**Remote validation**: Validate explicit workdir git remotes against the target repo.",
                 ],
             ),
+            structured_pr_review(state="approved", summary="LGTM."),
         ],
         claude_outputs=[
             structured_plan_review(
@@ -12999,6 +13007,7 @@ def test_issue_loop_plan_first_deduplicates_plan_followup_issues_across_reviewer
                 ],
                 reviewer="Anthropic Claude",
             ),
+            structured_pr_review(state="approved", summary="LGTM.", reviewer="Anthropic Claude"),
         ],
         issue_urls=["https://github.com/OWNER/REPO/issues/99"],
     )
@@ -13009,14 +13018,26 @@ def test_issue_loop_plan_first_deduplicates_plan_followup_issues_across_reviewer
         approved_followups="issue",
     )
 
-    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
 
     assert len(runner.issues) == 1
     body = runner.issues[0]["body"]
     assert "Reviewers: Codex, Claude" in body
     assert "Original plan item ID(s): item-1, item-2" in body
     assert body.count("**Remote validation**") == 3
-    assert "Reconciliation: 1 filed, 1 deduplicated, 0 skipped by cap." in runner.comments[-1]
+    assert any(
+        "Reconciliation: 1 filed, 1 deduplicated, 0 skipped by cap." in comment
+        for comment in runner.comments
+    )
 
 
 def test_issue_loop_plan_first_plan_followup_marker_prevents_duplicate_issue_creation(tmp_path):
@@ -13031,6 +13052,12 @@ def test_issue_loop_plan_first_plan_followup_marker_prevents_duplicate_issue_cre
         source_status="future",
     )
     runner = FakeRunner(
+        claude_outputs=[
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
         issue_comments=[
             {
                 "author": {"login": "bot"},
@@ -13079,10 +13106,22 @@ def test_issue_loop_plan_first_plan_followup_marker_prevents_duplicate_issue_cre
     )
     config = make_config(tmp_path, approved_followups="issue")
 
-    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
 
     assert runner.issues == []
-    assert runner.comments == []
+    assert not any(
+        "Filed future follow-up issues:" in comment or "Approved plan future follow-ups:" in comment
+        for comment in runner.comments
+    )
 
 
 def test_issue_loop_plan_first_decompose_only_creates_child_issues(tmp_path):


### PR DESCRIPTION
## Summary
- file approved plan-stage future follow-ups before implementation in issue-filing modes
- add plan-stage provenance, idempotency markers, and planning-complete summary wording
- prevent PR reviewers from dispositioning planning item IDs as PR prior items

Fixes #235

## Tests
- python3 -m pytest tests/test_agent_loop.py -k "plan_first_approved_future_followups or files_approved_future_followups_before_implementation or ignore_mode_keeps_pr_prior_ledger_clean or deduplicates_plan_followup_issues_across_reviewers or plan_followup_marker_prevents_duplicate_issue_creation or review_prompt"
- python3 -m pytest