### PR TITLE
Fix #281: recreate stale default workdirs after reboot when only logs remain

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 import shlex
+import shutil
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -133,6 +134,23 @@ def ensure_workdir(path: Path, option_name: str) -> None:
         raise AgentLoopError(f"Could not create {option_name} at {path}: {exc}") from exc
 
 
+_TOOL_ARTIFACT_NAMES = frozenset({
+    ".agent-loop-logs",
+    ".agent-loop",
+    ".agent-loop-responses",
+})
+
+
+def _is_stale_default_workdir(path: Path) -> bool:
+    """Return True if path has no git checkout and contains only tool-owned log artifacts."""
+    if not path.is_dir():
+        return False
+    if (path / ".git").exists():
+        return False
+    contents = {item.name for item in path.iterdir()}
+    return bool(contents) and contents.issubset(_TOOL_ARTIFACT_NAMES)
+
+
 def _looks_like_repo_remote(remote_url: str, repo: str) -> bool:
     normalized = remote_url.strip().removesuffix(".git").lower()
     repo = repo.lower()
@@ -226,6 +244,10 @@ def _sync_base_branch(
 
 
 def ensure_temp_checkout(path: Path, *, agent: AgentName, config: AgentLoopConfig, runner: Runner) -> None:
+    if _is_stale_default_workdir(path):
+        log(config, f"Stale default {agent} workdir detected (no checkout, only logs remain); recreating: {path}")
+        shutil.rmtree(path)
+
     if not path.exists():
         try:
             path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12076,6 +12076,79 @@ def test_existing_auto_agent_dir_must_be_git_checkout(tmp_path):
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
 
 
+def test_stale_default_workdir_only_logs_is_recreated(tmp_path, capsys):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    (codex_dir / ".agent-loop-logs").mkdir()
+
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+        quiet=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    clone_cmds = [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "repo", "clone"]]
+    assert any(cmd[4] == str(codex_dir) for cmd in clone_cmds), "Expected fresh clone of stale workdir"
+
+    captured = capsys.readouterr()
+    assert "Stale default codex workdir detected" in captured.err
+    assert "recreating" in captured.err
+
+
+def test_stale_default_workdir_with_unknown_files_still_fails(tmp_path):
+    runner = FakeRunner(git_inside=False)
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    (codex_dir / ".agent-loop-logs").mkdir()
+    (codex_dir / "some-user-file.py").write_text("# user work", encoding="utf-8")
+
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="not a git checkout"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:3] == ["gh", "repo", "clone"] for cmd, _cwd in runner.commands)
+
+
+def test_explicit_dir_not_git_checkout_is_not_recreated(tmp_path):
+    runner = FakeRunner(git_inside=False)
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    (codex_dir / ".agent-loop-logs").mkdir()
+
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        create_dirs=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="not a git checkout"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:3] == ["gh", "repo", "clone"] for cmd, _cwd in runner.commands)
+
+
 def test_existing_auto_agent_dir_must_match_requested_repo(tmp_path):
     runner = FakeRunner(git_remote="git@github.com:OTHER/REPO.git")
     codex_dir = tmp_path / "codex"


### PR DESCRIPTION
## Summary

Fixes #281

After a machine reboot, a tool-owned default agent workdir under `/tmp/coding-review-agent-loop/...` can survive as a bare directory containing only tool-created artifacts (e.g., `.agent-loop-logs/`) with no git checkout. Previously the tool aborted with:

```
Default claude workdir exists but is not a git checkout: ...
Remove it or pass an explicit agent directory
```

This PR adds auto-recreation for that stale scenario:

- **`_is_stale_default_workdir(path)`** — detects a dir that exists, has no `.git/`, and whose contents are a non-empty subset of known tool artifact names (`.agent-loop-logs`, `.agent-loop`, `.agent-loop-responses`). Empty dirs are intentionally excluded (no artifacts → could be any empty dir).
- **`ensure_temp_checkout()`** — calls `shutil.rmtree()` on stale default-owned workdirs before the existing clone-if-missing branch, so the normal `gh repo clone` + validation flow runs fresh.
- Explicit agent dirs (`--claude-dir` / `--codex-dir` / `--gemini-dir`) are unchanged — they still fail clearly when not a git checkout.
- Existing dirty-checkout behavior for valid default-owned git repos is preserved.

## Test plan

- `test_stale_default_workdir_only_logs_is_recreated` — default auto workdir with only `.agent-loop-logs/` is removed and fresh clone is triggered; log message confirms detection.
- `test_stale_default_workdir_with_unknown_files_still_fails` — dir with `.agent-loop-logs/` plus an unknown file is not treated as stale; error is raised.
- `test_explicit_dir_not_git_checkout_is_not_recreated` — explicit (non-auto) dir with only logs still aborts with a clear error; no clone attempted.
- All 716 existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)