### PR TITLE
Clarify PR follow-up classification

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1501,11 +1501,17 @@ exactly one top-level JSON object and no prose or code fences before it:
   ]
 }}
 
-`blocking_items` and `same_pr_followups` must be mutually exclusive: a single
-concern belongs in exactly one list. Put merge-blocking defects, missing
-requirements, regressions, security issues, and consistency gaps in
-`blocking_items`; put only small Same-PR cleanup that is not itself the reason
-the PR is blocked in `same_pr_followups`.
+`blocking_items`, `same_pr_followups`, and `future_followups` have distinct
+roles. `blocking_items` are merge-blocking defects, missing requirements,
+regressions, security issues, or consistency gaps. `same_pr_followups` are
+small, localized cleanup in touched files or directly adjacent code that should
+be handled before merge, but is not itself a major correctness blocker.
+`future_followups` are independent later work that remains valid after this PR
+is merge-ready. Keep `blocking_items` and `same_pr_followups` mutually
+exclusive: a single current-PR concern belongs in exactly one of those lists.
+Before approving, self-check every `future_followups` entry: if it is trivial
+or local to the current PR, reclassify it as `same_pr_followups` and return
+`blocking`, or omit it if it is only a nit.
 
 After the JSON object, include only:
 1. optional `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`
@@ -1611,6 +1617,9 @@ Contradictory forms like `same-pr: none`, `still blocking: none`, and `future fo
 Non-blocking follow-ups sections in approved reviews; this run is configured to
 ignore approved-review follow-up sections. Mark the review blocking instead
 when cleanup should be fixed before merge.
+Trivial style nits in touched code should be omitted unless worth requiring
+before merge; if required, they are current-PR work and the review is blocking,
+not approved with Future follow-ups.
 """
     elif config.approved_followups.startswith("fix-and-"):
         followup_guidance = f"""For small, localized, low-risk cleanup that must still be fixed in this PR
@@ -1620,8 +1629,10 @@ under this exact heading:
 ### Same-PR follow-ups
 
 Use Same-PR follow-ups only for narrow current-PR cleanup in files already
-touched by this PR or directly adjacent code. Do not use this section for
-larger redesigns, broad refactors, or independent future work.
+touched by this PR or directly adjacent code. This includes indentation or
+style cleanup in touched code when it is worth requiring before merge, and
+duplicated helper or prompt wording introduced by this PR. Do not use this
+section for larger redesigns, broad refactors, or independent future work.
 Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
 `blocking_items` for defects, missing requirements, regressions, security
 issues, or consistency gaps that make the PR not merge-ready. Use
@@ -1637,13 +1648,20 @@ three highest-value items under this exact heading:
 
 ### Future follow-ups
 
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups; classify it as Same-PR if it should be
+done before merge, otherwise omit it.
 Approved means there are no blocking issues, no Same-PR follow-ups, and no
 carried-forward prior unresolved items left active for this round.
 Same-PR follow-ups will be sent back to {coder_name} and require another review
-round before final approval. Do not put trivial style nits in either follow-up
-section. If you return `<!-- AGENT_STATE: blocking -->`, do not use structured
-Future follow-ups; keep all required current-round work in the blocking review
-so it is not missed during revision.
+round before final approval. Before returning approved, self-check that no
+Future follow-up is trivial or local to the current PR; reclassify it as
+Same-PR or omit it. Do not put trivial style nits in either follow-up section.
+If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
+follow-ups; keep all required current-round work in the blocking review so it
+is not missed during revision.
 """
     else:
         followup_guidance = """If you approve but notice substantial work that is better handled separately in
@@ -1652,8 +1670,17 @@ heading:
 
 ### Future follow-ups
 
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups. Indentation/style cleanup in touched
+code should be omitted unless worth requiring before merge; duplicated helper
+or prompt wording introduced by this PR should make the review blocking if it
+must be fixed now.
 Do not use the Same-PR follow-ups section in this mode; mark the review blocking
 instead when small or local cleanup should be fixed before merge.
+Before returning approved, self-check that no Future follow-up is trivial or
+local to the current PR; reclassify it as blocking current-PR work or omit it.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
@@ -1790,6 +1817,9 @@ Contradictory forms like `same-pr: none`, `still blocking: none`, and `future fo
 Non-blocking follow-ups sections in approved reviews; this run is configured to
 ignore approved-review follow-up sections. Mark the review blocking instead
 when cleanup should be fixed before merge.
+Trivial style nits in touched code should be omitted unless worth requiring
+before merge; if required, they are current-PR work and the review is blocking,
+not approved with Future follow-ups.
 """
     elif config.approved_followups.startswith("fix-and-"):
         followup_guidance = f"""For small, localized, low-risk cleanup that must still be fixed in this PR
@@ -1799,8 +1829,10 @@ under this exact heading:
 ### Same-PR follow-ups
 
 Use Same-PR follow-ups only for narrow current-PR cleanup in files already
-touched by this PR or directly adjacent code. Do not use this section for
-larger redesigns, broad refactors, or independent future work.
+touched by this PR or directly adjacent code. This includes indentation or
+style cleanup in touched code when it is worth requiring before merge, and
+duplicated helper or prompt wording introduced by this PR. Do not use this
+section for larger redesigns, broad refactors, or independent future work.
 Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
 `blocking_items` for defects, missing requirements, regressions, security
 issues, or consistency gaps that make the PR not merge-ready. Use
@@ -1816,13 +1848,20 @@ three highest-value items under this exact heading:
 
 ### Future follow-ups
 
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups; classify it as Same-PR if it should be
+done before merge, otherwise omit it.
 Approved means there are no blocking issues, no Same-PR follow-ups, and no
 carried-forward prior unresolved items left active for this round.
 Same-PR follow-ups will be sent back to {coder_name} and require another review
-round before final approval. Do not put trivial style nits in either follow-up
-section. If you return `<!-- AGENT_STATE: blocking -->`, do not use structured
-Future follow-ups; keep all required current-round work in the blocking review
-so it is not missed during revision.
+round before final approval. Before returning approved, self-check that no
+Future follow-up is trivial or local to the current PR; reclassify it as
+Same-PR or omit it. Do not put trivial style nits in either follow-up section.
+If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
+follow-ups; keep all required current-round work in the blocking review so it
+is not missed during revision.
 """
     else:
         followup_guidance = """If you approve but notice substantial work that is better handled separately in
@@ -1831,8 +1870,17 @@ heading:
 
 ### Future follow-ups
 
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups. Indentation/style cleanup in touched
+code should be omitted unless worth requiring before merge; duplicated helper
+or prompt wording introduced by this PR should make the review blocking if it
+must be fixed now.
 Do not use the Same-PR follow-ups section in this mode; mark the review blocking
 instead when small or local cleanup should be fixed before merge.
+Before returning approved, self-check that no Future follow-up is trivial or
+local to the current PR; reclassify it as blocking current-PR work or omit it.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
@@ -1909,11 +1957,17 @@ exactly one top-level JSON object and no prose or code fences before it:
   ]
 }}
 
-`blocking_items` and `same_pr_followups` must be mutually exclusive: a single
-concern belongs in exactly one list. Put merge-blocking defects, missing
-requirements, regressions, security issues, and consistency gaps in
-`blocking_items`; put only small Same-PR cleanup that is not itself the reason
-the PR is blocked in `same_pr_followups`.
+`blocking_items`, `same_pr_followups`, and `future_followups` have distinct
+roles. `blocking_items` are merge-blocking defects, missing requirements,
+regressions, security issues, or consistency gaps. `same_pr_followups` are
+small, localized cleanup in touched files or directly adjacent code that should
+be handled before merge, but is not itself a major correctness blocker.
+`future_followups` are independent later work that remains valid after this PR
+is merge-ready. Keep `blocking_items` and `same_pr_followups` mutually
+exclusive: a single current-PR concern belongs in exactly one of those lists.
+Before approving, self-check every `future_followups` entry: if it is trivial
+or local to the current PR, reclassify it as `same_pr_followups` and return
+`blocking`, or omit it if it is only a nit.
 
 After the JSON object, include only:
 1. optional `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -871,24 +871,6 @@ def _normalized_review_item_text(text: str) -> str:
     return normalized.casefold()
 
 
-def _dedupe_same_pr_against_blocking(
-    blocking_items: tuple[ApprovedFollowup, ...],
-    same_pr_followups: tuple[ApprovedFollowup, ...],
-) -> tuple[ApprovedFollowup, ...]:
-    blocking_texts = {
-        normalized
-        for item in blocking_items
-        if (normalized := _normalized_review_item_text(item.text))
-    }
-    if not blocking_texts:
-        return same_pr_followups
-    return tuple(
-        item
-        for item in same_pr_followups
-        if _normalized_review_item_text(item.text) not in blocking_texts
-    )
-
-
 def _dedupe_followups_against(
     items: tuple[ApprovedFollowup, ...],
     *authoritative_groups: tuple[ApprovedFollowup, ...],
@@ -912,6 +894,17 @@ def _dedupe_plan_review_items(items: PlanReviewItems) -> PlanReviewItems:
     if same_plan is items.same_plan and future is items.future:
         return items
     return PlanReviewItems(blocking=items.blocking, same_plan=same_plan, future=future)
+
+
+def _dedupe_pr_review_items(
+    blocking_items: tuple[ApprovedFollowup, ...],
+    followups: ApprovedFollowups,
+) -> ApprovedFollowups:
+    same_pr = _dedupe_followups_against(followups.same_pr, blocking_items)
+    future = _dedupe_followups_against(followups.future, blocking_items, same_pr)
+    if same_pr is followups.same_pr and future is followups.future:
+        return followups
+    return ApprovedFollowups(same_pr=same_pr, future=future)
 
 
 def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | None:
@@ -963,21 +956,21 @@ def parse_structured_pr_review(text: str, *, reviewer: str) -> ParsedReview | No
         allowed_same_status="same-pr",
         is_plan_review=False,
     )
-    if state == "blocking" and future_followups:
-        raise AgentLoopError("Blocking structured reviews may not include future follow-ups.")
     structured_blocking_items = _structured_followups(blocking_items, reviewer=reviewer)
-    structured_same_pr_followups = _dedupe_same_pr_against_blocking(
+    followups = _dedupe_pr_review_items(
         structured_blocking_items,
-        _structured_followups(same_pr_followups, reviewer=reviewer),
+        ApprovedFollowups(
+            same_pr=_structured_followups(same_pr_followups, reviewer=reviewer),
+            future=_structured_followups(future_followups, reviewer=reviewer),
+        ),
     )
+    if state == "blocking" and followups.future:
+        raise AgentLoopError("Blocking structured reviews may not include future follow-ups.")
     return _finalize_parsed_review(
         state=state,
         summary=summary,
         blocking_items=structured_blocking_items,
-        followups=ApprovedFollowups(
-            same_pr=structured_same_pr_followups,
-            future=_structured_followups(future_followups, reviewer=reviewer),
-        ),
+        followups=followups,
         dispositions=dispositions,
     )
 
@@ -1549,10 +1542,7 @@ def parse_review(text: str, *, reviewer: str) -> ParsedReview:
     summary = review_freeform_summary_text(text)
     blocking_items = parse_pr_blocking_items(text, reviewer=reviewer)
     followups = parse_approved_followups(text, reviewer=reviewer)
-    followups = ApprovedFollowups(
-        same_pr=_dedupe_same_pr_against_blocking(blocking_items, followups.same_pr),
-        future=followups.future,
-    )
+    followups = _dedupe_pr_review_items(blocking_items, followups)
     dispositions = parse_unresolved_item_dispositions(text, reviewer=reviewer)
     return _finalize_parsed_review(
         state=state,

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -168,6 +168,12 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 - If the same plan-review concern or paraphrase appears in same_plan_followups and future_followups, keep same_plan_followups/current-plan work and drop the duplicate future_followups entry.
 - If the same plan-review concern or paraphrase appears in blocking_plan_issues and future_followups, keep blocking_plan_issues and drop the duplicate future_followups entry.
 
+## DEDUPE RULES (Format A):
+- Same-PR follow-ups and Future follow-ups are mutually exclusive.
+- If the same PR-review concern or paraphrase appears in blocking_items and same_pr_followups, keep blocking_items and drop the duplicate same_pr_followups entry.
+- If the same PR-review concern or paraphrase appears in same_pr_followups and future_followups, keep same_pr_followups/current-PR work and drop the duplicate future_followups entry.
+- If the same PR-review concern or paraphrase appears in blocking_items and future_followups, keep blocking_items and drop the duplicate future_followups entry.
+
 ## STATE RULES (Format C):
 ### APPROVED: remaining_items=[]
 ### BLOCKING: remaining_items is non-empty

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2676,6 +2676,45 @@ def test_parse_review_dedupes_same_pr_items_that_duplicate_blocking_items():
     assert parsed.followups.same_pr == ()
 
 
+def test_parse_review_prefers_same_pr_over_duplicate_future_followups():
+    review = """
+    Blocking on a local cleanup.
+
+    ### Same-PR follow-ups
+    - Fix the duplicated prompt wording introduced by this PR.
+
+    ### Future follow-ups
+    - `Fix the duplicated prompt wording introduced by this PR.`
+
+    <!-- AGENT_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    parsed = parse_review(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in parsed.followups.same_pr] == [
+        "Fix the duplicated prompt wording introduced by this PR."
+    ]
+    assert parsed.followups.future == ()
+
+
+def test_parse_review_prefers_blocking_over_duplicate_future_followups():
+    review = (
+        "Blocking issue summary."
+        + blocking_issues("Fix the indentation in the touched `orchestrator.py` call.")
+        + "\n\n### Future follow-ups\n"
+        + "- fix the indentation in the touched orchestrator.py call\n"
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = parse_review(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in parsed.blocking_items] == [
+        "Fix the indentation in the touched `orchestrator.py` call."
+    ]
+    assert parsed.followups.future == ()
+
+
 def test_parse_structured_pr_review_dedupes_exact_normalized_same_pr_duplicates():
     review = json.dumps(
         {
@@ -2697,6 +2736,42 @@ def test_parse_structured_pr_review_dedupes_exact_normalized_same_pr_duplicates(
         "- Add the missing `share.html` CSS update."
     ]
     assert parsed.followups.same_pr == ()
+
+
+def test_parse_structured_pr_review_prefers_same_pr_over_duplicate_future_followups():
+    review = structured_pr_review(
+        state="blocking",
+        summary="Blocked on local cleanup.",
+        blocking_items=[],
+        same_pr_followups=["Fix the duplicated prompt wording introduced by this PR."],
+        future_followups=["fix the duplicated prompt wording introduced by this PR"],
+    )
+
+    parsed = parse_pr_review(review, reviewer="OpenAI Codex")
+
+    assert parsed.blocking_items == ()
+    assert [item.text for item in parsed.followups.same_pr] == [
+        "Fix the duplicated prompt wording introduced by this PR."
+    ]
+    assert parsed.followups.future == ()
+
+
+def test_parse_structured_pr_review_prefers_blocking_over_duplicate_future_followups():
+    review = structured_pr_review(
+        state="blocking",
+        summary="Blocked.",
+        blocking_items=["Fix the indentation in the touched `orchestrator.py` call."],
+        same_pr_followups=[],
+        future_followups=["fix the indentation in the touched orchestrator.py call"],
+    )
+
+    parsed = parse_pr_review(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in parsed.blocking_items] == [
+        "Fix the indentation in the touched `orchestrator.py` call."
+    ]
+    assert parsed.followups.same_pr == ()
+    assert parsed.followups.future == ()
 
 
 def test_parse_structured_pr_review_keeps_near_but_distinct_same_pr_items():
@@ -2721,6 +2796,32 @@ def test_parse_structured_pr_review_keeps_near_but_distinct_same_pr_items():
     ]
     assert [item.text for item in parsed.followups.same_pr] == [
         "Add the missing share.html print CSS update."
+    ]
+
+
+def test_pr_239_style_followup_classification_fixture():
+    review = """
+    PR #239-style cleanup classification.
+
+    ### Same-PR follow-ups
+    - orchestrator.py line 2100: subject=current_pr_subject is indented 4 extra spaces relative to sibling keyword arguments.
+    - _repair_prior_item_ids_instruction duplicates the same-round warning/context in the repair prompt.
+
+    ### Future follow-ups
+    - _round_ledger_may_be_incomplete cross-subject branch could be bounded if comment history grows very large.
+
+    <!-- AGENT_STATE: blocking -->
+    -- OpenAI Codex
+    """
+
+    followups = parse_approved_followups(review, reviewer="OpenAI Codex")
+
+    assert [item.text for item in followups.same_pr] == [
+        "orchestrator.py line 2100: subject=current_pr_subject is indented 4 extra spaces relative to sibling keyword arguments.",
+        "_repair_prior_item_ids_instruction duplicates the same-round warning/context in the repair prompt.",
+    ]
+    assert [item.text for item in followups.future] == [
+        "_round_ledger_may_be_incomplete cross-subject branch could be bounded if comment history grows very large."
     ]
 
 
@@ -4168,7 +4269,11 @@ def test_config_and_cli_default_to_full_pr_review_context(tmp_path):
 
 
 def test_compact_pr_review_prompt_preserves_context_and_omits_raw_history(tmp_path):
-    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    config = make_config(
+        tmp_path,
+        approved_followups="fix-and-summarize",
+        reviewer=("codex", "gemini"),
+    )
     issue_context = _compact_pr_issue_context()
     prompt = build_review_prompt(
         77,
@@ -4226,6 +4331,11 @@ def test_compact_pr_review_prompt_preserves_context_and_omits_raw_history(tmp_pa
     assert "[item-4] resolved: old resolved item" in prefix
     assert "Coder says the compact mode wiring is complete." in prefix
     assert "python -m pytest tests/test_agent_loop.py -k compact_pr" in prefix
+    assert "Use Future follow-ups only for independent later work" in prefix
+    assert "broader scaling or performance refinement\nfor very large histories" in prefix
+    assert "indentation or\nstyle cleanup in touched code" in prefix
+    assert "duplicated helper or prompt wording introduced by this PR" in prefix
+    assert "Before approving, self-check every `future_followups` entry" in prefix
     assert "Review compact PR context mode." in tail
     assert "Head SHA: abc123" in tail
     assert "gh pr diff 77 --repo OWNER/REPO" in tail
@@ -8549,6 +8659,12 @@ def test_review_prompt_requests_future_followups_when_processed(tmp_path):
     assert "### Future follow-ups" in prompt
     assert "legacy heading `### Non-blocking follow-ups`" in prompt
     assert "Do not use the Same-PR follow-ups section in this mode" in prompt
+    assert "Use Future follow-ups only for independent later work" in prompt
+    assert "broader scaling or performance refinement\nfor very large histories" in prompt
+    assert "Do not put small cleanup in touched or directly\nadjacent code under Future follow-ups" in prompt
+    assert "Indentation/style cleanup in touched\ncode should be omitted unless worth requiring before merge" in prompt
+    assert "duplicated helper\nor prompt wording introduced by this PR should make the review blocking" in prompt
+    assert "Before returning approved, self-check that no Future follow-up is trivial or\nlocal to the current PR" in prompt
     assert "Use blocking only for issues that should prevent merge." in prompt
 
 
@@ -8563,6 +8679,11 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     assert "### Future follow-ups" in prompt
     assert "small, localized, low-risk cleanup" in prompt
     assert "narrow current-PR cleanup in files already\ntouched by this PR or directly adjacent code" in prompt
+    assert "indentation or\nstyle cleanup in touched code" in prompt
+    assert "duplicated helper or prompt wording introduced by this PR" in prompt
+    assert "Use Future follow-ups only for independent later work" in prompt
+    assert "broader scaling or performance refinement\nfor very large histories" in prompt
+    assert "Do not put small cleanup in touched or directly\nadjacent code under Future follow-ups" in prompt
     assert "Keep `blocking_items` and `same_pr_followups` mutually exclusive." in prompt
     assert (
         "Use\n`blocking_items` for defects, missing requirements, regressions, security\n"
@@ -8575,18 +8696,18 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     assert "Same-PR follow-ups may appear only in blocking reviews." in prompt
     assert "will be sent back to Claude and require another review" in prompt
     assert "Approved means there are no blocking issues, no Same-PR follow-ups, and no\ncarried-forward prior unresolved items left active" in prompt
-    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not use structured\nFuture follow-ups" in prompt
+    assert "Before returning approved, self-check that no\nFuture follow-up is trivial or local to the current PR" in prompt
+    assert "If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future\nfollow-ups" in prompt
     assert (
-        "`blocking_items` and `same_pr_followups` must be mutually exclusive: a single\n"
-        "concern belongs in exactly one list."
+        "`blocking_items`, `same_pr_followups`, and `future_followups` have distinct\n"
+        "roles."
     ) in prompt
+    assert "small, localized cleanup in touched files or directly adjacent code" in prompt
+    assert "`future_followups` are independent later work that remains valid after this PR\nis merge-ready." in prompt
+    assert "Before approving, self-check every `future_followups` entry" in prompt
     assert (
-        "Put merge-blocking defects, missing\nrequirements, regressions, security "
-        "issues, and consistency gaps in\n`blocking_items`"
-    ) in prompt
-    assert (
-        "put only small Same-PR cleanup that is not itself the reason\n"
-        "the PR is blocked in `same_pr_followups`."
+        "`blocking_items` are merge-blocking defects, missing requirements,\n"
+        "regressions, security issues, or consistency gaps."
     ) in prompt
 
 
@@ -15180,6 +15301,17 @@ def test_repair_prompt_includes_plan_review_dedupe_guidance():
         in _REPAIR_PROMPT
     )
     assert "keep blocking_plan_issues and drop the duplicate future_followups entry" in _REPAIR_PROMPT
+
+
+def test_repair_prompt_includes_pr_review_dedupe_guidance():
+    assert "## DEDUPE RULES (Format A):" in _REPAIR_PROMPT
+    assert "Same-PR follow-ups and Future follow-ups are mutually exclusive" in _REPAIR_PROMPT
+    assert "keep blocking_items and drop the duplicate same_pr_followups entry" in _REPAIR_PROMPT
+    assert (
+        "keep same_pr_followups/current-PR work and drop the duplicate future_followups entry"
+        in _REPAIR_PROMPT
+    )
+    assert "keep blocking_items and drop the duplicate future_followups entry" in _REPAIR_PROMPT
 
 
 def test_repair_prompt_includes_skip_trust_in_cli_invocation():


### PR DESCRIPTION
## Summary
- tighten PR-review prompt guidance for Same-PR versus Future follow-ups in full and compact contexts
- dedupe PR-review buckets so blocking/Same-PR items win over duplicate Future entries
- add repair prompt guidance and regression coverage for PR #239-style classifications

Fixes #245

## Tests
- python3 -m pytest tests/test_agent_loop.py