### PR TITLE
docs: correct Claude billing note (Agent SDK credit change postponed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ of calling model APIs directly. If your local agent CLIs are backed by existing
 AI subscriptions or authenticated developer accounts, the review loop can use
 those existing entitlements rather than requiring separate model API keys.
 
-**Claude billing note (effective June 15, 2026):** Non-interactive `claude`
-usage — including `claude -p` as used by this tool — draws from a separate
-monthly Agent SDK credit rather than your interactive subscription pool. Credits
-vary by plan ($20/month on Pro, $100 on Max 5×, $200 on Max 20×). See
+**Claude billing note:** Anthropic had announced that non-interactive `claude`
+usage — including `claude -p` as used by this tool — would move from your
+subscription's rate limits to a separate monthly Agent SDK credit. As of
+June 15, 2026 that change has been **postponed**: `claude -p` / Agent SDK usage
+continues to draw from your existing Claude subscription as before, with no
+separate credit, and Anthropic has said it will give advance notice before any
+future change. See
 [Anthropic's support article](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-for details. Gemini CLI and Codex CLI have their own separate billing models.
+for the latest. Gemini CLI and Codex CLI have their own separate billing models.
 
 ## Who This Is For
 
@@ -36,10 +39,10 @@ That makes it easier to experiment with agent-to-agent review loops before
 committing to hosted automation. It also keeps local workspace setup,
 credentials, and agent approval prompts under your direct control.
 
-Note that as of June 15, 2026, Claude CLI non-interactive usage draws from a
-separate monthly Agent SDK credit (see billing note above) rather than being
-unlimited within a subscription — so very high-volume automated use may still
-incur costs depending on your plan.
+Note that Claude subscriptions have their own usage limits, and Anthropic's
+terms for non-interactive (`claude -p` / Agent SDK) usage may change in the
+future (see the billing note above) — so very high-volume automated use may
+incur costs or hit limits depending on your plan.
 
 ## Compared To Similar Tools
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -2,7 +2,7 @@
 
 `coding-review-agent-loop` is a local CLI that orchestrates coding agents through a GitHub pull request review loop. Its main advantage is account reuse: it shells out to locally authenticated `claude`, `codex`, `gemini`, and `gh` CLIs instead of calling model APIs directly. If your local agent CLIs are backed by existing AI subscriptions or authenticated developer accounts, the review loop can use those existing entitlements rather than requiring separate model API keys.
 
-**Claude billing note (effective June 15, 2026):** Non-interactive `claude` usage — including `claude -p` as used by this tool — draws from a separate monthly Agent SDK credit rather than your interactive subscription pool ($20/month on Pro, $100 on Max 5×, $200 on Max 20×). See [Anthropic's support article](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) for details.
+**Claude billing note:** Anthropic had announced that non-interactive `claude` usage — including `claude -p` as used by this tool — would move from your subscription's rate limits to a separate monthly Agent SDK credit. As of June 15, 2026 that change has been **postponed**: `claude -p` / Agent SDK usage continues to draw from your existing Claude subscription as before, with no separate credit, and Anthropic has said it will give advance notice before any future change. See [Anthropic's support article](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) for the latest.
 
 The default flow is:
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -8,7 +8,7 @@ instead of through `claude -p` subprocesses.
 
 | Aspect | Headless CLI mode | Skill mode |
 |--------|-------------------|------------|
-| Claude turns | `claude -p` subprocess (Agent SDK credits) | Active Claude Code session |
+| Claude turns | `claude -p` subprocess | Active Claude Code session |
 | Codex turns | `codex exec` subprocess | Same `codex exec` subprocess |
 | Gemini turns | `gemini` subprocess | Same `gemini` subprocess |
 | GitHub ops | Python `gh` wrapper | Same `gh` wrapper |


### PR DESCRIPTION
Docs-only. Anthropic notified (2026-06-15) that the previously-announced move of
non-interactive `claude` usage (`claude -p` / Agent SDK / third-party apps) from
subscription rate limits to a separate monthly **Agent SDK credit** is **not**
taking effect as stated — usage continues to draw from the existing subscription
as before, with advance notice promised before any future change.

The README asserted the change as already in effect ("effective June 15, 2026 …
draws from a separate monthly Agent SDK credit"), which is now inaccurate.

## Changes

- **README.md** — reframe the billing note: the credit change was *announced but
  postponed*; `claude -p` / Agent SDK keeps drawing from the existing subscription
  (no separate credit); drop the now-inapplicable per-plan credit amounts; soften
  the "Why Not GitHub Actions?" note to talk about subscription limits + possible
  future changes rather than asserting the credit.
- **docs/skill_mode.md** — drop the "(Agent SDK credits)" qualifier from the
  headless-mode table cell.

The already-hedged "Billing and terms" sections (SKILL.md / skill_mode.md) didn't
assert the credit and are left as-is.

Note: wording reflects an Anthropic billing-policy notification; reviewers can't
verify the source, so this is a factual/wording correction for a human to confirm
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude