### PR TITLE
Address lightweight follow-up issues #266, #269, #271, #274, #275

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1026,6 +1026,46 @@ def _run_validated_agent(
                     if normalized is not None:
                         try:
                             marker_value = validate(normalized)
+                        except UnknownPriorItemDispositionError as norm_exc:
+                            # Combined fix (issue #274): envelope normalization removed the
+                            # trailing defect but the normalized candidate still has unknown
+                            # prior dispositions. Try stripping them from the normalized text
+                            # so both defects are resolved in one deterministic pass.
+                            # Only apply when the original error was structural; when it was
+                            # already UnknownPriorItemDispositionError, block 2 handles it.
+                            if (
+                                not isinstance(exc, UnknownPriorItemDispositionError)
+                                and not ledger_incomplete
+                                and repair_expected_kind in {"pr_review", "plan_review", "plan_revision"}
+                            ):
+                                stripped_from_normalized = strip_unknown_prior_item_dispositions(
+                                    normalized,
+                                    allowed_ids=frozenset(norm_exc.allowed_ids),
+                                    expected_kind=repair_expected_kind,
+                                )
+                                if stripped_from_normalized is not None:
+                                    try:
+                                        marker_value = validate(stripped_from_normalized)
+                                    except AgentLoopError:
+                                        pass
+                                    else:
+                                        removed = ", ".join(sorted(norm_exc.unknown_ids))
+                                        allowed_str = ", ".join(sorted(norm_exc.allowed_ids)) or "(none)"
+                                        log(
+                                            config,
+                                            f"{agent_name}: combined envelope normalization and "
+                                            f"deterministic strip recovered malformed response; "
+                                            f"removed prior-item ID(s) {removed}; "
+                                            f"allowed carried prior IDs: {allowed_str}",
+                                        )
+                                        if usage_record is not None:
+                                            usage_record.validation_status = "validated"
+                                        return ValidatedAgentResponse(
+                                            text=stripped_from_normalized,
+                                            session_id=result.session_id,
+                                            marker_value=marker_value,
+                                            usage=usage,
+                                        )
                         except AgentLoopError:
                             pass
                         else:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1188,6 +1188,7 @@ def build_plan_revision_prompt(
 
 Revise the plan in this local checkout without editing code. Do not create a
 branch, commit, push, or open a pull request during this planning stage.
+{_coder_workdir_guidance(config, implementation=False)}
 {_scratch_file_guidance()}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -65,10 +65,11 @@ def strip_unknown_prior_item_dispositions(
     ]
     if len(filtered) == len(dispositions):
         return None
-    return (
-        json.dumps({**payload, disposition_field: filtered}, ensure_ascii=False)
-        + stripped[json_end:]
-    )
+    json_str = json.dumps({**payload, disposition_field: filtered}, ensure_ascii=False)
+    tail = stripped[json_end:]
+    if tail and not tail.startswith("\n"):
+        tail = "\n" + tail
+    return json_str + tail
 
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -96,6 +96,9 @@ class Runner:
         with log_path.open("w", encoding="utf-8") as log_file:
             log_file.write(header)
             log_file.flush()
+            # stderr=subprocess.STDOUT merges stderr into the log file.
+            # All agent backends (Claude, Codex, Gemini) use run_with_log,
+            # so stderr capture is uniform across them (issue #266).
             proc = subprocess.Popen(
                 cmd,
                 cwd=cwd,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4202,6 +4202,38 @@ def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositio
     assert "fall back to markdown" not in prompt.lower()
 
 
+def test_non_compact_plan_revision_prompt_includes_workdir_guidance(tmp_path):
+    """Non-compact build_plan_revision_prompt must include workdir guidance (issue #269)."""
+    config = make_config(tmp_path)
+    prompt = build_plan_revision_prompt(
+        56,
+        1,
+        "Previous plan text.",
+        "Claude plan review:\n\nBlocking issue found.",
+        config,
+        compact_context=False,
+    )
+
+    assert "Assigned checkout:" in prompt
+    assert "AGENT_LOOP_WORKDIR" in prompt
+
+
+def test_compact_plan_revision_prompt_includes_workdir_guidance(tmp_path):
+    """Compact build_plan_revision_prompt also includes workdir guidance (regression guard)."""
+    config = make_config(tmp_path)
+    prompt = build_plan_revision_prompt(
+        56,
+        1,
+        "Previous plan text.",
+        "Claude plan review:\n\nBlocking issue found.",
+        config,
+        compact_context=True,
+    )
+
+    assert "Assigned checkout:" in prompt
+    assert "AGENT_LOOP_WORKDIR" in prompt
+
+
 def _compact_issue_context() -> IssueContext:
     return IssueContext(
         number=56,
@@ -7549,6 +7581,175 @@ def test_run_validated_agent_skips_unknown_prior_item_repair_when_ledger_incompl
 
     repair_mock.assert_not_called()
     assert "item-1" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Issue #271: coder_followup path through attempt_envelope_normalization
+# ---------------------------------------------------------------------------
+
+def test_envelope_normalization_coder_followup_duplicate_state_footer():
+    """attempt_envelope_normalization handles coder_followup with a duplicate AGENT_STATE footer."""
+    raw = (
+        structured_coder_followup(
+            state="approved",
+            reviewer="Anthropic Claude",
+            addressed_items=["item-1"],
+        )
+        + "\n\n<!-- AGENT_STATE: approved -->"
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="coder_followup")
+
+    assert normalized is not None
+    parsed = validate_structured_coder_followup(normalized)
+    assert parsed is not None
+    assert parsed.addressed_items == ("item-1",)
+    assert normalized.count("<!-- AGENT_STATE: approved -->") == 1
+
+
+def test_envelope_normalization_coder_followup_trailing_prose_after_signature():
+    """attempt_envelope_normalization strips trailing prose after coder_followup signature."""
+    raw = (
+        structured_coder_followup(
+            state="blocking",
+            reviewer="Anthropic Claude",
+            remaining_items=["item-2"],
+        )
+        + "\n\nExtra prose that should be stripped."
+    )
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="coder_followup")
+
+    assert normalized is not None
+    assert "Extra prose" not in normalized
+    parsed = validate_structured_coder_followup(normalized)
+    assert parsed is not None
+    assert parsed.remaining_items == ("item-2",)
+
+
+def test_envelope_normalization_coder_followup_returns_none_when_prose_before_footer():
+    """attempt_envelope_normalization returns None for coder_followup with prose before the footer."""
+    raw = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "approved",
+                "summary": "Done.",
+                "addressed_items": [],
+                "remaining_items": [],
+                "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+            }
+        )
+        + "\nSome unexpected prose here.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"
+    )
+
+    assert attempt_envelope_normalization(raw, expected_kind="coder_followup") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #275: strip_unknown_prior_item_dispositions with tightly-packed input
+# ---------------------------------------------------------------------------
+
+def test_strip_unknown_prior_item_dispositions_tightly_packed_no_newline_before_footer():
+    """strip_unknown_prior_item_dispositions inserts a newline when the original had none."""
+    payload = {
+        "schema_version": 1,
+        "kind": "pr_review",
+        "state": "approved",
+        "summary": "LGTM.",
+        "blocking_items": [],
+        "same_pr_followups": [],
+        "future_followups": [],
+        "prior_item_dispositions": [{"item_id": "item-99", "disposition": "resolved"}],
+    }
+    # Tightly packed: no newline between JSON and footer
+    raw = json.dumps(payload) + "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+
+    result = strip_unknown_prior_item_dispositions(
+        raw, allowed_ids=frozenset(), expected_kind="pr_review"
+    )
+
+    assert result is not None
+    # Validate parses correctly even after tight packing
+    parsed_payload, json_end = json.JSONDecoder().raw_decode(result.lstrip())
+    assert parsed_payload["prior_item_dispositions"] == []
+    tail = result.lstrip()[json_end:]
+    assert "<!-- AGENT_STATE: approved -->" in tail
+    assert "-- Google Gemini" in tail
+    # The footer must be separated from the JSON by at least a newline
+    assert tail.startswith("\n")
+
+
+def test_strip_unknown_prior_item_dispositions_tightly_packed_result_validates():
+    """Tight-packing case validates successfully through parse_structured_pr_review."""
+    payload = {
+        "schema_version": 1,
+        "kind": "pr_review",
+        "state": "approved",
+        "summary": "LGTM.",
+        "blocking_items": [],
+        "same_pr_followups": [],
+        "future_followups": [],
+        "prior_item_dispositions": [{"item_id": "item-99", "disposition": "resolved"}],
+    }
+    raw = json.dumps(payload) + "<!-- AGENT_STATE: approved -->\n-- Google Gemini"
+
+    result = strip_unknown_prior_item_dispositions(
+        raw, allowed_ids=frozenset(), expected_kind="pr_review"
+    )
+
+    assert result is not None
+    parsed = parse_structured_pr_review(result, reviewer="Google Gemini")
+    assert parsed is not None
+    assert parsed.dispositions == ()
+
+
+# ---------------------------------------------------------------------------
+# Issue #274: combined envelope+disposition strip via _run_validated_agent
+# ---------------------------------------------------------------------------
+
+def test_run_validated_agent_combined_envelope_and_disposition_fix(tmp_path):
+    """When a response has both an envelope defect and unknown prior dispositions,
+    stripping dispositions from the envelope-normalized candidate recovers it."""
+    # Build a plan_review with an unknown disposition AND a duplicate footer (envelope defect).
+    # strip_unknown_prior_item_dispositions on the original fails to validate because the
+    # duplicate footer is still present. Envelope normalization on the original produces a
+    # normalized candidate; stripping dispositions from that candidate should succeed.
+    base = structured_plan_review(
+        state="approved",
+        summary="Plan approved.",
+        prior_plan_item_dispositions=[{"item_id": "item-99", "disposition": "resolved"}],
+        reviewer="Google Gemini",
+    )
+    # Add a duplicate footer to create the envelope defect
+    malformed = base + "\n\n<!-- AGENT_PLAN_STATE: approved -->"
+
+    runner = FakeRunner(gemini_outputs=[malformed])
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair") as repair_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the plan.",
+            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+            validate=lambda text: _validate_plan_review_response(
+                text,
+                reviewer="Google Gemini",
+                unresolved_items=(),
+            ),
+            use_repair=True,
+            repair_expected_kind="plan_review",
+            repair_allowed_prior_item_ids=(),
+            ledger_incomplete=False,
+        )
+
+    repair_mock.assert_not_called()
+    parsed = json.loads(response.text.split("\n")[0])
+    assert parsed["prior_plan_item_dispositions"] == []
+    assert parsed["state"] == "approved"
 
 
 def test_run_validated_agent_rejects_repair_that_invents_prior_item_id(tmp_path):


### PR DESCRIPTION
## Summary

This PR addresses five lightweight follow-up issues from earlier planning and PR reviews.

### #266 — stderr routing uniform across all backends
Verified that `run_with_log` already uses `stderr=subprocess.STDOUT` for all three agent backends (Claude, Codex, Gemini). Added a comment in `runner.py` documenting this intentional, uniform behavior.

### #269 — Non-compact plan revision prompt missing workdir guidance
Added `_coder_workdir_guidance(config, implementation=False)` to the non-compact `build_plan_revision_prompt` return value (line 1187 in `prompts.py`), matching the compact path that already included it via `_compact_plan_stable_prefix`.

### #271 — coder_followup path through attempt_envelope_normalization untested
Added three unit tests covering the `coder_followup` path through `attempt_envelope_normalization`: duplicate AGENT_STATE footer (fixed), trailing prose after signature (fixed), and prose before footer (returns None).

### #274 — Combined envelope+disposition strip
When `attempt_envelope_normalization` fixes a structural defect but `validate(normalized)` raises `UnknownPriorItemDispositionError`, the orchestrator now attempts a combined deterministic strip from the normalized candidate. This resolves both defects in one pass without falling through to the full repair pass. Added an integration test that exercises this combined path.

### #275 — json.dumps tight-packing fix
`strip_unknown_prior_item_dispositions` now inserts a `\n` separator between the re-encoded JSON and the trailing footer/signature when the original had no whitespace between them. Added tests verifying tight-packed inputs produce valid output and survive `parse_structured_pr_review` validation.

## Test plan

- [x] All 707 tests pass: `python3 -m pytest tests/test_agent_loop.py -q`
- [x] 8 new tests added covering issues #269, #271, #274, #275

Closes #266, #269, #271, #274, #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)