### PR TITLE
Fix reviewer prompts embedding wrong checkout path (#297)

### DIFF
--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -25,13 +25,28 @@ def _make_minimal_config(
     repo: str,
     coder: AgentName,
     reviewer_names: Sequence[AgentName],
+    *,
+    reviewer: AgentName | None = None,
+    workdir: str | None = None,
 ) -> AgentLoopConfig:
-    tmp = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / "skill-runner"
+    base = Path(tempfile.gettempdir()) / "coding-review-agent-loop"
+    legacy = base / "skill-runner"
+
+    def _agent_dir(agent: AgentName) -> Path:
+        # The active reviewer's dir must match where the agent actually runs, so the
+        # checkout path embedded in the prompt is real. The default mirrors
+        # skill_runner._workdir_for_agent ("skill-runner-{agent}"); previously this
+        # hardcoded the bare "skill-runner" path, which never exists and made
+        # reviewers (notably Codex) block on a missing checkout (#297).
+        if workdir and agent == reviewer:
+            return Path(workdir)
+        return base / f"skill-runner-{agent}"
+
     return AgentLoopConfig(
         repo=repo,
-        claude_dir=tmp,
-        codex_dir=tmp,
-        gemini_dir=tmp,
+        claude_dir=_agent_dir("claude"),
+        codex_dir=_agent_dir("codex"),
+        gemini_dir=_agent_dir("gemini"),
         coder=coder,
         reviewer=tuple(reviewer_names),
         base="main",
@@ -52,13 +67,13 @@ def _make_minimal_config(
         ci_timeout_seconds=300,
         ci_poll_interval_seconds=30,
         quiet=False,
-        log_dir=tmp,
+        log_dir=legacy,
         progress_interval_seconds=30,
         agent_max_retries=0,
         agent_retry_backoff_seconds=(30,),
         agent_memory=False,
         refresh_agent_memory=False,
-        agent_memory_dir=tmp,
+        agent_memory_dir=legacy,
         refresh_test_profile=False,
         auto_agent_dirs=tuple(reviewer_names),
     )
@@ -85,6 +100,7 @@ def build_plan_review_prompt_for_skill(
     repo: str,
     coder: AgentName = "claude",
     all_reviewers: Sequence[AgentName] | None = None,
+    workdir: str | None = None,
 ) -> str:
     """Build a plan reviewer prompt from plain dicts.
 
@@ -97,9 +113,11 @@ def build_plan_review_prompt_for_skill(
         repo: Repository owner/name.
         coder: Agent name of the coder (default: "claude").
         all_reviewers: All configured reviewer names (defaults to [reviewer]).
+        workdir: The reviewer's actual checkout path, embedded in the prompt so
+            the agent inspects a directory that exists (#297).
     """
     reviewers_list: Sequence[AgentName] = all_reviewers or [reviewer]
-    config = _make_minimal_config(repo, coder, reviewers_list)
+    config = _make_minimal_config(repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir)
     issue_context = _make_issue_context(issue_dict)
     unresolved = [_deserialize_unresolved_item(item) for item in prior_items_raw]
     return build_plan_review_prompt(
@@ -124,6 +142,7 @@ def build_review_prompt_for_skill(
     pr_number: int,
     coder: AgentName = "claude",
     all_reviewers: Sequence[AgentName] | None = None,
+    workdir: str | None = None,
 ) -> str:
     """Build a PR reviewer prompt from plain dicts.
 
@@ -137,11 +156,13 @@ def build_review_prompt_for_skill(
         pr_number: Pull request number.
         coder: Agent name of the coder (default: "claude").
         all_reviewers: All configured reviewer names (defaults to [reviewer]).
+        workdir: The reviewer's actual checkout path, embedded in the prompt so
+            the agent inspects a directory that exists (#297).
     """
     from coding_review_agent_loop.github import PullRequestMetadata
 
     reviewers_list: Sequence[AgentName] = all_reviewers or [reviewer]
-    config = _make_minimal_config(repo, coder, reviewers_list)
+    config = _make_minimal_config(repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir)
     issue_context = _make_issue_context(issue_dict)
     unresolved = [_deserialize_unresolved_item(item) for item in prior_items_raw]
     pr_metadata = PullRequestMetadata(

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -831,6 +831,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
 
             # Build prompt
             issue_dict = _fetch_issue_json(repo, issue)
+            workdir = _workdir_for_agent(reviewer, args)
             try:
                 from helpers.prompt_builders import build_plan_review_prompt_for_skill
                 prompt_text = build_plan_review_prompt_for_skill(
@@ -841,6 +842,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
                     reviewer,  # type: ignore[arg-type]
                     repo=repo,
                     all_reviewers=[r for r in reviewers],  # type: ignore[misc]
+                    workdir=workdir,
                 )
             except Exception as exc:  # noqa: BLE001
                 prompt_text = (
@@ -857,7 +859,6 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
 
             # item_id_offset: highest numeric suffix across prior + current-round items
             item_id_offset = _max_item_number([next_prior_items_raw, current_round_items])
-            workdir = _workdir_for_agent(reviewer, args)
             record = _run_reviewer(
                 agent=reviewer,
                 prompt_text=prompt_text,
@@ -977,6 +978,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                 print(f"[skip] {reviewer_cap} already completed this round")
                 continue
 
+            workdir = _workdir_for_agent(reviewer, args)
             try:
                 from helpers.prompt_builders import build_review_prompt_for_skill
                 prompt_text = build_review_prompt_for_skill(
@@ -988,6 +990,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                     repo=repo,
                     pr_number=pr,
                     all_reviewers=[r for r in reviewers],  # type: ignore[misc]
+                    workdir=workdir,
                 )
             except Exception as exc:  # noqa: BLE001
                 prompt_text = (
@@ -1003,7 +1006,6 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
             }
 
             item_id_offset = _max_item_number([next_prior_items_raw, current_round_items])
-            workdir = _workdir_for_agent(reviewer, args)
             record = _run_reviewer(
                 agent=reviewer,
                 prompt_text=prompt_text,

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -943,3 +943,52 @@ class TestRunExternalRetries:
         assert exit_code == 1
         assert calls["n"] == 1  # transient, but retries disabled
         assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# helpers/prompt_builders.py  checkout path embedding (#297)
+# ---------------------------------------------------------------------------
+
+class TestPromptCheckoutPath:
+    _ISSUE = {
+        "number": 296, "repo": "wwind123/coding-review-agent-loop",
+        "title": "t", "body": "b", "url": "u",
+    }
+
+    def _no_bare_skill_runner(self, prompt: str) -> int:
+        import re
+        # the bare path (no -{agent} suffix) is the bug; it must not appear
+        return len(re.findall(r"/coding-review-agent-loop/skill-runner(?!-)", prompt))
+
+    def test_plan_prompt_embeds_explicit_reviewer_workdir(self) -> None:
+        from helpers.prompt_builders import build_plan_review_prompt_for_skill
+        wd = "/tmp/coding-review-agent-loop/skill-runner-codex"
+        prompt = build_plan_review_prompt_for_skill(
+            self._ISSUE, "PLAN", [], 1, "codex",
+            repo="wwind123/coding-review-agent-loop",
+            all_reviewers=["codex", "gemini"], workdir=wd,
+        )
+        assert wd in prompt
+        assert self._no_bare_skill_runner(prompt) == 0
+
+    def test_plan_prompt_default_uses_agent_suffixed_path(self) -> None:
+        from helpers.prompt_builders import build_plan_review_prompt_for_skill
+        prompt = build_plan_review_prompt_for_skill(
+            self._ISSUE, "PLAN", [], 1, "gemini",
+            repo="wwind123/coding-review-agent-loop",
+            all_reviewers=["codex", "gemini"],
+        )
+        # default mirrors _workdir_for_agent: skill-runner-{agent}, never the bare path
+        assert "skill-runner-gemini" in prompt
+        assert self._no_bare_skill_runner(prompt) == 0
+
+    def test_pr_prompt_embeds_explicit_reviewer_workdir(self) -> None:
+        from helpers.prompt_builders import build_review_prompt_for_skill
+        wd = "/tmp/coding-review-agent-loop/skill-runner-codex"
+        prompt = build_review_prompt_for_skill(
+            self._ISSUE, "diff --git a b", [], 1, "codex",
+            repo="wwind123/coding-review-agent-loop", pr_number=295,
+            all_reviewers=["codex", "gemini"], workdir=wd,
+        )
+        assert wd in prompt
+        assert self._no_bare_skill_runner(prompt) == 0


### PR DESCRIPTION
## What & why

Fixes #297. The skill embedded the **wrong checkout path** in every reviewer
prompt: `prompt_builders._make_minimal_config` hardcoded
`/tmp/coding-review-agent-loop/skill-runner` (no agent suffix), but reviewers
actually run in `/tmp/coding-review-agent-loop/skill-runner-{agent}` (per
`skill_runner._workdir_for_agent`).

So reviewers were told to inspect a directory that doesn't exist. Reviewers that
insist on local inspection (Codex, consistently) blocked with "No such file or
directory"; reviewers that work from the plan/diff text (Gemini) didn't notice.
This is the root cause of the recurring "reviewer checkout is messed up" blocks
— including the false Codex block on #296 round 2, where Codex resolved all six
plan items but blocked solely on the bogus path.

## Changes

- `prompt_builders._make_minimal_config` derives each agent's dir from the real
  `skill-runner-{agent}` pattern and uses the active reviewer's **actual**
  workdir when provided, instead of the bare `skill-runner` path.
- `build_plan_review_prompt_for_skill` / `build_review_prompt_for_skill` accept a
  `workdir` argument; both `skill_runner` call sites pass the value from
  `_workdir_for_agent` (honoring `--workdir` / `--workdir-{agent}` overrides),
  computed before prompt construction.

## Tests

- New `TestPromptCheckoutPath` asserts the built prompt embeds the reviewer's
  real workdir and never the bare `skill-runner` path — for explicit-workdir,
  default-workdir, and PR flows.
- Full suite: **752 passed**.

## Note

This is a prerequisite uncovered while reviewing increment 2 (#296) of the
automation-gap work (#294); it unblocks clean Codex reviews for everything after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
