### PR TITLE
Add transient-failure retries to skill's run_external (#294)

### DIFF
--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -106,7 +107,28 @@ def main() -> None:
         help="GitHub OWNER/REPO to clone if workdir is absent or stale. "
              "When provided, workdir is validated and re-cloned automatically.",
     )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=2,
+        help="Retries for transient agent failures (429/overloaded/timeout). "
+             "Total attempts = max-retries + 1 (default: 2, matching the CLI). "
+             "Use 0 to disable retries.",
+    )
+    parser.add_argument(
+        "--retry-backoff-seconds",
+        type=int,
+        nargs="+",
+        default=[15, 45],
+        help="Backoff delays before each retry; the final value is reused when "
+             "retries exceed the list length (default: 15 45).",
+    )
     args = parser.parse_args()
+
+    if args.max_retries < 0:
+        parser.error("--max-retries must be >= 0")
+    if any(delay <= 0 for delay in args.retry_backoff_seconds):
+        parser.error("--retry-backoff-seconds values must be > 0")
 
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -148,6 +170,7 @@ def main() -> None:
     from coding_review_agent_loop.agents.codex import CodexBackend
     from coding_review_agent_loop.agents.gemini import GeminiBackend
     from coding_review_agent_loop.config import AgentLoopConfig, AgentName, ensure_temp_checkout
+    from coding_review_agent_loop.transient import is_transient_agent_output
 
     agent_name: AgentName = args.agent
     default_cmds = {"codex": "codex", "gemini": "gemini"}
@@ -195,15 +218,50 @@ def main() -> None:
     )
 
     runner = Runner(dry_run=False)
+    # Re-clone (if requested) happens once, outside the retry loop: it raises
+    # deterministically and re-cloning per attempt would be wasteful.
     if args.repo:
         ensure_temp_checkout(workdir, agent=agent_name, config=config, runner=runner)
     backend = CodexBackend() if agent_name == "codex" else GeminiBackend()
-    try:
-        result = backend.run(runner, config, prompt)
-    except Exception as exc:  # noqa: BLE001
-        print(f"run_external: agent invocation failed: {exc}", file=sys.stderr)
+
+    # Retry transient agent failures (429 / overloaded / timeout / capacity).
+    # The primary failure path is a *returned* AgentResult with a non-zero
+    # returncode whose raw_output (merged stdout+stderr) carries the signal;
+    # a raised exception is the secondary path (its message embeds the captured
+    # output tail for AgentLoopError from run_with_log).
+    max_attempts = args.max_retries + 1
+    backoff = args.retry_backoff_seconds
+    result = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            candidate = backend.run(runner, config, prompt)
+        except Exception as exc:  # noqa: BLE001
+            failure_text = str(exc)
+        else:
+            if candidate.returncode != 0 or not candidate.text.strip():
+                failure_text = candidate.raw_output or candidate.text
+            else:
+                result = candidate
+                break
+
+        transient = is_transient_agent_output(failure_text or "")
+        if attempt < max_attempts and transient:
+            delay = backoff[min(attempt - 1, len(backoff) - 1)] if backoff else 1
+            print(
+                f"run_external: transient failure (attempt {attempt}/{max_attempts}), "
+                f"retrying in {delay}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        reason = "retries exhausted" if transient else "non-transient failure"
+        print(
+            f"run_external: agent invocation failed ({reason}): {failure_text}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
+    assert result is not None  # loop either set result or exited
     output_path.write_text(result.text, encoding="utf-8")
     print(f"agent result written to {output_path}")
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -97,6 +97,11 @@ from .protocol import (
 from .protocol import parse_review
 from .repair import attempt_envelope_normalization, attempt_repair, strip_unknown_prior_item_dispositions
 from .runner import Runner
+from .transient import (
+    NON_RETRYABLE_AGENT_OUTPUT_RE,
+    TRANSIENT_AGENT_OUTPUT_RE,
+    is_transient_agent_output,
+)
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
 from .workdir_guard import (
@@ -197,23 +202,9 @@ from .unresolved_items import (
 )
 
 
-TRANSIENT_AGENT_OUTPUT_RE = re.compile(
-    r"Invalid stream|empty response|malformed tool call|"
-    r"network (?:reset|timeout)|connection (?:reset|timed out|timeout)|"
-    r"\btimed out\b|\btimeout\b|"
-    r"Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|"
-    r"\b429\b|rate.?limit(?:ed)?|"
-    r"session.?limit.?exceeded|session_limit_exceeded|too many sessions|"
-    r"no capacity available|capacity.*(?:unavailable|exceeded)|"
-    r"resource.?exhausted|overloaded|"
-    r"\bquota\b",
-    re.I,
-)
-NON_RETRYABLE_AGENT_OUTPUT_RE = re.compile(
-    r"auth(?:entication|orization)?|unauthorized|forbidden|invalid api key|"
-    r"credit|billing|dirty (?:checkout|workdir|working tree)",
-    re.I,
-)
+# TRANSIENT_AGENT_OUTPUT_RE / NON_RETRYABLE_AGENT_OUTPUT_RE / is_transient_agent_output
+# now live in .transient (imported above) so dependency-light callers such as
+# helpers.run_external can reuse them without importing this module.
 NEAR_MISS_AGENT_MARKER_RE = re.compile(
     r"(?m)^[ \t]*AGENT_(?:PLAN_)?STATE:[ \t]*(?:approved|blocking)[ \t.]*$",
     re.I,
@@ -428,10 +419,8 @@ def _agent_log_context(log_paths: Sequence[object]) -> str:
     return "\nAttempt logs:\n" + "\n".join(f"- {path}" for path in paths)
 
 
-def _is_transient_agent_output(text: str) -> bool:
-    return bool(TRANSIENT_AGENT_OUTPUT_RE.search(text)) and not bool(
-        NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
-    )
+# Backwards-compatible alias: the implementation moved to .transient.
+_is_transient_agent_output = is_transient_agent_output
 
 
 def _decode_public_response_json_prefix(text: str) -> object | None:

--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -1,0 +1,39 @@
+"""Lightweight transient/non-retryable agent-output classification.
+
+Extracted from ``orchestrator`` so callers that must stay dependency-light
+(e.g. the skill's ``helpers.run_external`` subprocess launcher) can decide
+whether to retry an agent invocation without importing the full orchestrator.
+"""
+
+from __future__ import annotations
+
+import re
+
+TRANSIENT_AGENT_OUTPUT_RE = re.compile(
+    r"Invalid stream|empty response|malformed tool call|"
+    r"network (?:reset|timeout)|connection (?:reset|timed out|timeout)|"
+    r"\btimed out\b|\btimeout\b|"
+    r"Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|"
+    r"\b429\b|rate.?limit(?:ed)?|"
+    r"session.?limit.?exceeded|session_limit_exceeded|too many sessions|"
+    r"no capacity available|capacity.*(?:unavailable|exceeded)|"
+    r"resource.?exhausted|overloaded|"
+    r"\bquota\b",
+    re.I,
+)
+NON_RETRYABLE_AGENT_OUTPUT_RE = re.compile(
+    r"auth(?:entication|orization)?|unauthorized|forbidden|invalid api key|"
+    r"credit|billing|dirty (?:checkout|workdir|working tree)",
+    re.I,
+)
+
+
+def is_transient_agent_output(text: str) -> bool:
+    """Return True if ``text`` looks like a transient failure worth retrying.
+
+    A match on a transient pattern is overridden by any non-retryable signal
+    (auth/billing/dirty-checkout), which should never be retried blindly.
+    """
+    return bool(TRANSIENT_AGENT_OUTPUT_RE.search(text)) and not bool(
+        NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
+    )

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -851,3 +851,95 @@ class TestRetryValidate:
             assert output["state"] == "blocking"
             assert len(output["blocking_items"]) == 1
             assert output["blocking_items"][0]["text"] == "Address the followup from last round."
+
+
+# ---------------------------------------------------------------------------
+# helpers/run_external.py  retry loop (in-process, monkeypatched backend)
+# ---------------------------------------------------------------------------
+
+# Ensure the repo root is importable so `helpers.run_external` resolves in-process.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestRunExternalRetries:
+    def _invoke(self, monkeypatch, agent, outcomes, *, max_retries=2):
+        """Drive run_external.main with a fake backend; return (calls, sleeps, output_path, exit_code)."""
+        import helpers.run_external as rex
+        from coding_review_agent_loop.agents.base import AgentResult  # noqa: F401
+
+        calls = {"n": 0}
+
+        class FakeBackend:
+            def run(self, runner, config, prompt):
+                i = calls["n"]
+                calls["n"] += 1
+                outcome = outcomes[min(i, len(outcomes) - 1)]
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome
+
+        monkeypatch.setattr("coding_review_agent_loop.agents.codex.CodexBackend", FakeBackend)
+        monkeypatch.setattr("coding_review_agent_loop.agents.gemini.GeminiBackend", FakeBackend)
+        sleeps: list[int] = []
+        monkeypatch.setattr(rex.time, "sleep", lambda s: sleeps.append(s))
+
+        prompt_path = _write_tmp("Review this.")
+        output_path = _write_tmp("", suffix=".out.md")
+        argv = [
+            "run_external", "--agent", agent,
+            "--prompt-file", prompt_path, "--output", output_path,
+            "--workdir", "/tmp",
+            "--max-retries", str(max_retries),
+            "--retry-backoff-seconds", "1", "2",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        exit_code = 0
+        try:
+            rex.main()
+        except SystemExit as exc:
+            exit_code = exc.code or 0
+        return calls, sleeps, output_path, exit_code
+
+    def test_returned_transient_result_is_retried_then_succeeds(self, monkeypatch) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+        outcomes = [
+            AgentResult(text="", raw_output="Error: 429 Too Many Requests", returncode=1),
+            AgentResult(text="", raw_output="model overloaded", returncode=1),
+            AgentResult(text="final review body", returncode=0),
+        ]
+        calls, sleeps, output_path, exit_code = self._invoke(monkeypatch, "codex", outcomes)
+        assert exit_code == 0
+        assert calls["n"] == 3
+        assert sleeps == [1, 2]  # backoff[0], backoff[1]
+        assert Path(output_path).read_text(encoding="utf-8") == "final review body"
+
+    def test_raised_transient_exception_is_retried_then_succeeds(self, monkeypatch) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+        outcomes = [
+            RuntimeError("503 Service Unavailable"),
+            AgentResult(text="ok", returncode=0),
+        ]
+        calls, sleeps, output_path, exit_code = self._invoke(monkeypatch, "gemini", outcomes)
+        assert exit_code == 0
+        assert calls["n"] == 2
+        assert sleeps == [1]
+        assert Path(output_path).read_text(encoding="utf-8") == "ok"
+
+    def test_non_transient_returned_result_fails_fast(self, monkeypatch) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+        outcomes = [AgentResult(text="", raw_output="invalid api key", returncode=1)]
+        calls, sleeps, _output_path, exit_code = self._invoke(monkeypatch, "codex", outcomes)
+        assert exit_code == 1
+        assert calls["n"] == 1  # no retry on non-transient failure
+        assert sleeps == []
+
+    def test_max_retries_zero_makes_single_attempt(self, monkeypatch) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+        outcomes = [AgentResult(text="", raw_output="429 rate limit", returncode=1)]
+        calls, sleeps, _output_path, exit_code = self._invoke(
+            monkeypatch, "codex", outcomes, max_retries=0
+        )
+        assert exit_code == 1
+        assert calls["n"] == 1  # transient, but retries disabled
+        assert sleeps == []

--- a/tests/test_transient.py
+++ b/tests/test_transient.py
@@ -1,0 +1,35 @@
+"""Unit tests for the lightweight transient-output classifier."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from coding_review_agent_loop import orchestrator, transient
+
+
+def test_transient_signals_are_retryable() -> None:
+    assert transient.is_transient_agent_output("Error: 429 Too Many Requests")
+    assert transient.is_transient_agent_output("the model is overloaded")
+    assert transient.is_transient_agent_output("connection timed out")
+    assert transient.is_transient_agent_output("503 Service Unavailable")
+    assert transient.is_transient_agent_output("resource exhausted")
+
+
+def test_non_retryable_and_clean_output_are_not_transient() -> None:
+    assert not transient.is_transient_agent_output("invalid api key")
+    assert not transient.is_transient_agent_output("billing problem on your account")
+    assert not transient.is_transient_agent_output("the plan looks good to me")
+    assert not transient.is_transient_agent_output("")
+
+
+def test_non_retryable_overrides_transient_signal() -> None:
+    # A non-retryable signal (auth/billing) wins even when a transient term is present.
+    assert not transient.is_transient_agent_output("got 429 but the api key is unauthorized")
+
+
+def test_orchestrator_alias_preserves_identity() -> None:
+    # orchestrator keeps the old private name as an alias to the moved implementation.
+    assert orchestrator._is_transient_agent_output is transient.is_transient_agent_output


### PR DESCRIPTION
## What & why

Increment 1 of #294 (close the CLI↔skill automation gap). The skill's
`helpers/run_external` launched each Codex/Gemini reviewer turn exactly once and
exited 1 on any failure, so a flaky launch, a 429, or an "overloaded" response
aborted the whole round — exactly where the CLI would have retried (and the class
of failure that aborted the PR #293 round-1 run).

The design for this was reviewed via the skill's own plan-review loop and
**approved by both Codex and Gemini** on #294.

## Changes

- **New `src/coding_review_agent_loop/transient.py`** holding
  `TRANSIENT_AGENT_OUTPUT_RE`, `NON_RETRYABLE_AGENT_OUTPUT_RE`, and
  `is_transient_agent_output`. `run_external` deliberately avoids importing the
  heavy `orchestrator` graph, so the classifier had to live somewhere light
  rather than be duplicated.
- **`orchestrator.py`** imports those symbols from `transient.py` and keeps
  `_is_transient_agent_output` as an alias, preserving the existing internal call
  sites and the `tests/test_agent_loop.py` import contract.
- **`run_external.py`** gains `--max-retries` (default `2`, matching the CLI) and
  `--retry-backoff-seconds` (default `15 45`), and retries transient failures.
  The **primary** retry signal is a *returned* `AgentResult` with a non-zero
  returncode whose `raw_output` (merged stdout+stderr, since the backends use
  `run_with_log(check=False)`) carries the transient text; a raised exception is
  the **secondary** path. Non-transient failures (auth/billing/dirty-checkout)
  still fail fast; `--max-retries 0` reproduces today's single-attempt behavior.
  The `--repo` re-clone stays outside the retry loop.

## Tests

- New `tests/test_transient.py`: classifier positives/negatives, non-retryable
  override, and the orchestrator-alias identity.
- `tests/test_skill_helpers.py`: in-process retry tests with a monkeypatched
  backend — returned-transient-then-success, raised-transient-then-success,
  non-transient fail-fast, and `--max-retries 0` single attempt.
- Full suite: **749 passed**.

## Scope

Increments 2–4 (test gate, approved-followups publishing, `task`-round +
`SKILL.md` loop tightening) are tracked in #294 and will land as their own PRs.
CI-wait + auto-merge remain deliberately out of scope — merge stays a human
decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
