### PR TITLE
Recover plan revision human acknowledgements

### DIFF
--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -95,7 +95,10 @@ AGENT_CLARIFY markers in the file, as requested above.
 For structured responses, the file must start directly with {{, contain exactly
 one structured JSON object, then the required footer marker and signature. Do
 not put the stdout filtering marker, headings, prose, or markdown code fences in
-the response file.
+the response file. For structured plan revisions only, if signed human
+requirements are present, place `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` and the
+`### Human requirements` section after the JSON object and before the
+`AGENT_PLAN_STATE` footer.
 """
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1009,7 +1009,10 @@ def _run_validated_agent(
                     repair_kwargs: dict[str, object] = {"expected_kind": repair_expected_kind}
                     if repair_unresolved_item_ids is not None:
                         repair_kwargs["unresolved_item_ids"] = tuple(repair_unresolved_item_ids)
-                    if repair_surfaced_requirement_ids is not None:
+                    if (
+                        repair_expected_kind == "coder_followup"
+                        and repair_surfaced_requirement_ids is not None
+                    ):
                         repair_kwargs["surfaced_requirement_ids"] = tuple(repair_surfaced_requirement_ids)
                     if isinstance(exc, UnknownPriorItemDispositionError):
                         repair_kwargs["allowed_prior_item_ids"] = exc.allowed_ids

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -71,6 +71,7 @@ from .prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from .protocol import (
+    HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedPlanReview,
     ParsedReview,
     PUBLIC_RESPONSE_MARKER,
@@ -80,6 +81,7 @@ from .protocol import (
     UnresolvedReviewItem,
     human_requirements_resolved,
     is_clarification_request,
+    parse_human_requirements_acknowledgement,
     parse_agent_state,
     parse_plan_review,
     parse_plan_review_items,
@@ -217,6 +219,7 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
     {"plan_review", "pr_review", "coder_followup", "plan_revision"}
 )
+PLAN_REVISION_FOOTER_RE = re.compile(r"(?m)^<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$")
 STRUCTURED_FENCE_RE = re.compile(
     r"```(?:json)?[ \t]*\n(?P<body>\s*\{.*?\}\s*)```",
     re.I | re.S,
@@ -601,6 +604,145 @@ def _recover_valid_structured_candidate(
     return None
 
 
+@dataclass(frozen=True)
+class _HumanRequirementsRecoveryContext:
+    surfaced_requirement_ids: tuple[str, ...]
+    requires_direct_discussion_ack: bool
+
+
+def _split_reconstructable_plan_revision_response(text: str) -> tuple[str, str] | None:
+    normalized, _status = normalize_response_file_structured_text(text)
+    decoder = json.JSONDecoder()
+    stripped = normalized.strip()
+    try:
+        payload, end = decoder.raw_decode(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or payload.get("kind") != "plan_revision":
+        return None
+    json_prefix = stripped[:end].rstrip()
+    trailing = stripped[end:].lstrip()
+    footer_match = PLAN_REVISION_FOOTER_RE.search(trailing)
+    if footer_match is None:
+        return None
+    before_footer = trailing[: footer_match.start()].strip()
+    if before_footer:
+        return None
+    footer_and_signature = trailing[footer_match.start() :].strip()
+    return json_prefix, footer_and_signature
+
+
+def _plan_revision_missing_human_acknowledgement(
+    text: str,
+    *,
+    context: _HumanRequirementsRecoveryContext,
+) -> bool:
+    if not context.surfaced_requirement_ids and not context.requires_direct_discussion_ack:
+        return False
+    if _split_reconstructable_plan_revision_response(text) is None:
+        return False
+    parsed = parse_human_requirements_acknowledgement(text)
+    return not parsed.marker_present or not parsed.section_present
+
+
+def _human_requirements_acknowledgement_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    blocks: list[str] = []
+    for index, line in enumerate(lines):
+        if HUMAN_REQUIREMENTS_ADDRESSED_MARKER not in line:
+            continue
+        block_lines = [line.strip()]
+        section_seen = False
+        for next_line in lines[index + 1 :]:
+            if section_seen and (
+                PLAN_REVISION_FOOTER_RE.match(next_line.strip())
+                or re.match(r"^--\s+\S", next_line.strip())
+                or next_line.lstrip().startswith("{")
+            ):
+                break
+            block_lines.append(next_line.rstrip())
+            if re.match(r"^\s*###\s+Human requirements\s*$", next_line, re.I):
+                section_seen = True
+        blocks.append("\n".join(block_lines).strip())
+    return blocks
+
+
+def _recover_plan_revision_human_requirements_acknowledgement(
+    result: AgentResult,
+    *,
+    validate: Callable[[str], object],
+    context: _HumanRequirementsRecoveryContext,
+    config: AgentLoopConfig,
+    agent_name: str,
+) -> tuple[str, object] | None:
+    split = _split_reconstructable_plan_revision_response(result.text)
+    if split is None:
+        log(
+            config,
+            f"{agent_name}: refused plan_revision human-requirements recovery because "
+            "the public response file is not a reconstructable structured plan revision",
+        )
+        return None
+
+    valid_blocks: list[tuple[str, str]] = []
+    invalid_count = 0
+    incomplete_count = 0
+    for source, source_text in _candidate_source_texts(result):
+        for block in _human_requirements_acknowledgement_blocks(source_text):
+            parsed = parse_human_requirements_acknowledgement(block)
+            if not parsed.marker_present or not parsed.section_present:
+                incomplete_count += 1
+                continue
+            try:
+                validate_human_requirements_acknowledgement(
+                    block,
+                    surfaced_requirement_ids=context.surfaced_requirement_ids,
+                    requires_direct_discussion_ack=context.requires_direct_discussion_ack,
+                )
+            except AgentLoopError:
+                invalid_count += 1
+                continue
+            valid_blocks.append((source, block))
+
+    unique_valid: list[tuple[str, str]] = []
+    seen_blocks: set[str] = set()
+    for source, block in valid_blocks:
+        if block in seen_blocks:
+            continue
+        seen_blocks.add(block)
+        unique_valid.append((source, block))
+
+    if len(unique_valid) != 1:
+        if len(unique_valid) > 1:
+            reason = "multiple distinct valid acknowledgement blocks were present"
+        elif invalid_count:
+            reason = "captured acknowledgement evidence failed human-requirements validation"
+        elif incomplete_count:
+            reason = "captured acknowledgement evidence lacked the marker or section"
+        else:
+            reason = "no captured acknowledgement evidence was present"
+        log(config, f"{agent_name}: refused plan_revision human-requirements recovery because {reason}")
+        return None
+
+    json_prefix, footer_and_signature = split
+    source, block = unique_valid[0]
+    recovered_text = f"{json_prefix}\n{block}\n{footer_and_signature}"
+    try:
+        marker_value = validate(recovered_text)
+    except AgentLoopError as exc:
+        log(
+            config,
+            f"{agent_name}: refused plan_revision human-requirements recovery because "
+            f"the reconstructed response did not validate ({exc})",
+        )
+        return None
+    log(
+        config,
+        f"{agent_name}: recovered plan_revision human-requirements acknowledgement from {source}",
+    )
+    return recovered_text, marker_value
+
+
 def _retry_delay(config: AgentLoopConfig, retry_index: int) -> int:
     delays = config.agent_retry_backoff_seconds
     if not delays:
@@ -692,6 +834,7 @@ def _run_validated_agent(
     repair_expected_kind: str | None = None,
     repair_unresolved_item_ids: Sequence[str] | None = None,
     repair_surfaced_requirement_ids: Sequence[str] | None = None,
+    repair_requires_direct_discussion_ack: bool = False,
     repair_allowed_prior_item_ids: Sequence[str] | None = None,
     ledger_incomplete: bool = False,
 ) -> ValidatedAgentResponse:
@@ -805,6 +948,42 @@ def _run_validated_agent(
                         result,
                         validate=validate,
                         expected_kind=repair_expected_kind,
+                        config=config,
+                        agent_name=agent_name,
+                    )
+                    if recovered is not None:
+                        recovered_text, marker_value = recovered
+                        if usage_record is not None:
+                            usage_record.validation_status = "validated"
+                        return ValidatedAgentResponse(
+                            text=recovered_text,
+                            session_id=result.session_id,
+                            marker_value=marker_value,
+                            usage=usage,
+                        )
+                if (
+                    repair_expected_kind == "plan_revision"
+                    and result.response_file_text
+                    and not isinstance(exc, UnknownPriorItemDispositionError)
+                    and _plan_revision_missing_human_acknowledgement(
+                        result.text,
+                        context=_HumanRequirementsRecoveryContext(
+                            surfaced_requirement_ids=tuple(
+                                repair_surfaced_requirement_ids or ()
+                            ),
+                            requires_direct_discussion_ack=repair_requires_direct_discussion_ack,
+                        ),
+                    )
+                ):
+                    recovered = _recover_plan_revision_human_requirements_acknowledgement(
+                        result,
+                        validate=validate,
+                        context=_HumanRequirementsRecoveryContext(
+                            surfaced_requirement_ids=tuple(
+                                repair_surfaced_requirement_ids or ()
+                            ),
+                            requires_direct_discussion_ack=repair_requires_direct_discussion_ack,
+                        ),
                         config=config,
                         agent_name=agent_name,
                     )
@@ -1801,6 +1980,11 @@ def _run_plan_first_loop(
             f"Planning round {round_number}: {coder_name} revising the plan "
             f"(context mode: {context_mode}{context_reason})",
         )
+        plan_revision_human_requirements_context = render_coder_human_requirements_prompt_context(
+            issue_context.human_requirements,
+            requirement_scope="planning requirements",
+            full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+        )
         plan_response = _run_validated_agent(
             runner,
             agent=config.coder,
@@ -1836,6 +2020,12 @@ def _run_plan_first_loop(
             usage_context=usage_context,
             use_repair=True,
             repair_expected_kind="plan_revision",
+            repair_surfaced_requirement_ids=(
+                plan_revision_human_requirements_context.surfaced_requirement_ids
+            ),
+            repair_requires_direct_discussion_ack=(
+                plan_revision_human_requirements_context.requires_direct_discussion_ack
+            ),
             repair_allowed_prior_item_ids=tuple(item.item_id for item in must_fix_items),
             ledger_incomplete=round_ledger_incomplete,
         )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -646,9 +646,12 @@ Use this mandatory structured JSON response format:
 The orchestrator will normalize structured plan revisions into canonical
 markdown for stored plan state, reviewer prompts, subject hashing, and resume.
 Your response must start with exactly one top-level JSON object, with no prose
-or code fences before it. Put the `AGENT_PLAN_STATE` footer immediately after
-the JSON, make the footer state match the JSON state, and include only your
-standalone signature after the footer.
+or code fences before it. If signed human requirements are present, put
+`<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` and a `### Human requirements` section
+after the JSON object and before the `AGENT_PLAN_STATE` footer. Otherwise, put
+the `AGENT_PLAN_STATE` footer immediately after the JSON. Make the footer state
+match the JSON state, and include only your standalone signature after the
+footer.
 """
 
 
@@ -1194,9 +1197,12 @@ Use this mandatory structured JSON response format:
 The orchestrator will normalize structured plan revisions into canonical
 markdown for stored plan state, reviewer prompts, subject hashing, and resume.
 Your response must start with exactly one top-level JSON object, with no prose
-or code fences before it. Put the `AGENT_PLAN_STATE` footer immediately after
-the JSON, make the footer state match the JSON state, and include only your
-standalone signature after the footer.
+or code fences before it. If signed human requirements are present, put
+`<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` and a `### Human requirements` section
+after the JSON object and before the `AGENT_PLAN_STATE` footer. Otherwise, put
+the `AGENT_PLAN_STATE` footer immediately after the JSON. Make the footer state
+match the JSON state, and include only your standalone signature after the
+footer.
 
 This is planning round {round_number}. End your final response with exactly one
 planning marker:

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -318,6 +318,7 @@ CORRECT repair — output plan_revision JSON first, preserve the human requireme
 Notes:
 - When repairing plan_revision, do not output coder_followup even if the original contains a Human requirements section.
 - If the original plan revision includes <!-- HUMAN_REQUIREMENTS_ADDRESSED --> and a ### Human requirements section, preserve both after the JSON and before <!-- AGENT_PLAN_STATE: blocking -->.
+- If the original plan revision does not include both that marker and section, do not fabricate a human requirements acknowledgement.
 
 ## WORKED EXAMPLE 5 — coder follow-up with no signed human requirements:
 
@@ -487,7 +488,7 @@ Only genuinely independent later work should remain in future_followups on an ap
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,
    place that marker immediately after the JSON and before the AGENT_STATE/AGENT_PLAN_STATE footer.
-   For `plan_revision`, place the optional signed human requirements acknowledgement before the footer.
+   For `plan_revision`, place the optional signed human requirements acknowledgement before the footer only when it was present in the malformed original.
    Then: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
 3. JSON "state" matches X. Then: -- Agent Name. STOP. Nothing else.
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 import coding_review_agent_loop.orchestrator as orchestrator
+from coding_review_agent_loop.agents.base import with_public_response_file_instruction
 from coding_review_agent_loop.agents.claude import (
     BACKEND as CLAUDE_BACKEND,
     _normalize_claude_usage,
@@ -7192,6 +7193,7 @@ def test_structured_plan_revision_transient_terms_before_footer_runs_repair(tmp_
             validate=_validate_plan_revision_response,
             use_repair=True,
             repair_expected_kind="plan_revision",
+            repair_surfaced_requirement_ids=("Requirement 1",),
         )
 
     assert response.text == repaired_revision
@@ -14666,6 +14668,18 @@ def test_claude_review_loop_prefers_public_response_file_over_stdout(tmp_path):
     assert "PUBLIC RESPONSE FILE:" in claude_call[-1]
     assert "/coding-review-agent-loop/responses/OWNER-REPO/claude/" in claude_call[-1]
     assert runner.comments == ["**Review verdict:** Approved\n\nLGTM from response file.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"]
+
+
+def test_public_response_file_instruction_mentions_plan_revision_human_ack_exception(tmp_path):
+    prompt = with_public_response_file_instruction(
+        "Review the PR.",
+        tmp_path / "response.md",
+    )
+
+    assert "For structured plan revisions only" in prompt
+    assert "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->" in prompt
+    assert "`### Human requirements` section after the JSON object" in prompt
+    assert "before the\n`AGENT_PLAN_STATE` footer" in prompt
 
 
 def test_codex_task_loop_rejects_empty_task_text(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3923,6 +3923,9 @@ def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositio
     assert '"kind": "plan_revision"' in prompt
     assert '"plan_steps"' in prompt
     assert "normalize structured plan revisions into canonical\nmarkdown for stored plan state" in prompt
+    assert "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->" in prompt
+    assert "### Human requirements" in prompt
+    assert "after the JSON object and before the `AGENT_PLAN_STATE` footer" in prompt
     assert "Use this mandatory structured JSON response format" in prompt
     assert "fall back to markdown" not in prompt.lower()
 
@@ -4085,6 +4088,9 @@ def test_compact_plan_revision_prompt_preserves_context_and_omits_raw_prose(tmp_
     assert "Blocking review payload." in tail
     assert "Planning round: 2" in tail
     assert "subject-b" in tail
+    assert "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->" in prompt
+    assert "### Human requirements" in prompt
+    assert "after the JSON object and before the `AGENT_PLAN_STATE` footer" in prompt
 
 
 def test_full_plan_prompt_still_includes_raw_issue_comments(tmp_path):
@@ -6770,6 +6776,289 @@ def test_run_validated_agent_recovers_fenced_coder_followup_from_raw_stdout(tmp_
     )
 
     assert response.text == valid_followup
+
+
+def _plan_revision_validate_with_human_requirements(human_requirements):
+    return lambda text: orchestrator._validate_response_with_human_requirements(
+        text,
+        marker_validator=lambda revised_text: _validate_plan_revision_response(
+            revised_text,
+            unresolved_items=(),
+        ),
+        human_requirements=human_requirements,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+
+
+def test_run_validated_agent_recovers_plan_revision_human_ack_from_message_text(tmp_path):
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="wwind123",
+            created_at="2026-06-05T00:00:00Z",
+            url="https://github.com/OWNER/REPO/issues/237#issuecomment-1",
+            body="Cover stdout acknowledgement recovery.",
+        ),
+    )
+    context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+    response_file = structured_plan_revision(reviewer="Anthropic Claude")
+    acknowledgement = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+        "### Human requirements\n"
+        "- Requirement 1: The revised plan covers stdout acknowledgement recovery.\n"
+    )
+    message_text = structured_plan_revision(
+        reviewer="Anthropic Claude",
+        human_requirements=acknowledgement,
+    )
+    runner = FakeRunner(
+        claude_outputs=[(message_text, 0)],
+        public_response_outputs=[{"text": response_file}],
+    )
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Revise the plan.",
+            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+            validate=_plan_revision_validate_with_human_requirements(human_requirements),
+            use_repair=True,
+            repair_expected_kind="plan_revision",
+            repair_surfaced_requirement_ids=context.surfaced_requirement_ids,
+            repair_requires_direct_discussion_ack=context.requires_direct_discussion_ack,
+        )
+
+    repair_mock.assert_not_called()
+    assert "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->" in response.text
+    assert "### Human requirements" in response.text
+    assert response.text.index("### Human requirements") < response.text.index(
+        "<!-- AGENT_PLAN_STATE: blocking -->"
+    )
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n",
+        "\n### Human requirements\n- Requirement 1: Covered.\n",
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n### Human requirements\n- Requirement 99: Covered.\n",
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n### Human requirements\n- Requirement 1: Covered.\n- Requirement 1: Covered again.\n",
+    ],
+)
+def test_run_validated_agent_refuses_invalid_plan_revision_human_ack_evidence(tmp_path, evidence):
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="wwind123",
+            created_at="2026-06-05T00:00:00Z",
+            url="https://github.com/OWNER/REPO/issues/237#issuecomment-1",
+            body="Cover stdout acknowledgement recovery.",
+        ),
+    )
+    context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            (
+                structured_plan_revision(
+                    reviewer="Anthropic Claude",
+                    human_requirements=evidence,
+                ),
+                0,
+            )
+        ],
+        public_response_outputs=[{"text": structured_plan_revision(reviewer="Anthropic Claude")}],
+    )
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None) as repair_mock:
+        with pytest.raises(AgentLoopError, match="No review result was recorded"):
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Revise the plan.",
+                marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                validate=_plan_revision_validate_with_human_requirements(human_requirements),
+                use_repair=True,
+                repair_expected_kind="plan_revision",
+                repair_surfaced_requirement_ids=context.surfaced_requirement_ids,
+                repair_requires_direct_discussion_ack=context.requires_direct_discussion_ack,
+            )
+
+    repair_mock.assert_called_once()
+
+
+def test_run_validated_agent_refuses_plan_revision_missing_direct_discussion_ack(tmp_path):
+    context = render_coder_human_requirements_prompt_context(
+        (),
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+    acknowledgement = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+        "### Human requirements\n"
+        "- The prompt omitted the detailed signed human requirements.\n"
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            (
+                structured_plan_revision(
+                    reviewer="Anthropic Claude",
+                    human_requirements=acknowledgement,
+                ),
+                0,
+            )
+        ],
+        public_response_outputs=[{"text": structured_plan_revision(reviewer="Anthropic Claude")}],
+    )
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
+        with pytest.raises(AgentLoopError, match="No review result was recorded"):
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Revise the plan.",
+                marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                validate=lambda text: (
+                    _validate_plan_revision_response(text, unresolved_items=()),
+                    validate_human_requirements_acknowledgement(
+                        text,
+                        surfaced_requirement_ids=(),
+                        requires_direct_discussion_ack=True,
+                    ),
+                )[0],
+                use_repair=True,
+                repair_expected_kind="plan_revision",
+                repair_surfaced_requirement_ids=context.surfaced_requirement_ids,
+                repair_requires_direct_discussion_ack=True,
+            )
+
+
+def test_run_validated_agent_refuses_conflicting_plan_revision_human_ack_blocks(tmp_path):
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="wwind123",
+            created_at="2026-06-05T00:00:00Z",
+            url="https://github.com/OWNER/REPO/issues/237#issuecomment-1",
+            body="Cover stdout acknowledgement recovery.",
+        ),
+    )
+    context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+    first = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+        "### Human requirements\n- Requirement 1: Covered by the parser step.\n"
+    )
+    second = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+        "### Human requirements\n- Requirement 1: Covered by the orchestrator step.\n"
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            (
+                structured_plan_revision(
+                    reviewer="Anthropic Claude",
+                    human_requirements=first,
+                )
+                + "\n\n"
+                + second,
+                0,
+            )
+        ],
+        public_response_outputs=[{"text": structured_plan_revision(reviewer="Anthropic Claude")}],
+    )
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
+        with pytest.raises(AgentLoopError, match="No review result was recorded"):
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Revise the plan.",
+                marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                validate=_plan_revision_validate_with_human_requirements(human_requirements),
+                use_repair=True,
+                repair_expected_kind="plan_revision",
+                repair_surfaced_requirement_ids=context.surfaced_requirement_ids,
+                repair_requires_direct_discussion_ack=context.requires_direct_discussion_ack,
+            )
+
+
+def test_run_validated_agent_does_not_recover_unknown_prior_item_disposition(tmp_path):
+    human_requirements = (
+        HumanReviewRequirement(
+            source_type="Issue comment",
+            author="wwind123",
+            created_at="2026-06-05T00:00:00Z",
+            url="https://github.com/OWNER/REPO/issues/237#issuecomment-1",
+            body="Cover stdout acknowledgement recovery.",
+        ),
+    )
+    context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope="planning requirements",
+        full_omission_fallback="Fetch the issue discussion directly before revising the plan.",
+    )
+    acknowledgement = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+        "### Human requirements\n- Requirement 1: Covered.\n"
+    )
+    response_file = structured_plan_revision(
+        reviewer="Anthropic Claude",
+        prior_plan_item_dispositions=[
+            {"item_id": "item-unknown", "disposition": "resolved", "note": "Covered."}
+        ],
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            (
+                structured_plan_revision(
+                    reviewer="Anthropic Claude",
+                    human_requirements=acknowledgement,
+                ),
+                0,
+            )
+        ],
+        public_response_outputs=[{"text": response_file}],
+    )
+    config = make_config(tmp_path, coder="claude", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None) as repair_mock:
+        with pytest.raises(AgentLoopError, match="No review result was recorded"):
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Revise the plan.",
+                marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                validate=_plan_revision_validate_with_human_requirements(human_requirements),
+                use_repair=True,
+                repair_expected_kind="plan_revision",
+                repair_surfaced_requirement_ids=context.surfaced_requirement_ids,
+                repair_requires_direct_discussion_ack=context.requires_direct_discussion_ack,
+                repair_allowed_prior_item_ids=(),
+            )
+
+    repair_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- clarify plan-revision prompt ordering for signed human-requirements acknowledgements
- recover a missing plan_revision acknowledgement from captured Claude stdout/message text when exactly one valid block is present
- keep invalid, ambiguous, or unrelated validation failures deterministic and add regression coverage

Fixes #237

## Tests
- python3 -m pytest tests/test_agent_loop.py