### PR TITLE
Host-as-reviewer for the PR flow (#314)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -277,34 +277,38 @@ dir (manifest `role: coder`); fix `raw.md` and recover with
 `retry-validate --repair-dir <dir>` (no re-run of the agent), then re-run
 `run-plan-round`.
 
-### Host-as-reviewer (Claude reviews the plan)
+### Host-as-reviewer (Claude reviews the plan or PR)
 
-Put `claude` in `--reviewers` to have **you (the host) review** the posted plan —
-the natural reversed-roles pairing (external coder, Claude reviewer):
+Put `claude` in `--reviewers` to have **you (the host) review** — for both
+`run-plan-round` (review the posted plan) and `run-pr-round` (review the PR diff):
 
 ```bash
 python -m helpers.skill_runner run-plan-round \
-  --issue N --repo OWNER/REPO \
-  --coder codex \
-  --reviewers claude gemini
+  --issue N --repo OWNER/REPO --coder codex --reviewers claude gemini
+
+python -m helpers.skill_runner run-pr-round \
+  --pr N --repo OWNER/REPO --reviewers claude codex
 ```
 
 External reviewers always run first. The host can only review *after* reading the
-posted plan, so a configured `claude` reviewer becomes a **pending handoff**: the
-round returns `{"state": "pending", "pending_reviewers": ["Claude"], ...}` (never
-`approved`/`blocking` while it's outstanding) and prints a review-request dir.
-Read `{dir}/plan.md`, write your `plan_review` JSON to `{dir}/host-review.md`, then:
+posted plan/PR, so a configured `claude` reviewer becomes a **pending handoff**:
+the round returns `{"state": "pending", "pending_reviewers": ["Claude"], ...}`
+(never `approved`/`blocking` while it's outstanding) and prints a review-request
+dir. Read the material there (`{dir}/plan.md` for a plan, `{dir}/pr-diff.diff` for
+a PR), write your `plan_review`/`pr_review` JSON to `{dir}/host-review.md`, then:
 
 ```bash
 python -m helpers.skill_runner complete-host-review --dir <dir>
 ```
 
 That validates, renders, attaches `--agent Claude --role reviewer`, and posts your
-review. Re-run `run-plan-round` to recompute the round (it advances to `approved`,
-or revises via the coder when there are blocking/same-plan findings).
+review. Re-run the same round command to recompute the round (it advances to
+`approved`, or — for a plan — revises via the coder when there are blocking /
+same-plan findings).
 
-**Plan flow only.** PR-flow reverse and reverse implementation are deferred to
-later increments; `run-task-round` stays host-coder only.
+**Reviewer side only.** An external coder *implementing* a PR (PR-flow reverse
+coder / reverse implementation) is still deferred; `run-task-round` stays
+host-coder only.
 
 ---
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -1456,16 +1456,20 @@ def _run_external_coder_phase(
 
 
 # ---------------------------------------------------------------------------
-# Host-as-reviewer handoff (reversed roles: Claude reviews the posted plan) (#307)
+# Host-as-reviewer handoff (reversed roles: Claude reviews the posted plan/PR)
+# (plan flow #307; PR flow #314)
 # ---------------------------------------------------------------------------
 
 def _write_host_review_request(
     *,
+    flow: str,
+    validate_kind: str,
     issue: int,
     repo: str,
     new_round_number: int,
     round_subject: str,
-    plan_text: str,
+    review_material: str,
+    material_filename: str,
     next_prior_items_raw: list[dict],
     current_round_items: list[dict],
     item_id_offset: int,
@@ -1473,13 +1477,15 @@ def _write_host_review_request(
 ) -> Path:
     """Write a review-request dir for the host (Claude) reviewer turn.
 
-    Contains the plan to review (``plan.md``), the review context, prior items, and
-    a manifest mirroring the reviewer repair manifest so ``complete-host-review``
-    can drive ``_complete_reviewer_turn`` once the host writes ``host-review.md``.
+    Flow-agnostic: ``review_material`` (the plan text or the PR diff) is written to
+    ``{dir}/{material_filename}`` for the host to read, alongside the review
+    context, prior items, and a manifest mirroring the reviewer repair manifest so
+    ``complete-host-review`` can drive ``_complete_reviewer_turn`` once the host
+    writes ``host-review.md``.
     """
     request_dir = _REPAIR_BASE / f"{issue}-r{new_round_number}-claude"
     request_dir.mkdir(parents=True, exist_ok=True)
-    _write_text(request_dir / "plan.md", plan_text)
+    _write_text(request_dir / material_filename, review_material)
     _write_json(request_dir / "prior_items.json", next_prior_items_raw)
     _write_json(request_dir / "context.json", {
         "reviewer": "Claude",
@@ -1488,10 +1494,11 @@ def _write_host_review_request(
     })
     manifest = {
         "role": "reviewer",
-        "agent": "claude", "agent_cap": "Claude", "flow": "plan",
+        "agent": "claude", "agent_cap": "Claude", "flow": flow,
         "issue": issue, "repo": repo,
         "new_round_number": new_round_number, "round_subject": round_subject,
-        "item_id_offset": item_id_offset, "validate_kind": "plan_review",
+        "item_id_offset": item_id_offset, "validate_kind": validate_kind,
+        "material_filename": material_filename,
         "dry_run": dry_run,
     }
     (request_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
@@ -1745,8 +1752,10 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
     if "claude" in reviewers and "Claude" not in local_completed:
         item_id_offset = _max_item_number([next_prior_items_raw, current_round_items])
         request_dir = _write_host_review_request(
+            flow="plan", validate_kind="plan_review",
             issue=issue, repo=repo, new_round_number=new_round_number,
-            round_subject=plan_subject, plan_text=plan_text,
+            round_subject=plan_subject, review_material=plan_text,
+            material_filename="plan.md",
             next_prior_items_raw=next_prior_items_raw,
             current_round_items=current_round_items,
             item_id_offset=item_id_offset, dry_run=dry_run,
@@ -1871,10 +1880,15 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
             refresh=getattr(args, "refresh_agent_memory", False), dry_run=dry_run,
         )
 
-    # Step 6 — run pending reviewers
+    # Step 6 — run pending reviewers.
+    # External reviewers (Codex/Gemini) always run first, regardless of --reviewers
+    # order; a configured host reviewer ("claude") reviews the PR itself and becomes
+    # a pending handoff after the loop (#314).
+    pending_reviewers: list[str] = []
+    external_reviewers = [r for r in reviewers if r != "claude"]
     with tempfile.TemporaryDirectory() as tmpstr:
         tmpdir = Path(tmpstr)
-        for reviewer in reviewers:
+        for reviewer in external_reviewers:
             reviewer_cap = reviewer.capitalize() if reviewer in ("codex", "gemini") else reviewer
             if reviewer_cap in local_completed or reviewer in local_completed:
                 print(f"[skip] {reviewer_cap} already completed this round")
@@ -1935,6 +1949,30 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
             else:
                 round_approved_reviewers.append(record["reviewer_name"])
 
+    # Step 6b — host-as-reviewer handoff. The host (Claude) reviews the PR itself,
+    # so write a review-request dir (the PR diff for the host to read) and mark it
+    # pending; the host writes its pr_review JSON there and completes it via
+    # `complete-host-review` (#314).
+    if "claude" in reviewers and "Claude" not in local_completed:
+        item_id_offset = _max_item_number([next_prior_items_raw, current_round_items])
+        request_dir = _write_host_review_request(
+            flow="pr", validate_kind="pr_review",
+            issue=pr, repo=repo, new_round_number=new_round_number,
+            round_subject=head_sha or "", review_material=pr_diff,
+            material_filename="pr-diff.diff",
+            next_prior_items_raw=next_prior_items_raw,
+            current_round_items=current_round_items,
+            item_id_offset=item_id_offset, dry_run=dry_run,
+        )
+        pending_reviewers.append("Claude")
+        dry_run_flag = " --dry-run" if dry_run else ""
+        print(
+            f"skill_runner: host review pending — read the PR diff in {request_dir}/pr-diff.diff, "
+            f"write your pr_review JSON to {request_dir}/host-review.md, then run: "
+            f"python -m helpers.skill_runner complete-host-review --dir {request_dir}{dry_run_flag}",
+            file=sys.stderr,
+        )
+
     # Step 7 — write session
     if not dry_run:
         _run_helper(
@@ -1946,17 +1984,26 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
             }),
         )
 
-    # Step 8 — print result
-    overall_state = "blocking" if any_reviewer_blocked else "approved"
+    # Step 8 — print result.
+    # A configured-but-incomplete host reviewer makes the round "pending": never
+    # report approved/blocking (or publish followups / run the test gate, which
+    # belong to a settled round) while a reviewer is still outstanding (#314).
+    if pending_reviewers:
+        overall_state = "pending"
+    else:
+        overall_state = "blocking" if any_reviewer_blocked else "approved"
     result_json = {
         "state": overall_state,
         "round_number": new_round_number,
         "blocking_items": round_blocking_items,
         "approved_reviewers": round_approved_reviewers,
     }
+    if pending_reviewers:
+        result_json["pending_reviewers"] = pending_reviewers
     # Optional test gate: reports pass/fail; never blocks or merges. An explicit
     # empty --test-command "" is reported as a setup error, not silently skipped.
-    gate = _maybe_test_gate(
+    # Skipped while the round is pending a host review.
+    gate = None if pending_reviewers else _maybe_test_gate(
         getattr(args, "test_command", None),
         getattr(args, "test_workdir", "."),
         dry_run=dry_run,
@@ -2070,17 +2117,20 @@ def cmd_retry_validate(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
-# complete-host-review  (reversed roles: host (Claude) reviewer turn) (#307)
+# complete-host-review  (reversed roles: host (Claude) reviewer turn)
+# (plan flow #307; PR flow #314)
 # ---------------------------------------------------------------------------
 
 def cmd_complete_host_review(args: argparse.Namespace) -> None:
     """Complete a host (Claude) reviewer turn from a review-request dir.
 
-    The host reads ``{dir}/plan.md``, writes its ``plan_review`` JSON to
-    ``{dir}/host-review.md``, then runs this command. Reuses
-    ``_complete_reviewer_turn`` (agent=claude → display ``Claude``) to validate,
-    render, attach metadata, and post — so ``build-resume`` recognizes the review
-    and re-running ``run-plan-round`` recomputes the round's final state.
+    The host reads the posted plan/PR (``{dir}/<material>``), writes its
+    ``plan_review``/``pr_review`` JSON to ``{dir}/host-review.md``, then runs this
+    command. Reuses ``_complete_reviewer_turn`` (agent=claude → display ``Claude``)
+    to validate, render, attach metadata, and post — so ``build-resume`` recognizes
+    the review and re-running the round command recomputes the final state. Works
+    for both flows; the manifest's ``flow``/``validate_kind`` drive the behavior and
+    the user-facing wording.
     """
     request_dir = Path(args.dir)
     if not request_dir.exists():
@@ -2094,10 +2144,14 @@ def cmd_complete_host_review(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    flow             = manifest["flow"]
+    validate_kind    = manifest["validate_kind"]
+    round_command    = f"run-{flow}-round"
+
     review_file = request_dir / "host-review.md"
     if not review_file.exists():
         print(
-            f"skill_runner: write your plan_review JSON to {review_file} first, then re-run.",
+            f"skill_runner: write your {validate_kind} JSON to {review_file} first, then re-run.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -2111,7 +2165,7 @@ def cmd_complete_host_review(args: argparse.Namespace) -> None:
     try:
         result = _complete_reviewer_turn(
             agent="claude", agent_cap=agent_display_name("claude"),
-            flow=manifest["flow"], validate_kind=manifest["validate_kind"],
+            flow=flow, validate_kind=validate_kind,
             issue=issue, repo=repo,
             new_round_number=new_round_number, round_subject=manifest["round_subject"],
             next_prior_items_raw=prior_items_raw,
@@ -2139,7 +2193,7 @@ def cmd_complete_host_review(args: argparse.Namespace) -> None:
 
     print(json.dumps(result, indent=2))
     print(
-        "hint: host review posted — re-run run-plan-round to recompute the round.",
+        f"hint: host review posted — re-run {round_command} to recompute the round.",
         file=sys.stderr,
     )
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -2287,12 +2287,14 @@ def main() -> None:
     # complete-host-review
     p_host = subparsers.add_parser(
         "complete-host-review",
-        help="Complete a host (Claude) reviewer turn from a review-request dir (#307).",
+        help="Complete a host (Claude) reviewer turn from a review-request dir "
+             "(plan flow #307; PR flow #314).",
     )
     p_host.add_argument(
         "--dir", required=True,
-        help="Path to the host-review request dir printed by run-plan-round. "
-             "Write your plan_review JSON to {dir}/host-review.md first.",
+        help="Path to the host-review request dir printed by the round command "
+             "(run-plan-round or run-pr-round). Write your review JSON "
+             "(plan_review or pr_review) to {dir}/host-review.md first.",
     )
     p_host.add_argument("--dry-run", action="store_true")
 

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1930,3 +1930,13 @@ class TestHostReviewerPR:
             )
             assert result.returncode != 0
             assert "pr_review" in result.stderr
+
+    def test_complete_host_review_help_is_flow_neutral(self) -> None:
+        """The --dir CLI help must not be plan-only (it serves both flows)."""
+        result = _run(
+            "helpers.skill_runner", "complete-host-review", "--help",
+            check=False,
+        )
+        assert result.returncode == 0
+        assert "run-pr-round" in result.stdout
+        assert "pr_review" in result.stdout

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1809,3 +1809,124 @@ class TestHostReviewer:
             )
             assert result.returncode != 0
             assert "host-review.md" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — host-as-reviewer for the PR flow (#314)
+# ---------------------------------------------------------------------------
+
+_VALID_PR_REVIEW_DRY = json.dumps(
+    {
+        "schema_version": 1,
+        "kind": "pr_review",
+        "state": "approved",
+        "summary": "Host review: PR looks good.",
+        "prior_item_dispositions": [],
+    }
+) + "\n<!-- AGENT_STATE: approved -->\n-- Claude\n"
+
+
+class TestHostReviewerPR:
+    def _last_json(self, stdout: str) -> dict:
+        start = stdout.rfind("\n{")
+        if start < 0:
+            start = stdout.find("{")
+        return json.loads(stdout[start:].strip())
+
+    def test_pr_round_with_claude_reviewer_is_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            result = _run(
+                "helpers.skill_runner", "run-pr-round",
+                "--pr", "9994",
+                "--repo", "test/skill-repo",
+                "--reviewers", "claude",
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            output = self._last_json(result.stdout)
+            assert output["state"] == "pending"
+            assert output["pending_reviewers"] == ["Claude"]
+
+            request_dir = _REPAIR_BASE / "9994-r1-claude"
+            assert (request_dir / "pr-diff.diff").exists()
+            manifest = json.loads((request_dir / "manifest.json").read_text(encoding="utf-8"))
+            assert manifest["agent"] == "claude" and manifest["role"] == "reviewer"
+            assert manifest["flow"] == "pr"
+            assert manifest["validate_kind"] == "pr_review"
+
+    def test_external_pr_reviewer_runs_before_host_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            result = _run(
+                "helpers.skill_runner", "run-pr-round",
+                "--pr", "9993",
+                "--repo", "test/skill-repo",
+                "--reviewers", "claude", "codex",
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            output = self._last_json(result.stdout)
+            assert output["state"] == "pending"
+            assert output["pending_reviewers"] == ["Claude"]
+            assert "Codex" in output["approved_reviewers"]
+
+    def _make_pr_host_review_dir(self, tmpdir: Path) -> Path:
+        request_dir = tmpdir / "9994-r1-claude"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        (request_dir / "pr-diff.diff").write_text("diff --git a/x b/x", encoding="utf-8")
+        (request_dir / "prior_items.json").write_text("[]", encoding="utf-8")
+        (request_dir / "context.json").write_text(
+            json.dumps({"reviewer": "Claude", "prior_items": [], "current_round_items": []}),
+            encoding="utf-8",
+        )
+        (request_dir / "host-review.md").write_text(_VALID_PR_REVIEW_DRY, encoding="utf-8")
+        manifest = {
+            "role": "reviewer", "agent": "claude", "agent_cap": "Claude", "flow": "pr",
+            "issue": 9994, "repo": "OWNER/REPO", "new_round_number": 1,
+            "round_subject": "abc123def", "item_id_offset": 0,
+            "validate_kind": "pr_review", "material_filename": "pr-diff.diff",
+            "dry_run": True,
+        }
+        (request_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        return request_dir
+
+    def test_complete_host_review_pr_dry_run_and_flow_aware_hint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            request_dir = self._make_pr_host_review_dir(tmppath)
+            result = _run(
+                "helpers.skill_runner", "complete-host-review",
+                "--dir", str(request_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+            assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+            output = json.loads(result.stdout[result.stdout.find("{"):].strip())
+            assert output["reviewer_name"] == "Claude"
+            # Flow-aware hint must point at run-pr-round, not run-plan-round.
+            assert "run-pr-round" in result.stderr
+            assert "run-plan-round" not in result.stderr
+
+    def test_complete_host_review_pr_missing_file_references_pr_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            request_dir = self._make_pr_host_review_dir(tmppath)
+            (request_dir / "host-review.md").unlink()
+            result = _run(
+                "helpers.skill_runner", "complete-host-review",
+                "--dir", str(request_dir),
+                "--dry-run",
+                check=False,
+            )
+            assert result.returncode != 0
+            assert "pr_review" in result.stderr


### PR DESCRIPTION
Closes #314. Extends host-as-reviewer to the **PR flow** in `run-pr-round`,
mirroring the plan-flow machinery from #313 (part 3 of #307). `claude` is now a
supported PR reviewer instead of a crash — which also resolves #314's "guard
`claude` in run-pr-round" item by supporting it outright. **Reviewer side only**;
an external coder *implementing* a PR remains deferred.

## Changes

- **`_write_host_review_request` is flow-agnostic** — takes `flow`,
  `validate_kind`, `review_material`, `material_filename`; writes the material the
  host reads (`plan.md` for a plan, `pr-diff.diff` for a PR) + context + manifest.
  The plan-flow caller passes the plan values; **behavior unchanged**.
- **`run-pr-round`** mirrors the plan flow: external reviewers run first
  (regardless of `--reviewers` order); a configured `claude` reviewer becomes a
  pending handoff (PR diff to review), and the round returns
  `{"state": "pending", "pending_reviewers": ["Claude"]}` — never a final state,
  and the test gate / approved-followups are skipped while pending.
- **`complete-host-review` messages are flow-aware** (round-1 review feedback):
  the missing-file error references the manifest's `validate_kind`, the success
  hint points at `run-{flow}-round`, and the `--dir` help is flow-neutral. The
  validate/render/attach/post core was already flow-agnostic.

## Tests

`tests/test_skill_helpers.py`: a PR round with a `claude` reviewer is `pending`
(with a `flow: pr` / `validate_kind: pr_review` manifest + `pr-diff.diff`); an
external reviewer (Codex) still runs first; `complete-host-review` on a `flow: pr`
dir posts as `Claude` and its hint references `run-pr-round` (not `run-plan-round`);
the missing-file error references `pr_review`. **Full suite: 818 passed.**

Plan approved on #314 (plan-r2, two rounds). PR-flow reverse coder / reverse
implementation remain deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude