### PR TITLE
Normalize structured response envelopes before repair

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -95,7 +95,7 @@ from .protocol import (
     validate_structured_plan_revision,
 )
 from .protocol import parse_review
-from .repair import attempt_repair
+from .repair import attempt_envelope_normalization, attempt_repair
 from .runner import Runner
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
@@ -1002,6 +1002,37 @@ def _run_validated_agent(
                             marker_value=marker_value,
                             usage=usage,
                         )
+                if (
+                    use_repair
+                    and not public_text_is_transient
+                    and repair_expected_kind in STRUCTURED_PUBLIC_RESPONSE_KINDS
+                    and not (
+                        isinstance(exc, UnknownPriorItemDispositionError)
+                        and ledger_incomplete
+                    )
+                ):
+                    normalized = attempt_envelope_normalization(
+                        text,
+                        expected_kind=repair_expected_kind,
+                    )
+                    if normalized is not None:
+                        try:
+                            marker_value = validate(normalized)
+                        except AgentLoopError:
+                            pass
+                        else:
+                            log(
+                                config,
+                                f"{agent_name}: envelope normalization recovered malformed response",
+                            )
+                            if usage_record is not None:
+                                usage_record.validation_status = "validated"
+                            return ValidatedAgentResponse(
+                                text=normalized,
+                                session_id=result.session_id,
+                                marker_value=marker_value,
+                                usage=usage,
+                            )
                 if (
                     use_repair
                     and not public_text_is_transient

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -8,13 +8,98 @@ treats the result as blocking per the issue guardrails.
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 import subprocess
 from collections.abc import Sequence
 
 from .agents.gemini import _parse_gemini_payload
+from .protocol import (
+    HUMAN_REQUIREMENTS_RESOLVED_RE,
+    PLAN_STATE_RE,
+    STATE_RE,
+    parse_human_requirements_acknowledgement,
+)
 
 _logger = logging.getLogger(__name__)
+
+_SIGNATURE_LINE_RE = re.compile(r"(?m)^--\s+\S[^\n]*")
+
+
+def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
+    """Trim envelope-only trailing material without changing structured JSON."""
+    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup"}:
+        return None
+
+    stripped = raw.lstrip()
+    if not stripped.startswith("{"):
+        return None
+    try:
+        payload, json_end = json.JSONDecoder().raw_decode(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    json_text = stripped[:json_end].rstrip()
+    trailing = stripped[json_end:]
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision"} else STATE_RE
+    state_match = state_re.search(trailing)
+    if state_match is None:
+        return None
+
+    before_footer = trailing[: state_match.start()]
+    preserved_before = ""
+    if expected_kind in {"pr_review", "plan_review"}:
+        before_lstripped = before_footer.lstrip()
+        marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(before_lstripped)
+        if marker_match is not None and before_lstripped[marker_match.end() :].strip() == "":
+            preserved_before = before_lstripped[: marker_match.end()].strip()
+        elif before_footer.strip():
+            return None
+    elif expected_kind == "plan_revision" and before_footer.strip():
+        parsed_human_requirements = parse_human_requirements_acknowledgement(before_footer)
+        if (
+            parsed_human_requirements.marker_present
+            and parsed_human_requirements.section_present
+        ):
+            preserved_before = before_footer.strip()
+        else:
+            return None
+    elif before_footer.strip():
+        return None
+
+    footer = trailing[state_match.start() : state_match.end()].strip()
+    after_footer = trailing[state_match.end() :]
+    after_footer_lstripped = after_footer.lstrip()
+    preserved_after = ""
+    if expected_kind == "pr_review":
+        marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(after_footer_lstripped)
+        if marker_match is not None:
+            preserved_after = after_footer_lstripped[: marker_match.end()].strip()
+            after_footer_lstripped = after_footer_lstripped[marker_match.end() :]
+        signature_match = _SIGNATURE_LINE_RE.match(after_footer_lstripped.lstrip())
+    else:
+        signature_match = _SIGNATURE_LINE_RE.search(after_footer_lstripped)
+
+    if signature_match is None:
+        return None
+    signature_source = (
+        after_footer_lstripped.lstrip()
+        if expected_kind == "pr_review"
+        else after_footer_lstripped
+    )
+    signature = signature_source[signature_match.start() : signature_match.end()].strip()
+
+    parts = [json_text]
+    if preserved_before:
+        parts.append(preserved_before)
+    parts.append(footer)
+    if preserved_after:
+        parts.append(preserved_after)
+    parts.append(signature)
+    return "\n".join(parts)
 
 # v13 prompt — adds repair guidance for human-requirements marker, active approved dispositions,
 # blocking+future dispositions, approved+current-plan future_followups, and same-round confusion:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -6788,7 +6788,7 @@ def test_public_response_structured_json_after_known_artifact_is_not_transient()
     assert not _is_transient_public_response(text, repair_expected_kind="coder_followup")
 
 
-def test_structured_plan_review_transient_terms_with_trailing_prose_runs_repair(tmp_path):
+def test_structured_plan_review_transient_terms_with_trailing_prose_normalizes(tmp_path):
     malformed_review = (
         structured_plan_review(
             state="approved",
@@ -6800,15 +6800,10 @@ def test_structured_plan_review_transient_terms_with_trailing_prose_runs_repair(
         )
         + "\nTrailing prose after the signature should be repaired."
     )
-    repaired_review = structured_plan_review(
-        state="approved",
-        summary="Plan review repaired.",
-        reviewer="Google Gemini",
-    )
     runner = FakeRunner(gemini_outputs=[malformed_review])
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
 
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review) as repair_mock:
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
         response = _run_validated_agent(
             runner,
             agent="gemini",
@@ -6824,16 +6819,19 @@ def test_structured_plan_review_transient_terms_with_trailing_prose_runs_repair(
             repair_expected_kind="plan_review",
         )
 
-    assert response.text == repaired_review
-    repair_mock.assert_called_once_with(
-        malformed_review,
-        config.gemini_cmd,
-        expected_kind="plan_review",
+    assert response.text == structured_plan_review(
+        state="approved",
+        summary=(
+            "The plan discusses 429, quota, resource exhausted, timeout, capacity, "
+            "and transient retry handling as domain text."
+        ),
+        reviewer="Google Gemini",
     )
+    repair_mock.assert_not_called()
     assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
-def test_structured_pr_review_transient_terms_duplicate_footer_fails_deterministically(tmp_path):
+def test_structured_pr_review_transient_terms_duplicate_footer_normalizes(tmp_path):
     malformed_review = (
         structured_pr_review(
             state="approved",
@@ -6848,31 +6846,31 @@ def test_structured_pr_review_transient_terms_duplicate_footer_fails_determinist
     runner = FakeRunner(gemini_outputs=[malformed_review])
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
 
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value="still invalid") as repair_mock:
-        with pytest.raises(AgentLoopError) as exc_info:
-            _run_validated_agent(
-                runner,
-                agent="gemini",
-                config=config,
-                prompt="Review the PR.",
-                marker_description="<!-- AGENT_STATE: approved|blocking -->",
-                validate=lambda text: _validate_review_response(
-                    text,
-                    reviewer="Google Gemini",
-                    unresolved_items=(),
-                ),
-                use_repair=True,
-                repair_expected_kind="pr_review",
-            )
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_review_response(
+                text,
+                reviewer="Google Gemini",
+                unresolved_items=(),
+            ),
+            use_repair=True,
+            repair_expected_kind="pr_review",
+        )
 
-    repair_mock.assert_called_once_with(
-        malformed_review,
-        config.gemini_cmd,
-        expected_kind="pr_review",
+    assert response.text == structured_pr_review(
+        state="approved",
+        summary=(
+            "The review covers capacity, timeout, 429, quota, resource-exhausted, "
+            "and transient classifier behavior."
+        ),
+        reviewer="Google Gemini",
     )
-    message = str(exc_info.value)
-    assert "Failure category: deterministic" in message
-    assert "Failure category: transient" not in message
+    repair_mock.assert_not_called()
     assert not any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
 
 
@@ -7693,7 +7691,7 @@ def test_run_validated_agent_plan_revision_unknown_prior_disposition_fails_when_
     assert "item-18" in str(exc_info.value)
 
 
-def test_gemini_duplicate_trailing_agent_state_marker_is_repairable(tmp_path):
+def test_gemini_duplicate_trailing_agent_state_marker_normalizes_without_repair(tmp_path):
     malformed_public_review = (
         structured_pr_review(
             state="approved",
@@ -7703,24 +7701,15 @@ def test_gemini_duplicate_trailing_agent_state_marker_is_repairable(tmp_path):
         + "\n\n<!-- AGENT_STATE: approved -->"
     )
     raw_stdout = f"{PUBLIC_RESPONSE_MARKER}\n{malformed_public_review}"
-    repaired_review = structured_pr_review(
-        state="approved",
-        summary="Duplicate marker repaired.",
-        reviewer="Google Gemini",
-    )
     runner = FakeRunner(gemini_outputs=[{"stdout": raw_stdout}])
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
 
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired_review) as repair_mock:
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
         assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    repair_mock.assert_called_once_with(
-        malformed_public_review,
-        config.gemini_cmd,
-        expected_kind="pr_review",
-        allowed_prior_item_ids=(),
-    )
-    assert any("Duplicate marker repaired." in comment for comment in runner.comments)
+    repair_mock.assert_not_called()
+    assert any("Found one issue." in comment for comment in runner.comments)
+    assert all(comment.count("<!-- AGENT_STATE: approved -->") == 1 for comment in runner.comments)
 
 
 def test_gemini_pre_marker_429_malformed_public_response_fails_deterministically(tmp_path):
@@ -15077,7 +15066,212 @@ def test_claude_review_loop_rejects_non_open_pr(tmp_path):
 # Repair pass tests
 # ---------------------------------------------------------------------------
 
-from coding_review_agent_loop.repair import attempt_repair, _REPAIR_PROMPT
+from coding_review_agent_loop.repair import (
+    _REPAIR_PROMPT,
+    attempt_envelope_normalization,
+    attempt_repair,
+)
+
+
+def test_envelope_normalization_duplicate_pr_state_footer_preserves_dispositions():
+    raw = (
+        structured_pr_review(
+            state="approved",
+            reviewer="Google Gemini",
+            prior_item_dispositions=[
+                {"item_id": "item-1", "disposition": "resolved"},
+                {"item_id": "item-2", "disposition": "future"},
+                {"item_id": "item-3", "disposition": "resolved"},
+            ],
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="pr_review")
+
+    assert normalized is not None
+    parsed = parse_structured_pr_review(normalized, reviewer="Google Gemini")
+    assert parsed is not None
+    assert {
+        disposition.item_id: disposition.disposition
+        for disposition in parsed.dispositions
+    } == {
+        "item-1": "resolved",
+        "item-2": "future",
+        "item-3": "resolved",
+    }
+    assert normalized.count("<!-- AGENT_STATE: approved -->") == 1
+
+
+def test_envelope_normalization_trailing_prose_after_signature():
+    raw = (
+        structured_pr_review(state="approved", reviewer="Google Gemini")
+        + "\n\nExtra prose after the signature."
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="pr_review")
+
+    assert normalized is not None
+    assert "Extra prose" not in normalized
+    assert parse_structured_pr_review(normalized, reviewer="Google Gemini") is not None
+
+
+def test_envelope_normalization_duplicate_plan_state_footer():
+    raw = (
+        structured_plan_review(
+            state="approved",
+            reviewer="Google Gemini",
+            prior_plan_item_dispositions=[
+                {"item_id": "item-1", "disposition": "resolved"},
+            ],
+        )
+        + "\n\n<!-- AGENT_PLAN_STATE: approved -->"
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="plan_review")
+
+    assert normalized is not None
+    parsed = parse_structured_plan_review(normalized, reviewer="Google Gemini")
+    assert parsed is not None
+    assert [(item.item_id, item.disposition) for item in parsed.dispositions] == [
+        ("item-1", "resolved")
+    ]
+    assert normalized.count("<!-- AGENT_PLAN_STATE: approved -->") == 1
+
+
+def test_envelope_normalization_preserves_hr_resolved_before_footer_for_reviews():
+    for expected_kind, raw, parser in (
+        (
+            "pr_review",
+            structured_pr_review(
+                state="approved",
+                reviewer="Google Gemini",
+                human_requirements_resolved=True,
+            ),
+            parse_structured_pr_review,
+        ),
+        (
+            "plan_review",
+            structured_plan_review(
+                state="approved",
+                reviewer="Google Gemini",
+                human_requirements_resolved=True,
+            ),
+            parse_structured_plan_review,
+        ),
+    ):
+        normalized = attempt_envelope_normalization(
+            raw + "\n\nTrailing prose.",
+            expected_kind=expected_kind,
+        )
+
+        assert normalized is not None
+        assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in normalized
+        assert parser(normalized, reviewer="Google Gemini") is not None
+
+
+def test_envelope_normalization_preserves_hr_resolved_after_footer_for_pr_review():
+    raw = (
+        structured_pr_review(state="approved", reviewer="Google Gemini").replace(
+            "\n-- Google Gemini",
+            "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n-- Google Gemini",
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="pr_review")
+
+    assert normalized is not None
+    assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" in normalized
+    assert parse_structured_pr_review(normalized, reviewer="Google Gemini") is not None
+
+
+def test_envelope_normalization_plan_review_drops_after_footer_hr_marker():
+    raw = (
+        structured_plan_review(
+            state="approved",
+            reviewer="Google Gemini",
+            prior_plan_item_dispositions=[
+                {"item_id": "item-1", "disposition": "resolved"},
+                {"item_id": "item-2", "disposition": "future"},
+            ],
+        ).replace(
+            "\n-- Google Gemini",
+            "\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n-- Google Gemini",
+        )
+        + "\n\n<!-- AGENT_PLAN_STATE: approved -->\nTrailing prose."
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="plan_review")
+
+    assert normalized is not None
+    assert "<!-- HUMAN_REQUIREMENTS_RESOLVED -->" not in normalized
+    parsed = parse_structured_plan_review(normalized, reviewer="Google Gemini")
+    assert parsed is not None
+    assert {
+        disposition.item_id: disposition.disposition
+        for disposition in parsed.dispositions
+    } == {
+        "item-1": "resolved",
+        "item-2": "future",
+    }
+
+
+def test_envelope_normalization_returns_none_when_no_footer():
+    raw = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "approved",
+            "summary": "Review complete.",
+            "prior_item_dispositions": [],
+        }
+    )
+
+    assert attempt_envelope_normalization(raw, expected_kind="pr_review") is None
+
+
+def test_envelope_normalization_returns_none_when_no_signature():
+    raw = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Review complete.",
+                "prior_item_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->"
+    )
+
+    assert attempt_envelope_normalization(raw, expected_kind="pr_review") is None
+
+
+def test_envelope_normalization_returns_none_when_json_invalid():
+    raw = '{"schema_version": 1,\n<!-- AGENT_STATE: approved -->\n-- Google Gemini'
+
+    assert attempt_envelope_normalization(raw, expected_kind="pr_review") is None
+
+
+def test_envelope_normalization_semantic_defect_still_fails_validate():
+    raw = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "pr_review",
+                "state": "approved",
+                "summary": "Review complete.",
+            }
+        )
+        + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini\n\nTrailing prose."
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="pr_review")
+
+    assert normalized is not None
+    with pytest.raises(AgentLoopError):
+        parse_structured_pr_review(normalized, reviewer="Google Gemini")
 
 
 def test_attempt_repair_returns_none_when_subprocess_fails(monkeypatch):
@@ -15327,6 +15521,89 @@ def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):
 
     assert len(captured_repairs) == 1
     assert "AGENT_STATE: approved" in captured_repairs[0]
+
+
+def test_run_validated_agent_envelope_normalization_recovers_duplicate_footer(tmp_path):
+    malformed_review = (
+        structured_pr_review(
+            state="approved",
+            reviewer="Google Gemini",
+            prior_item_dispositions=[
+                {"item_id": "item-1", "disposition": "resolved"},
+                {"item_id": "item-2", "disposition": "future"},
+                {"item_id": "item-3", "disposition": "resolved"},
+            ],
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: parse_structured_pr_review(
+                text,
+                reviewer="Google Gemini",
+            ).state,
+            use_repair=True,
+            repair_expected_kind="pr_review",
+        )
+
+    repair_mock.assert_not_called()
+    parsed = parse_structured_pr_review(response.text, reviewer="Google Gemini")
+    assert parsed is not None
+    assert {
+        disposition.item_id: disposition.disposition
+        for disposition in parsed.dispositions
+    } == {
+        "item-1": "resolved",
+        "item-2": "future",
+        "item-3": "resolved",
+    }
+
+
+def test_run_validated_agent_envelope_normalization_semantic_defect_uses_repair(tmp_path):
+    malformed_review = (
+        structured_pr_review(
+            state="approved",
+            reviewer="Google Gemini",
+            blocking_items=["This is semantically inconsistent."],
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+    repaired_review = structured_pr_review(state="approved", reviewer="Google Gemini")
+    runner = FakeRunner(gemini_outputs=[malformed_review])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch(
+        "coding_review_agent_loop.orchestrator.attempt_repair",
+        return_value=repaired_review,
+    ) as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: parse_structured_pr_review(
+                text,
+                reviewer="Google Gemini",
+            ).state,
+            use_repair=True,
+            repair_expected_kind="pr_review",
+        )
+
+    assert response.text == repaired_review
+    repair_mock.assert_called_once_with(
+        malformed_review,
+        config.gemini_cmd,
+        expected_kind="pr_review",
+    )
 
 
 def test_run_pr_loop_repairs_format_failure_with_5xx_source_line_reference(tmp_path):


### PR DESCRIPTION
## Summary
- add deterministic envelope normalization for structured public responses before generative repair
- preserve accepted human-requirements markers while trimming trailing duplicate footers/prose after signatures
- add PR review and plan review regression coverage for preserved prior dispositions and repair fallthrough

Fixes #264

## Tests
- python3 -m pytest tests/test_agent_loop.py -k "envelope_normalization or structured_plan_review_transient_terms_with_trailing_prose_normalizes or structured_pr_review_transient_terms_duplicate_footer_normalizes or duplicate_trailing_agent_state_marker_normalizes_without_repair"
- python3 -m pytest