### PR TITLE
Wire agent-memory into skill reviewer prompts (#306)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -208,6 +208,14 @@ Plan-loop onward (including the optional Implement step + PR-loop).
   ```json
   "approved_followups": { "mode": "summarize", "published": true, "count": 2 }
   ```
+- **Agent memory** (plan-loop and PR-loop): repo-scoped orientation context
+  (repo summary, architecture map, module index, test profile, toolchain,
+  changed-file summaries) is generated deterministically (git + static analysis,
+  no LLM) and included in the reviewer prompts so Codex/Gemini get the same
+  context the CLI gives them. On by default; `--no-agent-memory` disables it,
+  `--refresh-agent-memory` forces regeneration. The cache lives under the skill
+  session dir and is incremental. Generation is advisory — if it fails, the round
+  continues without memory.
 - **Merge is always a human decision.** The skill never runs CI-wait or
   auto-merge; every mode stops at "ready to merge."
 

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from coding_review_agent_loop.agents.base import AgentName
 from coding_review_agent_loop.config import AgentLoopConfig
 from coding_review_agent_loop.github import IssueContext, IssueComment
+from coding_review_agent_loop.memory import AgentMemoryContext
 from coding_review_agent_loop.prompts import build_plan_review_prompt, build_review_prompt
 from coding_review_agent_loop.round_state import _deserialize_unresolved_item
 
@@ -29,6 +30,9 @@ def make_minimal_config(
     reviewer: AgentName | None = None,
     workdir: str | None = None,
     approved_followups: str = "ignore",
+    agent_memory: bool = False,
+    agent_memory_dir: Path | None = None,
+    refresh_agent_memory: bool = False,
 ) -> AgentLoopConfig:
     base = Path(tempfile.gettempdir()) / "coding-review-agent-loop"
     legacy = base / "skill-runner"
@@ -72,9 +76,9 @@ def make_minimal_config(
         progress_interval_seconds=30,
         agent_max_retries=0,
         agent_retry_backoff_seconds=(30,),
-        agent_memory=False,
-        refresh_agent_memory=False,
-        agent_memory_dir=legacy,
+        agent_memory=agent_memory,
+        refresh_agent_memory=refresh_agent_memory,
+        agent_memory_dir=agent_memory_dir if agent_memory_dir is not None else legacy,
         refresh_test_profile=False,
         auto_agent_dirs=tuple(reviewer_names),
         approved_followups=approved_followups,
@@ -103,6 +107,7 @@ def build_plan_review_prompt_for_skill(
     coder: AgentName = "claude",
     all_reviewers: Sequence[AgentName] | None = None,
     workdir: str | None = None,
+    memory: AgentMemoryContext | None = None,
 ) -> str:
     """Build a plan reviewer prompt from plain dicts.
 
@@ -117,6 +122,7 @@ def build_plan_review_prompt_for_skill(
         all_reviewers: All configured reviewer names (defaults to [reviewer]).
         workdir: The reviewer's actual checkout path, embedded in the prompt so
             the agent inspects a directory that exists (#297).
+        memory: Repo-scoped agent memory to include for reviewer orientation (#306).
     """
     reviewers_list: Sequence[AgentName] = all_reviewers or [reviewer]
     config = make_minimal_config(repo, coder, reviewers_list, reviewer=reviewer, workdir=workdir)
@@ -128,6 +134,7 @@ def build_plan_review_prompt_for_skill(
         plan_text,
         config,
         reviewer=reviewer,
+        memory=memory,
         issue_context=issue_context,
         unresolved_items=unresolved,
     )
@@ -146,6 +153,7 @@ def build_review_prompt_for_skill(
     all_reviewers: Sequence[AgentName] | None = None,
     workdir: str | None = None,
     approved_followups: str = "ignore",
+    memory: AgentMemoryContext | None = None,
 ) -> str:
     """Build a PR reviewer prompt from plain dicts.
 
@@ -164,6 +172,7 @@ def build_review_prompt_for_skill(
         approved_followups: Approved-followups mode; when not "ignore" the prompt
             instructs the reviewer to surface future follow-ups so they can be
             published on approval (#300).
+        memory: Repo-scoped agent memory to include for reviewer orientation (#306).
     """
     from coding_review_agent_loop.github import PullRequestMetadata
 
@@ -188,6 +197,7 @@ def build_review_prompt_for_skill(
         round_number,
         config,
         reviewer=reviewer,
+        memory=memory,
         pr_metadata=pr_metadata,
         issue_context=issue_context,
         unresolved_items=unresolved,

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -50,11 +50,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.agents.base import AgentName
+from coding_review_agent_loop.config import ensure_temp_checkout
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.followups import (
     _approved_followup_from_unresolved_item,
     _publish_approved_followups,
 )
+from coding_review_agent_loop.memory import AgentMemoryContext, prepare_agent_memory
 from coding_review_agent_loop.runner import Runner, tail_text
 from coding_review_agent_loop.protocol import ReviewItemDisposition, UnresolvedReviewItem
 from coding_review_agent_loop.round_state import (
@@ -305,6 +307,50 @@ def _workdir_for_agent(agent: str, args: argparse.Namespace) -> str:
     tmp = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / f"skill-runner-{agent}"
     tmp.mkdir(parents=True, exist_ok=True)
     return str(tmp)
+
+
+def _agent_memory_dir(repo: str) -> Path:
+    slug = repo.replace("/", "-").replace(":", "-")
+    state_home = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    return state_home / "coding-review-agent-loop" / "skill-sessions" / slug / "agent-memory"
+
+
+def _prepare_skill_memory(
+    repo: str,
+    reviewers: list[str],
+    memory_workdir: str,
+    *,
+    refresh: bool,
+    dry_run: bool,
+) -> AgentMemoryContext | None:
+    """Build repo-scoped agent memory once for a round (advisory; never crashes).
+
+    Memory generation is deterministic (git + static analysis) but needs a
+    checked-out target repo, so this ensures `memory_workdir` exists first. The
+    config's coder is set to ``reviewers[0]`` with its dir = `memory_workdir` so
+    `active_workdir(config)` resolves there. Failures degrade to None.
+    """
+    if dry_run or not reviewers:
+        return None
+    from helpers.prompt_builders import make_minimal_config
+    first = reviewers[0]
+    try:
+        config = dataclasses.replace(
+            make_minimal_config(
+                repo, first, tuple(reviewers),
+                reviewer=first, workdir=memory_workdir,
+            ),
+            agent_memory=True,
+            agent_memory_dir=_agent_memory_dir(repo),
+            refresh_agent_memory=refresh,
+        )
+        runner = Runner(dry_run=False)
+        ensure_temp_checkout(Path(memory_workdir), agent=first, config=config, runner=runner)
+        return prepare_agent_memory(runner, config)
+    except Exception as exc:  # noqa: BLE001 — advisory only
+        print(f"skill_runner: agent memory unavailable ({exc}); continuing without it",
+              file=sys.stderr)
+        return None
 
 
 def _run_test_gate(command: str, workdir: str, *, dry_run: bool) -> dict:
@@ -1093,6 +1139,14 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
 
     plan_text = plan_file.read_text(encoding="utf-8")
 
+    # Repo-scoped agent memory for reviewer orientation (#306), prepared once.
+    memory = None
+    if getattr(args, "agent_memory", True):
+        memory = _prepare_skill_memory(
+            repo, reviewers, _workdir_for_agent(reviewers[0], args),
+            refresh=getattr(args, "refresh_agent_memory", False), dry_run=dry_run,
+        )
+
     # Step 6 — run pending reviewers
     with tempfile.TemporaryDirectory() as tmpstr:
         tmpdir = Path(tmpstr)
@@ -1116,6 +1170,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
                     repo=repo,
                     all_reviewers=[r for r in reviewers],  # type: ignore[misc]
                     workdir=workdir,
+                    memory=memory,
                 )
             except Exception as exc:  # noqa: BLE001
                 prompt_text = (
@@ -1242,6 +1297,14 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     pr_diff = _fetch_pr_diff(repo, pr)
     issue_dict = _fetch_pr_json(repo, pr)
 
+    # Repo-scoped agent memory for reviewer orientation (#306), prepared once.
+    memory = None
+    if getattr(args, "agent_memory", True):
+        memory = _prepare_skill_memory(
+            repo, reviewers, _workdir_for_agent(reviewers[0], args),
+            refresh=getattr(args, "refresh_agent_memory", False), dry_run=dry_run,
+        )
+
     # Step 6 — run pending reviewers
     with tempfile.TemporaryDirectory() as tmpstr:
         tmpdir = Path(tmpstr)
@@ -1265,6 +1328,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                     all_reviewers=[r for r in reviewers],  # type: ignore[misc]
                     workdir=workdir,
                     approved_followups=getattr(args, "approved_followups", "ignore"),
+                    memory=memory,
                 )
             except Exception as exc:  # noqa: BLE001
                 prompt_text = (
@@ -1418,6 +1482,13 @@ def main() -> None:
     p_plan.add_argument("--workdir-codex", default=None)
     p_plan.add_argument("--workdir-gemini", default=None)
     p_plan.add_argument("--workdir", default=None)
+    p_plan_mem = p_plan.add_mutually_exclusive_group()
+    p_plan_mem.add_argument("--agent-memory", dest="agent_memory", action="store_true", default=True,
+                            help="Include repo-scoped agent memory in reviewer prompts (default).")
+    p_plan_mem.add_argument("--no-agent-memory", dest="agent_memory", action="store_false",
+                            help="Disable repo-scoped agent memory.")
+    p_plan.add_argument("--refresh-agent-memory", action="store_true",
+                        help="Regenerate the agent-memory cache before this round.")
     p_plan.add_argument("--dry-run", action="store_true")
 
     # run-pr-round
@@ -1450,6 +1521,13 @@ def main() -> None:
              "'summarize' posts one PR comment; 'issue' files follow-up issues; "
              "'ignore' (default) discards them. Never blocks or merges.",
     )
+    p_pr_mem = p_pr.add_mutually_exclusive_group()
+    p_pr_mem.add_argument("--agent-memory", dest="agent_memory", action="store_true", default=True,
+                          help="Include repo-scoped agent memory in reviewer prompts (default).")
+    p_pr_mem.add_argument("--no-agent-memory", dest="agent_memory", action="store_false",
+                          help="Disable repo-scoped agent memory.")
+    p_pr.add_argument("--refresh-agent-memory", action="store_true",
+                      help="Regenerate the agent-memory cache before this round.")
     p_pr.add_argument("--dry-run", action="store_true")
 
     # retry-validate
@@ -1480,6 +1558,13 @@ def main() -> None:
     p_task.add_argument("--workdir-codex", default=None)
     p_task.add_argument("--workdir-gemini", default=None)
     p_task.add_argument("--workdir", default=None)
+    p_task_mem = p_task.add_mutually_exclusive_group()
+    p_task_mem.add_argument("--agent-memory", dest="agent_memory", action="store_true", default=True,
+                            help="Include repo-scoped agent memory in reviewer prompts (default).")
+    p_task_mem.add_argument("--no-agent-memory", dest="agent_memory", action="store_false",
+                            help="Disable repo-scoped agent memory.")
+    p_task.add_argument("--refresh-agent-memory", action="store_true",
+                        help="Regenerate the agent-memory cache before this round.")
     p_task.add_argument("--dry-run", action="store_true")
 
     args = parser.parse_args()

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1303,3 +1303,73 @@ class TestRunTaskRound:
         assert created["n"] == 0 and delegated["n"] == 0
         out = capsys.readouterr().out
         assert "would_reuse_issue" in out and "88" in out
+
+
+# ---------------------------------------------------------------------------
+# agent-memory wiring (#306)
+# ---------------------------------------------------------------------------
+
+class TestAgentMemory:
+    def _ctx(self):
+        from coding_review_agent_loop.memory import AgentMemoryContext
+        return AgentMemoryContext(
+            memory_dir=Path("/tmp/mem"), current_commit="abc123",
+            last_analyzed_commit=None, changed_files=(),
+            repo_summary="REPO SUMMARY TEXT", architecture_map=None,
+            test_profile=None, toolchain=None,
+        )
+
+    _ISSUE = {"number": 9, "repo": "o/r", "title": "t", "body": "b", "url": "u"}
+
+    def test_plan_prompt_includes_memory(self) -> None:
+        from helpers.prompt_builders import build_plan_review_prompt_for_skill
+        common = dict(repo="o/r", all_reviewers=["codex", "gemini"])
+        without = build_plan_review_prompt_for_skill(self._ISSUE, "PLAN", [], 1, "codex", **common)
+        with_mem = build_plan_review_prompt_for_skill(self._ISSUE, "PLAN", [], 1, "codex", memory=self._ctx(), **common)
+        assert with_mem != without
+        assert "Cached repo memory is available" in with_mem
+        assert "REPO SUMMARY TEXT" in with_mem
+
+    def test_pr_prompt_includes_memory(self) -> None:
+        from helpers.prompt_builders import build_review_prompt_for_skill
+        common = dict(repo="o/r", pr_number=9, all_reviewers=["codex", "gemini"])
+        without = build_review_prompt_for_skill(self._ISSUE, "diff", [], 1, "codex", **common)
+        with_mem = build_review_prompt_for_skill(self._ISSUE, "diff", [], 1, "codex", memory=self._ctx(), **common)
+        assert with_mem != without
+        assert "Cached repo memory is available" in with_mem
+
+    def test_prepare_memory_dry_run_is_noop(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        called = {"checkout": 0, "prepare": 0}
+        monkeypatch.setattr(sr, "ensure_temp_checkout", lambda *a, **k: called.__setitem__("checkout", 1))
+        monkeypatch.setattr(sr, "prepare_agent_memory", lambda *a, **k: called.__setitem__("prepare", 1))
+        assert sr._prepare_skill_memory("o/r", ["codex"], "/tmp/wd", refresh=False, dry_run=True) is None
+        assert called == {"checkout": 0, "prepare": 0}
+
+    def test_prepare_memory_no_reviewers(self) -> None:
+        import helpers.skill_runner as sr
+        assert sr._prepare_skill_memory("o/r", [], "/tmp/wd", refresh=False, dry_run=False) is None
+
+    def test_prepare_memory_resilient_to_errors(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        monkeypatch.setattr(sr, "ensure_temp_checkout", lambda *a, **k: None)
+        def boom(*a, **k):
+            raise RuntimeError("git exploded")
+        monkeypatch.setattr(sr, "prepare_agent_memory", boom)
+        assert sr._prepare_skill_memory("o/r", ["codex"], "/tmp/wd", refresh=False, dry_run=False) is None
+
+    def test_prepare_memory_success_builds_enabled_config(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        from coding_review_agent_loop.workdirs import active_workdir
+        captured = {}
+        sentinel = object()
+        monkeypatch.setattr(sr, "ensure_temp_checkout", lambda *a, **k: None)
+        def fake_prepare(runner, config):
+            captured["config"] = config
+            return sentinel
+        monkeypatch.setattr(sr, "prepare_agent_memory", fake_prepare)
+        out = sr._prepare_skill_memory("o/r", ["codex", "gemini"], "/tmp/skill-runner-codex", refresh=True, dry_run=False)
+        assert out is sentinel
+        cfg = captured["config"]
+        assert cfg.agent_memory is True and cfg.refresh_agent_memory is True
+        assert str(active_workdir(cfg)) == "/tmp/skill-runner-codex"


### PR DESCRIPTION
## What & why

Closes #306 — part of #294. The skill never passed repo-scoped **agent memory**
to its external reviewers, unlike the CLI. This generates it once per round and
threads it into the Codex/Gemini prompts so they get the same orientation context
(repo summary, architecture map, module index, test profile, toolchain,
changed-file summaries). Generation is **deterministic** — git + static analysis,
no LLM.

## Changes

- `prompt_builders.make_minimal_config` gains `agent_memory` /
  `agent_memory_dir` / `refresh_agent_memory`; `build_plan_review_prompt_for_skill`
  and `build_review_prompt_for_skill` gain a `memory` arg passed through to the
  underlying builders (which already render a memory block — the skill just never
  supplied it).
- `skill_runner._prepare_skill_memory` prepares memory once before the reviewer
  loop: it ensures a target-repo checkout exists (reusing `ensure_temp_checkout`
  on `reviewers[0]`'s workdir, so the path the prompt embeds is real), points the
  config's active workdir there, and calls `prepare_agent_memory`. **Advisory
  only** — any failure degrades to "no memory" and never crashes the round.
  Cached under the skill session dir, incremental across runs.
- New flags on `run-plan-round` / `run-pr-round` / `run-task-round`:
  `--agent-memory` (default on) / `--no-agent-memory` / `--refresh-agent-memory`.
- `SKILL.md` documents it under Gates & guardrails.

## Tests

Prompt threading (plan + PR include the memory block / differ from no-memory);
`_prepare_skill_memory` dry-run noop, no-reviewers, error-resilience, and
success-builds-an-enabled-config. Full suite: **791 passed**.

## Notes

- Default on for CLI parity; disable per-round with `--no-agent-memory`. Tradeoff:
  larger reviewer prompts (more tokens) — flagged for reviewers.
- Memory reflects the checked-out repo state; advisory, so base-state is
  acceptable even for PR rounds.

## Review provenance

Design reviewed via the skill's own plan-review loop on #306 — approved by Gemini
and Codex in round 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
