### PR TITLE
Add run-implement: external coder implements an approved plan into a PR (#316)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -306,9 +306,31 @@ review. Re-run the same round command to recompute the round (it advances to
 `approved`, or — for a plan — revises via the coder when there are blocking /
 same-plan findings).
 
-**Reviewer side only.** An external coder *implementing* a PR (PR-flow reverse
-coder / reverse implementation) is still deferred; `run-task-round` stays
-host-coder only.
+### Reverse implementation (external coder opens the PR)
+
+`run-implement` has an **external coder** implement an approved plan and open a PR,
+which you then review with `run-pr-round` (`claude` reviewer optional):
+
+```bash
+python -m helpers.skill_runner run-implement \
+  --issue N --repo OWNER/REPO \
+  --coder codex \
+  --plan-file <approved-plan.md> \
+  --workdir <push-capable-clone> [--base main]
+# → prints {"pr": N, ...}; then:
+python -m helpers.skill_runner run-pr-round --pr N --repo OWNER/REPO --reviewers claude gemini
+```
+
+This is **side-effecting**: the coder commits, pushes a branch, and opens a real
+PR, so it needs a **push-capable** `--workdir`. The response is validated like the
+CLI's implement path — a real PR marker, the signed-human-requirements
+acknowledgement, in-workdir test reports, an advanced checkout HEAD, and that the
+PR is open and references the issue — before a `role: coder` PR comment is posted.
+It is **idempotent per plan** (the one-shot handoff marker): re-running returns the
+existing PR instead of opening a duplicate. A response that fails validation is
+non-retryable — fix the cause and re-run. `--dry-run` does no pushes/PRs.
+
+`run-task-round` stays host-coder only.
 
 ---
 

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -19,6 +19,7 @@ from coding_review_agent_loop.config import AgentLoopConfig
 from coding_review_agent_loop.github import IssueContext, IssueComment
 from coding_review_agent_loop.memory import AgentMemoryContext
 from coding_review_agent_loop.prompts import (
+    build_issue_implementation_prompt,
     build_issue_plan_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
@@ -34,13 +35,14 @@ def make_minimal_config(
     *,
     reviewer: AgentName | None = None,
     workdir: str | None = None,
+    base: str = "main",
     approved_followups: str = "ignore",
     agent_memory: bool = False,
     agent_memory_dir: Path | None = None,
     refresh_agent_memory: bool = False,
 ) -> AgentLoopConfig:
-    base = Path(tempfile.gettempdir()) / "coding-review-agent-loop"
-    legacy = base / "skill-runner"
+    tmp_base = Path(tempfile.gettempdir()) / "coding-review-agent-loop"
+    legacy = tmp_base / "skill-runner"
 
     def _agent_dir(agent: AgentName) -> Path:
         # The active reviewer's dir must match where the agent actually runs, so the
@@ -50,7 +52,7 @@ def make_minimal_config(
         # reviewers (notably Codex) block on a missing checkout (#297).
         if workdir and agent == reviewer:
             return Path(workdir)
-        return base / f"skill-runner-{agent}"
+        return tmp_base / f"skill-runner-{agent}"
 
     return AgentLoopConfig(
         repo=repo,
@@ -59,7 +61,7 @@ def make_minimal_config(
         gemini_dir=_agent_dir("gemini"),
         coder=coder,
         reviewer=tuple(reviewer_names),
-        base="main",
+        base=base,
         max_rounds=1,
         auto_merge=False,
         dry_run=False,
@@ -265,4 +267,30 @@ def build_plan_revision_prompt_for_skill(
         memory,
         issue_context,
         unresolved_items=unresolved,
+    )
+
+
+def build_implementation_prompt_for_skill(
+    issue_context: IssueContext,
+    approved_plan: str,
+    *,
+    repo: str,
+    coder: AgentName,
+    workdir: str,
+    base: str = "main",
+    memory: AgentMemoryContext | None = None,
+) -> str:
+    """Build the external-coder implementation prompt (reversed roles, #316).
+
+    Takes a full ``IssueContext`` (built by the caller via ``get_issue_context``)
+    rather than a bare dict, so issue comments + signed human requirements reach the
+    coder. Sets the coder's checkout dir to ``workdir`` and the config ``base`` so
+    the embedded checkout guidance and "open a PR against {base}" instruction match
+    the real run dir + requested base.
+    """
+    config = make_minimal_config(
+        repo, coder, (coder,), reviewer=coder, workdir=workdir, base=base,
+    )
+    return build_issue_implementation_prompt(
+        issue_context.number, approved_plan, config, memory, issue_context=issue_context,
     )

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -71,10 +71,20 @@ _CANNED_PLAN_STATE = """\
 -- Codex (dry-run stub)
 """
 
+# Coder implementation turn (reversed roles, #316). Reports a PR number and makes
+# no out-of-workdir test claims, so the workdir test guard passes trivially.
+_CANNED_IMPLEMENTATION = """\
+Implemented the approved plan (dry-run stub): created a branch, made the changes,
+and opened a pull request.
+
+<!-- AGENT_PR: 0 -->
+-- Codex (dry-run stub)
+"""
+
 
 def _build_dry_run_response(role: str, flow: str = "plan") -> str:
     if role == "coder":
-        return _CANNED_PLAN_STATE
+        return _CANNED_IMPLEMENTATION if flow == "pr" else _CANNED_PLAN_STATE
     if flow == "pr":
         return _CANNED_PR_REVIEW + _CANNED_PR_REVIEW_FOOTER
     return _CANNED_PLAN_REVIEW + _CANNED_PLAN_REVIEW_FOOTER
@@ -142,7 +152,7 @@ def main() -> None:
     if args.dry_run:
         flow = args.flow
         if args.role == "coder":
-            stub_kind = "plan_state"
+            stub_kind = "implementation" if flow == "pr" else "plan_state"
         elif flow == "pr":
             stub_kind = "pr_review"
         else:

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -36,6 +36,18 @@ Subcommands:
     round pending; write your plan_review JSON to {dir}/host-review.md, then run
     this subcommand to validate, render, attach (--agent Claude), and post it.
 
+  run-implement
+    --issue N --repo OWNER/REPO
+    --coder {codex,gemini}
+    --plan-file PATH
+    [--base BRANCH] [--workdir PATH] [--dry-run]
+
+    Reversed roles: an external coder implements an approved plan and opens a PR
+    (validated for the PR marker, human-requirements ack, in-workdir tests, an
+    advanced HEAD, and that the PR is open and references the issue), then posts a
+    role: coder PR comment so run-pr-round can review it. Idempotent per plan via
+    the one-shot handoff marker. Requires a push-capable workdir.
+
 Prints a JSON result to stdout and exits 0:
   {"state": "approved"|"blocking", "round_number": N,
    "blocking_items": [...], "approved_reviewers": [...]}
@@ -2199,6 +2211,253 @@ def cmd_complete_host_review(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
+# run-implement  (reversed roles: external coder implements an approved plan) (#316)
+# ---------------------------------------------------------------------------
+
+def _git_head(workdir: str) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", workdir, "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _validate_coder_implementation_response(
+    coder_output: str,
+    *,
+    workdir: str,
+    human_requirements,
+) -> int:
+    """Validate an external coder's implementation response; return the PR number.
+
+    Mirrors the guards in ``orchestrator._implement_approved_issue``: a valid
+    ``<!-- AGENT_PR: N -->`` marker, the signed-human-requirements acknowledgement
+    (when any were surfaced), and that the coder's reported test commands ran inside
+    the assigned workdir. Raises ``AgentLoopError`` on any failure (the caller treats
+    that as non-retryable). Factored out so the guards are directly unit-testable.
+    """
+    from coding_review_agent_loop.orchestrator import (
+        _require_pr_number,
+        _validate_response_with_human_requirements,
+    )
+    from coding_review_agent_loop.workdir_guard import validate_response_tests_within_workdir
+
+    pr_number = _validate_response_with_human_requirements(
+        coder_output,
+        marker_validator=_require_pr_number,
+        human_requirements=human_requirements,
+        requirement_scope="implementation requirements",
+        full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
+    validate_response_tests_within_workdir(coder_output, assigned_workdir=Path(workdir))
+    return int(pr_number)
+
+
+def cmd_run_implement(args: argparse.Namespace) -> None:
+    issue: int = args.issue
+    repo: str = args.repo
+    coder: str = args.coder
+    base: str = args.base
+    dry_run: bool = args.dry_run
+
+    plan_file = Path(args.plan_file)
+    if not plan_file.exists():
+        print(f"skill_runner: plan file not found: {plan_file}", file=sys.stderr)
+        sys.exit(1)
+    approved_plan = plan_file.read_text(encoding="utf-8")
+
+    explicit_workdir = getattr(args, f"workdir_{coder}", None) or getattr(args, "workdir", None)
+    if not dry_run and not explicit_workdir:
+        print(
+            "skill_runner: run-implement requires an explicit push-capable "
+            "--workdir (or --workdir-codex/--workdir-gemini); the external coder "
+            "commits, pushes a branch, and opens a PR there.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    workdir = _workdir_for_agent(coder, args)
+
+    from coding_review_agent_loop.config import sync_coder_base_before_implementation
+    from coding_review_agent_loop.decomposition import (
+        approved_plan_hash,
+        find_existing_one_shot_impl_handoff,
+        format_one_shot_impl_handoff_comment,
+    )
+    from coding_review_agent_loop.github import (
+        get_issue_context,
+        get_pr_review_context,
+        validate_open_pr,
+        validate_pr_references_issue,
+    )
+    from coding_review_agent_loop.workdir_guard import validate_assigned_head_advanced
+    from helpers.prompt_builders import (
+        build_implementation_prompt_for_skill,
+        make_minimal_config,
+    )
+
+    plan_hash = approved_plan_hash(approved_plan)
+    plan_subject = _plan_subject(approved_plan)
+    mode = "implement-one-shot"
+    coder_cap = agent_display_name(coder)  # type: ignore[arg-type]
+
+    config = dataclasses.replace(
+        make_minimal_config(repo, coder, (coder,), reviewer=coder, workdir=str(workdir), base=base),  # type: ignore[arg-type]
+        dry_run=dry_run,
+    )
+    runner = Runner(dry_run=dry_run)
+
+    # Idempotency — reuse the durable one-shot handoff marker (no duplicate PRs).
+    comments = [types.SimpleNamespace(body=b) for b in _fetch_issue_comments_raw(repo, issue)]
+    existing = find_existing_one_shot_impl_handoff(
+        comments, parent_issue=issue, plan_hash=plan_hash, mode=mode,
+    )
+    if existing is not None:
+        pr_open = True
+        try:
+            validate_open_pr(runner, config=config, pr_number=existing.pr_number)
+        except AgentLoopError:
+            pr_open = False
+        if pr_open:
+            print(json.dumps({
+                "pr": existing.pr_number,
+                "head_sha": existing.pr_head_sha,
+                "issue": issue,
+                "reused": True,
+            }, indent=2))
+            print(
+                f"hint: PR #{existing.pr_number} already implements this plan — "
+                f"review it with run-pr-round.",
+                file=sys.stderr,
+            )
+            return
+
+    issue_context = get_issue_context(runner, config=config, issue_number=issue)
+    prompt_text = build_implementation_prompt_for_skill(
+        issue_context, approved_plan,
+        repo=repo, coder=coder, workdir=str(workdir), base=base,  # type: ignore[arg-type]
+    )
+
+    # Sync the workdir to the requested base and capture HEAD *after* the sync, so
+    # the head-advanced check reflects the coder's commits (not the sync).
+    if dry_run:
+        print(f"[dry-run] would sync {workdir} to base '{base}' and run {coder_cap} implementation")
+        head_before = None
+    else:
+        sync_coder_base_before_implementation(config, runner)
+        head_before = _git_head(str(workdir))
+
+    with tempfile.TemporaryDirectory() as tmpstr:
+        tmpdir = Path(tmpstr)
+        prompt_file = tmpdir / "impl-prompt.md"
+        raw_output = tmpdir / "impl-raw.md"
+        usage_file = tmpdir / "impl-usage.json"
+        _write_text(prompt_file, prompt_text)
+
+        # No --repo: run_external would otherwise ensure_temp_checkout the workdir
+        # against its own base="main" config, resetting it away from --base right
+        # before the coder runs (#316).
+        _run_helper(
+            "helpers.run_external",
+            "--agent", coder,
+            "--role", "coder",
+            "--prompt-file", str(prompt_file),
+            "--output", str(raw_output),
+            "--workdir", str(workdir),
+            "--flow", "pr",
+            "--usage-output", str(usage_file),
+            *(["--dry-run"] if dry_run else []),
+        )
+        coder_output = raw_output.read_text(encoding="utf-8")
+        coder_usage: dict | None = None
+        if usage_file.exists():
+            try:
+                coder_usage = json.loads(usage_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                coder_usage = None
+
+        # Validate the coder response (PR marker + human-requirements ack +
+        # tests-within-workdir). Non-retryable: an implementation turn can't be
+        # file-repaired, so save a debug copy and exit before posting anything.
+        try:
+            pr_number = _validate_coder_implementation_response(
+                coder_output, workdir=str(workdir),
+                human_requirements=issue_context.human_requirements,
+            )
+        except AgentLoopError as exc:
+            debug_dir = _REPAIR_BASE / f"{issue}-implement-debug"
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(raw_output, debug_dir / "raw.md")
+            print(f"skill_runner: implementation response rejected: {exc}", file=sys.stderr)
+            print(
+                f"skill_runner: raw response saved to {debug_dir}/raw.md — fix the "
+                f"underlying issue and re-run run-implement (non-retryable).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # Validate the workdir + PR state.
+        if dry_run:
+            head_sha = "dry-run-sha"
+        else:
+            head_after = _git_head(str(workdir))
+            validate_assigned_head_advanced(
+                before_head=head_before, after_head=head_after,
+                assigned_workdir=Path(str(workdir)),
+            )
+            validate_open_pr(runner, config=config, pr_number=pr_number)
+            validate_pr_references_issue(
+                runner, config=config, pr_number=pr_number, issue_number=issue,
+            )
+            head_sha = get_pr_review_context(
+                runner, config=config, pr_number=pr_number,
+            ).metadata.head_sha or "unknown"
+
+        # Post the role: coder PR comment so run-pr-round's build-resume recognizes
+        # the round anchor. --state is required by attach-metadata; approved matches
+        # the other coder posts and is not load-bearing for PR-review resume.
+        tagged = tmpdir / "impl-tagged.md"
+        _run_helper(
+            "helpers.state_manager", "attach-metadata",
+            "--body-file", str(raw_output),
+            "--output", str(tagged),
+            "--flow", "pr",
+            "--role", "coder",
+            "--agent", coder_cap,
+            "--round-number", "1",
+            "--subject", str(head_sha),
+            "--state", "approved",
+        )
+        if not dry_run:
+            _run_helper(
+                "helpers.gh_ops", "post-issue-comment",
+                "--issue", str(pr_number), "--file", str(tagged), "--repo", repo,
+            )
+            # Record idempotency: the durable one-shot handoff marker on the issue.
+            handoff = tmpdir / "impl-handoff.md"
+            _write_text(handoff, format_one_shot_impl_handoff_comment(
+                parent_issue=issue, mode=mode, plan_hash=plan_hash,
+                plan_subject=plan_subject, pr_number=pr_number, pr_head_sha=head_sha,
+            ))
+            _run_helper(
+                "helpers.gh_ops", "post-issue-comment",
+                "--issue", str(issue), "--file", str(handoff), "--repo", repo,
+            )
+        else:
+            print(f"[dry-run] would post coder PR comment + handoff for PR #{pr_number}")
+
+    result_json: dict = {"pr": pr_number, "head_sha": head_sha, "issue": issue}
+    usage = _aggregate_reviewer_usage([{"usage": coder_usage}] if coder_usage else [])
+    if usage is not None:
+        result_json["usage"] = usage
+    print(json.dumps(result_json, indent=2))
+    print(
+        f"hint: PR #{pr_number} opened — review it with: python -m helpers.skill_runner "
+        f"run-pr-round --pr {pr_number} --repo {repo} --reviewers claude gemini",
+        file=sys.stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -2298,6 +2557,31 @@ def main() -> None:
     )
     p_host.add_argument("--dry-run", action="store_true")
 
+    # run-implement
+    p_impl = subparsers.add_parser(
+        "run-implement",
+        help="Reversed roles: an external coder implements an approved plan and "
+             "opens a PR, which you then review with run-pr-round (#316).",
+    )
+    p_impl.add_argument("--issue", type=int, required=True)
+    p_impl.add_argument("--repo", required=True)
+    p_impl.add_argument(
+        "--coder", choices=["codex", "gemini"], required=True,
+        help="External coder that implements the plan (the host implements in-session).",
+    )
+    p_impl.add_argument("--plan-file", required=True, help="Approved plan to implement.")
+    p_impl.add_argument(
+        "--base", default="main", help="Branch to base the PR on (default: main).",
+    )
+    p_impl.add_argument(
+        "--workdir", default=None,
+        help="Push-capable clone where the coder commits/pushes/opens the PR "
+             "(required for a real run).",
+    )
+    p_impl.add_argument("--workdir-codex", default=None)
+    p_impl.add_argument("--workdir-gemini", default=None)
+    p_impl.add_argument("--dry-run", action="store_true")
+
     # run-task-round
     p_task = subparsers.add_parser(
         "run-task-round",
@@ -2334,6 +2618,7 @@ def main() -> None:
         "run-pr-round": cmd_run_pr_round,
         "retry-validate": cmd_retry_validate,
         "complete-host-review": cmd_complete_host_review,
+        "run-implement": cmd_run_implement,
         "run-task-round": cmd_run_task_round,
     }
     dispatch[args.subcommand](args)

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -2300,9 +2300,13 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
     mode = "implement-one-shot"
     coder_cap = agent_display_name(coder)  # type: ignore[arg-type]
 
+    # auto_agent_dirs=() so the explicit, user-provided push-capable workdir is
+    # treated as user-owned: sync_coder_base_before_implementation then *rejects* a
+    # dirty checkout instead of `git reset --hard`/`clean -fd`-ing the user's clone (#316).
     config = dataclasses.replace(
         make_minimal_config(repo, coder, (coder,), reviewer=coder, workdir=str(workdir), base=base),  # type: ignore[arg-type]
         dry_run=dry_run,
+        auto_agent_dirs=(),
     )
     runner = Runner(dry_run=dry_run)
 
@@ -2312,12 +2316,17 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
         comments, parent_issue=issue, plan_hash=plan_hash, mode=mode,
     )
     if existing is not None:
-        pr_open = True
+        # Only reuse a recorded PR that is still open AND still references this issue
+        # — a stale/injected same-plan-hash marker must not return an unrelated PR.
+        reusable = True
         try:
             validate_open_pr(runner, config=config, pr_number=existing.pr_number)
+            validate_pr_references_issue(
+                runner, config=config, pr_number=existing.pr_number, issue_number=issue,
+            )
         except AgentLoopError:
-            pr_open = False
-        if pr_open:
+            reusable = False
+        if reusable:
             print(json.dumps({
                 "pr": existing.pr_number,
                 "head_sha": existing.pr_head_sha,

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1940,3 +1940,143 @@ class TestHostReviewerPR:
         assert result.returncode == 0
         assert "run-pr-round" in result.stdout
         assert "pr_review" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — reverse implementation: run-implement (#316)
+# ---------------------------------------------------------------------------
+
+_IMPL_WITH_PR = "Implemented the plan.\n\n<!-- AGENT_PR: 5 -->\n-- Codex\n"
+
+
+def _human_req():
+    from coding_review_agent_loop.github import HumanReviewRequirement
+    return HumanReviewRequirement(
+        source_type="Issue comment", author="wwind123",
+        created_at="2026-06-14T00:00:00Z", url="https://example/1",
+        body="Must keep the public API backward compatible.",
+    )
+
+
+class TestRunExternalImplStub:
+    def test_coder_pr_dry_run_writes_pr_marker_stub(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "out.md"
+            result = _run(
+                "helpers.run_external",
+                "--agent", "codex", "--role", "coder", "--flow", "pr",
+                "--prompt-file", _write_tmp("implement it"),
+                "--output", str(out), "--workdir", tmpdir,
+                "--dry-run",
+            )
+            assert result.returncode == 0
+            assert "<!-- AGENT_PR:" in out.read_text(encoding="utf-8")
+
+
+class TestImplementationPrompt:
+    def test_includes_plan_workdir_and_human_requirement(self) -> None:
+        from coding_review_agent_loop.github import IssueContext
+        from helpers.prompt_builders import build_implementation_prompt_for_skill
+        ctx = IssueContext(
+            number=42, repo="o/r", title="T", body="B", url="u",
+            comments=(), human_requirements=(_human_req(),),
+        )
+        prompt = build_implementation_prompt_for_skill(
+            ctx, "APPROVED PLAN BODY XYZ",
+            repo="o/r", coder="codex", workdir="/tmp/skill-runner-codex",
+            base="release-x",
+        )
+        assert "APPROVED PLAN BODY XYZ" in prompt
+        assert "/tmp/skill-runner-codex" in prompt
+        assert "release-x" in prompt  # PR-base instruction threads --base
+        assert "backward compatible" in prompt  # signed human requirement surfaced
+
+
+class TestValidateCoderImplementationResponse:
+    def test_well_formed_returns_pr_number(self) -> None:
+        from helpers.skill_runner import _validate_coder_implementation_response
+        pr = _validate_coder_implementation_response(
+            _IMPL_WITH_PR, workdir="/tmp/wd", human_requirements=(),
+        )
+        assert pr == 5
+
+    def test_missing_human_ack_rejected(self) -> None:
+        from coding_review_agent_loop.errors import AgentLoopError
+        from helpers.skill_runner import _validate_coder_implementation_response
+        with pytest.raises(AgentLoopError):
+            _validate_coder_implementation_response(
+                _IMPL_WITH_PR, workdir="/tmp/wd", human_requirements=(_human_req(),),
+            )
+
+    def test_out_of_workdir_test_rejected(self) -> None:
+        from coding_review_agent_loop.errors import AgentLoopError
+        from helpers.skill_runner import _validate_coder_implementation_response
+        bad = (
+            "Implemented the plan.\n"
+            "Tests: cd /nonexistent/other-dir && pytest passed.\n\n"
+            "<!-- AGENT_PR: 5 -->\n-- Codex\n"
+        )
+        with pytest.raises(AgentLoopError):
+            _validate_coder_implementation_response(
+                bad, workdir="/tmp/wd", human_requirements=(),
+            )
+
+    def test_missing_pr_marker_rejected(self) -> None:
+        from coding_review_agent_loop.errors import AgentLoopError
+        from helpers.skill_runner import _validate_coder_implementation_response
+        with pytest.raises(AgentLoopError):
+            _validate_coder_implementation_response(
+                "I implemented it but forgot the marker.", workdir="/tmp/wd",
+                human_requirements=(),
+            )
+
+
+class TestRunImplement:
+    def _last_json(self, stdout: str) -> dict:
+        start = stdout.rfind("\n{")
+        if start < 0:
+            start = stdout.find("{")
+        return json.loads(stdout[start:].strip())
+
+    def test_dry_run_runs_coder_and_prints_pr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            plan = tmppath / "plan.md"
+            plan.write_text(_VALID_PLAN_STATE, encoding="utf-8")
+            result = _run(
+                "helpers.skill_runner", "run-implement",
+                "--issue", "9992", "--repo", "test/skill-repo",
+                "--coder", "codex", "--plan-file", str(plan),
+                "--workdir", str(tmppath), "--base", "release-x",
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            output = self._last_json(result.stdout)
+            assert output["pr"] == 0 and output["issue"] == 9992
+            # Launcher base behavior is observable (not only the prompt text).
+            assert "release-x" in result.stdout
+
+    def test_invalid_coder_rejected(self) -> None:
+        result = _run(
+            "helpers.skill_runner", "run-implement",
+            "--issue", "1", "--repo", "o/r", "--coder", "claude",
+            "--plan-file", "/tmp/x.md", "--dry-run",
+            check=False,
+        )
+        assert result.returncode != 0  # argparse choices reject 'claude'
+
+    def test_missing_workdir_rejected_for_real_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plan = Path(tmpdir) / "plan.md"
+            plan.write_text(_VALID_PLAN_STATE, encoding="utf-8")
+            result = _run(
+                "helpers.skill_runner", "run-implement",
+                "--issue", "1", "--repo", "o/r", "--coder", "codex",
+                "--plan-file", str(plan),
+                check=False,
+            )
+            assert result.returncode != 0
+            assert "push-capable" in result.stderr


### PR DESCRIPTION
Closes #316. Closes the reversed-roles loop end to end (#294/#307/#314): an
**external coder** (Codex/Gemini) implements an approved plan and opens a PR,
which `run-pr-round` then reviews (`claude` reviewer optional, #314).

## Surface

```bash
python -m helpers.skill_runner run-implement \
  --issue N --repo OWNER/REPO --coder codex \
  --plan-file <approved-plan.md> --workdir <push-capable-clone> [--base main]
# → {"pr": N, ...}; then review with run-pr-round --pr N --reviewers claude gemini
```

## Behavior (mirrors `orchestrator._implement_approved_issue`)

- Builds the implementation prompt from a **full `IssueContext`** via
  `get_issue_context` (comments + signed human requirements), not the minimal dict.
- Syncs the workdir to `--base`, then runs the coder via `run_external --role coder
  --flow pr` **without `--repo`** — otherwise `run_external` would re-sync the
  workdir to its own `base="main"` right before the coder runs.
- Validates the response (non-retryable on failure, before posting anything):
  `_validate_coder_implementation_response` = PR marker (`_require_pr_number`) +
  signed-human-requirements ack (`_validate_response_with_human_requirements`) +
  in-workdir test reports (`validate_response_tests_within_workdir`); then advanced
  HEAD, PR open, PR references the issue.
- Posts a `role: coder` PR comment so `run-pr-round`'s `build-resume` recognizes the
  round anchor (`--state approved`, required by attach-metadata, not load-bearing).
- **Idempotent per plan** via the durable `AGENT_PLAN_ONE_SHOT_IMPL` handoff
  (`approved_plan_hash` / `find_existing_one_shot_impl_handoff` /
  `format_one_shot_impl_handoff_comment`): a re-run returns the existing PR rather
  than opening a duplicate.

## Supporting changes

- `prompt_builders`: `build_implementation_prompt_for_skill`; `make_minimal_config`
  gains a `base` param (default `main`, existing callers unchanged).
- `run_external`: dry-run emits an implementation stub (`AGENT_PR` marker) for
  `--role coder --flow pr`, so `run-implement` is testable end to end.

## Tests

The validation helper (ok / missing PR marker / missing human-req ack /
out-of-workdir test), the prompt wrapper (plan + workdir + `--base` + human
requirement), the dry-run stub, and `run-implement --dry-run` (+ base launcher
behavior, invalid-coder and missing-workdir rejections). **Full suite: 828 passed.**

## Notes

**Side-effecting**: the coder commits, pushes a branch, and opens a real PR —
needs a push-capable `--workdir`; `--dry-run` does none of that. Building this does
not invoke it. PR-flow multi-phase / decompose parity stays deferred.

Plan approved on #316 (plan-r6, six rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude