### PR TITLE
fix: detect .git-only stale workdir; wire run_external repo cloning

### DIFF
--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -147,9 +147,9 @@ def main() -> None:
     # Import backends lazily to avoid heavy import in dry-run path
     from coding_review_agent_loop.agents.codex import CodexBackend
     from coding_review_agent_loop.agents.gemini import GeminiBackend
-    from coding_review_agent_loop.config import AgentLoopConfig, ensure_temp_checkout
+    from coding_review_agent_loop.config import AgentLoopConfig, AgentName, ensure_temp_checkout
 
-    agent_name = args.agent
+    agent_name: AgentName = args.agent
     default_cmds = {"codex": "codex", "gemini": "gemini"}
     cmd = args.cmd or default_cmds[agent_name]
 
@@ -164,7 +164,7 @@ def main() -> None:
         codex_dir=workdir,
         gemini_dir=workdir,
         coder="claude",
-        reviewer=(agent_name,),  # type: ignore[arg-type]
+        reviewer=(agent_name,),
         base="main",
         max_rounds=1,
         auto_merge=False,
@@ -191,12 +191,12 @@ def main() -> None:
         refresh_agent_memory=False,
         agent_memory_dir=log_dir,
         refresh_test_profile=False,
-        auto_agent_dirs=(agent_name,),  # type: ignore[arg-type]
+        auto_agent_dirs=(agent_name,),
     )
 
     runner = Runner(dry_run=False)
     if args.repo:
-        ensure_temp_checkout(workdir, agent=agent_name, config=config, runner=runner)  # type: ignore[arg-type]
+        ensure_temp_checkout(workdir, agent=agent_name, config=config, runner=runner)
     backend = CodexBackend() if agent_name == "codex" else GeminiBackend()
     try:
         result = backend.run(runner, config, prompt)

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -100,6 +100,12 @@ def main() -> None:
         help="Review flow: 'plan' (default) or 'pr'. Affects dry-run stub kind.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Write a canned stub and exit.")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub OWNER/REPO to clone if workdir is absent or stale. "
+             "When provided, workdir is validated and re-cloned automatically.",
+    )
     args = parser.parse_args()
 
     output_path = Path(args.output)
@@ -141,7 +147,7 @@ def main() -> None:
     # Import backends lazily to avoid heavy import in dry-run path
     from coding_review_agent_loop.agents.codex import CodexBackend
     from coding_review_agent_loop.agents.gemini import GeminiBackend
-    from coding_review_agent_loop.config import AgentLoopConfig
+    from coding_review_agent_loop.config import AgentLoopConfig, ensure_temp_checkout
 
     agent_name = args.agent
     default_cmds = {"codex": "codex", "gemini": "gemini"}
@@ -153,7 +159,7 @@ def main() -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
 
     config = AgentLoopConfig(
-        repo="skill/run",
+        repo=args.repo or "skill/run",
         claude_dir=workdir,
         codex_dir=workdir,
         gemini_dir=workdir,
@@ -189,6 +195,8 @@ def main() -> None:
     )
 
     runner = Runner(dry_run=False)
+    if args.repo:
+        ensure_temp_checkout(workdir, agent=agent_name, config=config, runner=runner)  # type: ignore[arg-type]
     backend = CodexBackend() if agent_name == "codex" else GeminiBackend()
     try:
         result = backend.run(runner, config, prompt)

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -292,7 +292,7 @@ def _workdir_for_agent(agent: str, args: argparse.Namespace) -> str:
     generic = getattr(args, "workdir", None)
     if generic:
         return generic
-    # Auto-clone to a temp path; run_external handles this via --workdir
+    # Auto-clone to a temp path; run_external validates/re-clones via --repo
     tmp = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / f"skill-runner-{agent}"
     tmp.mkdir(parents=True, exist_ok=True)
     return str(tmp)
@@ -672,6 +672,7 @@ def _run_reviewer(
         "--prompt-file", str(prompt_file),
         "--output", str(raw_output),
         "--workdir", workdir,
+        "--repo", repo,
         "--flow", flow,
         *(["--dry-run"] if dry_run else []),
     )

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -142,11 +142,18 @@ _TOOL_ARTIFACT_NAMES = frozenset({
 
 
 def _is_stale_default_workdir(path: Path) -> bool:
-    """Return True if path has no git checkout and contains only tool-owned log artifacts."""
+    """Return True if path has no real checkout and contains only tool-owned artifacts.
+
+    Covers two cases:
+    - No .git at all, only log/artifact dirs (original case).
+    - .git present but working tree is empty — happens when a prior cleanup removed
+      source files but left the .git dir (e.g. response storage at .git/agent-loop/).
+    """
     if not path.is_dir():
         return False
     if (path / ".git").exists():
-        return False
+        non_git = {item.name for item in path.iterdir() if item.name != ".git"}
+        return not non_git or non_git.issubset(_TOOL_ARTIFACT_NAMES)
     contents = {item.name for item in path.iterdir()}
     return bool(contents) and contents.issubset(_TOOL_ARTIFACT_NAMES)
 

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -155,7 +155,7 @@ def _is_stale_default_workdir(path: Path) -> bool:
         non_git = {item.name for item in path.iterdir() if item.name != ".git"}
         return not non_git or non_git.issubset(_TOOL_ARTIFACT_NAMES)
     contents = {item.name for item in path.iterdir()}
-    return bool(contents) and contents.issubset(_TOOL_ARTIFACT_NAMES)
+    return contents.issubset(_TOOL_ARTIFACT_NAMES)  # empty dir is also stale
 
 
 def _looks_like_repo_remote(remote_url: str, repo: str) -> bool:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12128,6 +12128,36 @@ def test_stale_default_workdir_with_unknown_files_still_fails(tmp_path):
     assert not any(cmd[:3] == ["gh", "repo", "clone"] for cmd, _cwd in runner.commands)
 
 
+def test_stale_default_workdir_git_only_is_recreated(tmp_path, capsys):
+    """A workdir with only a .git dir (no working tree) is treated as stale and re-cloned."""
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()
+    (codex_dir / ".git").mkdir()  # .git present, but no source files
+
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+        quiet=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    clone_cmds = [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "repo", "clone"]]
+    assert any(cmd[4] == str(codex_dir) for cmd in clone_cmds), "Expected fresh clone of git-only stale workdir"
+
+    captured = capsys.readouterr()
+    assert "Stale default codex workdir detected" in captured.err
+    assert "recreating" in captured.err
+
+
 def test_explicit_dir_not_git_checkout_is_not_recreated(tmp_path):
     runner = FakeRunner(git_inside=False)
     codex_dir = tmp_path / "codex"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12128,6 +12128,35 @@ def test_stale_default_workdir_with_unknown_files_still_fails(tmp_path):
     assert not any(cmd[:3] == ["gh", "repo", "clone"] for cmd, _cwd in runner.commands)
 
 
+def test_stale_default_workdir_empty_is_recreated(tmp_path, capsys):
+    """An empty workdir (no .git, no files) is treated as stale and re-cloned."""
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir()  # exists but empty
+
+    config = make_config(
+        tmp_path,
+        codex_dir=codex_dir,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+        create_dirs=False,
+        quiet=False,
+    )
+    config.claude_dir.mkdir(parents=True)
+    config.gemini_dir.mkdir(parents=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    clone_cmds = [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "repo", "clone"]]
+    assert any(cmd[4] == str(codex_dir) for cmd in clone_cmds), "Expected fresh clone of empty stale workdir"
+
+    captured = capsys.readouterr()
+    assert "Stale default codex workdir detected" in captured.err
+    assert "recreating" in captured.err
+
+
 def test_stale_default_workdir_git_only_is_recreated(tmp_path, capsys):
     """A workdir with only a .git dir (no working tree) is treated as stale and re-cloned."""
     runner = FakeRunner(


### PR DESCRIPTION
## Summary

- **`_is_stale_default_workdir` extended** (`config.py`): previously returned `False` as soon as `.git/` existed, so a workdir with `.git/` but no source files (e.g. after accidental wipe leaving only response storage at `.git/agent-loop/`) was never detected as stale. Now also flags the case where `.git` is present but the working tree contains no non-artifact files.

- **`run_external.py` now validates/re-clones the workdir** (`run_external.py`, `skill_runner.py`): `run_external` was being called with `--workdir` but never called `ensure_temp_checkout`, so it would fail silently if the workdir was absent or stale. Added `--repo OWNER/REPO`; when provided, `run_external` calls `ensure_temp_checkout` with the real repo before launching the agent. `skill_runner` now passes `--repo` on every `run_external` invocation.

- Fixed a misleading comment in `skill_runner.py` that claimed cloning was handled by `--workdir` (it wasn't).

## Test plan

- [ ] `tests/test_agent_loop.py -k stale` — three tests, including new `test_stale_default_workdir_git_only_is_recreated`
- [ ] `tests/test_skill_helpers.py` — 22 tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude