### PR TITLE
Add run-task-round entry point (#302)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -194,6 +194,36 @@ EOF
 
 ---
 
+## Task mode (free-form task, no pre-existing issue)
+
+For a free-form task that has no GitHub issue yet, use `run-task-round`. It
+creates a scratch issue from the task text (idempotently — re-running the same
+task reuses its issue, tracked in a local task index), then runs the normal plan
+round on it:
+
+```bash
+python -m helpers.skill_runner run-task-round \
+  --task "Add a --verbose flag to the CLI" \
+  --repo OWNER/REPO \
+  --plan-file /tmp/agent-loop-skill/{session-id}/plan-r{N}.md \
+  --reviewers codex gemini
+```
+
+Use `--task-file PATH` (or `--task-file -` for stdin) instead of `--task` for
+longer descriptions. `--dry-run` reports the issue it *would* create without
+creating it. After the first round the flow is identical to a plan loop (Step 3
+onward): address blocking items, revise the plan, and re-run on the same issue.
+
+Because the host **is** the coder, two manual paths are equivalent and need no
+new subcommand:
+
+- **Plan-first:** `gh issue create …` then `run-plan-round` (this is what
+  `run-task-round` automates).
+- **Implement-then-review:** implement the task, open a PR, then `run-pr-round`
+  (with the optional `--test-command` and `--approved-followups` gates).
+
+---
+
 ## Reversed roles (Codex as coder, Claude as reviewer)
 
 Reversed-roles mode (Codex writes the plan, Claude reviews) is tracked in

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -37,6 +37,7 @@ import argparse
 import dataclasses
 import hashlib
 import json
+import os
 import re
 import shlex
 import shutil
@@ -856,6 +857,129 @@ def _run_reviewer(
 
 
 # ---------------------------------------------------------------------------
+# run-task-round  (free-form task -> scratch issue -> plan round)
+# ---------------------------------------------------------------------------
+
+def _resolve_task_text(args: argparse.Namespace) -> str:
+    task = getattr(args, "task", None)
+    task_file = getattr(args, "task_file", None)
+    if task is not None and task_file is not None:
+        print("skill_runner: pass either --task or --task-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if task_file is not None:
+        text = sys.stdin.read() if task_file == "-" else Path(task_file).read_text(encoding="utf-8")
+    elif task is not None:
+        text = task
+    else:
+        print("skill_runner: provide --task or --task-file", file=sys.stderr)
+        sys.exit(1)
+    if not text.strip():
+        print("skill_runner: task description is empty", file=sys.stderr)
+        sys.exit(1)
+    return text
+
+
+def _task_key(task_text: str) -> str:
+    return hashlib.sha256(task_text.strip().encode("utf-8")).hexdigest()
+
+
+def _task_index_path(repo: str) -> Path:
+    slug = repo.replace("/", "-").replace(":", "-")
+    state_home = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    return state_home / "coding-review-agent-loop" / "skill-sessions" / slug / "task-index.json"
+
+
+def _load_task_index(repo: str) -> dict:
+    path = _task_index_path(repo)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _issue_is_open(repo: str, issue: int, gh_cmd: str = "gh") -> bool:
+    result = subprocess.run(
+        [gh_cmd, "issue", "view", str(issue), "--repo", repo, "--json", "state"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        return json.loads(result.stdout).get("state", "").upper() == "OPEN"
+    except json.JSONDecodeError:
+        return False
+
+
+def _lookup_task_issue(repo: str, task_key: str) -> int | None:
+    number = _load_task_index(repo).get(task_key)
+    if isinstance(number, int) and _issue_is_open(repo, number):
+        return number
+    return None
+
+
+def _record_task_issue(repo: str, task_key: str, number: int) -> None:
+    path = _task_index_path(repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    index = _load_task_index(repo)
+    index[task_key] = number
+    path.write_text(json.dumps(index, indent=2), encoding="utf-8")
+
+
+def _title_from_task(task_text: str) -> str:
+    for line in task_text.splitlines():
+        stripped = line.lstrip("#").strip()
+        if stripped:
+            return stripped[:80]
+    return "Agent task"
+
+
+def _create_task_issue(repo: str, task_text: str, task_key: str, gh_cmd: str = "gh") -> int:
+    body = f"{task_text.rstrip()}\n\n<!-- AGENT_TASK_KEY: {task_key} -->\n"
+    result = subprocess.run(
+        [gh_cmd, "issue", "create", "--repo", repo,
+         "--title", _title_from_task(task_text), "--body", body],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        print(f"skill_runner: gh issue create failed: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    match = re.search(r"/issues/(\d+)", result.stdout)
+    if not match:
+        print(f"skill_runner: could not parse issue number from: {result.stdout.strip()}", file=sys.stderr)
+        sys.exit(1)
+    number = int(match.group(1))
+    _record_task_issue(repo, task_key, number)
+    return number
+
+
+def cmd_run_task_round(args: argparse.Namespace) -> None:
+    repo: str = args.repo
+    dry_run: bool = args.dry_run
+    task_text = _resolve_task_text(args)
+    key = _task_key(task_text)
+    issue = _lookup_task_issue(repo, key)
+
+    if dry_run and issue is None:
+        # Never create an issue in dry-run; delegating with a fake number would
+        # break cmd_run_plan_round (it fetches the issue unconditionally).
+        print(json.dumps({
+            "would_create_issue": True,
+            "task_key": key,
+            "title": _title_from_task(task_text),
+        }, indent=2))
+        return
+
+    if issue is None:
+        issue = _create_task_issue(repo, task_text, key)
+        print(f"created scratch issue #{issue} for task {key[:12]}")
+    else:
+        print(f"reusing issue #{issue} for task {key[:12]}")
+
+    args.issue = issue
+    cmd_run_plan_round(args)
+
+
+# ---------------------------------------------------------------------------
 # run-plan-round
 # ---------------------------------------------------------------------------
 
@@ -1336,11 +1460,31 @@ def main() -> None:
     )
     p_retry.add_argument("--dry-run", action="store_true")
 
+    # run-task-round
+    p_task = subparsers.add_parser(
+        "run-task-round",
+        help="Create (or reuse) a scratch issue from free-form task text, then run a plan round.",
+    )
+    task_src = p_task.add_mutually_exclusive_group(required=True)
+    task_src.add_argument("--task", default=None, help="Free-form task description.")
+    task_src.add_argument(
+        "--task-file", default=None,
+        help="Read task description from this file ('-' for stdin).",
+    )
+    p_task.add_argument("--repo", required=True)
+    p_task.add_argument("--plan-file", required=True)
+    p_task.add_argument("--reviewers", nargs="+", required=True)
+    p_task.add_argument("--workdir-codex", default=None)
+    p_task.add_argument("--workdir-gemini", default=None)
+    p_task.add_argument("--workdir", default=None)
+    p_task.add_argument("--dry-run", action="store_true")
+
     args = parser.parse_args()
     dispatch = {
         "run-plan-round": cmd_run_plan_round,
         "run-pr-round": cmd_run_pr_round,
         "retry-validate": cmd_retry_validate,
+        "run-task-round": cmd_run_task_round,
     }
     dispatch[args.subcommand](args)
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -959,14 +959,17 @@ def cmd_run_task_round(args: argparse.Namespace) -> None:
     key = _task_key(task_text)
     issue = _lookup_task_issue(repo, key)
 
-    if dry_run and issue is None:
-        # Never create an issue in dry-run; delegating with a fake number would
-        # break cmd_run_plan_round (it fetches the issue unconditionally).
-        print(json.dumps({
-            "would_create_issue": True,
-            "task_key": key,
-            "title": _title_from_task(task_text),
-        }, indent=2))
+    if dry_run:
+        # Dry-run is a pure preview of the task issue: never create, never delegate
+        # to the plan round (which would fetch issue state and touch session state).
+        if issue is None:
+            print(json.dumps({
+                "would_create_issue": True,
+                "task_key": key,
+                "title": _title_from_task(task_text),
+            }, indent=2))
+        else:
+            print(json.dumps({"would_reuse_issue": issue, "task_key": key}, indent=2))
         return
 
     if issue is None:

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1289,3 +1289,17 @@ class TestRunTaskRound:
         sr.cmd_run_task_round(self._task_args(dry_run=True))
         assert created["n"] == 0 and delegated["n"] == 0
         assert "would_create_issue" in capsys.readouterr().out
+
+    def test_task_round_dry_run_existing_issue_does_not_delegate(self, monkeypatch, capsys) -> None:
+        # Regression (#302/#303): dry-run is a pure preview even when the task
+        # already maps to an open issue — it must not delegate to the plan round.
+        import helpers.skill_runner as sr
+        monkeypatch.setattr(sr, "_lookup_task_issue", lambda repo, key: 88)
+        created = {"n": 0}
+        monkeypatch.setattr(sr, "_create_task_issue", lambda *a, **k: created.__setitem__("n", created["n"] + 1) or 1)
+        delegated = {"n": 0}
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: delegated.__setitem__("n", delegated["n"] + 1))
+        sr.cmd_run_task_round(self._task_args(dry_run=True))
+        assert created["n"] == 0 and delegated["n"] == 0
+        out = capsys.readouterr().out
+        assert "would_reuse_issue" in out and "88" in out

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1188,3 +1188,104 @@ class TestApprovedFollowups:
         monkeypatch.setattr(sr, "_publish_approved_followups", fake_publish)
         sr._publish_pr_followups("o/r", 1, "sha", "summarize", [self._future_item()], [], dry_run=False)
         assert seen["exists"] is True
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py  run-task-round (#302, increment 4)
+# ---------------------------------------------------------------------------
+
+import argparse as _argparse
+import io as _io
+
+
+class TestRunTaskRound:
+    def test_resolve_task_text_inline(self) -> None:
+        from helpers.skill_runner import _resolve_task_text
+        args = _argparse.Namespace(task="do the thing", task_file=None)
+        assert _resolve_task_text(args) == "do the thing"
+
+    def test_resolve_task_text_from_file(self) -> None:
+        from helpers.skill_runner import _resolve_task_text
+        p = _write_tmp("task from file", suffix=".txt")
+        args = _argparse.Namespace(task=None, task_file=p)
+        assert _resolve_task_text(args).strip() == "task from file"
+
+    def test_resolve_task_text_stdin(self, monkeypatch) -> None:
+        from helpers.skill_runner import _resolve_task_text
+        monkeypatch.setattr(sys, "stdin", _io.StringIO("piped task"))
+        args = _argparse.Namespace(task=None, task_file="-")
+        assert _resolve_task_text(args) == "piped task"
+
+    def test_resolve_task_text_empty_errors(self) -> None:
+        from helpers.skill_runner import _resolve_task_text
+        with pytest.raises(SystemExit):
+            _resolve_task_text(_argparse.Namespace(task="   ", task_file=None))
+
+    def test_resolve_task_text_neither_errors(self) -> None:
+        from helpers.skill_runner import _resolve_task_text
+        with pytest.raises(SystemExit):
+            _resolve_task_text(_argparse.Namespace(task=None, task_file=None))
+
+    def test_title_from_task(self) -> None:
+        from helpers.skill_runner import _title_from_task
+        assert _title_from_task("# My Heading\nbody") == "My Heading"
+        assert _title_from_task("\n\n  first real line\nmore") == "first real line"
+        assert _title_from_task("   \n  ") == "Agent task"
+        assert _title_from_task("x" * 200) == "x" * 80
+
+    def test_task_index_round_trip(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        sr._record_task_issue("o/r", "key123", 55)
+        monkeypatch.setattr(sr, "_issue_is_open", lambda repo, n: True)
+        assert sr._lookup_task_issue("o/r", "key123") == 55
+
+    def test_task_index_missing_returns_none(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        assert sr._lookup_task_issue("o/r", "absent") is None
+
+    def test_task_index_closed_issue_returns_none(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        sr._record_task_issue("o/r", "key123", 55)
+        monkeypatch.setattr(sr, "_issue_is_open", lambda repo, n: False)  # closed/deleted
+        assert sr._lookup_task_issue("o/r", "key123") is None
+
+    def _task_args(self, **over):
+        base = dict(task="do X", task_file=None, repo="o/r", plan_file="/tmp/p.md",
+                    reviewers=["codex"], workdir=None, workdir_codex=None,
+                    workdir_gemini=None, dry_run=False)
+        base.update(over)
+        return _argparse.Namespace(**base)
+
+    def test_task_round_reuses_existing_issue(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setattr(sr, "_lookup_task_issue", lambda repo, key: 77)
+        created = {"n": 0}
+        monkeypatch.setattr(sr, "_create_task_issue", lambda *a, **k: created.__setitem__("n", created["n"] + 1) or 999)
+        seen = {}
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.__setitem__("issue", args.issue))
+        sr.cmd_run_task_round(self._task_args())
+        assert created["n"] == 0          # did not create a duplicate
+        assert seen["issue"] == 77        # delegated with the reused issue
+
+    def test_task_round_creates_when_absent(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setattr(sr, "_lookup_task_issue", lambda repo, key: None)
+        monkeypatch.setattr(sr, "_create_task_issue", lambda repo, text, key: 123)
+        seen = {}
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.__setitem__("issue", args.issue))
+        sr.cmd_run_task_round(self._task_args())
+        assert seen["issue"] == 123
+
+    def test_task_round_dry_run_creates_nothing(self, monkeypatch, capsys) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setattr(sr, "_lookup_task_issue", lambda repo, key: None)
+        created = {"n": 0}
+        monkeypatch.setattr(sr, "_create_task_issue", lambda *a, **k: created.__setitem__("n", created["n"] + 1) or 1)
+        delegated = {"n": 0}
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: delegated.__setitem__("n", delegated["n"] + 1))
+        sr.cmd_run_task_round(self._task_args(dry_run=True))
+        assert created["n"] == 0 and delegated["n"] == 0
+        assert "would_create_issue" in capsys.readouterr().out


### PR DESCRIPTION
## What & why

Closes #302 — increment 4 of #294 (final). Adds a `run-task-round` subcommand:
turn free-form task text into a scratch GitHub issue, then run the normal plan
round on it. Since the host is already the coder, this is a thin convenience
layer over `gh issue create` + `run-plan-round`, giving task work a single entry
point that mirrors the CLI `task` command.

## Behavior

```bash
python -m helpers.skill_runner run-task-round \
  --task "Add a --verbose flag" --repo OWNER/REPO \
  --plan-file PLAN.md --reviewers codex gemini
```
(`--task-file PATH` / `-` for stdin; `--dry-run` reports without creating.)

- **Idempotent**: a local task index
  (`{XDG_STATE_HOME}/.../skill-sessions/{slug}/task-index.json`) maps task-key →
  issue number, with open-issue verification (a closed/deleted issue is treated
  as absent) and an `AGENT_TASK_KEY` body marker. Re-running the same task reuses
  its issue rather than creating duplicates.
- **Dry-run never creates an issue**: it reports the issue it *would* create and
  does not delegate (the plan round fetches the issue unconditionally).
- After the first round it's identical to a plan loop.

## Tests

Task-text resolution (inline/file/stdin/empty/neither), title derivation,
task-index round-trip / missing / closed-issue, and `cmd_run_task_round`
reuse / create / dry-run paths. Full suite: **784 passed**.

## Docs

`SKILL.md` documents task mode and notes the two equivalent manual paths
(`gh issue create` → `run-plan-round`; implement → PR → `run-pr-round` with the
increment 2–3 gates).

## Review provenance

Design reviewed via the skill's own plan-review loop on #302 — approved by Gemini
and Codex in round 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
