### PR TITLE
Add approved-followups publishing to run-pr-round (#300)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -135,7 +135,8 @@ python -m helpers.skill_runner run-pr-round \
   [--workdir-codex /path/to/checkout] \
   [--workdir-gemini /path/to/checkout] \
   [--test-command "pytest -q"] \
-  [--test-workdir .]
+  [--test-workdir .] \
+  [--approved-followups summarize|issue]
 ```
 
 The JSON result shape is the same as for plan rounds.  There is no "write plan"
@@ -158,6 +159,23 @@ rather than crashing the round. The gate never blocks and never merges:
 `state` stays reviewer-driven, and **"ready to merge" = `state == "approved"`
 AND `tests.passed`**. Treat a failing or errored `tests` result as a hard stop
 before merging, even when reviewers approved.
+
+### Optional approved-followups publishing
+
+Pass `--approved-followups summarize|issue` to publish reviewers' future
+follow-ups when (and only when) a round is **approved**. `summarize` posts one
+PR comment listing the reconciled follow-ups; `issue` files up to three
+follow-up issues; `ignore` (default) discards them. The mode is also threaded
+into the reviewer prompt, so reviewers only surface future follow-ups when a
+non-`ignore` mode is set. Publishing is idempotent — one publish per PR head SHA
++ mode (re-running or resuming a round will not double-post). The outcome is
+reported in the JSON result under `approved_followups`:
+
+```json
+"approved_followups": { "mode": "summarize", "published": true, "count": 2 }
+```
+
+This never blocks and never merges; merge stays a human decision.
 
 When the result is `"state": "blocking"`, address the items, push the fixes, and
 post a change-summary comment on the PR before running the next round:

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -21,13 +21,14 @@ from coding_review_agent_loop.prompts import build_plan_review_prompt, build_rev
 from coding_review_agent_loop.round_state import _deserialize_unresolved_item
 
 
-def _make_minimal_config(
+def make_minimal_config(
     repo: str,
     coder: AgentName,
     reviewer_names: Sequence[AgentName],
     *,
     reviewer: AgentName | None = None,
     workdir: str | None = None,
+    approved_followups: str = "ignore",
 ) -> AgentLoopConfig:
     base = Path(tempfile.gettempdir()) / "coding-review-agent-loop"
     legacy = base / "skill-runner"
@@ -76,6 +77,7 @@ def _make_minimal_config(
         agent_memory_dir=legacy,
         refresh_test_profile=False,
         auto_agent_dirs=tuple(reviewer_names),
+        approved_followups=approved_followups,
     )
 
 
@@ -117,7 +119,7 @@ def build_plan_review_prompt_for_skill(
             the agent inspects a directory that exists (#297).
     """
     reviewers_list: Sequence[AgentName] = all_reviewers or [reviewer]
-    config = _make_minimal_config(repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir)
+    config = make_minimal_config(repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir)
     issue_context = _make_issue_context(issue_dict)
     unresolved = [_deserialize_unresolved_item(item) for item in prior_items_raw]
     return build_plan_review_prompt(
@@ -143,6 +145,7 @@ def build_review_prompt_for_skill(
     coder: AgentName = "claude",
     all_reviewers: Sequence[AgentName] | None = None,
     workdir: str | None = None,
+    approved_followups: str = "ignore",
 ) -> str:
     """Build a PR reviewer prompt from plain dicts.
 
@@ -158,11 +161,17 @@ def build_review_prompt_for_skill(
         all_reviewers: All configured reviewer names (defaults to [reviewer]).
         workdir: The reviewer's actual checkout path, embedded in the prompt so
             the agent inspects a directory that exists (#297).
+        approved_followups: Approved-followups mode; when not "ignore" the prompt
+            instructs the reviewer to surface future follow-ups so they can be
+            published on approval (#300).
     """
     from coding_review_agent_loop.github import PullRequestMetadata
 
     reviewers_list: Sequence[AgentName] = all_reviewers or [reviewer]
-    config = _make_minimal_config(repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir)
+    config = make_minimal_config(
+        repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir,
+        approved_followups=approved_followups,
+    )
     issue_context = _make_issue_context(issue_dict)
     unresolved = [_deserialize_unresolved_item(item) for item in prior_items_raw]
     pr_metadata = PullRequestMetadata(

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -34,6 +34,7 @@ Prints a JSON result to stdout and exits 0:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import hashlib
 import json
 import re
@@ -42,13 +43,18 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import types
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.agents.base import AgentName
 from coding_review_agent_loop.errors import AgentLoopError
-from coding_review_agent_loop.runner import tail_text
+from coding_review_agent_loop.followups import (
+    _approved_followup_from_unresolved_item,
+    _publish_approved_followups,
+)
+from coding_review_agent_loop.runner import Runner, tail_text
 from coding_review_agent_loop.protocol import ReviewItemDisposition, UnresolvedReviewItem
 from coding_review_agent_loop.round_state import (
     PostedRoundMetadata,
@@ -353,6 +359,86 @@ def _maybe_test_gate(
     return _run_test_gate(test_command, test_workdir, dry_run=dry_run)
 
 
+def _mint_new_items(
+    *,
+    blocking_texts: list[str],
+    same_texts: list[str],
+    future_texts: list[str],
+    flow: str,
+    agent_cap: str,
+    new_round_number: int,
+    item_id_offset: int,
+) -> list[dict]:
+    """Serialize a reviewer's items with globally-unique IDs.
+
+    Future follow-ups are minted with status="future" so they flow through
+    AGENT_LOOP_META -> build-resume -> the resume path (resume-safe) and can be
+    published on an approved round (#300). Normalize clears future_followups for
+    blocking reviews, so blocking rounds pass an empty future_texts.
+    """
+    same_s = "same-plan" if flow == "plan" else "same-pr"
+    groups = [
+        ("blocking", "blocking", blocking_texts),
+        (same_s, same_s, same_texts),
+        ("future", "future", future_texts),
+    ]
+    items: list[dict] = []
+    counter = item_id_offset + 1
+    for status, source_status, texts in groups:
+        for text in texts:
+            items.append({
+                "item_id": f"item-{counter}",
+                "reviewer": agent_cap,
+                "source_round": new_round_number,
+                "text": str(text),
+                "status": status,
+                "source_status": source_status,
+                "notes": [],
+            })
+            counter += 1
+    return items
+
+
+def _publish_pr_followups(
+    repo: str,
+    pr: int,
+    head_sha: str | None,
+    mode: str,
+    future_items: list[dict],
+    pr_comments: list,
+    *,
+    dry_run: bool,
+) -> dict:
+    """Publish approved future follow-ups for a PR via the library logic (#300).
+
+    Reuses ``followups._publish_approved_followups`` (reconcile, dedupe,
+    idempotency marker, post-comment / file-issues). Returns a small dict for the
+    round result. Never publishes for mode 'ignore' or when there are no items.
+    """
+    if mode == "ignore" or not future_items:
+        return {"mode": mode, "published": False, "count": 0}
+    approved = [
+        _approved_followup_from_unresolved_item(_deserialize_unresolved_item(item))
+        for item in future_items
+    ]
+    if dry_run:
+        return {"mode": mode, "dry_run": True, "count": len(approved)}
+    from helpers.prompt_builders import make_minimal_config
+    config = dataclasses.replace(
+        make_minimal_config(repo, "claude", ("codex", "gemini")),
+        approved_followups=mode,
+    )
+    published = _publish_approved_followups(
+        Runner(dry_run=False),
+        config=config,
+        pr_number=pr,
+        head_sha=head_sha,
+        pr_comments=pr_comments,
+        followups=approved,
+    )
+    return {"mode": mode, "published": bool(published), "count": len(approved)}
+
+
 def _fetch_issue_json(repo: str, issue: int, gh_cmd: str = "gh") -> dict:
     result = subprocess.run(
         [gh_cmd, "issue", "view", str(issue), "--repo", repo,
@@ -393,6 +479,22 @@ def _fetch_issue_comments_raw(repo: str, issue: int, gh_cmd: str = "gh") -> list
     # without the multiline-splitting bug that `--jq .[].body` produces.
     result = subprocess.run(
         [gh_cmd, "issue", "view", str(issue), "--repo", repo, "--json", "comments"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return []
+    try:
+        data = json.loads(result.stdout)
+        return [c["body"] for c in data.get("comments", []) if isinstance(c, dict) and "body" in c]
+    except (json.JSONDecodeError, KeyError):
+        return []
+
+
+def _fetch_pr_comments_raw(repo: str, pr: int, gh_cmd: str = "gh") -> list[str]:
+    # PR conversation comments live behind `gh pr view` (not `gh issue view`,
+    # which rejects PR numbers). Used for the approved-followups idempotency marker.
+    result = subprocess.run(
+        [gh_cmd, "pr", "view", str(pr), "--repo", repo, "--json", "comments"],
         capture_output=True, text=True, check=False,
     )
     if result.returncode != 0:
@@ -616,31 +718,15 @@ def _complete_reviewer_turn(
     _write_json(dispositions_file, raw_dispositions)
 
     # --- Mint IDs globally unique across rounds ---
-    new_items_serialized: list[dict] = []
-    item_counter = item_id_offset + 1
-    for text in blocking_texts:
-        new_items_serialized.append({
-            "item_id": f"item-{item_counter}",
-            "reviewer": agent_cap,
-            "source_round": new_round_number,
-            "text": str(text),
-            "status": "blocking",
-            "source_status": "blocking",
-            "notes": [],
-        })
-        item_counter += 1
-    for text in new_unresolved_texts:
-        same_s = "same-plan" if flow == "plan" else "same-pr"
-        new_items_serialized.append({
-            "item_id": f"item-{item_counter}",
-            "reviewer": agent_cap,
-            "source_round": new_round_number,
-            "text": str(text),
-            "status": same_s,
-            "source_status": same_s,
-            "notes": [],
-        })
-        item_counter += 1
+    new_items_serialized = _mint_new_items(
+        blocking_texts=blocking_texts,
+        same_texts=new_unresolved_texts,
+        future_texts=[str(t) for t in review_json.get("future_followups", [])],
+        flow=flow,
+        agent_cap=agent_cap,
+        new_round_number=new_round_number,
+        item_id_offset=item_id_offset,
+    )
     _write_json(new_items_file, new_items_serialized)
 
     # --- Attach metadata ---
@@ -1046,6 +1132,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                     pr_number=pr,
                     all_reviewers=[r for r in reviewers],  # type: ignore[misc]
                     workdir=workdir,
+                    approved_followups=getattr(args, "approved_followups", "ignore"),
                 )
             except Exception as exc:  # noqa: BLE001
                 prompt_text = (
@@ -1113,6 +1200,23 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     )
     if gate is not None:
         result_json["tests"] = gate
+
+    # Optional approved-followups publishing (#300): only on an approved round and
+    # when a non-ignore mode is set. PR comments are fetched lazily here (for the
+    # idempotency marker) so blocking/ignore rounds make no extra network call.
+    followups_mode = getattr(args, "approved_followups", "ignore")
+    if overall_state == "approved" and followups_mode != "ignore":
+        round_future_items = [
+            item for item in current_round_items if item.get("status") == "future"
+        ]
+        pr_comments = [
+            types.SimpleNamespace(body=body)
+            for body in _fetch_pr_comments_raw(repo, pr)
+        ]
+        result_json["approved_followups"] = _publish_pr_followups(
+            repo, pr, head_sha, followups_mode, round_future_items, pr_comments,
+            dry_run=dry_run,
+        )
     print(json.dumps(result_json, indent=2))
 
 
@@ -1205,6 +1309,14 @@ def main() -> None:
         default=".",
         help="Directory to run --test-command in (default: current directory, "
              "where the host coder has the PR branch checked out).",
+    )
+    p_pr.add_argument(
+        "--approved-followups",
+        choices=("ignore", "summarize", "issue"),
+        default="ignore",
+        help="On an approved round, publish reviewers' future follow-ups: "
+             "'summarize' posts one PR comment; 'issue' files follow-up issues; "
+             "'ignore' (default) discards them. Never blocks or merges.",
     )
     p_pr.add_argument("--dry-run", action="store_true")
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -424,10 +424,15 @@ def _publish_pr_followups(
     if dry_run:
         return {"mode": mode, "dry_run": True, "count": len(approved)}
     from helpers.prompt_builders import make_minimal_config
+    from coding_review_agent_loop.workdirs import active_workdir
     config = dataclasses.replace(
         make_minimal_config(repo, "claude", ("codex", "gemini")),
         approved_followups=mode,
     )
+    # The library posts via `gh --repo`, but runs gh with cwd=active_workdir(config)
+    # (the coder dir). The Codex+Gemini skill flow never creates a Claude checkout,
+    # so ensure that directory exists or gh raises FileNotFoundError (#300).
+    Path(active_workdir(config)).mkdir(parents=True, exist_ok=True)
     published = _publish_approved_followups(
         Runner(dry_run=False),
         config=config,

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1173,3 +1173,18 @@ class TestApprovedFollowups:
         ignore_prompt = build_review_prompt_for_skill(issue, "d", [], 1, "codex", approved_followups="ignore", **common)
         summ_prompt = build_review_prompt_for_skill(issue, "d", [], 1, "codex", approved_followups="summarize", **common)
         assert ignore_prompt != summ_prompt
+
+    def test_publish_ensures_active_workdir_exists(self, monkeypatch) -> None:
+        # Regression (#300/#301): the library runs gh with cwd=active_workdir(config);
+        # the Codex+Gemini flow has no Claude checkout, so the helper must create it.
+        import helpers.skill_runner as sr
+        from coding_review_agent_loop.workdirs import active_workdir
+        seen = {}
+
+        def fake_publish(runner, *, config, **kwargs):
+            seen["exists"] = Path(active_workdir(config)).is_dir()
+            return True
+
+        monkeypatch.setattr(sr, "_publish_approved_followups", fake_publish)
+        sr._publish_pr_followups("o/r", 1, "sha", "summarize", [self._future_item()], [], dry_run=False)
+        assert seen["exists"] is True

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1074,3 +1074,102 @@ class TestRunTestGate:
         assert r["passed"] is False
         assert r["exit_code"] == 1
         assert "output_tail" in r  # decoded with replacement rather than raising
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py  approved-followups publishing (#300, increment 3)
+# ---------------------------------------------------------------------------
+
+class TestApprovedFollowups:
+    def test_mint_includes_future_items(self) -> None:
+        from helpers.skill_runner import _mint_new_items
+        items = _mint_new_items(
+            blocking_texts=[], same_texts=[], future_texts=["do X later", "do Y later"],
+            flow="pr", agent_cap="Codex", new_round_number=2, item_id_offset=0,
+        )
+        future = [i for i in items if i["status"] == "future"]
+        assert len(future) == 2
+        assert {i["text"] for i in future} == {"do X later", "do Y later"}
+        assert all(i["reviewer"] == "Codex" and i["source_status"] == "future" for i in future)
+        assert [i["item_id"] for i in items] == ["item-1", "item-2"]
+
+    def test_mint_blocking_round_has_no_future(self) -> None:
+        # Normalize clears future_followups for blocking reviews -> empty future_texts.
+        from helpers.skill_runner import _mint_new_items
+        items = _mint_new_items(
+            blocking_texts=["must fix"], same_texts=[], future_texts=[],
+            flow="pr", agent_cap="Gemini", new_round_number=1, item_id_offset=0,
+        )
+        assert [i["status"] for i in items] == ["blocking"]
+
+    def test_resume_safe_collection_filter(self) -> None:
+        # Mirrors cmd_run_pr_round: future items recovered via completed_reviewer_data
+        # (build-resume) are picked up by the same filter as fresh-round items.
+        current_round_items = [
+            {"status": "blocking", "text": "b"},
+            {"status": "future", "text": "f1", "reviewer": "Codex"},
+            {"status": "same-pr", "text": "s"},
+            {"status": "future", "text": "f2", "reviewer": "Gemini"},
+        ]
+        future = [i for i in current_round_items if i.get("status") == "future"]
+        assert [i["text"] for i in future] == ["f1", "f2"]
+
+    def _future_item(self, text="later", reviewer="Codex"):
+        return {
+            "item_id": "item-1", "reviewer": reviewer, "source_round": 1,
+            "text": text, "status": "future", "source_status": "future", "notes": [],
+        }
+
+    def test_publish_ignore_mode_noop(self) -> None:
+        from helpers.skill_runner import _publish_pr_followups
+        r = _publish_pr_followups("o/r", 1, "sha", "ignore", [self._future_item()], [], dry_run=False)
+        assert r == {"mode": "ignore", "published": False, "count": 0}
+
+    def test_publish_dry_run_does_not_post(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        called = {"n": 0}
+        monkeypatch.setattr(sr, "_publish_approved_followups", lambda *a, **k: called.__setitem__("n", called["n"] + 1) or True)
+        r = sr._publish_pr_followups("o/r", 1, "sha", "summarize", [self._future_item()], [], dry_run=True)
+        assert r == {"mode": "summarize", "dry_run": True, "count": 1}
+        assert called["n"] == 0  # never posted in dry-run
+
+    def test_publish_summarize_threads_mode_and_followups(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        captured = {}
+
+        def fake_publish(runner, *, config, pr_number, head_sha, pr_comments, followups):
+            captured["mode"] = config.approved_followups
+            captured["pr_number"] = pr_number
+            captured["head_sha"] = head_sha
+            captured["followup_texts"] = [f.text for f in followups]
+            captured["reviewers"] = [f.reviewer for f in followups]
+            return True
+
+        monkeypatch.setattr(sr, "_publish_approved_followups", fake_publish)
+        r = sr._publish_pr_followups(
+            "o/r", 42, "deadbeef", "summarize",
+            [self._future_item("ship docs", "Gemini")], [], dry_run=False,
+        )
+        assert r == {"mode": "summarize", "published": True, "count": 1}
+        assert captured["mode"] == "summarize"
+        assert captured["pr_number"] == 42 and captured["head_sha"] == "deadbeef"
+        assert captured["followup_texts"] == ["ship docs"]
+        assert captured["reviewers"] == ["Gemini"]
+
+    def test_publish_idempotent_with_existing_marker(self) -> None:
+        # Exercises the real _publish_approved_followups: a pre-existing marker for
+        # this pr/head/mode short-circuits before any network post.
+        import types as _t
+        from helpers.skill_runner import _publish_pr_followups
+        marker = "<!-- AGENT_APPROVED_FOLLOWUPS: pr=7 head=abc123 mode=summarize -->"
+        pr_comments = [_t.SimpleNamespace(body=f"prior summary\n{marker}")]
+        r = _publish_pr_followups("o/r", 7, "abc123", "summarize", [self._future_item()], pr_comments, dry_run=False)
+        assert r == {"mode": "summarize", "published": False, "count": 1}
+
+    def test_pr_prompt_mode_changes_instruction(self) -> None:
+        from helpers.prompt_builders import build_review_prompt_for_skill
+        issue = {"number": 7, "repo": "o/r", "title": "t", "body": "b", "url": "u"}
+        common = dict(repo="o/r", pr_number=7, all_reviewers=["codex", "gemini"])
+        ignore_prompt = build_review_prompt_for_skill(issue, "d", [], 1, "codex", approved_followups="ignore", **common)
+        summ_prompt = build_review_prompt_for_skill(issue, "d", [], 1, "codex", approved_followups="summarize", **common)
+        assert ignore_prompt != summ_prompt


### PR DESCRIPTION
## What & why

Closes #300 — increment 3 of #294 (close the CLI↔skill automation gap). On an
approved PR round the skill discarded reviewers' future follow-ups; the CLI
publishes them. This adds `--approved-followups {ignore,summarize,issue}` to
`run-pr-round`, reusing the library's `followups._publish_approved_followups`
(reconcile, dedupe, idempotency marker, post-comment / file-issues).

Merge stays a human decision (#294): publishing happens only on an **approved**
round and never blocks or merges.

## Changes

- **Resume-safe capture.** Future follow-ups are minted as `new_items` with
  `status="future"` (new `_mint_new_items` helper), so they flow through
  `AGENT_LOOP_META` → `build-resume` → the resume path. An interrupted round that
  resumes to finish remaining reviewers still publishes earlier reviewers'
  follow-ups (recovered from posted metadata) — this was the key round-1 review
  finding.
- **Prompt threading.** The mode reaches the reviewer prompt
  (`make_minimal_config`, now public, + `build_review_prompt_for_skill`), so
  reviewers surface future follow-ups only when a non-`ignore` mode is set —
  otherwise there'd be nothing to publish.
- **`_publish_pr_followups`** builds follow-ups via
  `_approved_followup_from_unresolved_item`, fetches PR comments lazily (only on
  an approved, non-`ignore` round) for the idempotency marker, and calls the
  library publisher. Dry-run reports without posting.
- `_fetch_pr_comments_raw` uses `gh pr view` (PR numbers are rejected by
  `gh issue view`).
- `SKILL.md` documents the flag, modes, approved-round-only publishing, and the
  one-publish-per-head-SHA+mode idempotency.

Result gains an `approved_followups` field:
```json
"approved_followups": { "mode": "summarize", "published": true, "count": 2 }
```

## Scope

`run-pr-round` only (a plan round has no code); non-coding modes only
(`summarize`/`issue`). Plan-flow follow-ups and `fix-*` modes are deferred.

## Tests

Future-item minting, blocking-round-mints-none, resume-safe collection filter,
ignore/dry-run/summarize/idempotency publish paths (the idempotency test
exercises the real library publisher with a pre-existing marker — offline), and
prompt-mode threading. Full suite: **771 passed**.

## Review provenance

Design reviewed via the skill's own plan-review loop on #300 — approved by Gemini
and Codex after three rounds (resume-safety, prompt threading, and public-config
/ lazy-fetch refinements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
