### PR TITLE
Prevent agents from leaving assigned workdir

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -352,6 +352,22 @@ Explicit workdirs remain conservative. A dirty explicit git checkout fails
 clearly, and an explicit checkout whose origin does not match `--repo` is
 rejected.
 
+Coder prompts name the active assigned checkout as an absolute path and set
+`AGENT_LOOP_WORKDIR` to that same path for the agent subprocess. Implementation,
+inspection, tests, commits, and pushes are expected to stay in that checkout
+unless the user explicitly authorizes another path. Coder prompts also ask the
+agent to run `pwd` and `git status --branch --short` before tests or commits,
+and to avoid sibling, home, deployment, or duplicate clones such as `~/REPO` or
+`~/claude-code/REPO`.
+
+The orchestrator validates coder-reported test commands before posting normal
+coder progress. If a `Tests:` report or structured `tests_run` entry references
+an absolute, `$HOME`, or `~/` path outside the assigned checkout, the loop fails
+with an `AgentLoopError` naming the offending command and assigned checkout.
+For initial issue, task, and approved-plan implementations, the loop also
+checks that the assigned checkout `HEAD` advanced when the coder reports a PR;
+unchanged `HEAD` is rejected before the coder PR comment is posted.
+
 These temporary checkouts may disappear after reboot or `/tmp` cleanup. Large
 projects and long-lived agent setups should use explicit persistent workdirs to
 avoid repeated clone, dependency setup, and indexing costs.
@@ -468,6 +484,10 @@ This applies:
 | `claude` | `--dangerously-skip-permissions` |
 | `codex exec` | `--dangerously-bypass-approvals-and-sandbox` |
 | `gemini` | `--yolo --skip-trust` |
+
+Dangerous permissions do not relax the assigned-checkout rule. They make it
+more important: the CLI may allow cross-checkout mutation, but the prompt and
+response validation still require coder work to remain in `AGENT_LOOP_WORKDIR`.
 
 You can also provide exact per-agent replacements. Repeat once per token:
 

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -94,6 +94,7 @@ class ClaudeBackend:
             label="Claude",
             progress_interval_seconds=config.progress_interval_seconds,
             check=False,
+            env={"AGENT_LOOP_WORKDIR": str(config.claude_dir.resolve())},
         )
         log(config, f"Claude finished; log: {log_path}")
         message_text, new_session_id, usage, raw_usage = _parse_claude_output(result.stdout)

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -128,6 +128,7 @@ class CodexBackend:
                     prompt,
                 ],
                 cwd=config.codex_dir,
+                env={"AGENT_LOOP_WORKDIR": str(config.codex_dir.resolve())},
             )
             log(config, f"Codex finished; log: {log_path}")
             return AgentResult(
@@ -159,6 +160,7 @@ class CodexBackend:
                 label="Codex",
                 progress_interval_seconds=config.progress_interval_seconds,
                 check=False,
+                env={"AGENT_LOOP_WORKDIR": str(config.codex_dir.resolve())},
             )
             response_file_text = read_public_response_file(response_path)
             message_text = _read_codex_message_file(Path(output_path)) or result.stdout

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -189,6 +189,7 @@ class GeminiBackend:
             label="Gemini",
             progress_interval_seconds=config.progress_interval_seconds,
             check=False,
+            env={"AGENT_LOOP_WORKDIR": str(config.gemini_dir.resolve())},
         )
         log(config, f"Gemini finished; log: {log_path}")
         message_text, new_session_id, usage, raw_usage, message_source = _parse_gemini_payload(result.stdout)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -99,6 +99,11 @@ from .repair import attempt_repair
 from .runner import Runner
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
+from .workdir_guard import (
+    validate_assigned_head_advanced,
+    validate_response_tests_within_workdir,
+    validate_test_commands_within_workdir,
+)
 from .checks import (
     _format_pr_checks_comment,
     _pr_check_blocking_review,
@@ -1222,6 +1227,17 @@ def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
     return "blocking with blocking plan issues"
 
 
+def _read_assigned_workdir_head(runner: Runner, config: AgentLoopConfig) -> str | None:
+    result = runner.run(
+        ("git", "rev-parse", "HEAD"),
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def _round_ledger_may_be_incomplete(
     *,
     current_resume: ResumedReviewRound | None,
@@ -1262,6 +1278,7 @@ def _implement_approved_issue(
     coder_name = agent_display_name(config.coder)
     sync_coder_base_before_implementation(config, runner)
     log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
+    assigned_head_before = _read_assigned_workdir_head(runner, config)
     coder_response = _run_validated_agent(
         runner,
         agent=config.coder,
@@ -1285,6 +1302,12 @@ def _implement_approved_issue(
         usage_context=usage_context,
     )
     coder_output = coder_response.text
+    validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
+    validate_assigned_head_advanced(
+        before_head=assigned_head_before,
+        after_head=_read_assigned_workdir_head(runner, config),
+        assigned_workdir=active_workdir(config),
+    )
     pr_number = int(coder_response.marker_value)
     log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
     validate_open_pr(runner, config=config, pr_number=pr_number)
@@ -2105,6 +2128,7 @@ def run_issue_loop(
             )
 
         sync_coder_base_before_implementation(config, runner)
+        assigned_head_before = _read_assigned_workdir_head(runner, config)
         coder_response = _run_validated_agent(
             runner,
             agent=config.coder,
@@ -2122,6 +2146,12 @@ def run_issue_loop(
         )
         coder_output = coder_response.text
         coder_session_id = coder_response.session_id
+        validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
+        validate_assigned_head_advanced(
+            before_head=assigned_head_before,
+            after_head=_read_assigned_workdir_head(runner, config),
+            assigned_workdir=active_workdir(config),
+        )
         pr_number = int(coder_response.marker_value)
         log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
         validate_open_pr(runner, config=config, pr_number=pr_number)
@@ -2210,6 +2240,7 @@ def run_task_loop(
         for attempt in range(max_clarification_rounds + 1):
             if attempt == 0:
                 sync_coder_base_before_implementation(config, runner)
+            assigned_head_before = _read_assigned_workdir_head(runner, config)
             log(config, f"Task attempt {attempt + 1}: invoking {coder_name}")
             coder_response = _run_validated_agent(
                 runner,
@@ -2225,6 +2256,12 @@ def run_task_loop(
             session_id = coder_response.session_id
 
             if isinstance(coder_response.marker_value, int):
+                validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
+                validate_assigned_head_advanced(
+                    before_head=assigned_head_before,
+                    after_head=_read_assigned_workdir_head(runner, config),
+                    assigned_workdir=active_workdir(config),
+                )
                 pr_number = coder_response.marker_value
                 log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
                 validate_open_pr(runner, config=config, pr_number=pr_number)
@@ -2915,11 +2952,20 @@ def run_pr_loop(
             public_comment = coder_output
             raw_structured_coder_response: str | None = None
             if isinstance(coder_response.marker_value, StructuredCoderFollowup):
+                validate_test_commands_within_workdir(
+                    coder_response.marker_value.tests_run,
+                    assigned_workdir=active_workdir(config),
+                )
                 raw_structured_coder_response = coder_output
                 public_comment = _render_public_coder_followup_comment(
                     coder_response.marker_value,
                     signature=agent_signature(config.coder),
                     prior_items=tuple(unresolved_items),
+                )
+            else:
+                validate_response_tests_within_workdir(
+                    coder_output,
+                    assigned_workdir=active_workdir(config),
                 )
 
             unresolved_items = _reconcile_human_requirements_ack_item(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -19,6 +19,7 @@ from .protocol import (
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
     UnresolvedReviewItem,
 )
+from .workdirs import active_workdir
 
 
 @dataclass(frozen=True)
@@ -81,6 +82,42 @@ def _coder_test_reporting_guidance() -> str:
         "locally. In your final response, include a short `Tests:` line listing "
         "the exact commands run and whether they passed. If you cannot run tests, "
         "explain why in that `Tests:` line.\n"
+    )
+
+
+def _coder_workdir_guidance(config: AgentLoopConfig, *, implementation: bool = True) -> str:
+    workdir = active_workdir(config).resolve()
+    repo_name = config.repo.rsplit("/", 1)[-1]
+    scope = (
+        "Implementation, inspection, tests, commits, and pushes"
+        if implementation
+        else "Inspection"
+    )
+    dangerous_args = {
+        "--dangerously-skip-permissions",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--yolo",
+    }
+    active_args = {
+        "claude": config.claude_args,
+        "codex": config.codex_args,
+        "gemini": config.gemini_args,
+    }[config.coder]
+    dangerous_warning = ""
+    if any(arg in dangerous_args for arg in active_args):
+        dangerous_warning = (
+            " Dangerous agent permissions are active, so the CLI may allow writes "
+            "outside this checkout; treat the assigned-workdir rule as mandatory."
+        )
+    return (
+        f"Assigned checkout: `{workdir}`. `AGENT_LOOP_WORKDIR` is set to this path "
+        "for agent subprocesses. "
+        f"{scope} must stay in that directory unless the user explicitly authorizes "
+        "a different path. Do not `cd` into sibling, home, deployment, or duplicate "
+        f"clones such as `~/{repo_name}` or `~/claude-code/{repo_name}`. Before "
+        "running tests or committing, run `pwd` and `git status --branch --short` "
+        "and confirm the path is the assigned checkout."
+        f"{dangerous_warning}\n"
     )
 
 
@@ -743,6 +780,7 @@ def build_issue_prompt(
 
 Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
+{_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
@@ -787,6 +825,7 @@ Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this planning stage.
 Write a concise implementation plan covering the intended approach, key files or
 areas to change, edge cases, and test strategy.
+{_coder_workdir_guidance(config, implementation=False)}
 {_scratch_file_guidance()}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1303,6 +1342,7 @@ def build_issue_implementation_prompt(
 Use this local checkout as your workspace. Create a branch, implement the
 approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
+{_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
@@ -1346,6 +1386,7 @@ Task:
 {_memory_block(memory)}
 
 Use this local checkout as your workspace. Decide between two paths:
+{_coder_workdir_guidance(config)}
 
 (a) If the task is clear enough to implement, create a branch, implement the
     change, run relevant tests, commit, push, and open a pull request against
@@ -2013,6 +2054,7 @@ def build_followup_prompt(
 Address the review below in this local checkout. Pull/sync the PR branch if
 needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
+{_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 {_issue_context_block(issue_context)}
@@ -2057,6 +2099,7 @@ def build_same_pr_followup_prompt(
 Address the follow-up items below in this local checkout. Pull/sync the PR
 branch if needed, implement fixes, run relevant tests, commit, and push to the
 same PR. Do not create a new PR.
+{_coder_workdir_guidance(config)}
 These same-PR follow-ups are intended to be small, localized cleanup for the
 current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead. The PR

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -19,7 +19,7 @@ from .protocol import (
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
     UnresolvedReviewItem,
 )
-from .workdirs import active_workdir
+from .workdirs import agent_workdir
 
 
 @dataclass(frozen=True)
@@ -85,8 +85,11 @@ def _coder_test_reporting_guidance() -> str:
     )
 
 
-def _coder_workdir_guidance(config: AgentLoopConfig, *, implementation: bool = True) -> str:
-    workdir = active_workdir(config).resolve()
+def _coder_workdir_guidance(
+    config: AgentLoopConfig, *, implementation: bool = True, agent: AgentName | None = None
+) -> str:
+    active_agent = agent or config.coder
+    workdir = agent_workdir(config, active_agent).resolve()
     repo_name = config.repo.rsplit("/", 1)[-1]
     scope = (
         "Implementation, inspection, tests, commits, and pushes"
@@ -102,7 +105,7 @@ def _coder_workdir_guidance(config: AgentLoopConfig, *, implementation: bool = T
         "claude": config.claude_args,
         "codex": config.codex_args,
         "gemini": config.gemini_args,
-    }[config.coder]
+    }[active_agent]
     dangerous_warning = ""
     if any(arg in dangerous_args for arg in active_args):
         dangerous_warning = (
@@ -695,6 +698,7 @@ footer.
 def _compact_plan_stable_prefix(
     *,
     config: AgentLoopConfig,
+    workdir_guidance: str,
     memory: AgentMemoryContext | None,
     issue_context: IssueContext | None,
     unresolved_items: Sequence[UnresolvedReviewItem],
@@ -708,6 +712,7 @@ def _compact_plan_stable_prefix(
         for part in (
             "Compact cache-aware planning context",
             f"Repository: {config.repo}",
+            workdir_guidance,
             _scratch_file_guidance(),
             response_protocol,
             _memory_block(memory),
@@ -915,6 +920,7 @@ Contradictory forms like `same-plan: none`, `still blocking: none`, and `future 
 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this planning review.
+{_coder_workdir_guidance(config, implementation=False, agent=reviewer)}
 {_scratch_file_guidance()}
 {human_requirements_block}{_issue_context_block(issue_context)}
 {unresolved_items_block}{_memory_block(memory)}
@@ -1030,6 +1036,7 @@ Contradictory forms like `same-plan: none`, `still blocking: none`, and `future 
         unresolved_items_guidance = ""
     stable_prefix = _compact_plan_stable_prefix(
         config=config,
+        workdir_guidance=_coder_workdir_guidance(config, implementation=False, agent=reviewer),
         memory=memory,
         issue_context=issue_context,
         unresolved_items=unresolved_items,
@@ -1275,6 +1282,7 @@ def _build_compact_plan_revision_prompt(
     )
     stable_prefix = _compact_plan_stable_prefix(
         config=config,
+        workdir_guidance=_coder_workdir_guidance(config, implementation=False),
         memory=memory,
         issue_context=issue_context,
         unresolved_items=unresolved_items,
@@ -1511,6 +1519,7 @@ def _compact_coder_followup_block(
 def _compact_pr_review_stable_prefix(
     *,
     config: AgentLoopConfig,
+    workdir_guidance: str,
     memory: AgentMemoryContext | None,
     pr_metadata: PullRequestMetadata,
     issue_context: IssueContext | None,
@@ -1595,6 +1604,7 @@ adds a merge migration.
         for part in (
             "Compact cache-aware PR review context",
             f"Repository: {config.repo}",
+            workdir_guidance,
             _scratch_file_guidance(),
             response_schema,
             unresolved_items_guidance,
@@ -1727,6 +1737,7 @@ follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
     stable_prefix = _compact_pr_review_stable_prefix(
         config=config,
+        workdir_guidance=_coder_workdir_guidance(config, implementation=False, agent=reviewer),
         memory=memory,
         pr_metadata=pr_metadata,
         issue_context=issue_context,
@@ -1940,6 +1951,7 @@ review round is about. If local files do not match that SHA, refresh/fetch the
 checkout before reviewing. Do not spend time discovering the PR
 branch. Do not report findings based on untracked files unless those files are
 present in the PR diff.
+{_coder_workdir_guidance(config, implementation=False, agent=reviewer)}
 {_scratch_file_guidance()}
 {checks_block}{_issue_context_block(issue_context)}
 {_human_requirements_block(human_requirements)}

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
 from .errors import AgentLoopError
 
@@ -44,6 +45,7 @@ class Runner:
         cwd: Path,
         input_text: str | None = None,
         check: bool = True,
+        env: Mapping[str, str] | None = None,
     ) -> CommandResult:
         cmd = [str(a) for a in args]
         if self.dry_run:
@@ -60,6 +62,7 @@ class Runner:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
+            env={**os.environ, **env} if env is not None else None,
         )
         result = CommandResult(cmd, cwd, proc.stdout, proc.stderr, proc.returncode)
         if check and proc.returncode != 0:
@@ -78,6 +81,7 @@ class Runner:
         label: str,
         progress_interval_seconds: int,
         check: bool = True,
+        env: Mapping[str, str] | None = None,
     ) -> CommandResult:
         cmd = [str(a) for a in args]
         if self.dry_run:
@@ -99,6 +103,7 @@ class Runner:
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 text=True,
+                env={**os.environ, **env} if env is not None else None,
             )
             try:
                 while True:

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -75,8 +75,9 @@ def validate_test_commands_within_workdir(
                 continue
             if WINDOWS_PATH_RE.fullmatch(raw_path.strip().strip("`'\".,")):
                 raise AgentLoopError(
-                    "Coder reported tests from a Windows-style path outside the assigned "
-                    f"checkout: {raw_path!r} in command {command!r}. Assigned checkout: {assigned}"
+                    "Coder reported tests from a Windows-style path that cannot be "
+                    "validated against the assigned Unix checkout: "
+                    f"{raw_path!r} in command {command!r}. Assigned checkout: {assigned}"
                 )
             if path == assigned or _is_inside(path, assigned):
                 continue

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -1,0 +1,137 @@
+"""Validation helpers for keeping coder-reported work inside the assigned checkout."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .errors import AgentLoopError
+
+
+TEST_SECTION_RE = re.compile(r"(?im)^\s*tests(?:\s+run)?\s*:\s*(?P<body>.*)$")
+ABSOLUTE_PATH_RE = re.compile(r"(?<![\w.-])/(?:[^\s`'\"|;&)<>]+)")
+HOME_PATH_RE = re.compile(r"(?<![\w.-])(?:~|\$HOME)/(?:[^\s`'\"|;&)<>]+)")
+WINDOWS_PATH_RE = re.compile(r"(?<![\w.-])[A-Za-z]:\\[^\s`'\"|;&)<>]+")
+
+
+def _canonical(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _is_inside(path: Path, assigned_workdir: Path) -> bool:
+    try:
+        path.relative_to(assigned_workdir)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_reported_path(raw_path: str) -> Path | None:
+    cleaned = raw_path.strip().strip("`'\".,")
+    if not cleaned:
+        return None
+    if cleaned.startswith("$HOME/"):
+        cleaned = str(Path.home()) + cleaned[len("$HOME") :]
+    if cleaned.startswith("~/") or cleaned.startswith("/"):
+        return _canonical(Path(cleaned))
+    if WINDOWS_PATH_RE.fullmatch(cleaned):
+        return Path(cleaned)
+    return None
+
+
+def _reported_paths(command: str) -> Iterable[str]:
+    yield from HOME_PATH_RE.findall(command)
+    yield from ABSOLUTE_PATH_RE.findall(command)
+    yield from WINDOWS_PATH_RE.findall(command)
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    for index, token in enumerate(tokens):
+        if token in {"cd", "-C", "--directory"} and index + 1 < len(tokens):
+            yield tokens[index + 1]
+        elif token.startswith("--directory="):
+            yield token.split("=", 1)[1]
+        elif token.startswith("$HOME/") or token.startswith("~/") or token.startswith("/"):
+            yield token
+
+
+def validate_test_commands_within_workdir(
+    tests_run: Sequence[str] | None,
+    *,
+    assigned_workdir: Path,
+) -> None:
+    if not tests_run:
+        return
+    assigned = _canonical(assigned_workdir)
+    for command in tests_run:
+        for raw_path in _reported_paths(command):
+            path = _normalize_reported_path(raw_path)
+            if path is None:
+                continue
+            if WINDOWS_PATH_RE.fullmatch(raw_path.strip().strip("`'\".,")):
+                raise AgentLoopError(
+                    "Coder reported tests from a Windows-style path outside the assigned "
+                    f"checkout: {raw_path!r} in command {command!r}. Assigned checkout: {assigned}"
+                )
+            if path == assigned or _is_inside(path, assigned):
+                continue
+            raise AgentLoopError(
+                "Coder reported tests from outside the assigned checkout: "
+                f"{raw_path!r} in command {command!r}. Assigned checkout: {assigned}"
+            )
+
+
+def extract_reported_tests_from_response(text: str) -> tuple[str, ...]:
+    """Return the coder's public test-report lines, avoiding quoted issue context."""
+    lines = text.splitlines()
+    reports: list[str] = []
+    for index, line in enumerate(lines):
+        match = TEST_SECTION_RE.match(line)
+        if not match:
+            continue
+        body = match.group("body").strip()
+        if body:
+            reports.append(body)
+            continue
+        continuation: list[str] = []
+        for next_line in lines[index + 1 :]:
+            stripped = next_line.strip()
+            if not stripped:
+                if continuation:
+                    break
+                continue
+            if stripped.startswith("<!-- AGENT_") or stripped.startswith("-- "):
+                break
+            if re.match(r"^#{1,6}\s+", stripped):
+                break
+            continuation.append(stripped.removeprefix("- ").strip())
+        if continuation:
+            reports.extend(continuation)
+    return tuple(reports)
+
+
+def validate_response_tests_within_workdir(text: str, *, assigned_workdir: Path) -> None:
+    validate_test_commands_within_workdir(
+        extract_reported_tests_from_response(text),
+        assigned_workdir=assigned_workdir,
+    )
+
+
+def validate_assigned_head_advanced(
+    *,
+    before_head: str | None,
+    after_head: str | None,
+    assigned_workdir: Path,
+) -> None:
+    if not before_head or not after_head:
+        return
+    if before_head == after_head:
+        raise AgentLoopError(
+            "Coder reported a PR, but the assigned checkout HEAD did not advance. "
+            f"Assigned checkout: {_canonical(assigned_workdir)}; HEAD: {after_head}"
+        )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -119,6 +119,7 @@ from coding_review_agent_loop.prompts import (
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
     build_issue_prompt,
+    build_task_prompt,
     build_same_pr_followup_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
@@ -154,6 +155,11 @@ from coding_review_agent_loop.protocol import (
     validate_structured_coder_followup,
     validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_revision,
+)
+from coding_review_agent_loop.workdir_guard import (
+    extract_reported_tests_from_response,
+    validate_response_tests_within_workdir,
+    validate_test_commands_within_workdir,
 )
 
 from unittest.mock import MagicMock, patch
@@ -214,6 +220,7 @@ class FakeRunner(Runner):
         diff_stderr="",
         issue_urls=None,
         public_response_outputs=None,
+        advance_git_head_on_pr=True,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -273,6 +280,8 @@ class FakeRunner(Runner):
         self.diff_stderr = diff_stderr
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
+        self.advance_git_head_on_pr = advance_git_head_on_pr
+        self._agent_pr_counter = 0
 
     def _normalize_legacy_agent_output(self, output: str, prompt: str) -> str:
         stripped = output.lstrip()
@@ -412,6 +421,14 @@ class FakeRunner(Runner):
             response = self._normalize_legacy_agent_output(response, prompt)
         response_path.write_text(response, encoding="utf-8")
 
+    def _maybe_advance_git_head_for_agent_pr(self, text: str) -> None:
+        if not self.advance_git_head_on_pr:
+            return
+        if "<!-- AGENT_PR:" not in text and "github.com/OWNER/REPO/pull/" not in text:
+            return
+        self._agent_pr_counter += 1
+        self.git_head = f"{self.git_head}-agent-{self._agent_pr_counter}"
+
     def run_with_log(
         self,
         args,
@@ -421,6 +438,7 @@ class FakeRunner(Runner):
         label,
         progress_interval_seconds,
         check=True,
+        env=None,
     ):
         cmd, cwd_path = self._record_command(args, cwd)
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -431,6 +449,7 @@ class FakeRunner(Runner):
             if isinstance(output, str):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
+            self._maybe_advance_git_head_for_agent_pr(output)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
@@ -451,6 +470,7 @@ class FakeRunner(Runner):
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
+            self._maybe_advance_git_head_for_agent_pr(public_response)
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
@@ -467,18 +487,20 @@ class FakeRunner(Runner):
             if isinstance(output, str) and not explicit_stdout:
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
+            self._maybe_advance_git_head_for_agent_pr(output)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
         return self.run(args, cwd=cwd, check=check)
 
-    def run(self, args, *, cwd, input_text=None, check=True):
+    def run(self, args, *, cwd, input_text=None, check=True, env=None):
         cmd, cwd_path = self._record_command(args, cwd)
 
         if cmd[:1] == ["claude"]:
             output, returncode = self._next_agent_output(self.claude_outputs)
             if isinstance(output, str):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
+            self._maybe_advance_git_head_for_agent_pr(output)
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
@@ -497,6 +519,7 @@ class FakeRunner(Runner):
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
+            self._maybe_advance_git_head_for_agent_pr(public_response)
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
         if cmd[:3] == ["gh", "pr", "comment"]:
@@ -842,6 +865,74 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         config["codex_dir"].mkdir(parents=True, exist_ok=True)
         config["gemini_dir"].mkdir(parents=True, exist_ok=True)
     return AgentLoopConfig(**config)
+
+
+def test_workdir_guard_rejects_outside_home_path(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        validate_test_commands_within_workdir(
+            ("cd ~/llm-dialectic && python -m pytest",),
+            assigned_workdir=assigned,
+        )
+
+
+def test_workdir_guard_accepts_assigned_absolute_path(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    tests_dir = assigned / "tests"
+    tests_dir.mkdir(parents=True)
+
+    validate_test_commands_within_workdir(
+        (f"cd {assigned} && python -m pytest {tests_dir}",),
+        assigned_workdir=assigned,
+    )
+
+
+def test_workdir_guard_accepts_relative_test_commands(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+
+    validate_test_commands_within_workdir(
+        ("python -m pytest tests/test_agent_loop.py", "make test"),
+        assigned_workdir=assigned,
+    )
+
+
+def test_workdir_guard_extracts_tests_section_only(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+    text = (
+        "Issue context mentioned Tests: cd ~/other && pytest.\n\n"
+        "Implemented.\n"
+        "Tests: python -m pytest tests/test_agent_loop.py passed.\n"
+        "<!-- AGENT_PR: 77 -->"
+    )
+
+    assert extract_reported_tests_from_response(text) == (
+        "python -m pytest tests/test_agent_loop.py passed.",
+    )
+    validate_response_tests_within_workdir(text, assigned_workdir=assigned)
+
+
+def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
+    config = make_config(tmp_path, coder="codex")
+    assigned = str(config.codex_dir.resolve())
+
+    prompts = [
+        build_issue_prompt(56, config),
+        build_issue_implementation_prompt(56, "1. Fix it.", config),
+        build_task_prompt("Fix the bug.", config),
+        build_followup_prompt(77, 1, "Needs tests.", config),
+        build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+    ]
+
+    for prompt in prompts:
+        assert f"Assigned checkout: `{assigned}`" in prompt
+        assert "`AGENT_LOOP_WORKDIR` is set to this path" in prompt
+        assert "must stay in that directory" in prompt
+        assert "Do not `cd` into sibling, home, deployment, or duplicate clones" in prompt
+        assert "`pwd` and `git status --branch --short`" in prompt
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -14632,6 +14723,51 @@ def test_codex_issue_loop_requires_codex_to_report_pr_number(tmp_path):
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
 
+def test_issue_loop_rejects_outside_workdir_tests_before_posting_pr_comment(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Fixed issue.\n"
+            "Tests: cd ~/llm-dialectic && python -m pytest\n"
+            "<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n"
+            "-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert runner.comments == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_rejects_reported_pr_when_assigned_head_unchanged(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Fixed issue.\n"
+            "Tests: python -m pytest passed.\n"
+            "<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n"
+            "-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        advance_git_head_on_pr=False,
+    )
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError, match="HEAD did not advance"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert runner.comments == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
 def test_codex_task_loop_creates_pr_then_claude_approves(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
@@ -14648,6 +14784,36 @@ def test_codex_task_loop_creates_pr_then_claude_approves(tmp_path):
     assert len(runner.comments) == 2
     assert runner.comments[0].startswith("Implemented task.")
     assert runner.comments[1].startswith("**Review verdict:** Approved\n\nShip it.")
+
+
+def test_pr_loop_rejects_structured_followup_outside_workdir_tests_before_posting(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Needs a test.",
+                blocking_items=["Add a regression test."],
+                reviewer="Anthropic Claude",
+            ),
+            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_coder_followup(
+                summary="Added the test.",
+                addressed_items=["item-1"],
+                tests_run=["cd ~/llm-dialectic && python -m pytest"],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(runner.comments) == 1
+    assert runner.comments[0].startswith("**Review verdict:** Blocking")
+    assert not any("Added the test." in comment for comment in runner.comments)
 
 
 def test_codex_task_loop_picks_up_pr_url_when_marker_missing(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -878,6 +878,20 @@ def test_workdir_guard_rejects_outside_home_path(tmp_path):
         )
 
 
+def test_workdir_guard_rejects_windows_path_with_clear_message(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+
+    with pytest.raises(
+        AgentLoopError,
+        match="cannot be validated against the assigned Unix checkout",
+    ):
+        validate_test_commands_within_workdir(
+            (r"cd C:\Users\dev\repo && python -m pytest",),
+            assigned_workdir=assigned,
+        )
+
+
 def test_workdir_guard_accepts_assigned_absolute_path(tmp_path):
     assigned = tmp_path / "claude" / "repo"
     tests_dir = assigned / "tests"
@@ -921,6 +935,7 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
 
     prompts = [
         build_issue_prompt(56, config),
+        build_issue_plan_prompt(56, config),
         build_issue_implementation_prompt(56, "1. Fix it.", config),
         build_task_prompt("Fix the bug.", config),
         build_followup_prompt(77, 1, "Needs tests.", config),
@@ -933,6 +948,38 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
         assert "must stay in that directory" in prompt
         assert "Do not `cd` into sibling, home, deployment, or duplicate clones" in prompt
         assert "`pwd` and `git status --branch --short`" in prompt
+
+
+def test_reviewer_prompts_use_reviewer_assigned_workdir_rule(tmp_path):
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer=("codex",),
+        claude_args=(),
+        codex_args=("--dangerously-bypass-approvals-and-sandbox",),
+    )
+    reviewer_assigned = str(config.codex_dir.resolve())
+    coder_assigned = str(config.claude_dir.resolve())
+
+    prompts = [
+        build_plan_review_prompt(56, 1, "Plan.", config, reviewer="codex"),
+        build_plan_review_prompt(
+            56,
+            1,
+            "Plan.",
+            config,
+            reviewer="codex",
+            compact_context=True,
+        ),
+        build_review_prompt(77, 1, config, reviewer="codex"),
+        build_review_prompt(77, 1, config, reviewer="codex", compact_context=True),
+    ]
+
+    for prompt in prompts:
+        assert f"Assigned checkout: `{reviewer_assigned}`" in prompt
+        assert f"Assigned checkout: `{coder_assigned}`" not in prompt
+        assert "Inspection must stay in that directory" in prompt
+        assert "Dangerous agent permissions are active" in prompt
 
 
 def _git(cwd: Path, *args: str) -> None:


### PR DESCRIPTION
## Summary
- add assigned-checkout guidance to coder prompts and pass AGENT_LOOP_WORKDIR to agent subprocesses
- validate coder-reported test paths and reject outside-workdir reports before posting coder progress
- reject initial PR reports when the assigned checkout HEAD did not advance
- document assigned-workdir behavior and dangerous-permission implications

Fixes #247

## Tests
- python3 -m pytest tests/test_agent_loop.py: passed
- python3 -m compileall src/coding_review_agent_loop: passed