### PR TITLE
Capture external-agent usage/cost in the skill (#308)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -216,6 +216,18 @@ Plan-loop onward (including the optional Implement step + PR-loop).
   `--refresh-agent-memory` forces regeneration. The cache lives under the skill
   session dir and is incremental. Generation is advisory — if it fails, the round
   continues without memory.
+- **Usage/cost** (plan-loop and PR-loop): the round result includes a `usage`
+  field with token totals for the external reviewers (Codex/Gemini), aggregated
+  per agent. It is **external-agents-only** — the host's Claude coder/plan turns
+  run in the interactive session and have no programmatic token count, so the
+  numbers are *not* a session total (the field's `scope`/`note` say so). Usage is
+  persisted in `AGENT_LOOP_META`, so resumed rounds aggregate the full
+  external-agent cost.
+  ```json
+  "usage": { "scope": "external-agents-only", "note": "...host turns not counted...",
+             "totals": { "call_count": 2, "total_tokens": 250, ... },
+             "per_agent": { "codex": {...}, "gemini": {...} } }
+  ```
 - **Merge is always a human decision.** The skill never runs CI-wait or
   auto-merge; every mode stops at "ready to merge."
 

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -123,6 +123,12 @@ def main() -> None:
         help="Backoff delays before each retry; the final value is reused when "
              "retries exceed the list length (default: 15 45).",
     )
+    parser.add_argument(
+        "--usage-output",
+        default=None,
+        help="Write the agent's token usage (JSON) to this path for external-agent "
+             "cost tracking (#308). Skipped in --dry-run.",
+    )
     args = parser.parse_args()
 
     if args.max_retries < 0:
@@ -171,6 +177,7 @@ def main() -> None:
     from coding_review_agent_loop.agents.gemini import GeminiBackend
     from coding_review_agent_loop.config import AgentLoopConfig, AgentName, ensure_temp_checkout
     from coding_review_agent_loop.transient import is_transient_agent_output
+    from coding_review_agent_loop.usage import estimate_usage
 
     agent_name: AgentName = args.agent
     default_cmds = {"codex": "codex", "gemini": "gemini"}
@@ -264,6 +271,22 @@ def main() -> None:
     assert result is not None  # loop either set result or exited
     output_path.write_text(result.text, encoding="utf-8")
     print(f"agent result written to {output_path}")
+
+    # External-agent usage for cost tracking (#308). Advisory — never fail the run.
+    if args.usage_output:
+        try:
+            usage = result.usage or estimate_usage(prompt, result.text)
+            Path(args.usage_output).write_text(
+                json.dumps({
+                    "agent": agent_name,
+                    "session_id": result.session_id,
+                    "returncode": result.returncode,
+                    "usage": usage.to_dict(),
+                }, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"run_external: could not write usage output: {exc}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -58,6 +58,7 @@ from coding_review_agent_loop.followups import (
 )
 from coding_review_agent_loop.memory import AgentMemoryContext, prepare_agent_memory
 from coding_review_agent_loop.runner import Runner, tail_text
+from coding_review_agent_loop.usage import RunUsageContext, UsageMetadata
 from coding_review_agent_loop.protocol import ReviewItemDisposition, UnresolvedReviewItem
 from coding_review_agent_loop.round_state import (
     PostedRoundMetadata,
@@ -446,6 +447,43 @@ def _mint_new_items(
     return items
 
 
+def _aggregate_reviewer_usage(records: list[dict]) -> dict | None:
+    """Aggregate external-agent usage across reviewer records (#308).
+
+    Each record's ``usage`` is the sidecar dict written by run_external
+    (``{agent, session_id, returncode, usage: <UsageMetadata dict>}``). Returns a
+    labeled, external-agents-only summary, or None if no record carried usage.
+    ``success_count`` is intentionally dropped: it is a validation metric not
+    tracked per usage record here, and would otherwise read 0.
+    """
+    ctx = RunUsageContext(run_id="skill", summary_path=Path(tempfile.gettempdir()) / "skill-usage.json")
+    found = False
+    for rec in records:
+        sidecar = rec.get("usage") if isinstance(rec, dict) else None
+        if not isinstance(sidecar, dict) or not isinstance(sidecar.get("usage"), dict):
+            continue
+        found = True
+        ctx.add_record(
+            agent=sidecar.get("agent", "codex"),
+            session_id=sidecar.get("session_id"),
+            returncode=int(sidecar.get("returncode", 0) or 0),
+            usage=UsageMetadata(**sidecar["usage"]),
+        )
+    if not found:
+        return None
+
+    def _strip(d: dict) -> dict:
+        d.pop("success_count", None)
+        return d
+
+    return {
+        "scope": "external-agents-only",
+        "note": "Host (Claude) coder/plan turns run in the interactive session and are not counted.",
+        "totals": _strip(ctx.totals().to_dict()),
+        "per_agent": {agent: _strip(t.to_dict()) for agent, t in ctx.per_agent_totals().items()},
+    }
+
+
 def _publish_pr_followups(
     repo: str,
     pr: int,
@@ -781,6 +819,17 @@ def _complete_reviewer_turn(
     )
     _write_json(new_items_file, new_items_serialized)
 
+    # External-agent usage sidecar written by run_external (#308); persist it in
+    # AGENT_LOOP_META so resumed rounds can aggregate the complete cost.
+    usage_file = work_dir / f"{agent}-usage.json"
+    reviewer_usage: dict | None = None
+    if usage_file.exists():
+        try:
+            reviewer_usage = json.loads(usage_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            reviewer_usage = None
+    usage_args = ["--usage-file", str(usage_file)] if usage_file.exists() else []
+
     # --- Attach metadata ---
     _run_helper(
         "helpers.state_manager", "attach-metadata",
@@ -795,6 +844,7 @@ def _complete_reviewer_turn(
         "--dispositions-file", str(dispositions_file),
         "--new-items-file", str(new_items_file),
         "--subject", round_subject,
+        *usage_args,
     )
 
     # --- Post ---
@@ -820,6 +870,7 @@ def _complete_reviewer_turn(
         "state": parsed_state,
         "blocking_items": [{"text": t} for t in reported_blocking],
         "new_items": new_items_serialized,
+        "usage": reviewer_usage,
     }
 
 
@@ -859,6 +910,7 @@ def _run_reviewer(
     _write_json(prior_items_file, next_prior_items_raw)
 
     # --- Run agent ---
+    usage_file = tmpdir / f"{agent}-usage.json"
     _run_helper(
         "helpers.run_external",
         "--agent", agent,
@@ -867,6 +919,7 @@ def _run_reviewer(
         "--workdir", workdir,
         "--repo", repo,
         "--flow", flow,
+        "--usage-output", str(usage_file),
         *(["--dry-run"] if dry_run else []),
     )
 
@@ -1121,12 +1174,14 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
     # In a new round, completed_reviewer_data belongs to the previous round and must not
     # contaminate the current round's result.
     current_round_items: list[dict] = []
+    round_reviewer_records: list[dict] = []
     round_blocking_items: list[dict] = []
     round_approved_reviewers: list[str] = []
     any_reviewer_blocked = False
     if not is_new_round:
         for record in resume.get("completed_reviewer_data", []):
             current_round_items.extend(record.get("new_items", []))
+            round_reviewer_records.append(record)
             if record.get("state") == "blocking":
                 any_reviewer_blocked = True
                 round_blocking_items.extend(
@@ -1205,6 +1260,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
                 item_id_offset=item_id_offset,
             )
             current_round_items.extend(record["new_items"])
+            round_reviewer_records.append(record)
             if record["state"] == "blocking":
                 any_reviewer_blocked = True
                 round_blocking_items.extend(record["blocking_items"])
@@ -1231,6 +1287,9 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
         "blocking_items": round_blocking_items,
         "approved_reviewers": round_approved_reviewers,
     }
+    usage = _aggregate_reviewer_usage(round_reviewer_records)
+    if usage is not None:
+        result_json["usage"] = usage
     print(json.dumps(result_json, indent=2))
 
 
@@ -1278,12 +1337,14 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     # In a new round, completed_reviewer_data belongs to the previous round and must not
     # contaminate the current round's result.
     current_round_items: list[dict] = []
+    round_reviewer_records: list[dict] = []
     round_blocking_items: list[dict] = []
     round_approved_reviewers: list[str] = []
     any_reviewer_blocked = False
     if not is_new_round:
         for record in resume.get("completed_reviewer_data", []):
             current_round_items.extend(record.get("new_items", []))
+            round_reviewer_records.append(record)
             if record.get("state") == "blocking":
                 any_reviewer_blocked = True
                 round_blocking_items.extend(
@@ -1362,6 +1423,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                 item_id_offset=item_id_offset,
             )
             current_round_items.extend(record["new_items"])
+            round_reviewer_records.append(record)
             if record["state"] == "blocking":
                 any_reviewer_blocked = True
                 round_blocking_items.extend(record["blocking_items"])
@@ -1413,6 +1475,9 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
             repo, pr, head_sha, followups_mode, round_future_items, pr_comments,
             dry_run=dry_run,
         )
+    usage = _aggregate_reviewer_usage(round_reviewer_records)
+    if usage is not None:
+        result_json["usage"] = usage
     print(json.dumps(result_json, indent=2))
 
 

--- a/helpers/state_manager.py
+++ b/helpers/state_manager.py
@@ -201,6 +201,7 @@ def cmd_build_resume(args: argparse.Namespace) -> None:
                             _serialize_unresolved_item(item)
                             for item in record.metadata.new_items
                         ],
+                        "usage": record.metadata.usage,
                     }
                     for record in resumed.completed_reviews
                 ]
@@ -239,6 +240,7 @@ def cmd_build_resume(args: argparse.Namespace) -> None:
                             _serialize_unresolved_item(item)
                             for item in record.metadata.new_items
                         ],
+                        "usage": record.metadata.usage,
                     }
                     for record in result.completed_reviews
                 ]
@@ -301,6 +303,14 @@ def cmd_attach_metadata(args: argparse.Namespace) -> None:
             print(f"state_manager: cannot read canonical plan file: {exc}", file=sys.stderr)
             sys.exit(1)
 
+    usage: dict | None = None
+    if getattr(args, "usage_file", None):
+        try:
+            loaded = json.loads(Path(args.usage_file).read_text(encoding="utf-8"))
+            usage = loaded if isinstance(loaded, dict) else None
+        except (OSError, json.JSONDecodeError):
+            usage = None  # advisory; never block posting on usage
+
     metadata = PostedRoundMetadata(
         flow=args.flow,
         role=args.role,
@@ -312,6 +322,7 @@ def cmd_attach_metadata(args: argparse.Namespace) -> None:
         new_items=new_items,
         state=args.state,
         canonical_plan=canonical_plan,
+        usage=usage,
     )
     augmented = _attach_round_metadata(body, metadata)
 
@@ -382,6 +393,8 @@ def main() -> None:
                         help="JSON array of serialized ReviewItemDisposition.")
     p_meta.add_argument("--new-items-file", default=None,
                         help="JSON array of serialized UnresolvedReviewItem (new items from this turn).")
+    p_meta.add_argument("--usage-file", default=None,
+                        help="JSON file with external-agent usage to persist in AGENT_LOOP_META (#308).")
     p_meta.add_argument("--canonical-plan-file", default=None,
                         help="Plan text file (written as canonical_plan for coder turns).")
 

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -37,6 +37,7 @@ class PostedRoundMetadata:
     canonical_plan: str | None = None
     raw_structured_coder_response: str | None = None
     compact_prior_summaries: tuple[str, ...] = ()
+    usage: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -126,6 +127,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "canonical_plan": metadata.canonical_plan,
         "raw_structured_coder_response": metadata.raw_structured_coder_response,
         "compact_prior_summaries": list(metadata.compact_prior_summaries),
+        "usage": metadata.usage,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -162,6 +164,7 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             compact_prior_summaries=tuple(
                 str(summary) for summary in payload.get("compact_prior_summaries", [])
             ),
+            usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else None,
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1373,3 +1373,112 @@ class TestAgentMemory:
         cfg = captured["config"]
         assert cfg.agent_memory is True and cfg.refresh_agent_memory is True
         assert str(active_workdir(cfg)) == "/tmp/skill-runner-codex"
+
+
+# ---------------------------------------------------------------------------
+# external-agent usage/cost tracking (#308)
+# ---------------------------------------------------------------------------
+
+class TestUsageTracking:
+    def _rec(self, agent, mode, inp, out, returncode=0):
+        return {
+            "reviewer_name": agent.capitalize(),
+            "usage": {
+                "agent": agent, "session_id": f"s-{agent}", "returncode": returncode,
+                "usage": {"mode": mode, "input_tokens": inp, "output_tokens": out,
+                          "total_tokens": inp + out},
+            },
+        }
+
+    def test_aggregate_sums_and_preserves_modes(self) -> None:
+        from helpers.skill_runner import _aggregate_reviewer_usage
+        out = _aggregate_reviewer_usage([
+            self._rec("codex", "exact", 100, 50),
+            self._rec("gemini", "estimated", 80, 20),
+            {"reviewer_name": "NoUsage"},  # carries no usage → ignored
+        ])
+        assert out["scope"] == "external-agents-only"
+        assert "note" in out
+        totals = out["totals"]
+        assert totals["call_count"] == 2
+        assert totals["input_tokens"] == 180 and totals["output_tokens"] == 70
+        assert totals["total_tokens"] == 250
+        # modes preserved across reviewers
+        assert totals["exact_calls"] == 1 and totals["estimated_calls"] == 1
+        # success_count omitted (would be a misleading 0)
+        assert "success_count" not in totals
+        assert set(out["per_agent"]) == {"codex", "gemini"}
+        assert "success_count" not in out["per_agent"]["codex"]
+
+    def test_aggregate_none_when_no_usage(self) -> None:
+        from helpers.skill_runner import _aggregate_reviewer_usage
+        assert _aggregate_reviewer_usage([{"reviewer_name": "x"}, {"reviewer_name": "y"}]) is None
+        assert _aggregate_reviewer_usage([]) is None
+
+    def test_metadata_round_trips_usage(self) -> None:
+        # PostedRoundMetadata.usage survives encode -> decode (so build-resume
+        # can recover it for resumed-round aggregation).
+        from coding_review_agent_loop.round_state import (
+            PostedRoundMetadata, _encode_round_metadata, _decode_round_metadata,
+        )
+        usage = {"agent": "codex", "returncode": 0, "usage": {"mode": "exact", "total_tokens": 5}}
+        meta = PostedRoundMetadata(flow="pr", role="reviewer", agent="Codex",
+                                   round_number=1, subject="abc", usage=usage)
+        decoded = _decode_round_metadata(_encode_round_metadata(meta))
+        assert decoded.usage == usage
+
+    def test_metadata_usage_defaults_none(self) -> None:
+        from coding_review_agent_loop.round_state import (
+            PostedRoundMetadata, _encode_round_metadata, _decode_round_metadata,
+        )
+        meta = PostedRoundMetadata(flow="plan", role="coder", agent="Claude",
+                                   round_number=1, subject="x")
+        assert _decode_round_metadata(_encode_round_metadata(meta)).usage is None
+
+    def _run_external_usage(self, monkeypatch, tmp_path, agent, result):
+        import helpers.run_external as rex
+        class FakeBackend:
+            def run(self, runner, config, prompt):
+                return result
+        monkeypatch.setattr("coding_review_agent_loop.agents.codex.CodexBackend", FakeBackend)
+        monkeypatch.setattr("coding_review_agent_loop.agents.gemini.GeminiBackend", FakeBackend)
+        usage_path = tmp_path / "u.json"
+        monkeypatch.setattr(sys, "argv", [
+            "run_external", "--agent", agent,
+            "--prompt-file", _write_tmp("Prompt text here."),
+            "--output", _write_tmp("", suffix=".out.md"),
+            "--workdir", "/tmp", "--usage-output", str(usage_path),
+        ])
+        rex.main()
+        return usage_path
+
+    def test_run_external_writes_exact_usage(self, monkeypatch, tmp_path) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+        from coding_review_agent_loop.usage import UsageMetadata
+        result = AgentResult(
+            text="review body", returncode=0, session_id="sess1",
+            usage=UsageMetadata(mode="exact", input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+        usage_path = self._run_external_usage(monkeypatch, tmp_path, "codex", result)
+        data = json.loads(usage_path.read_text(encoding="utf-8"))
+        assert data["agent"] == "codex" and data["session_id"] == "sess1"
+        assert data["usage"]["mode"] == "exact" and data["usage"]["total_tokens"] == 15
+
+    def test_run_external_estimates_usage_when_backend_omits(self, monkeypatch, tmp_path) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+        result = AgentResult(text="some response text", returncode=0, usage=None)
+        usage_path = self._run_external_usage(monkeypatch, tmp_path, "gemini", result)
+        data = json.loads(usage_path.read_text(encoding="utf-8"))
+        assert data["usage"]["mode"] == "estimated"
+
+    def test_run_external_dry_run_writes_no_usage(self, monkeypatch, tmp_path) -> None:
+        import helpers.run_external as rex
+        usage_path = tmp_path / "u.json"
+        monkeypatch.setattr(sys, "argv", [
+            "run_external", "--agent", "codex",
+            "--prompt-file", _write_tmp("Review this."),
+            "--output", _write_tmp("", suffix=".out.md"),
+            "--workdir", "/tmp", "--usage-output", str(usage_path), "--dry-run",
+        ])
+        rex.main()
+        assert not usage_path.exists()


### PR DESCRIPTION
## What & why

Closes #308 — part of #294. The skill discarded Codex/Gemini token usage; the CLI
tracks it. This captures it per round and surfaces it in the round result.

**Inherently partial, and labeled as such:** the host's Claude coder/plan turns
run in the interactive session and have no programmatic token count, so the
numbers cover the **external reviewers only** — never a session total. The `usage`
field carries an explicit `scope: external-agents-only` + `note`.

## Changes

- **`run_external`**: `--usage-output PATH` writes a usage sidecar after a live
  run (`result.usage`, or `estimate_usage(prompt, text)` when the backend omits
  it); dry-run writes nothing; never raises.
- **Resume-safe persistence**: `PostedRoundMetadata` gains an optional `usage`
  field (backward-compatible; the CLI doesn't set it), threaded through
  `state_manager attach-metadata --usage-file` and surfaced by `build-resume` on
  each completed-reviewer record — so resumed rounds aggregate the full cost, not
  just the current invocation.
- **`skill_runner`**: `_run_reviewer` passes `--usage-output` and attaches the
  sidecar to the reviewer record; `_aggregate_reviewer_usage` reuses
  `RunUsageContext` to emit a labeled `usage` dict, dropping `success_count` (a
  validation metric that would otherwise read a misleading 0). Both round commands
  aggregate live + resumed records into `result_json["usage"]`.
- `SKILL.md` documents the field.

```json
"usage": { "scope": "external-agents-only", "note": "...host turns not counted...",
           "totals": { "call_count": 2, "total_tokens": 250, ... },
           "per_agent": { "codex": {...}, "gemini": {...} } }
```

## Tests

Aggregation (multi-reviewer summing; exact-vs-estimated mode preservation;
`success_count` omitted; None when empty), `PostedRoundMetadata.usage` encode→
decode round-trip + default-None, and `run_external` sidecar (exact /
estimated-fallback / dry-run-writes-nothing). Full suite: **798 passed**.

## Review provenance

Design reviewed via the skill's own plan-review loop on #308 — approved by Gemini
and Codex after 3 rounds (persist-in-metadata for resume completeness; drop the
misleading `success_count`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
