### PR TITLE
Reversed roles part 1: coder-prompt wrappers + raw-response metadata (#307)

### DIFF
--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -18,7 +18,12 @@ from coding_review_agent_loop.agents.base import AgentName
 from coding_review_agent_loop.config import AgentLoopConfig
 from coding_review_agent_loop.github import IssueContext, IssueComment
 from coding_review_agent_loop.memory import AgentMemoryContext
-from coding_review_agent_loop.prompts import build_plan_review_prompt, build_review_prompt
+from coding_review_agent_loop.prompts import (
+    build_issue_plan_prompt,
+    build_plan_review_prompt,
+    build_plan_revision_prompt,
+    build_review_prompt,
+)
 from coding_review_agent_loop.round_state import _deserialize_unresolved_item
 
 
@@ -205,3 +210,59 @@ def build_review_prompt_for_skill(
     if pr_diff:
         prompt += f"\n\n## PR diff\n\n```diff\n{pr_diff}\n```\n"
     return prompt
+
+
+def build_plan_prompt_for_skill(
+    issue_dict: dict,
+    *,
+    repo: str,
+    coder: AgentName,
+    reviewers: Sequence[AgentName],
+    workdir: str,
+    memory: AgentMemoryContext | None = None,
+) -> str:
+    """Build the round-1 coder (plan) prompt for an external coder (#307).
+
+    Sets the coder's checkout dir to ``workdir`` so the embedded checkout guidance
+    points at the real run directory.
+    """
+    config = make_minimal_config(
+        repo, coder, tuple(reviewers), reviewer=coder, workdir=workdir,
+    )
+    issue_context = _make_issue_context(issue_dict)
+    return build_issue_plan_prompt(issue_context.number, config, memory, issue_context)
+
+
+def build_plan_revision_prompt_for_skill(
+    issue_dict: dict,
+    *,
+    repo: str,
+    coder: AgentName,
+    reviewers: Sequence[AgentName],
+    workdir: str,
+    round_number: int,
+    previous_plan: str,
+    reviewer_feedback: str,
+    prior_items_raw: list[dict],
+    memory: AgentMemoryContext | None = None,
+) -> str:
+    """Build the round-N+1 coder (plan revision) prompt for an external coder (#307).
+
+    ``reviewer_feedback`` is the aggregated prose feedback (each reviewer's summary
+    + item texts) the caller assembles from the resume's completed reviewers.
+    """
+    config = make_minimal_config(
+        repo, coder, tuple(reviewers), reviewer=coder, workdir=workdir,
+    )
+    issue_context = _make_issue_context(issue_dict)
+    unresolved = [_deserialize_unresolved_item(item) for item in prior_items_raw]
+    return build_plan_revision_prompt(
+        issue_context.number,
+        round_number,
+        previous_plan,
+        reviewer_feedback,
+        config,
+        memory,
+        issue_context,
+        unresolved_items=unresolved,
+    )

--- a/helpers/state_manager.py
+++ b/helpers/state_manager.py
@@ -311,6 +311,16 @@ def cmd_attach_metadata(args: argparse.Namespace) -> None:
         except (OSError, json.JSONDecodeError):
             usage = None  # advisory; never block posting on usage
 
+    raw_structured_coder_response: str | None = None
+    if getattr(args, "raw_structured_coder_response_file", None):
+        try:
+            raw_structured_coder_response = Path(
+                args.raw_structured_coder_response_file
+            ).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"state_manager: cannot read raw coder response file: {exc}", file=sys.stderr)
+            sys.exit(1)
+
     metadata = PostedRoundMetadata(
         flow=args.flow,
         role=args.role,
@@ -323,6 +333,7 @@ def cmd_attach_metadata(args: argparse.Namespace) -> None:
         state=args.state,
         canonical_plan=canonical_plan,
         usage=usage,
+        raw_structured_coder_response=raw_structured_coder_response,
     )
     augmented = _attach_round_metadata(body, metadata)
 
@@ -395,6 +406,9 @@ def main() -> None:
                         help="JSON array of serialized UnresolvedReviewItem (new items from this turn).")
     p_meta.add_argument("--usage-file", default=None,
                         help="JSON file with external-agent usage to persist in AGENT_LOOP_META (#308).")
+    p_meta.add_argument("--raw-structured-coder-response-file", default=None,
+                        help="Raw structured coder response (plan_revision JSON) to persist in "
+                             "AGENT_LOOP_META for reversed-roles revision rounds (#307).")
     p_meta.add_argument("--canonical-plan-file", default=None,
                         help="Plan text file (written as canonical_plan for coder turns).")
 

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1482,3 +1482,51 @@ class TestUsageTracking:
         ])
         rex.main()
         assert not usage_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# reversed-roles helpers, behavior-neutral pieces (#307, sub-PR 1)
+# ---------------------------------------------------------------------------
+
+class TestReverseRolesHelpers:
+    _ISSUE = {"number": 5, "repo": "o/r", "title": "t", "body": "b", "url": "u"}
+
+    def test_build_plan_prompt_for_skill_embeds_coder_workdir(self) -> None:
+        from helpers.prompt_builders import build_plan_prompt_for_skill
+        p = build_plan_prompt_for_skill(
+            self._ISSUE, repo="o/r", coder="codex",
+            reviewers=["codex", "claude"], workdir="/tmp/skill-runner-codex",
+        )
+        assert "/tmp/skill-runner-codex" in p
+        assert "5" in p  # issue number referenced
+
+    def test_build_plan_revision_prompt_for_skill_includes_feedback(self) -> None:
+        from helpers.prompt_builders import build_plan_revision_prompt_for_skill
+        p = build_plan_revision_prompt_for_skill(
+            self._ISSUE, repo="o/r", coder="codex",
+            reviewers=["codex", "claude"], workdir="/tmp/skill-runner-codex",
+            round_number=2, previous_plan="OLD PLAN TEXT",
+            reviewer_feedback="REVIEWER FEEDBACK XYZ", prior_items_raw=[],
+        )
+        assert "REVIEWER FEEDBACK XYZ" in p
+        assert "OLD PLAN TEXT" in p
+
+    def test_attach_metadata_persists_raw_structured_coder_response(self) -> None:
+        import re as _re
+        from coding_review_agent_loop.round_state import _decode_round_metadata
+        body = _write_tmp("## Revised plan\nrendered markdown body")
+        raw = _write_tmp('{"kind": "plan_revision", "x": 1}', suffix=".json")
+        out = _write_tmp("", suffix=".md")
+        _run(
+            "helpers.state_manager", "attach-metadata",
+            "--body-file", body, "--output", out,
+            "--flow", "plan", "--role", "coder", "--agent", "Codex",
+            "--round-number", "2", "--state", "approved", "--subject", "abc123",
+            "--raw-structured-coder-response-file", raw,
+        )
+        text = Path(out).read_text(encoding="utf-8")
+        m = _re.search(r"AGENT_LOOP_META:\s*([A-Za-z0-9+/=_-]+)", text)
+        assert m is not None
+        meta = _decode_round_metadata(m.group(1))
+        assert meta.agent == "Codex"
+        assert meta.raw_structured_coder_response.strip() == '{"kind": "plan_revision", "x": 1}'


### PR DESCRIPTION
## What & why

**Part 1 of #307** (reversed roles — Codex as coder, Claude as reviewer), split
out as the safe, **behavior-neutral** groundwork. The full plan was approved on
#307 over six review rounds; per that plan, the external-coder turn and
host-as-reviewer paths land as follow-up PRs. This PR changes no existing flow.

## Changes

- **`prompt_builders`**: `build_plan_prompt_for_skill` (round-1 coder/plan prompt)
  and `build_plan_revision_prompt_for_skill` (round-N+1 revision prompt — the
  caller passes aggregated reviewer feedback as the `review` string). Both set the
  coder's checkout dir to the given `workdir` so the embedded checkout guidance
  points at the real run directory.
- **`state_manager`**: `attach-metadata --raw-structured-coder-response-file`
  persists structured plan_revision JSON into
  `PostedRoundMetadata.raw_structured_coder_response` (the field already
  round-trips through `AGENT_LOOP_META`), so revision rounds can keep the raw
  response while the posted comment stays rendered markdown.

## Tests

Both prompt wrappers (coder workdir embedded; revision feedback + previous plan
included) and the `attach-metadata` raw-response round-trip. Full suite:
**801 passed**.

## Follow-ups (against the #307 plan)

- The external-coder turn in `skill_runner` (round-1 `plan_state` / round-N+1
  `plan_revision`, the `_external_coder_phase` state machine, clarification +
  coder-repair).
- Host-as-reviewer (`pending_reviewers` + `complete-host-review`), the
  `retry-validate` coder branch, and the `agent_display_name` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
