### PR TITLE
Resilient reviewer turns: degrade gracefully on agent/CLI failure (#322)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -262,6 +262,20 @@ Plan-loop onward (including the optional Implement step + PR-loop).
              "totals": { "call_count": 2, "total_tokens": 250, ... },
              "per_agent": { "codex": {...}, "gemini": {...} } }
   ```
+- **Reviewer resilience** (plan-loop and PR-loop): if an external reviewer's CLI
+  fails to produce a usable review (an agent/tooling failure — e.g. an empty or
+  malformed-tool-call response — *not* a fixable malformed review), the skill does
+  **not** abort the round. It marks that reviewer **unavailable**, continues with
+  the remaining reviewers, and lists it under `unavailable_reviewers`; the reviewer
+  is re-attempted on the next run (or drop it from `--reviewers` to proceed). A
+  round with an unavailable reviewer is never reported `approved`: its `state` is
+  `incomplete` (or `blocking`/`pending` if those apply first). A genuinely
+  malformed-but-content-bearing review still uses the `retry-validate` repair path.
+- **Round states.** `approved` (all configured reviewers signed off) · `blocking`
+  (a reviewer reported must-fix items) · `pending` (a host `claude` review handoff
+  is outstanding — complete it with `complete-host-review`) · `incomplete` (a
+  configured reviewer was unavailable; rerun). Precedence when several apply:
+  `pending` > `blocking` > `incomplete` > `approved`.
 - **Merge is always a human decision.** The skill never runs CI-wait or
   auto-merge; every mode stops at "ready to merge."
 

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -302,6 +302,13 @@ def main() -> None:
             f"run_external: agent invocation failed ({reason}): {failure_text}",
             file=sys.stderr,
         )
+        # Write the failure text to --output (not just stderr) so a caller can read
+        # and classify it — e.g. the skill's reviewer-unavailable path (#322) — and
+        # decide whether to skip the reviewer rather than only seeing a non-zero exit.
+        try:
+            output_path.write_text(failure_text or "", encoding="utf-8")
+        except OSError:
+            pass
         sys.exit(1)
 
     assert result is not None  # loop either set result or exited

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -1001,6 +1001,10 @@ def _run_reviewer(
     _write_json(prior_items_file, next_prior_items_raw)
 
     # --- Run agent ---
+    # check=False: a non-zero run_external exit (agent/CLI failure, which now writes
+    # its failure text to --output, #322) must not abort the whole round here — let
+    # the validation + agent-unavailable classification below decide whether to skip
+    # this reviewer and continue.
     usage_file = tmpdir / f"{agent}-usage.json"
     _run_helper(
         "helpers.run_external",
@@ -1012,7 +1016,12 @@ def _run_reviewer(
         "--flow", flow,
         "--usage-output", str(usage_file),
         *(["--dry-run"] if dry_run else []),
+        check=False,
     )
+    if not raw_output.exists():
+        # run_external failed before writing anything; synthesize an empty body so
+        # the classifier marks the reviewer unavailable instead of crashing.
+        _write_text(raw_output, "")
 
     # Save raw response to stable repair dir BEFORE normalization
     repair_dir = _save_raw_to_repair_dir(

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -923,6 +923,52 @@ def _complete_reviewer_turn(
 # Per-reviewer run
 # ---------------------------------------------------------------------------
 
+# Signatures of an external agent/CLI *failure* — a turn that produced no usable
+# review (e.g. Gemini reaching for a missing tool and returning an empty/malformed
+# stream, #322) — as opposed to a malformed-but-content-bearing review the user can
+# repair. Kept narrow and CLI-specific so a genuine review (even a plain-text one
+# with findings) is never misclassified; matched only after validation has failed.
+_AGENT_UNAVAILABLE_SIGNATURES = (
+    "invalid stream",
+    "empty response or malformed tool call",
+    "error executing tool",
+    "not found. did you mean one of",
+)
+
+
+def _is_agent_unavailable_output(text: str) -> str | None:
+    """Return a short reason if ``text`` is an agent/CLI failure (no usable review),
+    else ``None``. Conservative: only truly-empty output or a known tooling-failure
+    signature qualifies — a content-bearing response stays on the repair path."""
+    stripped = text.strip()
+    if not stripped:
+        return "empty response"
+    lowered = stripped.lower()
+    for signature in _AGENT_UNAVAILABLE_SIGNATURES:
+        if signature in lowered:
+            return signature
+    return None
+
+
+def _round_overall_state(
+    *,
+    pending_reviewers: list[str],
+    any_reviewer_blocked: bool,
+    unavailable_reviewers: list[str],
+) -> str:
+    """Top-level round state by precedence (#314, #322): pending (a host review is
+    outstanding) > blocking > incomplete (a configured reviewer was unavailable) >
+    approved. Never reports approved/blocking while a host review is pending, and
+    never approved while a reviewer was unavailable."""
+    if pending_reviewers:
+        return "pending"
+    if any_reviewer_blocked:
+        return "blocking"
+    if unavailable_reviewers:
+        return "incomplete"
+    return "approved"
+
+
 def _run_reviewer(
     *,
     agent: str,
@@ -989,6 +1035,32 @@ def _run_reviewer(
             work_dir=tmpdir,
         )
     except _ValidationError as exc:
+        # Distinguish an agent/CLI failure (no usable review -> skip this reviewer
+        # for the round, re-attempt on rerun) from a fixable malformed review (keep
+        # the retry-validate handoff) (#322).
+        raw_text = raw_output.read_text(encoding="utf-8") if raw_output.exists() else ""
+        reason = _is_agent_unavailable_output(raw_text)
+        if reason is not None:
+            print(
+                f"skill_runner: {agent_cap} unavailable: agent/CLI failure ({reason}) — "
+                f"not a fixable review; it will be re-attempted on rerun. "
+                f"Raw response saved to: {repair_dir}/raw.md",
+                file=sys.stderr,
+            )
+            reviewer_usage = None
+            if usage_file.exists():
+                try:
+                    reviewer_usage = json.loads(usage_file.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    reviewer_usage = None
+            return {
+                "reviewer_name": agent_cap,
+                "state": "unavailable",
+                "reason": reason,
+                "blocking_items": [],
+                "new_items": [],
+                "usage": reviewer_usage,
+            }
         print(str(exc), file=sys.stderr)
         print(f"skill_runner: raw response saved to: {repair_dir}/raw.md", file=sys.stderr)
         dry_run_flag = " --dry-run" if dry_run else ""
@@ -1694,6 +1766,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
     round_reviewer_records: list[dict] = []
     round_blocking_items: list[dict] = []
     round_approved_reviewers: list[str] = []
+    unavailable_reviewers: list[str] = []
     any_reviewer_blocked = False
     if not is_new_round:
         for record in resume.get("completed_reviewer_data", []):
@@ -1772,6 +1845,12 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
                 tmpdir=tmpdir,
                 item_id_offset=item_id_offset,
             )
+            if record["state"] == "unavailable":
+                # Agent/CLI failure: skip this reviewer for the round (re-attempted
+                # on rerun); still fold its usage into the aggregate (#322).
+                unavailable_reviewers.append(record["reviewer_name"])
+                round_reviewer_records.append(record)
+                continue
             current_round_items.extend(record["new_items"])
             round_reviewer_records.append(record)
             if record["state"] == "blocking":
@@ -1819,10 +1898,15 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
     # report approved/blocking while a reviewer is still outstanding (#307).
     # Otherwise use any_reviewer_blocked to catch reviewers that blocked via
     # same-plan followups only.
-    if pending_reviewers:
-        overall_state = "pending"
-    else:
-        overall_state = "blocking" if any_reviewer_blocked else "approved"
+    # Precedence: pending (host review outstanding) > blocking > incomplete
+    # (a configured reviewer was unavailable) > approved. Both reviewer lists are
+    # always surfaced when non-empty so neither the host handoff nor a failed
+    # reviewer is ever hidden, and a round is never falsely reported approved (#322).
+    overall_state = _round_overall_state(
+        pending_reviewers=pending_reviewers,
+        any_reviewer_blocked=any_reviewer_blocked,
+        unavailable_reviewers=unavailable_reviewers,
+    )
     result_json = {
         "state": overall_state,
         "round_number": new_round_number,
@@ -1831,6 +1915,8 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
     }
     if pending_reviewers:
         result_json["pending_reviewers"] = pending_reviewers
+    if unavailable_reviewers:
+        result_json["unavailable_reviewers"] = unavailable_reviewers
     # Include the external coder's usage (if any) alongside the reviewers'.
     usage_records = list(round_reviewer_records)
     if coder_usage is not None:
@@ -1888,6 +1974,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     round_reviewer_records: list[dict] = []
     round_blocking_items: list[dict] = []
     round_approved_reviewers: list[str] = []
+    unavailable_reviewers: list[str] = []
     any_reviewer_blocked = False
     if not is_new_round:
         for record in resume.get("completed_reviewer_data", []):
@@ -1975,6 +2062,12 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                 tmpdir=tmpdir,
                 item_id_offset=item_id_offset,
             )
+            if record["state"] == "unavailable":
+                # Agent/CLI failure: skip this reviewer for the round (re-attempted
+                # on rerun); still fold its usage into the aggregate (#322).
+                unavailable_reviewers.append(record["reviewer_name"])
+                round_reviewer_records.append(record)
+                continue
             current_round_items.extend(record["new_items"])
             round_reviewer_records.append(record)
             if record["state"] == "blocking":
@@ -2022,10 +2115,15 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     # A configured-but-incomplete host reviewer makes the round "pending": never
     # report approved/blocking (or publish followups / run the test gate, which
     # belong to a settled round) while a reviewer is still outstanding (#314).
-    if pending_reviewers:
-        overall_state = "pending"
-    else:
-        overall_state = "blocking" if any_reviewer_blocked else "approved"
+    # Precedence: pending (host review outstanding) > blocking > incomplete
+    # (a configured reviewer was unavailable) > approved. Both reviewer lists are
+    # always surfaced when non-empty so neither the host handoff nor a failed
+    # reviewer is ever hidden, and a round is never falsely reported approved (#322).
+    overall_state = _round_overall_state(
+        pending_reviewers=pending_reviewers,
+        any_reviewer_blocked=any_reviewer_blocked,
+        unavailable_reviewers=unavailable_reviewers,
+    )
     result_json = {
         "state": overall_state,
         "round_number": new_round_number,
@@ -2034,10 +2132,13 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     }
     if pending_reviewers:
         result_json["pending_reviewers"] = pending_reviewers
+    if unavailable_reviewers:
+        result_json["unavailable_reviewers"] = unavailable_reviewers
     # Optional test gate: reports pass/fail; never blocks or merges. An explicit
     # empty --test-command "" is reported as a setup error, not silently skipped.
-    # Skipped while the round is pending a host review.
-    gate = None if pending_reviewers else _maybe_test_gate(
+    # Skipped while the round is unsettled (pending a host review, or a reviewer
+    # was unavailable) so it isn't read as a terminal result (#314, #322).
+    gate = None if (pending_reviewers or unavailable_reviewers) else _maybe_test_gate(
         getattr(args, "test_command", None),
         getattr(args, "test_workdir", "."),
         dry_run=dry_run,

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -945,6 +945,21 @@ class TestRunExternalRetries:
         assert calls["n"] == 1  # transient, but retries disabled
         assert sleeps == []
 
+    def test_failure_writes_failure_text_to_output(self, monkeypatch) -> None:
+        # On a non-transient agent failure, run_external exits non-zero AND writes the
+        # failure text to --output so a caller can classify it (#322).
+        from coding_review_agent_loop.agents.base import AgentResult
+        outcomes = [AgentResult(
+            text="",
+            raw_output="[ERROR] Invalid stream: empty response or malformed tool call",
+            returncode=1,
+        )]
+        _calls, _sleeps, output_path, exit_code = self._invoke(
+            monkeypatch, "gemini", outcomes, max_retries=0
+        )
+        assert exit_code == 1
+        assert "Invalid stream" in Path(output_path).read_text(encoding="utf-8")
+
 
 # ---------------------------------------------------------------------------
 # helpers/prompt_builders.py  checkout path embedding (#297)
@@ -2620,10 +2635,17 @@ class TestRunReviewerUnavailable:
     def test_agent_failure_returns_unavailable_sentinel(self, monkeypatch, tmp_path) -> None:
         import helpers.skill_runner as sr
 
-        def fake_run_helper(*args, **_kw):
+        # Simulate run_external exiting NON-ZERO (the empty/invalid-stream path) while
+        # writing its failure text to --output, and honor check= so a check=True call
+        # would abort. The fix passes check=False, so _run_reviewer must reach the
+        # classifier and return the unavailable sentinel rather than SystemExit (#322).
+        def fake_run_helper(*args, check=True, **_kw):
             if "helpers.run_external" in args:
                 out = Path(args[args.index("--output") + 1])
                 out.write_text(_GEMINI_CLI_FAILURE, encoding="utf-8")
+                if check:
+                    raise SystemExit(1)
+                return subprocess.CompletedProcess(args, 1, "", "")
             return subprocess.CompletedProcess(args, 0, "", "")
 
         monkeypatch.setattr(sr, "_run_helper", fake_run_helper)

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2551,3 +2551,140 @@ class TestRunImplementByPhase:
             assert output["phase"]["automation"] == "agent-pr"
             assert output["would_post_phase_handoff"] is True
             assert output["child_implementation_preview"]["pr"] == 0
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — resilient reviewer turns (#322)
+# ---------------------------------------------------------------------------
+
+_GEMINI_CLI_FAILURE = (
+    'Error executing tool run_shell_command: Tool "run_shell_command" not found. '
+    "Did you mean one of: grep_search?\n"
+    "[ERROR] Invalid stream: The model returned an empty response or malformed tool call.\n"
+)
+
+
+class TestAgentUnavailableClassifier:
+    def test_tooling_signature_is_unavailable(self) -> None:
+        from helpers.skill_runner import _is_agent_unavailable_output
+        assert _is_agent_unavailable_output(_GEMINI_CLI_FAILURE) is not None
+
+    def test_empty_output_is_unavailable(self) -> None:
+        from helpers.skill_runner import _is_agent_unavailable_output
+        assert _is_agent_unavailable_output("   \n  ") == "empty response"
+
+    def test_schema_invalid_json_is_not_unavailable(self) -> None:
+        from helpers.skill_runner import _is_agent_unavailable_output
+        # JSON but wrong schema -> repairable, not unavailable.
+        assert _is_agent_unavailable_output('{"foo": "bar"}') is None
+
+    def test_content_bearing_prose_is_not_unavailable(self) -> None:
+        from helpers.skill_runner import _is_agent_unavailable_output
+        # A plain-text review with actionable findings must stay on the repair path.
+        prose = "This plan is missing error handling in step 3; that is blocking."
+        assert _is_agent_unavailable_output(prose) is None
+
+
+class TestRoundOverallState:
+    def test_precedence(self) -> None:
+        from helpers.skill_runner import _round_overall_state
+        f = _round_overall_state
+        # pending wins over everything (incl. an unavailable external reviewer).
+        assert f(pending_reviewers=["Claude"], any_reviewer_blocked=True,
+                 unavailable_reviewers=["Gemini"]) == "pending"
+        assert f(pending_reviewers=["Claude"], any_reviewer_blocked=False,
+                 unavailable_reviewers=["Gemini"]) == "pending"
+        # then blocking, then incomplete (unavailable), then approved.
+        assert f(pending_reviewers=[], any_reviewer_blocked=True,
+                 unavailable_reviewers=["Gemini"]) == "blocking"
+        assert f(pending_reviewers=[], any_reviewer_blocked=False,
+                 unavailable_reviewers=["Gemini"]) == "incomplete"
+        assert f(pending_reviewers=[], any_reviewer_blocked=False,
+                 unavailable_reviewers=[]) == "approved"
+
+
+class TestRunReviewerUnavailable:
+    def _ctx(self):
+        return {"reviewer": "Gemini", "prior_items": [], "current_round_items": []}
+
+    def _call(self, tmp_path):
+        import helpers.skill_runner as sr
+        return sr._run_reviewer(
+            agent="gemini", prompt_text="review it", context=self._ctx(),
+            round_subject="subj", next_prior_items_raw=[], new_round_number=1,
+            issue=1, repo="o/r", flow="plan", role="reviewer",
+            state_key="plan_review", workdir=str(tmp_path), dry_run=False,
+            tmpdir=tmp_path, item_id_offset=0,
+        )
+
+    def test_agent_failure_returns_unavailable_sentinel(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+
+        def fake_run_helper(*args, **_kw):
+            if "helpers.run_external" in args:
+                out = Path(args[args.index("--output") + 1])
+                out.write_text(_GEMINI_CLI_FAILURE, encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+        record = self._call(tmp_path)
+        assert record["state"] == "unavailable"
+        assert record["reason"]
+        assert record["reviewer_name"] == "Gemini"
+
+    def test_content_bearing_failure_aborts_to_repair(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+
+        def fake_run_helper(*args, **_kw):
+            if "helpers.run_external" in args:
+                out = Path(args[args.index("--output") + 1])
+                # Content-bearing but invalid review -> repair path (SystemExit), not unavailable.
+                out.write_text("I reviewed this and it looks fine, ship it.", encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+        with pytest.raises(SystemExit):
+            self._call(tmp_path)
+
+    def test_round_continues_with_unavailable_external_and_pending_host(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        """gemini unavailable + claude host-review pending: the round does not abort,
+        reports state=pending, and surfaces BOTH reviewer lists (no false approval,
+        host handoff not hidden)."""
+        import helpers.skill_runner as sr
+
+        plan = tmp_path / "plan.md"
+        plan.write_text(_VALID_PLAN_STATE, encoding="utf-8")
+
+        monkeypatch.setattr(sr, "_build_resume", lambda *a, **k: {})
+        monkeypatch.setattr(
+            sr, "_fetch_issue_json",
+            lambda *a, **k: {"number": 1, "title": "t", "body": "b", "url": "u"},
+        )
+
+        def fake_run_helper(*args, **_kw):
+            # Only the external reviewer (gemini) goes through run_external here; make
+            # it the Gemini-CLI failure so it is classified unavailable.
+            if "helpers.run_external" in args:
+                out = Path(args[args.index("--output") + 1])
+                out.write_text(_GEMINI_CLI_FAILURE, encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+
+        sr.cmd_run_plan_round(types.SimpleNamespace(
+            issue=1, repo="o/r", reviewers=["gemini", "claude"],
+            coder="claude", plan_file=str(plan), dry_run=True,
+            agent_memory=False, refresh_agent_memory=False,
+            workdir=str(tmp_path), workdir_codex=None, workdir_gemini=None,
+        ))
+
+        out = capsys.readouterr().out
+        start = out.rfind("\n{")
+        if start < 0:
+            start = out.find("{")
+        output = json.loads(out[start:].strip())
+        assert output["state"] == "pending"
+        assert output["pending_reviewers"] == ["Claude"]
+        assert output["unavailable_reviewers"] == ["Gemini"]


### PR DESCRIPTION
Closes #322. When an external reviewer's CLI fails to produce a usable review (an
agent/tooling failure — e.g. the Gemini CLI reaching for a missing
`run_shell_command` tool and returning an empty/malformed stream, observed while
reviewing #321), the skill no longer aborts the whole round with a misleading
`retry-validate` hint. It marks that reviewer **unavailable**, continues with the
others, and re-attempts it on rerun.

## Changes

- **`_is_agent_unavailable_output`** — classifies a turn as agent-unavailable ONLY
  on truly-empty output or a narrow set of deterministic CLI-failure signatures
  (`Invalid stream`, `empty response or malformed tool call`, `error executing
  tool`, `not found. did you mean one of`). A content-bearing response (including a
  plain-text review with findings) is **never** unavailable — it stays on the
  existing repair / `retry-validate` path. (Tightened per the plan review.)
- **`_run_reviewer`** — on validation failure, an agent-unavailable turn returns a
  `state: "unavailable"` sentinel (with the matched `reason` + the failed turn's
  `usage`) instead of `sys.exit(1)`. The plan/PR reviewer loops record it in
  `unavailable_reviewers`, fold its usage into the aggregate, and continue.
- **`_round_overall_state`** — centralizes precedence: `pending` > `blocking` >
  `incomplete` (a configured reviewer was unavailable) > `approved`. Both
  `pending_reviewers` and `unavailable_reviewers` are always surfaced when
  non-empty, so neither the host handoff nor a failed reviewer is hidden and a
  round is never falsely `approved`. The PR test gate is skipped while `incomplete`
  (as it already is while `pending`).

## Tests

Classifier (signature/empty → unavailable; schema-invalid JSON + prose → repair
path), precedence helper (incl. **pending + unavailable → pending**), `_run_reviewer`
(agent-failure → unavailable sentinel; content-bearing → `SystemExit`), and an
**in-process mixed-case round** (`--reviewers gemini claude` with Gemini unavailable
+ Claude pending → `state: "pending"`, both reviewer lists present). **Full suite:
846 passed.** SKILL.md documents the round states + resilience.

## Scope / testability note

Out of scope (per #322): the Gemini CLI tool-config root cause (environment-level)
and any blanket retry — the failure is deterministic (it reproduced identically),
and `run_external` already retries genuine transients. The dry-run harness can't
emit a reviewer failure, so the round-level behavior is covered by the in-process
mixed-case test + unit tests of the composing pieces rather than a subprocess
dry-run test.

Plan approved on #322 (plan-r2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude