### PR TITLE
Add skill runner run-decompose command

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -330,6 +330,26 @@ It is **idempotent per plan** (the one-shot handoff marker): re-running returns 
 existing PR instead of opening a duplicate. A response that fails validation is
 non-retryable — fix the cause and re-run. `--dry-run` does no pushes/PRs.
 
+### Decompose an approved plan into phase issues
+
+`run-decompose` has an **external coder** turn an approved plan into structured
+phase child issues:
+
+```bash
+python -m helpers.skill_runner run-decompose \
+  --issue N --repo OWNER/REPO \
+  --coder codex \
+  --plan-file <approved-plan.md> \
+  [--workdir <checkout>]
+```
+
+Live runs are **side-effecting**: they create real GitHub child issues and post a
+parent summary marker. The command is idempotent by parent issue + approved-plan
+hash + `decompose-only` mode; re-running the same plan returns the recorded child
+issues instead of creating duplicates. `--dry-run` still exercises the
+decomposition parser and prints the child-issue preview JSON, but it does not
+create issues or post comments.
+
 `run-task-round` stays host-coder only.
 
 ---

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -21,6 +21,7 @@ from coding_review_agent_loop.memory import AgentMemoryContext
 from coding_review_agent_loop.prompts import (
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
+    build_plan_decomposition_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
     build_review_prompt,
@@ -292,5 +293,28 @@ def build_implementation_prompt_for_skill(
         repo, coder, (coder,), reviewer=coder, workdir=workdir, base=base,
     )
     return build_issue_implementation_prompt(
+        issue_context.number, approved_plan, config, memory, issue_context=issue_context,
+    )
+
+
+def build_plan_decomposition_prompt_for_skill(
+    issue_context: IssueContext,
+    approved_plan: str,
+    *,
+    repo: str,
+    coder: AgentName,
+    workdir: str,
+    memory: AgentMemoryContext | None = None,
+) -> str:
+    """Build the external-coder plan decomposition prompt (#318).
+
+    Takes a full ``IssueContext`` so issue comments + signed human requirements
+    reach the decomposer. Sets the coder's checkout dir to ``workdir`` so the
+    prompt's checkout guidance points at the actual skill-runner workspace.
+    """
+    config = make_minimal_config(
+        repo, coder, (coder,), reviewer=coder, workdir=workdir,
+    )
+    return build_plan_decomposition_prompt(
         issue_context.number, approved_plan, config, memory, issue_context=issue_context,
     )

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -81,9 +81,32 @@ and opened a pull request.
 -- Codex (dry-run stub)
 """
 
+_CANNED_PLAN_DECOMPOSITION = json.dumps(
+    {
+        "schema_version": 1,
+        "kind": "plan_decomposition",
+        "phases": [
+            {
+                "title": "Dry-run implementation phase",
+                "scope": "Dry-run stub: implement the approved plan in one child issue.",
+                "non_goals": "No real GitHub issue is created during dry-run.",
+                "dependency_notes": "First phase; no dependencies.",
+                "rollout_risk": "low - dry-run preview only.",
+                "validation": "Run the relevant project tests before opening a PR.",
+                "parent_context": "Dry-run stub derived from the approved parent plan.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            }
+        ],
+    },
+    indent=2,
+)
+
 
 def _build_dry_run_response(role: str, flow: str = "plan") -> str:
     if role == "coder":
+        if flow == "decompose":
+            return _CANNED_PLAN_DECOMPOSITION
         return _CANNED_IMPLEMENTATION if flow == "pr" else _CANNED_PLAN_STATE
     if flow == "pr":
         return _CANNED_PR_REVIEW + _CANNED_PR_REVIEW_FOOTER
@@ -107,8 +130,8 @@ def main() -> None:
     parser.add_argument(
         "--flow",
         default="plan",
-        choices=["plan", "pr"],
-        help="Review flow: 'plan' (default) or 'pr'. Affects dry-run stub kind.",
+        choices=["plan", "pr", "decompose"],
+        help="Review flow: 'plan' (default), 'pr', or 'decompose'. Affects dry-run stub kind.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Write a canned stub and exit.")
     parser.add_argument(
@@ -152,7 +175,10 @@ def main() -> None:
     if args.dry_run:
         flow = args.flow
         if args.role == "coder":
-            stub_kind = "implementation" if flow == "pr" else "plan_state"
+            if flow == "decompose":
+                stub_kind = "plan_decomposition"
+            else:
+                stub_kind = "implementation" if flow == "pr" else "plan_state"
         elif flow == "pr":
             stub_kind = "pr_review"
         else:

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -48,6 +48,17 @@ Subcommands:
     role: coder PR comment so run-pr-round can review it. Idempotent per plan via
     the one-shot handoff marker. Requires a push-capable workdir.
 
+  run-decompose
+    --issue N --repo OWNER/REPO
+    --coder {codex,gemini}
+    --plan-file PATH
+    [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH]
+    [--dry-run]
+
+    Reversed roles: an external coder decomposes an approved plan into child
+    phase issues. Live runs create real GitHub issues and post an idempotency
+    marker on the parent. Dry-run invokes a parseable stub and creates nothing.
+
 Prints a JSON result to stdout and exits 0:
   {"state": "approved"|"blocking", "round_number": N,
    "blocking_items": [...], "approved_reviewers": [...]}
@@ -2467,6 +2478,230 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
+# run-decompose  (external coder decomposes an approved plan into child issues) (#318)
+# ---------------------------------------------------------------------------
+
+def _issue_context_for_decompose_preview(repo: str, issue: int):
+    from coding_review_agent_loop.github import IssueContext, IssueComment
+
+    try:
+        issue_json = _fetch_issue_json(repo, issue)
+    except SystemExit:
+        return IssueContext(
+            number=issue,
+            repo=repo,
+            title=None,
+            body=None,
+            url=None,
+            comments=(),
+            human_requirements=(),
+        )
+    comments = tuple(
+        IssueComment(author=None, created_at=None, body=body)
+        for body in _fetch_issue_comments_raw(repo, issue)
+    )
+    return IssueContext(
+        number=int(issue_json.get("number") or issue),
+        repo=repo,
+        title=issue_json.get("title"),
+        body=issue_json.get("body"),
+        url=issue_json.get("url"),
+        comments=comments,
+        human_requirements=(),
+    )
+
+
+def _decomposition_phase_json(index: int, phase, *, issue_url: str | None = None,
+                              issue_number: int | None = None) -> dict:
+    return {
+        "index": index,
+        "title": phase.title,
+        "phase_title": f"Phase {index}: {phase.title}",
+        "automation": phase.automation,
+        "depends_on": list(getattr(phase, "depends_on", ()) or ()),
+        "scope": getattr(phase, "scope", None),
+        "non_goals": getattr(phase, "non_goals", None),
+        "dependency_notes": getattr(phase, "dependency_notes", None),
+        "rollout_risk": phase.rollout_risk,
+        "validation": getattr(phase, "validation", None),
+        "parent_context": phase.parent_context,
+        "issue_url": issue_url,
+        "issue_number": issue_number,
+    }
+
+
+def _existing_decomposition_json(existing) -> list[dict]:
+    phases = []
+    for index, (title, url, number) in enumerate(existing.children, start=1):
+        phases.append({
+            "index": index,
+            "title": title,
+            "phase_title": f"Phase {index}: {title}",
+            "automation": existing.automation[index - 1] if index <= len(existing.automation) else None,
+            "issue_url": url,
+            "issue_number": number,
+        })
+    return phases
+
+
+def cmd_run_decompose(args: argparse.Namespace) -> None:
+    issue: int = args.issue
+    repo: str = args.repo
+    coder: str = args.coder
+    dry_run: bool = args.dry_run
+    mode = "decompose-only"
+
+    plan_file = Path(args.plan_file)
+    if not plan_file.exists():
+        print(f"skill_runner: plan file not found: {plan_file}", file=sys.stderr)
+        sys.exit(1)
+    approved_plan = plan_file.read_text(encoding="utf-8")
+    if not approved_plan.strip():
+        print("skill_runner: plan file is empty; cannot decompose an empty plan", file=sys.stderr)
+        sys.exit(1)
+
+    workdir = _workdir_for_agent(coder, args)
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+
+    from coding_review_agent_loop.decomposition import (
+        approved_plan_hash,
+        create_decomposition_child_issues,
+        find_existing_decomposition,
+        parse_plan_decomposition,
+        post_decomposition_parent_summary,
+    )
+    from coding_review_agent_loop.github import get_issue_context
+    from helpers.prompt_builders import (
+        build_plan_decomposition_prompt_for_skill,
+        make_minimal_config,
+    )
+
+    config = dataclasses.replace(
+        make_minimal_config(repo, coder, (coder,), reviewer=coder, workdir=str(workdir)),  # type: ignore[arg-type]
+        dry_run=dry_run,
+    )
+    runner = Runner(dry_run=dry_run)
+    plan_hash = approved_plan_hash(approved_plan)
+
+    if dry_run:
+        issue_context = _issue_context_for_decompose_preview(repo, issue)
+    else:
+        issue_context = get_issue_context(runner, config=config, issue_number=issue)
+
+    existing = find_existing_decomposition(
+        issue_context.comments,
+        parent_issue=issue,
+        plan_hash=plan_hash,
+        mode=mode,
+    )
+    if existing is not None:
+        print(json.dumps({
+            "issue": issue,
+            "plan_hash": plan_hash,
+            "mode": mode,
+            "dry_run": dry_run,
+            "reused": True,
+            "phase_count": existing.phase_count,
+            "phases": _existing_decomposition_json(existing),
+        }, indent=2))
+        print(
+            f"hint: issue #{issue} already has a {mode} decomposition for this plan.",
+            file=sys.stderr,
+        )
+        return
+
+    prompt_text = build_plan_decomposition_prompt_for_skill(
+        issue_context, approved_plan, repo=repo, coder=coder, workdir=str(workdir),  # type: ignore[arg-type]
+    )
+
+    with tempfile.TemporaryDirectory() as tmpstr:
+        tmpdir = Path(tmpstr)
+        prompt_file = tmpdir / "decompose-prompt.md"
+        raw_output = tmpdir / "decompose-raw.md"
+        usage_file = tmpdir / "decompose-usage.json"
+        _write_text(prompt_file, prompt_text)
+
+        _run_helper(
+            "helpers.run_external",
+            "--agent", coder,
+            "--role", "coder",
+            "--prompt-file", str(prompt_file),
+            "--output", str(raw_output),
+            "--workdir", str(workdir),
+            "--repo", repo,
+            "--flow", "decompose",
+            "--usage-output", str(usage_file),
+            *(["--dry-run"] if dry_run else []),
+        )
+        coder_output = raw_output.read_text(encoding="utf-8")
+        coder_usage: dict | None = None
+        if usage_file.exists():
+            try:
+                coder_usage = json.loads(usage_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                coder_usage = None
+
+        try:
+            decomposition = parse_plan_decomposition(coder_output)
+        except AgentLoopError as exc:
+            debug_dir = _REPAIR_BASE / f"{issue}-decompose-debug"
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(raw_output, debug_dir / "raw.md")
+            shutil.copy2(prompt_file, debug_dir / "prompt.md")
+            print(f"skill_runner: decomposition response rejected: {exc}", file=sys.stderr)
+            print(
+                f"skill_runner: raw response saved to {debug_dir}/raw.md — fix the "
+                f"underlying issue and re-run run-decompose (non-retryable).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        result_json: dict = {
+            "issue": issue,
+            "plan_hash": plan_hash,
+            "mode": mode,
+            "dry_run": dry_run,
+            "reused": False,
+        }
+        if dry_run:
+            result_json["would_post_parent_summary"] = True
+            result_json["phases"] = [
+                _decomposition_phase_json(index, phase)
+                for index, phase in enumerate(decomposition.phases, start=1)
+            ]
+            print("[dry-run] would create child phase issues and post parent decomposition marker")
+        else:
+            created = create_decomposition_child_issues(
+                runner,
+                config=config,
+                parent_issue=issue,
+                approved_plan=approved_plan,
+                decomposition=decomposition,
+            )
+            post_decomposition_parent_summary(
+                runner,
+                config=config,
+                parent_issue=issue,
+                mode=mode,
+                plan_hash=plan_hash,
+                created=created,
+            )
+            result_json["phases"] = [
+                _decomposition_phase_json(
+                    index, created_issue.phase,
+                    issue_url=created_issue.issue_url,
+                    issue_number=created_issue.issue_number,
+                )
+                for index, created_issue in enumerate(created, start=1)
+            ]
+        result_json["phase_count"] = len(result_json["phases"])
+        usage = _aggregate_reviewer_usage([{"usage": coder_usage}] if coder_usage else [])
+        if usage is not None:
+            result_json["usage"] = usage
+        print(json.dumps(result_json, indent=2))
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -2591,6 +2826,24 @@ def main() -> None:
     p_impl.add_argument("--workdir-gemini", default=None)
     p_impl.add_argument("--dry-run", action="store_true")
 
+    # run-decompose
+    p_decompose = subparsers.add_parser(
+        "run-decompose",
+        help="Reversed roles: an external coder decomposes an approved plan into "
+             "child phase issues (#318).",
+    )
+    p_decompose.add_argument("--issue", type=int, required=True)
+    p_decompose.add_argument("--repo", required=True)
+    p_decompose.add_argument(
+        "--coder", choices=["codex", "gemini"], required=True,
+        help="External coder that decomposes the approved plan.",
+    )
+    p_decompose.add_argument("--plan-file", required=True, help="Approved plan to decompose.")
+    p_decompose.add_argument("--workdir", default=None)
+    p_decompose.add_argument("--workdir-codex", default=None)
+    p_decompose.add_argument("--workdir-gemini", default=None)
+    p_decompose.add_argument("--dry-run", action="store_true")
+
     # run-task-round
     p_task = subparsers.add_parser(
         "run-task-round",
@@ -2628,6 +2881,7 @@ def main() -> None:
         "retry-validate": cmd_retry_validate,
         "complete-host-review": cmd_complete_host_review,
         "run-implement": cmd_run_implement,
+        "run-decompose": cmd_run_decompose,
         "run-task-round": cmd_run_task_round,
     }
     dispatch[args.subcommand](args)

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1094,12 +1094,18 @@ def build_plan_decomposition_prompt(
     issue_context: IssueContext | None = None,
 ) -> str:
     coder_signature = agent_signature(config.coder)
+    human_requirements_block = _issue_human_requirements_block(
+        issue_context,
+        requirement_scope="decomposition requirements",
+        full_omission_fallback="Fetch the issue discussion directly before decomposing the plan.",
+    )
     return f"""Decompose the approved implementation plan for GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this decomposition stage.
+{_coder_workdir_guidance(config, implementation=False)}
 {_scratch_file_guidance()}
-{_issue_context_block(issue_context)}
+{human_requirements_block}{_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
 Approved implementation plan:

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import types
 from pathlib import Path
 
 import pytest
@@ -1973,6 +1974,24 @@ class TestRunExternalImplStub:
             assert "<!-- AGENT_PR:" in out.read_text(encoding="utf-8")
 
 
+class TestRunExternalDecomposeStub:
+    def test_coder_decompose_dry_run_writes_valid_decomposition_stub(self) -> None:
+        from coding_review_agent_loop.decomposition import parse_plan_decomposition
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "out.md"
+            result = _run(
+                "helpers.run_external",
+                "--agent", "codex", "--role", "coder", "--flow", "decompose",
+                "--prompt-file", _write_tmp("decompose it"),
+                "--output", str(out), "--workdir", tmpdir,
+                "--dry-run",
+            )
+            assert result.returncode == 0
+            parsed = parse_plan_decomposition(out.read_text(encoding="utf-8"))
+            assert parsed.phases[0].title == "Dry-run implementation phase"
+
+
 class TestImplementationPrompt:
     def test_includes_plan_workdir_and_human_requirement(self) -> None:
         from coding_review_agent_loop.github import IssueContext
@@ -1990,6 +2009,33 @@ class TestImplementationPrompt:
         assert "/tmp/skill-runner-codex" in prompt
         assert "release-x" in prompt  # PR-base instruction threads --base
         assert "backward compatible" in prompt  # signed human requirement surfaced
+
+
+class TestDecompositionPrompt:
+    def test_includes_plan_issue_context_and_workdir(self) -> None:
+        from coding_review_agent_loop.github import IssueContext, IssueComment
+        from helpers.prompt_builders import build_plan_decomposition_prompt_for_skill
+        ctx = IssueContext(
+            number=42,
+            repo="o/r",
+            title="Decompose this",
+            body="Issue body ABC",
+            url="https://example/42",
+            comments=(IssueComment(author="wwind123", created_at="2026-06-14T00:00:00Z", body="Comment XYZ"),),
+            human_requirements=(_human_req(),),
+        )
+        prompt = build_plan_decomposition_prompt_for_skill(
+            ctx,
+            "APPROVED PLAN BODY XYZ",
+            repo="o/r",
+            coder="codex",
+            workdir="/tmp/skill-runner-codex",
+        )
+        assert "APPROVED PLAN BODY XYZ" in prompt
+        assert "Issue body ABC" in prompt
+        assert "Comment XYZ" in prompt
+        assert "/tmp/skill-runner-codex" in prompt
+        assert "backward compatible" in prompt
 
 
 class TestValidateCoderImplementationResponse:
@@ -2080,3 +2126,183 @@ class TestRunImplement:
             )
             assert result.returncode != 0
             assert "push-capable" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — approved-plan decomposition: run-decompose (#318)
+# ---------------------------------------------------------------------------
+
+_DECOMP_JSON = json.dumps(
+    {
+        "schema_version": 1,
+        "kind": "plan_decomposition",
+        "phases": [
+            {
+                "title": "Schema helpers",
+                "scope": "Add parser dataclasses and tests.",
+                "non_goals": "No live orchestrator switch.",
+                "dependency_notes": "First phase; no dependencies.",
+                "rollout_risk": "low - internal only.",
+                "validation": "Run python -m pytest tests/test_agent_loop.py.",
+                "parent_context": "Approved plan slice: add schema helpers.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            }
+        ],
+    }
+)
+
+
+class TestRunDecompose:
+    def _last_json(self, stdout: str) -> dict:
+        start = stdout.rfind("\n{")
+        if start < 0:
+            start = stdout.find("{")
+        return json.loads(stdout[start:].strip())
+
+    def test_dry_run_runs_coder_parses_and_prints_preview(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            plan = tmppath / "plan.md"
+            plan.write_text(_VALID_PLAN_STATE, encoding="utf-8")
+            result = _run(
+                "helpers.skill_runner", "run-decompose",
+                "--issue", "9992", "--repo", "test/skill-repo",
+                "--coder", "codex", "--plan-file", str(plan),
+                "--workdir", str(tmppath),
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            output = self._last_json(result.stdout)
+            assert output["issue"] == 9992
+            assert output["mode"] == "decompose-only"
+            assert output["dry_run"] is True
+            assert output["reused"] is False
+            assert output["phase_count"] == 1
+            assert output["phases"][0]["automation"] == "agent-pr"
+            assert output["would_post_parent_summary"] is True
+
+    def test_live_path_creates_children_and_posts_parent_summary(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+        import coding_review_agent_loop.decomposition as decomp
+        import coding_review_agent_loop.github as gh
+        from coding_review_agent_loop.github import IssueContext
+
+        raw_outputs: list[str] = []
+        created_calls: list[dict] = []
+        posted_calls: list[dict] = []
+
+        def fake_run_helper(*args, **_kwargs):
+            raw_outputs.append(" ".join(args))
+            output = Path(args[args.index("--output") + 1])
+            output.write_text(_DECOMP_JSON, encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        def fake_get_issue_context(_runner, *, config, issue_number):
+            return IssueContext(
+                number=issue_number, repo=config.repo, title="T", body="B", url="u",
+                comments=(), human_requirements=(),
+            )
+
+        def fake_create(runner, *, config, parent_issue, approved_plan, decomposition):
+            created_calls.append({
+                "parent_issue": parent_issue,
+                "approved_plan": approved_plan,
+                "phase_count": len(decomposition.phases),
+            })
+            phase = decomposition.phases[0]
+            return (
+                decomp.CreatedPhaseIssue(
+                    phase=phase,
+                    issue_url="https://github.com/test/skill-repo/issues/123",
+                    issue_number=123,
+                ),
+            )
+
+        def fake_post(runner, *, config, parent_issue, mode, plan_hash, created):
+            posted_calls.append({
+                "parent_issue": parent_issue,
+                "mode": mode,
+                "plan_hash": plan_hash,
+                "created": created,
+            })
+
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+        monkeypatch.setattr(gh, "get_issue_context", fake_get_issue_context)
+        monkeypatch.setattr(decomp, "create_decomposition_child_issues", fake_create)
+        monkeypatch.setattr(decomp, "post_decomposition_parent_summary", fake_post)
+        plan = tmp_path / "plan.md"
+        plan.write_text("Approved plan body", encoding="utf-8")
+        sr.cmd_run_decompose(types.SimpleNamespace(
+            issue=77,
+            repo="test/skill-repo",
+            coder="codex",
+            plan_file=str(plan),
+            workdir=str(tmp_path),
+            workdir_codex=None,
+            workdir_gemini=None,
+            dry_run=False,
+        ))
+
+        assert raw_outputs and "--flow decompose" in raw_outputs[0]
+        assert created_calls == [{
+            "parent_issue": 77,
+            "approved_plan": "Approved plan body",
+            "phase_count": 1,
+        }]
+        assert posted_calls[0]["parent_issue"] == 77
+        assert posted_calls[0]["mode"] == "decompose-only"
+        assert posted_calls[0]["created"][0].issue_number == 123
+
+    def test_existing_marker_reuses_without_running_coder(self, monkeypatch, tmp_path, capsys) -> None:
+        import helpers.skill_runner as sr
+        import coding_review_agent_loop.decomposition as decomp
+        import coding_review_agent_loop.github as gh
+        from coding_review_agent_loop.github import IssueContext, IssueComment
+
+        plan_text = "Approved plan body"
+        marker = decomp.format_decomposition_parent_summary(
+            parent_issue=77,
+            mode="decompose-only",
+            plan_hash=decomp.approved_plan_hash(plan_text),
+            created=(
+                decomp.CreatedPhaseIssue(
+                    phase=decomp.RecordedPhase(title="Schema helpers", automation="agent-pr"),
+                    issue_url="https://github.com/test/skill-repo/issues/123",
+                    issue_number=123,
+                ),
+            ),
+        )
+
+        def fake_get_issue_context(_runner, *, config, issue_number):
+            return IssueContext(
+                number=issue_number, repo=config.repo, title="T", body="B", url="u",
+                comments=(IssueComment(author="bot", created_at=None, body=marker),),
+                human_requirements=(),
+            )
+
+        def fail_run_helper(*_args, **_kwargs):
+            raise AssertionError("coder should not run when decomposition marker exists")
+
+        monkeypatch.setattr(gh, "get_issue_context", fake_get_issue_context)
+        monkeypatch.setattr(sr, "_run_helper", fail_run_helper)
+        plan = tmp_path / "plan.md"
+        plan.write_text(plan_text, encoding="utf-8")
+        sr.cmd_run_decompose(types.SimpleNamespace(
+            issue=77,
+            repo="test/skill-repo",
+            coder="codex",
+            plan_file=str(plan),
+            workdir=str(tmp_path),
+            workdir_codex=None,
+            workdir_gemini=None,
+            dry_run=False,
+        ))
+
+        output = self._last_json(capsys.readouterr().out)
+        assert output["reused"] is True
+        assert output["phase_count"] == 1
+        assert output["phases"][0]["issue_number"] == 123


### PR DESCRIPTION
## Summary
- add a skill-level plan decomposition prompt wrapper and assigned-workdir guidance
- add `skill_runner run-decompose` with plan hashing, marker reuse, dry-run preview JSON, live child issue creation, and parent summary posting
- add dry-run decomposition support in `helpers.run_external` plus focused coverage and docs

Fixes #318

## Tests
- `python3 -m pytest tests/test_skill_helpers.py`
- `python3 -m pytest`