### PR TITLE
Add optional test gate to run-pr-round (#296)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -133,11 +133,31 @@ python -m helpers.skill_runner run-pr-round \
   --reviewers codex gemini \
   [--head-sha SHA] \
   [--workdir-codex /path/to/checkout] \
-  [--workdir-gemini /path/to/checkout]
+  [--workdir-gemini /path/to/checkout] \
+  [--test-command "pytest -q"] \
+  [--test-workdir .]
 ```
 
 The JSON result shape is the same as for plan rounds.  There is no "write plan"
 step — the PR diff is fetched automatically.
+
+### Optional test gate
+
+Pass `--test-command` to run the project's tests after the reviewer turns. The
+command runs in `--test-workdir` (default: the current directory, where you as
+the host coder have the PR branch checked out) and its outcome is added to the
+JSON result under `tests`:
+
+```json
+"tests": { "command": "pytest -q", "passed": true, "exit_code": 0, "output_tail": "..." }
+```
+
+A setup failure (empty command, bad quoting, missing executable, or a missing
+`--test-workdir`) is reported as `{"passed": false, "exit_code": null, "error": ...}`
+rather than crashing the round. The gate never blocks and never merges:
+`state` stays reviewer-driven, and **"ready to merge" = `state == "approved"`
+AND `tests.passed`**. Treat a failing or errored `tests` result as a hard stop
+before merging, even when reviewers approved.
 
 When the result is `"state": "blocking"`, address the items, push the fixes, and
 post a change-summary comment on the PR before running the next round:

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -322,6 +322,8 @@ def _run_test_gate(command: str, workdir: str, *, dry_run: bool) -> dict:
             argv,
             cwd=workdir,
             text=True,
+            errors="replace",  # test output may contain bytes invalid for the locale;
+                               # decode lossily so the gate never raises UnicodeDecodeError
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=False,

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -336,6 +336,21 @@ def _run_test_gate(command: str, workdir: str, *, dry_run: bool) -> dict:
     }
 
 
+def _maybe_test_gate(
+    test_command: str | None, test_workdir: str, *, dry_run: bool
+) -> dict | None:
+    """Return the test-gate result, or None when no --test-command was provided.
+
+    Distinguishes "not requested" (``None`` -> no gate, no ``tests`` field) from a
+    provided-but-empty command (``--test-command ""``), which flows through to
+    _run_test_gate and is reported as a setup error rather than silently
+    disabling the gate.
+    """
+    if test_command is None:
+        return None
+    return _run_test_gate(test_command, test_workdir, dry_run=dry_run)
+
+
 def _fetch_issue_json(repo: str, issue: int, gh_cmd: str = "gh") -> dict:
     result = subprocess.run(
         [gh_cmd, "issue", "view", str(issue), "--repo", repo,
@@ -1087,12 +1102,15 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
         "blocking_items": round_blocking_items,
         "approved_reviewers": round_approved_reviewers,
     }
-    # Optional test gate: reports pass/fail; never blocks or merges.
-    test_command = getattr(args, "test_command", None)
-    if test_command:
-        result_json["tests"] = _run_test_gate(
-            test_command, getattr(args, "test_workdir", "."), dry_run=dry_run
-        )
+    # Optional test gate: reports pass/fail; never blocks or merges. An explicit
+    # empty --test-command "" is reported as a setup error, not silently skipped.
+    gate = _maybe_test_gate(
+        getattr(args, "test_command", None),
+        getattr(args, "test_workdir", "."),
+        dry_run=dry_run,
+    )
+    if gate is not None:
+        result_json["tests"] = gate
     print(json.dumps(result_json, indent=2))
 
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -37,6 +37,7 @@ import argparse
 import hashlib
 import json
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -47,6 +48,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.agents.base import AgentName
 from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.runner import tail_text
 from coding_review_agent_loop.protocol import ReviewItemDisposition, UnresolvedReviewItem
 from coding_review_agent_loop.round_state import (
     PostedRoundMetadata,
@@ -296,6 +298,42 @@ def _workdir_for_agent(agent: str, args: argparse.Namespace) -> str:
     tmp = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / f"skill-runner-{agent}"
     tmp.mkdir(parents=True, exist_ok=True)
     return str(tmp)
+
+
+def _run_test_gate(command: str, workdir: str, *, dry_run: bool) -> dict:
+    """Run an optional test command and report the outcome. Never raises.
+
+    Distinguishes "ran and failed" (``exit_code`` int, ``output_tail``) from
+    "could not run" (``exit_code`` null, ``error``). Setup failures (bad quoting,
+    empty command, missing executable, bad workdir) are reported, not propagated,
+    so the review round is never crashed by the gate.
+    """
+    if dry_run:
+        return {"command": command, "skipped": True, "reason": "dry-run"}
+    base = {"command": command, "passed": False, "exit_code": None}
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        return {**base, "error": f"could not parse --test-command: {exc}"}
+    if not argv:
+        return {**base, "error": "--test-command is empty"}
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=workdir,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    except OSError as exc:  # FileNotFoundError, NotADirectoryError, ...
+        return {**base, "error": f"could not run --test-command: {exc}"}
+    return {
+        "command": command,
+        "passed": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "output_tail": tail_text(proc.stdout or "", max_lines=50),
+    }
 
 
 def _fetch_issue_json(repo: str, issue: int, gh_cmd: str = "gh") -> dict:
@@ -1049,6 +1087,12 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
         "blocking_items": round_blocking_items,
         "approved_reviewers": round_approved_reviewers,
     }
+    # Optional test gate: reports pass/fail; never blocks or merges.
+    test_command = getattr(args, "test_command", None)
+    if test_command:
+        result_json["tests"] = _run_test_gate(
+            test_command, getattr(args, "test_workdir", "."), dry_run=dry_run
+        )
     print(json.dumps(result_json, indent=2))
 
 
@@ -1129,6 +1173,19 @@ def main() -> None:
     p_pr.add_argument("--workdir", default=None)
     p_pr.add_argument("--workdir-codex", default=None)
     p_pr.add_argument("--workdir-gemini", default=None)
+    p_pr.add_argument(
+        "--test-command",
+        default=None,
+        help="Optional command to run as a test gate after the reviewer turns. "
+             "Result (pass/fail) is reported in the JSON 'tests' field; it never "
+             "blocks or merges. 'Ready to merge' = state approved AND tests.passed.",
+    )
+    p_pr.add_argument(
+        "--test-workdir",
+        default=".",
+        help="Directory to run --test-command in (default: current directory, "
+             "where the host coder has the PR branch checked out).",
+    )
     p_pr.add_argument("--dry-run", action="store_true")
 
     # retry-validate

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -992,3 +992,64 @@ class TestPromptCheckoutPath:
         )
         assert wd in prompt
         assert self._no_bare_skill_runner(prompt) == 0
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py  _run_test_gate (#296, increment 2)
+# ---------------------------------------------------------------------------
+
+class TestRunTestGate:
+    import shlex as _shlex
+    _PY = _shlex.quote(sys.executable)
+
+    def _gate(self, command, workdir=".", *, dry_run=False):
+        from helpers.skill_runner import _run_test_gate
+        return _run_test_gate(command, workdir, dry_run=dry_run)
+
+    def test_passing_command(self) -> None:
+        r = self._gate(f'{self._PY} -c "import sys; sys.exit(0)"')
+        assert r["passed"] is True
+        assert r["exit_code"] == 0
+        assert "output_tail" in r
+        assert "error" not in r
+
+    def test_failing_command_merges_stderr(self) -> None:
+        r = self._gate(f'{self._PY} -c "import sys; sys.stderr.write(chr(98)+chr(111)+chr(111)+chr(109)); sys.exit(3)"')
+        assert r["passed"] is False
+        assert r["exit_code"] == 3
+        assert "boom" in r["output_tail"]  # stderr merged into stdout
+
+    def test_missing_executable_reports_error(self) -> None:
+        r = self._gate("definitely-not-a-real-binary-xyz --flag")
+        assert r["passed"] is False
+        assert r["exit_code"] is None
+        assert "error" in r
+
+    def test_malformed_quoting_reports_error(self) -> None:
+        r = self._gate('echo "unbalanced')
+        assert r["passed"] is False
+        assert r["exit_code"] is None
+        assert "error" in r
+
+    def test_empty_command_reports_error(self) -> None:
+        r = self._gate("   ")
+        assert r["passed"] is False
+        assert "error" in r
+
+    def test_bad_workdir_reports_error(self) -> None:
+        r = self._gate(f'{self._PY} -c "pass"', workdir="/nonexistent/path/xyz-12345")
+        assert r["passed"] is False
+        assert r["exit_code"] is None
+        assert "error" in r
+
+    def test_dry_run_does_not_execute(self) -> None:
+        # command would error if run; dry-run must skip it
+        r = self._gate("definitely-not-a-real-binary-xyz", dry_run=True)
+        assert r["skipped"] is True
+        assert "error" not in r
+
+    def test_test_workdir_is_honored(self) -> None:
+        d = tempfile.mkdtemp()
+        r = self._gate(f'{self._PY} -c "import os; print(os.getcwd())"', workdir=d)
+        assert r["passed"] is True
+        assert os.path.basename(d) in r["output_tail"]

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1053,3 +1053,15 @@ class TestRunTestGate:
         r = self._gate(f'{self._PY} -c "import os; print(os.getcwd())"', workdir=d)
         assert r["passed"] is True
         assert os.path.basename(d) in r["output_tail"]
+
+    def test_maybe_gate_none_when_not_provided(self) -> None:
+        from helpers.skill_runner import _maybe_test_gate
+        assert _maybe_test_gate(None, ".", dry_run=False) is None
+
+    def test_maybe_gate_reports_explicit_empty_command(self) -> None:
+        # --test-command "" must be reported as a setup error, not silently skipped
+        from helpers.skill_runner import _maybe_test_gate
+        r = _maybe_test_gate("", ".", dry_run=False)
+        assert r is not None
+        assert r["passed"] is False
+        assert "error" in r

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1065,3 +1065,12 @@ class TestRunTestGate:
         assert r is not None
         assert r["passed"] is False
         assert "error" in r
+
+    def test_invalid_utf8_output_does_not_raise(self) -> None:
+        # A process emitting bytes invalid for the locale must not crash the gate.
+        r = self._gate(
+            f'{self._PY} -c "import sys; sys.stdout.buffer.write(bytes([255])); sys.exit(1)"'
+        )
+        assert r["passed"] is False
+        assert r["exit_code"] == 1
+        assert "output_tail" in r  # decoded with replacement rather than raising


### PR DESCRIPTION
## What & why

Closes #296 — increment 2 of #294 (close the CLI↔skill automation gap). The CLI
has a `--test-command` gate; the skill had nothing, so "did the tests actually
pass?" was left to the host's memory. This adds a deterministic, **reporting-only**
test gate to `run-pr-round`.

Merge stays a human decision (#294): the gate never blocks and never merges.

## Behavior

- New flags on `run-pr-round`: `--test-command` and `--test-workdir` (default `.`,
  where the host coder has the PR branch checked out).
- When `--test-command` is given, the JSON result gains a `tests` field:
  ```json
  "tests": { "command": "pytest -q", "passed": true, "exit_code": 0, "output_tail": "..." }
  ```
- `state` stays reviewer-driven. **Ready to merge = `state == "approved"` AND
  `tests.passed`** (documented in `SKILL.md`).
- Applies to PR rounds only — a plan round reviews a document, no code to test.

## Robustness

`_run_test_gate` is total by construction — it cannot crash the round. Setup
failures are reported, not raised, and distinguished from real test failures:
- ran and failed → `exit_code` int, `output_tail`.
- could not run (empty command, bad quoting, missing executable, missing
  `--test-workdir`) → `exit_code: null`, `error`.
- stderr is merged into stdout for the captured tail.

## Tests

`TestRunTestGate` covers passing, failing (with stderr-merge assertion), missing
executable, malformed quoting, empty command, bad workdir, dry-run (does not
execute), and `--test-workdir` honored. Full suite: **760 passed**.

## Review provenance

Design reviewed via the skill's own plan-review loop on #296 — Gemini approved;
Codex resolved all six plan items and blocked only on the prompt-path bug, which
is fixed in #298 (#297). With that fixed, Codex reviews cleanly again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
