### PR TITLE
feat(skill): support interactive repair when reviewer validation fails

### DIFF
--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -66,6 +66,10 @@ _HELPERS = Path(__file__).parent
 _REPAIR_BASE = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / "repair"
 
 
+class _ValidationError(Exception):
+    """Raised by _complete_reviewer_turn when the reviewer response fails validation."""
+
+
 def _run_helper(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         [sys.executable, "-m", *args],
@@ -512,9 +516,10 @@ def _complete_reviewer_turn(
         "--context-file", str(context_file),
     )
     if result.returncode != 0:
-        print(f"skill_runner: {agent} review validation failed: {result.stderr.strip()}", file=sys.stderr)
-        print(f"skill_runner: raw response at: {raw_output}", file=sys.stderr)
-        sys.exit(1)
+        raise _ValidationError(
+            f"skill_runner: {agent} review validation failed: {result.stderr.strip()}\n"
+            f"skill_runner: raw response at: {raw_output}"
+        )
 
     # --- Render ---
     _run_helper(
@@ -691,14 +696,15 @@ def _run_reviewer(
             raw_output=raw_output, context_file=context_file,
             work_dir=tmpdir,
         )
-    except SystemExit:
+    except _ValidationError as exc:
+        print(str(exc), file=sys.stderr)
         print(f"skill_runner: raw response saved to: {repair_dir}/raw.md", file=sys.stderr)
         print(
             f"skill_runner: fix raw.md, then run: "
             f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}",
             file=sys.stderr,
         )
-        raise
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -1069,15 +1075,19 @@ def cmd_retry_validate(args: argparse.Namespace) -> None:
     context_file    = repair_dir / "context.json"
     prior_items_raw = json.loads((repair_dir / "prior_items.json").read_text(encoding="utf-8"))
 
-    result = _complete_reviewer_turn(
-        agent=agent, agent_cap=agent_cap, flow=flow,
-        validate_kind=validate_kind, issue=issue, repo=repo,
-        new_round_number=new_round_number, round_subject=round_subject,
-        next_prior_items_raw=prior_items_raw,
-        item_id_offset=item_id_offset, dry_run=dry_run,
-        raw_output=raw_output, context_file=context_file,
-        work_dir=repair_dir,
-    )
+    try:
+        result = _complete_reviewer_turn(
+            agent=agent, agent_cap=agent_cap, flow=flow,
+            validate_kind=validate_kind, issue=issue, repo=repo,
+            new_round_number=new_round_number, round_subject=round_subject,
+            next_prior_items_raw=prior_items_raw,
+            item_id_offset=item_id_offset, dry_run=dry_run,
+            raw_output=raw_output, context_file=context_file,
+            work_dir=repair_dir,
+        )
+    except _ValidationError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
     print(json.dumps(result, indent=2))
     if result["state"] in ("approved", "approved-with-notes"):
         print("hint: reviewer approved — re-run the parent round command to continue.", file=sys.stderr)

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -17,6 +17,15 @@ Subcommands:
     [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH]
     [--dry-run]
 
+  retry-validate
+    --repair-dir PATH
+    [--dry-run]
+
+    Re-validate an already-written reviewer response without re-running the agent.
+    On validation failure, skill_runner saves the raw response plus context to a
+    stable repair dir and prints the retry command. Edit {repair_dir}/raw.md, then
+    run this subcommand to complete the round.
+
 Prints a JSON result to stdout and exits 0:
   {"state": "approved"|"blocking", "round_number": N,
    "blocking_items": [...], "approved_reviewers": [...]}
@@ -54,6 +63,7 @@ from coding_review_agent_loop.unresolved_items import apply_item_dispositions
 # ---------------------------------------------------------------------------
 
 _HELPERS = Path(__file__).parent
+_REPAIR_BASE = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / "repair"
 
 
 def _run_helper(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -128,6 +138,35 @@ def _normalize_disposition_values(text: str) -> str:
             if canonical:
                 disp["disposition"] = canonical
                 changed = True
+    # Flatten list fields whose items are dicts instead of plain strings.
+    # Agents occasionally write {"title": "...", "detail": "..."} objects.
+    for key in (
+        "blocking_plan_issues", "same_plan_followups",
+        "blocking_items", "same_pr_followups", "future_followups",
+    ):
+        if key not in data:
+            continue
+        flattened = []
+        any_dict = False
+        for item in data[key]:
+            if isinstance(item, dict):
+                any_dict = True
+                title = str(
+                    item.get("title") or item.get("text")
+                    or item.get("issue") or item.get("summary") or ""
+                )
+                detail = str(item.get("detail") or item.get("description") or "")
+                flattened.append(f"{title}: {detail}".strip(": ") if detail else title)
+            else:
+                flattened.append(item)
+        if any_dict:
+            data[key] = flattened
+            changed = True
+    # Blocking plan/PR reviews may not include future_followups per protocol.
+    # Strip them rather than failing validation on an otherwise-valid review.
+    if data.get("state") == "blocking" and data.get("future_followups"):
+        data["future_followups"] = []
+        changed = True
     if not changed:
         return text
     return json.dumps(data, indent=2) + "\n" + footer.lstrip()
@@ -195,6 +234,40 @@ def _normalize_raw_response(text: str) -> str:
     )
     prefix = (hr_resolved + "\n") if hr_resolved else ""
     return json_text.rstrip() + "\n" + prefix + state_and_sig.rstrip() + "\n"
+
+
+def _save_raw_to_repair_dir(
+    *,
+    agent: str,
+    agent_cap: str,
+    flow: str,
+    issue: int,
+    repo: str,
+    new_round_number: int,
+    round_subject: str,
+    item_id_offset: int,
+    validate_kind: str,
+    dry_run: bool,
+    raw_output: Path,
+    context_file: Path,
+    prior_items_file: Path,
+) -> Path:
+    """Copy raw response + context to a stable repair dir before normalization/validation."""
+    import shutil
+    repair_dir = _REPAIR_BASE / f"{issue}-r{new_round_number}-{agent}"
+    repair_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(raw_output, repair_dir / "raw.md")
+    shutil.copy2(context_file, repair_dir / "context.json")
+    shutil.copy2(prior_items_file, repair_dir / "prior_items.json")
+    manifest = {
+        "agent": agent, "agent_cap": agent_cap, "flow": flow,
+        "issue": issue, "repo": repo,
+        "new_round_number": new_round_number, "round_subject": round_subject,
+        "item_id_offset": item_id_offset, "validate_kind": validate_kind,
+        "dry_run": dry_run,
+    }
+    (repair_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return repair_dir
 
 
 def _max_item_number(item_lists: list[list[dict]]) -> int:
@@ -392,61 +465,46 @@ def _compute_next_prior_items(
 
 
 # ---------------------------------------------------------------------------
-# Per-reviewer run
+# Per-reviewer turn completion (shared by _run_reviewer and cmd_retry_validate)
 # ---------------------------------------------------------------------------
 
-def _run_reviewer(
+def _complete_reviewer_turn(
     *,
     agent: str,
-    prompt_text: str,
-    context: dict,
-    round_subject: str,
-    next_prior_items_raw: list[dict],
-    new_round_number: int,
+    agent_cap: str,
+    flow: str,
+    validate_kind: str,
     issue: int,
     repo: str,
-    flow: str,
-    role: str,
-    state_key: str,
-    workdir: str,
+    new_round_number: int,
+    round_subject: str,
+    next_prior_items_raw: list[dict],
+    item_id_offset: int,
     dry_run: bool,
-    tmpdir: Path,
-    item_id_offset: int = 0,
+    raw_output: Path,
+    context_file: Path,
+    work_dir: Path,
 ) -> dict:
-    """Run one reviewer turn; return {reviewer_name, state, blocking_items, new_items}."""
-    agent_cap = agent.capitalize() if agent in ("codex", "gemini") else agent
-    prompt_file = tmpdir / f"{agent}-prompt.md"
-    raw_output = tmpdir / f"{agent}-review-raw.md"
-    rendered_output = tmpdir / f"{agent}-review-rendered.md"
-    tagged_output = tmpdir / f"{agent}-review-tagged.md"
-    context_file = tmpdir / f"{agent}-context.json"
-    prior_items_file = tmpdir / f"{agent}-prior-items.json"
-    dispositions_file = tmpdir / f"{agent}-dispositions.json"
-    new_items_file = tmpdir / f"{agent}-new-items.json"
+    """Normalize, validate, render, parse, mint IDs, attach metadata, and post.
 
-    _write_text(prompt_file, prompt_text)
-    _write_json(context_file, context)
+    Normalizes raw_output in-place. Exits 1 on validation failure.
+    Returns {reviewer_name, state, blocking_items, new_items}.
+    """
+    rendered_output   = work_dir / f"{agent}-review-rendered.md"
+    tagged_output     = work_dir / f"{agent}-review-tagged.md"
+    prior_items_file  = work_dir / f"{agent}-prior-items.json"
+    dispositions_file = work_dir / f"{agent}-dispositions.json"
+    new_items_file    = work_dir / f"{agent}-new-items.json"
+
     _write_json(prior_items_file, next_prior_items_raw)
 
-    # --- Run agent ---
-    _run_helper(
-        "helpers.run_external",
-        "--agent", agent,
-        "--prompt-file", str(prompt_file),
-        "--output", str(raw_output),
-        "--workdir", workdir,
-        "--flow", flow,
-        *(["--dry-run"] if dry_run else []),
-    )
-
-    # Normalize: fix prose prefix / duplicate state markers / bad disposition values
+    # --- Normalize ---
     raw_text = raw_output.read_text(encoding="utf-8")
     raw_text = _normalize_raw_response(raw_text)
     raw_text = _normalize_disposition_values(raw_text)
     raw_output.write_text(raw_text, encoding="utf-8")
 
     # --- Validate ---
-    validate_kind = "pr_review" if flow == "pr" else "plan_review"
     result = _run_helper_capture(
         "helpers.validate_response",
         "--file", str(raw_output),
@@ -455,6 +513,7 @@ def _run_reviewer(
     )
     if result.returncode != 0:
         print(f"skill_runner: {agent} review validation failed: {result.stderr.strip()}", file=sys.stderr)
+        print(f"skill_runner: raw response at: {raw_output}", file=sys.stderr)
         sys.exit(1)
 
     # --- Render ---
@@ -479,7 +538,6 @@ def _run_reviewer(
     parsed_state = str(review_json.get("state", "approved"))
     disp_key = "prior_plan_item_dispositions" if flow == "plan" else "prior_item_dispositions"
     raw_dispositions = review_json.get(disp_key, [])
-    # Add reviewer field required by _deserialize_disposition
     for d in raw_dispositions:
         if "reviewer" not in d:
             d["reviewer"] = agent_cap
@@ -495,11 +553,9 @@ def _run_reviewer(
     if parsed_state == "blocking" and not blocking_texts:
         reported_blocking = new_unresolved_texts
 
-    # Serialize dispositions (with reviewer) for attach-metadata
     _write_json(dispositions_file, raw_dispositions)
 
-    # Mint IDs that are globally unique across rounds by starting from item_id_offset.
-    # item_id_offset = max numeric suffix seen across prior_items + already-minted round items.
+    # --- Mint IDs globally unique across rounds ---
     new_items_serialized: list[dict] = []
     item_counter = item_id_offset + 1
     for text in blocking_texts:
@@ -528,7 +584,7 @@ def _run_reviewer(
     _write_json(new_items_file, new_items_serialized)
 
     # --- Attach metadata ---
-    attach_args = [
+    _run_helper(
         "helpers.state_manager", "attach-metadata",
         "--body-file", str(rendered_output),
         "--output", str(tagged_output),
@@ -540,22 +596,20 @@ def _run_reviewer(
         "--prior-items-file", str(prior_items_file),
         "--dispositions-file", str(dispositions_file),
         "--new-items-file", str(new_items_file),
-    ]
-    attach_args += ["--subject", round_subject]
-    _run_helper(*attach_args)
+        "--subject", round_subject,
+    )
 
-    # --- Post (skip when dry_run) ---
+    # --- Post ---
     if not dry_run:
         _run_helper(
             "helpers.state_manager", "write-pending-comment",
             "--issue", str(issue), "--repo", repo,
             "--body", str(tagged_output),
         )
-        post_cmd = (
+        _run_helper(
             "helpers.gh_ops", "post-issue-comment",
             "--issue", str(issue), "--file", str(tagged_output), "--repo", repo,
         )
-        _run_helper(*post_cmd)
         _run_helper(
             "helpers.state_manager", "clear-pending-comment",
             "--issue", str(issue), "--repo", repo,
@@ -569,6 +623,82 @@ def _run_reviewer(
         "blocking_items": [{"text": t} for t in reported_blocking],
         "new_items": new_items_serialized,
     }
+
+
+# ---------------------------------------------------------------------------
+# Per-reviewer run
+# ---------------------------------------------------------------------------
+
+def _run_reviewer(
+    *,
+    agent: str,
+    prompt_text: str,
+    context: dict,
+    round_subject: str,
+    next_prior_items_raw: list[dict],
+    new_round_number: int,
+    issue: int,
+    repo: str,
+    flow: str,
+    role: str,
+    state_key: str,
+    workdir: str,
+    dry_run: bool,
+    tmpdir: Path,
+    item_id_offset: int = 0,
+) -> dict:
+    """Run one reviewer turn; return {reviewer_name, state, blocking_items, new_items}."""
+    agent_cap = agent.capitalize() if agent in ("codex", "gemini") else agent
+    validate_kind = "pr_review" if flow == "pr" else "plan_review"
+
+    prompt_file      = tmpdir / f"{agent}-prompt.md"
+    raw_output       = tmpdir / f"{agent}-review-raw.md"
+    context_file     = tmpdir / f"{agent}-context.json"
+    prior_items_file = tmpdir / f"{agent}-prior-items.json"
+
+    _write_text(prompt_file, prompt_text)
+    _write_json(context_file, context)
+    _write_json(prior_items_file, next_prior_items_raw)
+
+    # --- Run agent ---
+    _run_helper(
+        "helpers.run_external",
+        "--agent", agent,
+        "--prompt-file", str(prompt_file),
+        "--output", str(raw_output),
+        "--workdir", workdir,
+        "--flow", flow,
+        *(["--dry-run"] if dry_run else []),
+    )
+
+    # Save raw response to stable repair dir BEFORE normalization
+    repair_dir = _save_raw_to_repair_dir(
+        agent=agent, agent_cap=agent_cap, flow=flow,
+        issue=issue, repo=repo, new_round_number=new_round_number,
+        round_subject=round_subject, item_id_offset=item_id_offset,
+        validate_kind=validate_kind, dry_run=dry_run,
+        raw_output=raw_output, context_file=context_file,
+        prior_items_file=prior_items_file,
+    )
+
+    try:
+        return _complete_reviewer_turn(
+            agent=agent, agent_cap=agent_cap, flow=flow,
+            validate_kind=validate_kind, issue=issue, repo=repo,
+            new_round_number=new_round_number, round_subject=round_subject,
+            next_prior_items_raw=next_prior_items_raw,
+            item_id_offset=item_id_offset, dry_run=dry_run,
+            raw_output=raw_output, context_file=context_file,
+            work_dir=tmpdir,
+        )
+    except SystemExit:
+        print(f"skill_runner: raw response saved to: {repair_dir}/raw.md", file=sys.stderr)
+        print(
+            f"skill_runner: fix raw.md, then run: "
+            f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}",
+            file=sys.stderr,
+        )
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -913,6 +1043,49 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
+# retry-validate
+# ---------------------------------------------------------------------------
+
+def cmd_retry_validate(args: argparse.Namespace) -> None:
+    """Re-validate an already-written reviewer response from a repair dir."""
+    repair_dir = Path(args.repair_dir)
+    if not repair_dir.exists():
+        print(f"skill_runner: repair dir not found: {repair_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    manifest = json.loads((repair_dir / "manifest.json").read_text(encoding="utf-8"))
+    agent            = manifest["agent"]
+    agent_cap        = manifest["agent_cap"]
+    flow             = manifest["flow"]
+    validate_kind    = manifest["validate_kind"]
+    issue            = manifest["issue"]
+    repo             = manifest["repo"]
+    new_round_number = manifest["new_round_number"]
+    round_subject    = manifest["round_subject"]
+    item_id_offset   = manifest["item_id_offset"]
+    dry_run          = manifest.get("dry_run", False) or args.dry_run
+
+    raw_output      = repair_dir / "raw.md"
+    context_file    = repair_dir / "context.json"
+    prior_items_raw = json.loads((repair_dir / "prior_items.json").read_text(encoding="utf-8"))
+
+    result = _complete_reviewer_turn(
+        agent=agent, agent_cap=agent_cap, flow=flow,
+        validate_kind=validate_kind, issue=issue, repo=repo,
+        new_round_number=new_round_number, round_subject=round_subject,
+        next_prior_items_raw=prior_items_raw,
+        item_id_offset=item_id_offset, dry_run=dry_run,
+        raw_output=raw_output, context_file=context_file,
+        work_dir=repair_dir,
+    )
+    print(json.dumps(result, indent=2))
+    if result["state"] in ("approved", "approved-with-notes"):
+        print("hint: reviewer approved — re-run the parent round command to continue.", file=sys.stderr)
+    else:
+        print(f"hint: reviewer state={result['state']} — fix issues in raw.md and retry.", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -944,10 +1117,22 @@ def main() -> None:
     p_pr.add_argument("--workdir-gemini", default=None)
     p_pr.add_argument("--dry-run", action="store_true")
 
+    # retry-validate
+    p_retry = subparsers.add_parser(
+        "retry-validate",
+        help="Re-validate an already-written reviewer response without re-running the agent.",
+    )
+    p_retry.add_argument(
+        "--repair-dir", required=True,
+        help="Path to repair dir written by skill_runner on validation failure.",
+    )
+    p_retry.add_argument("--dry-run", action="store_true")
+
     args = parser.parse_args()
     dispatch = {
         "run-plan-round": cmd_run_plan_round,
         "run-pr-round": cmd_run_pr_round,
+        "retry-validate": cmd_retry_validate,
     }
     dispatch[args.subcommand](args)
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -548,13 +548,13 @@ def _complete_reviewer_turn(
             d["reviewer"] = agent_cap
 
     blocking_key = "blocking_plan_issues" if flow == "plan" else "blocking_items"
-    blocking_texts = list(review_json.get(blocking_key, []))
+    blocking_texts: list[str] = list(review_json.get(blocking_key, []))
     same_key = "same_plan_followups" if flow == "plan" else "same_pr_followups"
-    new_unresolved_texts = list(review_json.get(same_key, []))
+    new_unresolved_texts: list[str] = list(review_json.get(same_key, []))
 
     # When a reviewer blocks via same-round followups only (no explicit blocking issues),
     # surface those followups as blocking_items for the caller so the overall state is correct.
-    reported_blocking = blocking_texts
+    reported_blocking: list[str] = blocking_texts
     if parsed_state == "blocking" and not blocking_texts:
         reported_blocking = new_unresolved_texts
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -491,7 +491,7 @@ def _complete_reviewer_turn(
 ) -> dict:
     """Normalize, validate, render, parse, mint IDs, attach metadata, and post.
 
-    Normalizes raw_output in-place. Exits 1 on validation failure.
+    Normalizes raw_output in-place. Raises _ValidationError on validation failure.
     Returns {reviewer_name, state, blocking_items, new_items}.
     """
     rendered_output   = work_dir / f"{agent}-review-rendered.md"

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -37,6 +37,7 @@ import argparse
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -257,7 +258,6 @@ def _save_raw_to_repair_dir(
     prior_items_file: Path,
 ) -> Path:
     """Copy raw response + context to a stable repair dir before normalization/validation."""
-    import shutil
     repair_dir = _REPAIR_BASE / f"{issue}-r{new_round_number}-{agent}"
     repair_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(raw_output, repair_dir / "raw.md")
@@ -1069,7 +1069,7 @@ def cmd_retry_validate(args: argparse.Namespace) -> None:
     new_round_number = manifest["new_round_number"]
     round_subject    = manifest["round_subject"]
     item_id_offset   = manifest["item_id_offset"]
-    dry_run          = manifest.get("dry_run", False) or args.dry_run
+    dry_run          = args.dry_run
 
     raw_output      = repair_dir / "raw.md"
     context_file    = repair_dir / "context.json"

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -699,9 +699,10 @@ def _run_reviewer(
     except _ValidationError as exc:
         print(str(exc), file=sys.stderr)
         print(f"skill_runner: raw response saved to: {repair_dir}/raw.md", file=sys.stderr)
+        dry_run_flag = " --dry-run" if dry_run else ""
         print(
             f"skill_runner: fix raw.md, then run: "
-            f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}",
+            f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}{dry_run_flag}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -809,3 +809,45 @@ class TestRetryValidate:
             assert output["state"] == "blocking"
             assert len(output["blocking_items"]) == 1
             assert output["new_items"][0]["item_id"] == "item-1"
+
+    def test_retry_validate_blocking_via_same_followups_only(self, tmp_path):
+        """blocking state with empty blocking_plan_issues but non-empty same_plan_followups
+        surfaces the followups as blocking_items (exercises reported_blocking = new_unresolved_texts)."""
+        blocking_raw = json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "blocking",
+                "summary": "Unresolved followups remain.",
+                "blocking_plan_issues": [],
+                "same_plan_followups": ["Address the followup from last round."],
+                "future_followups": [],
+                "prior_plan_item_dispositions": [],
+            }
+        ) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex\n"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            repair_dir = _make_repair_dir(tmppath, raw_content=blocking_raw, dry_run=True)
+
+            result = _run(
+                "helpers.skill_runner", "retry-validate",
+                "--repair-dir", str(repair_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+            assert result.returncode == 0, (
+                f"Expected exit 0, got {result.returncode}\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            stdout = result.stdout
+            json_start = stdout.rfind("\n{")
+            if json_start < 0:
+                json_start = stdout.find("{")
+            output = json.loads(stdout[json_start:].strip())
+            assert output["state"] == "blocking"
+            assert len(output["blocking_items"]) == 1
+            assert output["blocking_items"][0]["text"] == "Address the followup from last round."

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -768,3 +768,44 @@ class TestRetryValidate:
                 f"Expected non-zero exit, but got 0\n"
                 f"stdout: {result.stdout}\nstderr: {result.stderr}"
             )
+
+    def test_retry_validate_blocking_response_returns_blocking_items(self) -> None:
+        """retry-validate with a blocking reviewer response returns state=blocking and items."""
+        blocking_raw = json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_review",
+                "state": "blocking",
+                "summary": "Has issues.",
+                "blocking_plan_issues": ["Fix the thing."],
+                "same_plan_followups": [],
+                "future_followups": [],
+                "prior_plan_item_dispositions": [],
+            }
+        ) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex\n"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            repair_dir = _make_repair_dir(tmppath, raw_content=blocking_raw, dry_run=True)
+
+            result = _run(
+                "helpers.skill_runner", "retry-validate",
+                "--repair-dir", str(repair_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+            assert result.returncode == 0, (
+                f"Expected exit 0, got {result.returncode}\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            stdout = result.stdout
+            json_start = stdout.rfind("\n{")
+            if json_start < 0:
+                json_start = stdout.find("{")
+            output = json.loads(stdout[json_start:].strip())
+            assert output["state"] == "blocking"
+            assert len(output["blocking_items"]) == 1
+            assert output["new_items"][0]["item_id"] == "item-1"

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -635,3 +635,136 @@ class TestSkillRunner:
             assert "round_number" in output
             assert "blocking_items" in output
             assert "approved_reviewers" in output
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — retry-validate / repair dir
+# ---------------------------------------------------------------------------
+
+_REPAIR_BASE = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / "repair"
+
+_VALID_PLAN_REVIEW_DRY = json.dumps(
+    {
+        "schema_version": 1,
+        "kind": "plan_review",
+        "state": "approved",
+        "summary": "LGTM.",
+        "blocking_plan_issues": [],
+        "same_plan_followups": [],
+        "future_followups": [],
+        "prior_plan_item_dispositions": [],
+    }
+) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Codex\n"
+
+_VALID_CONTEXT = json.dumps(
+    {"reviewer": "Codex", "prior_items": [], "current_round_items": []}
+)
+
+
+def _make_repair_dir(
+    tmpdir: Path,
+    *,
+    raw_content: str = _VALID_PLAN_REVIEW_DRY,
+    issue: int = 9998,
+    agent: str = "codex",
+    round_num: int = 1,
+    dry_run: bool = True,
+) -> Path:
+    repair_dir = tmpdir / f"{issue}-r{round_num}-{agent}"
+    repair_dir.mkdir(parents=True, exist_ok=True)
+    (repair_dir / "raw.md").write_text(raw_content, encoding="utf-8")
+    (repair_dir / "context.json").write_text(_VALID_CONTEXT, encoding="utf-8")
+    (repair_dir / "prior_items.json").write_text("[]", encoding="utf-8")
+    manifest = {
+        "agent": agent,
+        "agent_cap": agent.capitalize(),
+        "flow": "plan",
+        "issue": issue,
+        "repo": "OWNER/REPO",
+        "new_round_number": round_num,
+        "round_subject": "abc123",
+        "item_id_offset": 0,
+        "validate_kind": "plan_review",
+        "dry_run": dry_run,
+    }
+    (repair_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return repair_dir
+
+
+class TestRetryValidate:
+    def test_run_plan_round_saves_repair_dir(self) -> None:
+        """run-plan-round --dry-run always saves a repair dir before normalization."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            plan_path = tmppath / "plan.md"
+            plan_path.write_text(_VALID_PLAN_FOR_RUNNER, encoding="utf-8")
+
+            result = _run(
+                "helpers.skill_runner", "run-plan-round",
+                "--issue", "9998",
+                "--repo", "test/skill-repo",
+                "--plan-file", str(plan_path),
+                "--reviewers", "codex",
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0
+            repair_dir = _REPAIR_BASE / "9998-r1-codex"
+            assert (repair_dir / "raw.md").exists(), f"raw.md missing in {repair_dir}"
+            assert (repair_dir / "manifest.json").exists(), f"manifest.json missing in {repair_dir}"
+            manifest = json.loads((repair_dir / "manifest.json").read_text(encoding="utf-8"))
+            assert manifest["agent"] == "codex"
+            assert manifest["validate_kind"] == "plan_review"
+
+    def test_retry_validate_repair_dir_dry_run_exits_zero(self) -> None:
+        """retry-validate --repair-dir with a valid raw response exits 0."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            repair_dir = _make_repair_dir(tmppath, dry_run=True)
+
+            result = _run(
+                "helpers.skill_runner", "retry-validate",
+                "--repair-dir", str(repair_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+            assert result.returncode == 0, (
+                f"Expected exit 0, got {result.returncode}\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            stdout = result.stdout
+            json_start = stdout.rfind("\n{")
+            if json_start < 0:
+                json_start = stdout.find("{")
+            assert json_start >= 0, f"No JSON found in stdout:\n{stdout}"
+            output = json.loads(stdout[json_start:].strip())
+            assert output["state"] == "approved"
+
+    def test_retry_validate_invalid_raw_exits_nonzero(self) -> None:
+        """retry-validate with a clearly invalid raw file exits non-zero."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            repair_dir = _make_repair_dir(
+                tmppath,
+                raw_content="This is not JSON at all.\n",
+                dry_run=True,
+            )
+
+            result = _run(
+                "helpers.skill_runner", "retry-validate",
+                "--repair-dir", str(repair_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+            assert result.returncode != 0, (
+                f"Expected non-zero exit, but got 0\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )


### PR DESCRIPTION
## Summary

- Adds `_save_raw_to_repair_dir`: before any normalization, copies the raw reviewer response, `context.json`, and `prior_items.json` to a stable path at `/tmp/coding-review-agent-loop/repair/{issue}-r{N}-{agent}/` with a `manifest.json` encoding all round parameters.
- Extracts `_complete_reviewer_turn`: the shared normalize→validate→render→parse→mint-IDs→attach-metadata→post pipeline, now called by both `_run_reviewer` and the new `retry-validate` subcommand.
- Adds `retry-validate --repair-dir PATH [--dry-run]` subcommand: reads manifest.json and `prior_items.json`, calls `_complete_reviewer_turn` on the (user-edited) `raw.md`, and posts the completed review.
- On validation failure, `skill_runner` now prints the repair dir path and the exact retry command instead of just exiting 1.
- 3 new tests: repair dir creation after `run-plan-round`, successful `retry-validate --dry-run`, invalid raw exits non-zero.

## Test plan

- [ ] All 20 tests pass: `python -m pytest tests/test_skill_helpers.py -q`
- [ ] `retry-validate --help` shows the new subcommand
- [ ] After a validation failure, the repair dir is present with `raw.md`, `context.json`, `prior_items.json`, and `manifest.json`

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)