### PR TITLE
Add Antigravity (agy) agent backend + Gemini retirement guidance (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ Currently supported local agent CLIs:
 - Claude Code via `claude`
 - OpenAI Codex CLI via `codex`
 - Gemini CLI via `gemini`
+- Antigravity CLI via `agy` (Gemini CLI migration path — see below)
+
+### Gemini CLI → Antigravity migration
+
+Google is retiring **Gemini CLI consumer access** (free / Google AI Pro / Ultra)
+on **June 18, 2026**; personal-account `gemini` usage stops working after that
+(enterprise / API-key Gemini CLI paths remain supported). Use the Antigravity CLI
+(`agy`) instead — it runs the same Google account plans with its own quota model:
+
+```bash
+# install agy, authenticate, then select it as a coder or reviewer:
+agent-loop pr 123 --repo OWNER/REPO --reviewer antigravity
+agent-loop task "Fix the flaky test" --repo OWNER/REPO --coder antigravity --reviewer codex
+```
+
+Pick the model with `--antigravity-model "<name>"` (as listed by `agy models`;
+default `Gemini 3.1 Pro (High)`). When a `gemini` invocation fails with an
+auth/quota error near or after the cutoff, the tool surfaces this migration
+guidance. Notes: Antigravity turns are single-shot (no cross-round session
+resume) and report estimated token usage (`agy` emits no token counts).
 
 ## Install / Use
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -54,7 +54,10 @@ This is one skill with three modes; pick the procedure from what you're given:
 
 All modes share the sub-procedures below, the same primitives, the same session/
 resume model, and the same posture: **merge is always a human decision.** For any
-mode, you need `OWNER/REPO` and the reviewer set (`codex`, `gemini`, or both).
+mode, you need `OWNER/REPO` and the reviewer set (`codex`, `gemini`, and/or
+`antigravity` — the `agy` CLI, the migration path for Gemini CLI consumer access
+that Google retires on 2026-06-18). `antigravity` works wherever an external
+coder/reviewer does (`--coder antigravity` / `--reviewers antigravity ...`).
 
 ---
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -13,6 +13,8 @@ The default flow is:
 
 The default coder is Claude and the default reviewer is Codex. Reverse the direction with `--coder codex --reviewer claude`, or use Gemini with `--coder gemini` / `--reviewer gemini`. Repeat `--reviewer` to require multiple reviewer approvals.
 
+Gemini CLI consumer access (free / Google AI Pro / Ultra) is retiring on June 18, 2026; personal-account `gemini` users should migrate to the Antigravity CLI (`agy`) with `--coder antigravity` / `--reviewer antigravity` (pick the model via `--antigravity-model`, default `Gemini 3.1 Pro (High)`). Enterprise / API-key Gemini CLI paths remain supported. Antigravity turns are single-shot (no cross-round session resume) and report estimated usage.
+
 ## Architecture
 
 The tool is a local orchestrator. It does not call model APIs directly; it shells

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -22,7 +22,7 @@ Claude Code (interactive session)
 │
 ├── helpers/validate_response.py   ← validates structured protocol responses
 ├── helpers/state_manager.py       ← session state + GitHub comment resume
-├── helpers/run_external.py        ← invokes codex/gemini CLIs
+├── helpers/run_external.py        ← invokes codex / gemini / antigravity (agy) CLIs
 ├── helpers/gh_ops.py              ← GitHub issue/PR comment operations
 └── helpers/demo_loop.py           ← standalone dry-run demo
 ```
@@ -69,6 +69,12 @@ mirroring the CLI's `--coder` / `--reviewer` reversal — so an external agent
 End to end: external coder plans → reviewers review → external coder implements
 (one-shot / decompose / by-phase) → host + external reviewers review the PR.
 Merge stays a human decision.
+
+The external agent can be `codex`, `gemini`, or `antigravity` (the `agy` CLI —
+the migration path for Gemini CLI consumer access, which Google retires on
+2026-06-18; pick its model with `--antigravity-model`, default `Gemini 3.1 Pro
+(High)`). Antigravity turns are single-shot (no cross-round session resume) and
+report estimated token usage.
 
 ## Approved-plan execution helpers
 

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -60,6 +60,7 @@ def make_minimal_config(
         claude_dir=_agent_dir("claude"),
         codex_dir=_agent_dir("codex"),
         gemini_dir=_agent_dir("gemini"),
+        antigravity_dir=_agent_dir("antigravity"),
         coder=coder,
         reviewer=tuple(reviewer_names),
         base=base,

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -115,8 +115,13 @@ def _build_dry_run_response(role: str, flow: str = "plan") -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run one external agent turn.")
-    parser.add_argument("--agent", required=True, choices=["codex", "gemini"])
+    parser.add_argument("--agent", required=True, choices=["codex", "gemini", "antigravity"])
     parser.add_argument("--prompt-file", required=True, help="Path to prompt text file.")
+    parser.add_argument(
+        "--model", default=None,
+        help="Model override (antigravity only; as shown by `agy models`). "
+             "Defaults to 'Gemini 3.1 Pro (High)'.",
+    )
     parser.add_argument("--output", required=True, help="Path to write the agent response.")
     parser.add_argument("--workdir", required=True, help="Working directory for the agent.")
     parser.add_argument(
@@ -209,6 +214,7 @@ def main() -> None:
     workdir = Path(args.workdir)
 
     # Import backends lazily to avoid heavy import in dry-run path
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     from coding_review_agent_loop.agents.codex import CodexBackend
     from coding_review_agent_loop.agents.gemini import GeminiBackend
     from coding_review_agent_loop.config import AgentLoopConfig, AgentName, ensure_temp_checkout
@@ -216,8 +222,9 @@ def main() -> None:
     from coding_review_agent_loop.usage import estimate_usage
 
     agent_name: AgentName = args.agent
-    default_cmds = {"codex": "codex", "gemini": "gemini"}
+    default_cmds = {"codex": "codex", "gemini": "gemini", "antigravity": "agy"}
     cmd = args.cmd or default_cmds[agent_name]
+    antigravity_model = args.model or "Gemini 3.1 Pro (High)"
 
     # Build a minimal config sufficient for backend.run()
     import tempfile
@@ -229,6 +236,7 @@ def main() -> None:
         claude_dir=workdir,
         codex_dir=workdir,
         gemini_dir=workdir,
+        antigravity_dir=workdir,
         coder="claude",
         reviewer=(agent_name,),
         base="main",
@@ -239,6 +247,9 @@ def main() -> None:
         claude_cmd="claude",
         codex_cmd=cmd if agent_name == "codex" else "codex",
         gemini_cmd=cmd if agent_name == "gemini" else "gemini",
+        antigravity_cmd=cmd if agent_name == "antigravity" else "agy",
+        antigravity_args=("--dangerously-skip-permissions",),
+        antigravity_model=antigravity_model,
         gh_cmd="gh",
         claude_args=(),
         codex_args=("--dangerously-bypass-approvals-and-sandbox",),
@@ -265,7 +276,12 @@ def main() -> None:
     # deterministically and re-cloning per attempt would be wasteful.
     if args.repo:
         ensure_temp_checkout(workdir, agent=agent_name, config=config, runner=runner)
-    backend = CodexBackend() if agent_name == "codex" else GeminiBackend()
+    if agent_name == "codex":
+        backend = CodexBackend()
+    elif agent_name == "antigravity":
+        backend = AntigravityBackend()
+    else:
+        backend = GeminiBackend()
 
     # Retry transient agent failures (429 / overloaded / timeout / capacity).
     # The primary failure path is a *returned* AgentResult with a non-zero

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -988,7 +988,7 @@ def _run_reviewer(
     item_id_offset: int = 0,
 ) -> dict:
     """Run one reviewer turn; return {reviewer_name, state, blocking_items, new_items}."""
-    agent_cap = agent.capitalize() if agent in ("codex", "gemini") else agent
+    agent_cap = agent_display_name(agent)  # type: ignore[arg-type]
     validate_kind = "pr_review" if flow == "pr" else "plan_review"
 
     prompt_file      = tmpdir / f"{agent}-prompt.md"
@@ -1800,7 +1800,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
     with tempfile.TemporaryDirectory() as tmpstr:
         tmpdir = Path(tmpstr)
         for reviewer in external_reviewers:
-            reviewer_cap = reviewer.capitalize() if reviewer in ("codex", "gemini") else reviewer
+            reviewer_cap = agent_display_name(reviewer)  # type: ignore[arg-type]
             if reviewer_cap in local_completed or reviewer in local_completed:
                 print(f"[skip] {reviewer_cap} already completed this round")
                 continue
@@ -2019,7 +2019,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
     with tempfile.TemporaryDirectory() as tmpstr:
         tmpdir = Path(tmpstr)
         for reviewer in external_reviewers:
-            reviewer_cap = reviewer.capitalize() if reviewer in ("codex", "gemini") else reviewer
+            reviewer_cap = agent_display_name(reviewer)  # type: ignore[arg-type]
             if reviewer_cap in local_completed or reviewer in local_completed:
                 print(f"[skip] {reviewer_cap} already completed this round")
                 continue
@@ -3124,7 +3124,7 @@ def main() -> None:
     p_plan.add_argument("--issue", type=int, required=True)
     p_plan.add_argument("--repo", required=True)
     p_plan.add_argument(
-        "--coder", choices=["claude", "codex", "gemini"], default="claude",
+        "--coder", choices=["claude", "codex", "gemini", "antigravity"], default="claude",
         help="Who writes the plan: 'claude' (default, host supplies --plan-file) or "
              "an external coder ('codex'/'gemini') run by the skill (reversed roles, #307).",
     )
@@ -3218,7 +3218,7 @@ def main() -> None:
     p_impl.add_argument("--issue", type=int, required=True)
     p_impl.add_argument("--repo", required=True)
     p_impl.add_argument(
-        "--coder", choices=["codex", "gemini"], required=True,
+        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that implements the plan (the host implements in-session).",
     )
     p_impl.add_argument("--plan-file", required=True, help="Approved plan to implement.")
@@ -3243,7 +3243,7 @@ def main() -> None:
     p_impl_phase.add_argument("--issue", type=int, required=True)
     p_impl_phase.add_argument("--repo", required=True)
     p_impl_phase.add_argument(
-        "--coder", choices=["codex", "gemini"], required=True,
+        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that decomposes and implements the first agent phase.",
     )
     p_impl_phase.add_argument("--plan-file", required=True, help="Approved plan to decompose and implement.")
@@ -3268,7 +3268,7 @@ def main() -> None:
     p_decompose.add_argument("--issue", type=int, required=True)
     p_decompose.add_argument("--repo", required=True)
     p_decompose.add_argument(
-        "--coder", choices=["codex", "gemini"], required=True,
+        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that decomposes the approved plan.",
     )
     p_decompose.add_argument("--plan-file", required=True, help="Approved plan to decompose.")
@@ -3290,7 +3290,7 @@ def main() -> None:
     )
     p_task.add_argument("--repo", required=True)
     p_task.add_argument(
-        "--coder", choices=["claude", "codex", "gemini"], default="claude",
+        "--coder", choices=["claude", "codex", "gemini", "antigravity"], default="claude",
         help="Host coder only for now; external coders are rejected in task mode (#307).",
     )
     p_task.add_argument("--plan-file", required=True)

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -1,0 +1,89 @@
+"""Antigravity CLI (`agy`) backend.
+
+Migration path for Gemini CLI consumer users (#215): Google is retiring Gemini CLI
+consumer access (free / AI Pro / Ultra) on 2026-06-18 in favor of Antigravity. The
+`agy` CLI is Claude-Code-style (plain-text `--print` output, `--model`,
+`--dangerously-skip-permissions`, `--conversation` resume), so this backend mirrors
+the Claude backend rather than the Gemini one.
+
+Limitations this increment: `agy --print` does not surface a conversation id in its
+plain-text output, so turns are single-shot (no cross-round session resume), and it
+emits no token usage (usage falls back to the estimated path).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .base import (
+    AgentName,
+    AgentResult,
+    public_response_path,
+    read_public_response_file,
+    with_public_response_file_instruction,
+)
+from ..logging import agent_log_path, log
+from ..runner import Runner
+
+if TYPE_CHECKING:
+    from ..config import AgentLoopConfig
+
+
+class AntigravityBackend:
+    name: AgentName = "antigravity"
+    display_name = "Antigravity"
+    signature = "Google Antigravity"
+
+    def workdir(self, config: AgentLoopConfig) -> Path:
+        return config.antigravity_dir
+
+    def default_args(self, *, dangerous: bool) -> tuple[str, ...]:
+        return ("--dangerously-skip-permissions",) if dangerous else ()
+
+    def run(
+        self,
+        runner: Runner,
+        config: AgentLoopConfig,
+        prompt: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> AgentResult:
+        response_path = public_response_path(config, "antigravity")
+        args = [config.antigravity_cmd, "--print", "--model", config.antigravity_model, *config.antigravity_args]
+        # agy resumes by conversation id (not gemini's --resume). agy --print does
+        # not surface a conversation id in plain output, so in practice session_id
+        # is None and turns are single-shot; honor it if a caller ever supplies one.
+        if session_id:
+            args += ["--conversation", session_id]
+        args.append(with_public_response_file_instruction(prompt, response_path))
+        log_path = agent_log_path(config, "antigravity", run_id=run_id)
+        log(config, f"Starting Antigravity in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
+        result = runner.run_with_log(
+            args,
+            cwd=config.antigravity_dir,
+            log_path=log_path,
+            label="Antigravity",
+            progress_interval_seconds=config.progress_interval_seconds,
+            check=False,
+            env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+        )
+        log(config, f"Antigravity finished; log: {log_path}")
+        # agy --print emits plain text (no JSON wrapper). Prefer the public response
+        # file the prompt asks the agent to write; fall back to stdout.
+        response_file_text = read_public_response_file(response_path)
+        return AgentResult(
+            text=response_file_text or result.stdout,
+            raw_output=result.stdout,
+            text_source="response_file" if response_file_text is not None else "stdout",
+            response_file_text=response_file_text,
+            message_text=result.stdout,
+            session_id=None,
+            log_path=log_path,
+            returncode=result.returncode,
+            usage=None,
+            raw_usage=None,
+        )
+
+
+BACKEND = AntigravityBackend()

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -2,9 +2,19 @@
 
 Migration path for Gemini CLI consumer users (#215): Google is retiring Gemini CLI
 consumer access (free / AI Pro / Ultra) on 2026-06-18 in favor of Antigravity. The
-`agy` CLI is Claude-Code-style (plain-text `--print` output, `--model`,
-`--dangerously-skip-permissions`, `--conversation` resume), so this backend mirrors
-the Claude backend rather than the Gemini one.
+`agy` CLI is an autonomous, Claude-Code-style coding agent rather than a plain
+prompt->text tool, which drives two integration requirements:
+
+* **PTY.** `agy --print` detects whether stdout is a terminal and silently drops its
+  final response under a pipe / file / subprocess (upstream antigravity-cli issue
+  #76). We run it attached to a pseudo-terminal (``use_pty=True``) so it emits
+  normally, then strip ANSI control sequences from the captured output.
+* **Marker.** As an agent, `agy` narrates tool use before its answer. We ask it to
+  print a sentinel line immediately before the publishable response and keep only
+  what follows it (the same convention the Gemini backend uses).
+
+The prompt is the *value* of the ``--print`` flag (``--prompt`` is its alias), not a
+trailing positional argument, so it must come last after the other flags.
 
 Limitations this increment: `agy --print` does not surface a conversation id in its
 plain-text output, so turns are single-shot (no cross-round session resume), and it
@@ -19,15 +29,41 @@ from typing import TYPE_CHECKING
 from .base import (
     AgentName,
     AgentResult,
+    AgentTextSource,
     public_response_path,
     read_public_response_file,
     with_public_response_file_instruction,
 )
 from ..logging import agent_log_path, log
+from ..protocol import PUBLIC_RESPONSE_MARKER
 from ..runner import Runner
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
+
+
+def _with_public_response_marker_instruction(prompt: str) -> str:
+    return f"""{prompt}
+
+IMPORTANT FOR ANTIGRAVITY (agy) OUTPUT FILTERING:
+
+As an agent you may print planning narration, tool-use status, or diagnostics
+before your final answer.
+
+When you are ready to provide the response that should be posted publicly to
+GitHub, print this exact line immediately before it:
+
+{PUBLIC_RESPONSE_MARKER}
+
+Only content after that line will be posted to GitHub. Do not print the marker
+until you are done with all internal reasoning, tool use, and review work.
+"""
+
+
+def _strip_public_response_marker(raw: str) -> tuple[str, AgentTextSource]:
+    if PUBLIC_RESPONSE_MARKER not in raw:
+        return raw, "stdout"
+    return raw.rsplit(PUBLIC_RESPONSE_MARKER, 1)[1].lstrip("\n"), "stdout_marker"
 
 
 class AntigravityBackend:
@@ -50,13 +86,17 @@ class AntigravityBackend:
         run_id: str | None = None,
     ) -> AgentResult:
         response_path = public_response_path(config, "antigravity")
-        args = [config.antigravity_cmd, "--print", "--model", config.antigravity_model, *config.antigravity_args]
+        prompt_text = _with_public_response_marker_instruction(
+            with_public_response_file_instruction(prompt, response_path)
+        )
+        args = [config.antigravity_cmd, "--model", config.antigravity_model, *config.antigravity_args]
         # agy resumes by conversation id (not gemini's --resume). agy --print does
         # not surface a conversation id in plain output, so in practice session_id
         # is None and turns are single-shot; honor it if a caller ever supplies one.
         if session_id:
             args += ["--conversation", session_id]
-        args.append(with_public_response_file_instruction(prompt, response_path))
+        # The prompt is the value of --print (must be last), not a positional.
+        args += ["--print", prompt_text]
         log_path = agent_log_path(config, "antigravity", run_id=run_id)
         log(config, f"Starting Antigravity in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
         result = runner.run_with_log(
@@ -67,17 +107,22 @@ class AntigravityBackend:
             progress_interval_seconds=config.progress_interval_seconds,
             check=False,
             env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+            use_pty=True,
         )
         log(config, f"Antigravity finished; log: {log_path}")
-        # agy --print emits plain text (no JSON wrapper). Prefer the public response
-        # file the prompt asks the agent to write; fall back to stdout.
+        # Prefer the public response file the prompt asks the agent to write; else
+        # keep only what follows the public-response marker in stdout; else stdout.
         response_file_text = read_public_response_file(response_path)
+        if response_file_text is not None:
+            message_text, text_source = response_file_text, "response_file"
+        else:
+            message_text, text_source = _strip_public_response_marker(result.stdout)
         return AgentResult(
-            text=response_file_text or result.stdout,
+            text=message_text,
             raw_output=result.stdout,
-            text_source="response_file" if response_file_text is not None else "stdout",
+            text_source=text_source,
             response_file_text=response_file_text,
-            message_text=result.stdout,
+            message_text=message_text,
             session_id=None,
             log_path=log_path,
             returncode=result.returncode,

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -14,7 +14,7 @@ from ..usage import UsageMetadata
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
-AgentName = Literal["claude", "codex", "gemini"]
+AgentName = Literal["claude", "codex", "gemini", "antigravity"]
 AgentTextSource = Literal["response_file", "stdout_marker", "stdout"]
 
 

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,41 @@ from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
+
+
+# Gemini CLI consumer access (free / Google AI Pro / Ultra) is retiring on this
+# date; after it, personal-account Gemini CLI usage stops working and users should
+# migrate to Antigravity (`agy`) or a supported enterprise / API-key path (#215).
+GEMINI_CONSUMER_CUTOFF = date(2026, 6, 18)
+_GEMINI_CUTOFF_WARN_AHEAD_DAYS = 14
+
+_GEMINI_MIGRATION_GUIDANCE = (
+    "Gemini CLI consumer access (free / Google AI Pro / Ultra) is retiring on "
+    "2026-06-18. If you are on a personal Google account, migrate to Antigravity "
+    "(`agy`): --coder antigravity / --reviewer antigravity (skill: --agent "
+    "antigravity). Gemini CLI remains supported for enterprise / API-key paths."
+)
+
+# Substrings (lowercased) in a *failed* gemini invocation's output that suggest an
+# auth/quota/retirement problem, where the migration guidance is relevant.
+_GEMINI_RETIREMENT_SIGNATURES = (
+    "unauthenticated",
+    "permission denied",
+    "permission_denied",
+    "quota",
+    "resource exhausted",
+    "resource_exhausted",
+    "not authorized",
+    "unauthorized",
+    "no longer",
+    "retir",
+)
+
+
+def _gemini_retirement_signal(text: str) -> bool:
+    """True if failed-gemini output looks like an auth/quota/retirement problem."""
+    lowered = text.lower()
+    return any(signature in lowered for signature in _GEMINI_RETIREMENT_SIGNATURES)
 
 
 def _with_public_response_marker_instruction(prompt: str) -> str:
@@ -169,6 +205,8 @@ class GeminiBackend:
         )
         log_path = agent_log_path(config, "gemini", run_id=run_id)
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")
+        if date.today() >= GEMINI_CONSUMER_CUTOFF - timedelta(days=_GEMINI_CUTOFF_WARN_AHEAD_DAYS):
+            log(config, f"Gemini CLI advisory: {_GEMINI_MIGRATION_GUIDANCE}")
         args = [
             config.gemini_cmd,
             "--prompt",
@@ -189,6 +227,12 @@ class GeminiBackend:
             env={"AGENT_LOOP_WORKDIR": str(config.gemini_dir.resolve())},
         )
         log(config, f"Gemini finished; log: {log_path}")
+        if result.returncode != 0 and _gemini_retirement_signal(result.stdout or ""):
+            log(
+                config,
+                "Gemini CLI invocation failed with an auth/quota signal that may be the "
+                f"consumer retirement. {_GEMINI_MIGRATION_GUIDANCE}",
+            )
         message_text, new_session_id, usage, raw_usage, message_source = _parse_gemini_payload(result.stdout)
         response_file_text = read_public_response_file(response_path)
         return AgentResult(

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -227,7 +227,8 @@ class GeminiBackend:
             env={"AGENT_LOOP_WORKDIR": str(config.gemini_dir.resolve())},
         )
         log(config, f"Gemini finished; log: {log_path}")
-        if result.returncode != 0 and _gemini_retirement_signal(result.stdout or ""):
+        retired_failure = result.returncode != 0 and _gemini_retirement_signal(result.stdout or "")
+        if retired_failure:
             log(
                 config,
                 "Gemini CLI invocation failed with an auth/quota signal that may be the "
@@ -235,9 +236,17 @@ class GeminiBackend:
             )
         message_text, new_session_id, usage, raw_usage, message_source = _parse_gemini_payload(result.stdout)
         response_file_text = read_public_response_file(response_path)
+        raw_output = result.stdout
+        if retired_failure:
+            # Append the guidance to the *returned* output, not just stderr: callers
+            # such as helpers.run_external classify/persist failures from
+            # raw_output/text, so the migration guidance must travel with them (#215).
+            guidance_block = f"\n\n{_GEMINI_MIGRATION_GUIDANCE}"
+            raw_output = (raw_output or "") + guidance_block
+            message_text = (message_text or "") + guidance_block
         return AgentResult(
             text=response_file_text or message_text,
-            raw_output=result.stdout,
+            raw_output=raw_output,
             text_source="response_file" if response_file_text is not None else message_source,
             response_file_text=response_file_text,
             message_text=message_text,

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .base import AgentBackend, AgentName, AgentResult
+from .antigravity import BACKEND as ANTIGRAVITY_BACKEND
 from .claude import BACKEND as CLAUDE_BACKEND
 from .codex import BACKEND as CODEX_BACKEND
 from .gemini import BACKEND as GEMINI_BACKEND
@@ -18,6 +19,7 @@ BACKENDS: dict[AgentName, AgentBackend] = {
     "claude": CLAUDE_BACKEND,
     "codex": CODEX_BACKEND,
     "gemini": GEMINI_BACKEND,
+    "antigravity": ANTIGRAVITY_BACKEND,
 }
 
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -78,14 +78,20 @@ def build_parser() -> argparse.ArgumentParser:
             help="Gemini checkout. Defaults to a repo-scoped temporary checkout when Gemini is active.",
         )
         subparser.add_argument(
+            "--antigravity-dir",
+            type=Path,
+            default=None,
+            help="Antigravity (agy) checkout. Defaults to a repo-scoped temporary checkout when Antigravity is active.",
+        )
+        subparser.add_argument(
             "--coder",
-            choices=("claude", "codex", "gemini"),
+            choices=("claude", "codex", "gemini", "antigravity"),
             default="claude",
             help="Agent that creates and fixes the PR (default: claude).",
         )
         subparser.add_argument(
             "--reviewer",
-            choices=("claude", "codex", "gemini"),
+            choices=("claude", "codex", "gemini", "antigravity"),
             action="append",
             default=None,
             help=(
@@ -100,6 +106,12 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--claude-cmd", default="claude")
         subparser.add_argument("--codex-cmd", default="codex")
         subparser.add_argument("--gemini-cmd", default="gemini")
+        subparser.add_argument("--antigravity-cmd", default="agy")
+        subparser.add_argument(
+            "--antigravity-model",
+            default="Gemini 3.1 Pro (High)",
+            help="Antigravity (agy) model, as shown by `agy models` (default: 'Gemini 3.1 Pro (High)').",
+        )
         subparser.add_argument("--gh-cmd", default="gh")
         subparser.add_argument(
             "--dangerous-agent-permissions",
@@ -107,8 +119,9 @@ def build_parser() -> argparse.ArgumentParser:
             help=(
                 "Use permission-bypass defaults for configured agents. Only use in trusted "
                 "local repositories: Claude gets --dangerously-skip-permissions and "
-                "Codex gets --dangerously-bypass-approvals-and-sandbox, and Gemini "
-                "gets --yolo and --skip-trust."
+                "Codex gets --dangerously-bypass-approvals-and-sandbox, Gemini "
+                "gets --yolo and --skip-trust, and Antigravity gets "
+                "--dangerously-skip-permissions."
             ),
         )
         subparser.add_argument(
@@ -136,6 +149,15 @@ def build_parser() -> argparse.ArgumentParser:
             help=(
                 "Extra argument passed to gemini (repeat for multiple). "
                 "Providing any --gemini-arg replaces the default entirely."
+            ),
+        )
+        subparser.add_argument(
+            "--antigravity-arg",
+            action="append",
+            default=None,
+            help=(
+                "Extra argument passed to agy (repeat for multiple). "
+                "Providing any --antigravity-arg replaces the default entirely."
             ),
         )
         subparser.add_argument(

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -27,7 +27,8 @@ from .unresolved_items import HUMAN_REQUIREMENTS_ACK_ITEM_ID
 
 ITEM_SUMMARY_LIMIT = 100
 PUBLIC_REVIEWER_NAME_BY_DISPLAY = {
-    agent_display_name(agent): agent_signature(agent) for agent in ("claude", "codex", "gemini")
+    agent_display_name(agent): agent_signature(agent)
+    for agent in ("claude", "codex", "gemini", "antigravity")
 }
 
 

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -59,6 +59,12 @@ class AgentLoopConfig:
     planning_context_mode: str = "compact"
     pr_review_context_mode: str = "full"
     auto_agent_dirs: tuple[AgentName, ...] = ()
+    # Antigravity (`agy`) backend (#215). Defaulted so existing AgentLoopConfig
+    # constructions keep working; real values are set when antigravity is used.
+    antigravity_dir: Path = Path("antigravity")
+    antigravity_cmd: str = "agy"
+    antigravity_args: tuple[str, ...] = ()
+    antigravity_model: str = "Gemini 3.1 Pro (High)"
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -81,6 +87,7 @@ def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
         "claude": (config.claude_dir, "--claude-dir"),
         "codex": (config.codex_dir, "--codex-dir"),
         "gemini": (config.gemini_dir, "--gemini-dir"),
+        "antigravity": (config.antigravity_dir, "--antigravity-dir"),
     }
     active = [(agent, *paths[agent]) for agent in required]
     for index, (_left_agent, left_path, left_option) in enumerate(active):
@@ -173,6 +180,7 @@ def _agent_dir_option(agent: AgentName) -> str:
         "claude": "--claude-dir",
         "codex": "--codex-dir",
         "gemini": "--gemini-dir",
+        "antigravity": "--antigravity-dir",
     }[agent]
 
 
@@ -422,6 +430,7 @@ def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:
         "claude": (config.claude_dir, "--claude-dir"),
         "codex": (config.codex_dir, "--codex-dir"),
         "gemini": (config.gemini_dir, "--gemini-dir"),
+        "antigravity": (config.antigravity_dir, "--antigravity-dir"),
     }
     auto_dirs = set(config.auto_agent_dirs)
     for agent in required:
@@ -462,6 +471,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
             ("claude", args.claude_dir),
             ("codex", args.codex_dir),
             ("gemini", args.gemini_dir),
+            ("antigravity", args.antigravity_dir),
         )
         if value is None
     )
@@ -480,10 +490,16 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         if args.gemini_dir is not None
         else default_agent_workdir(repo, "gemini").resolve()
     )
+    antigravity_dir = (
+        args.antigravity_dir.resolve()
+        if args.antigravity_dir is not None
+        else default_agent_workdir(repo, "antigravity").resolve()
+    )
     primary_dir = {
         "claude": claude_dir,
         "codex": codex_dir,
         "gemini": gemini_dir,
+        "antigravity": antigravity_dir,
     }[args.coder]
     test_command = _split_command(args.test_command)
     if args.max_rounds <= 0:
@@ -529,6 +545,14 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
             if args.gemini_arg is not None
             else default_agent_args("gemini", dangerous=args.dangerous_agent_permissions)
         ),
+        antigravity_dir=antigravity_dir,
+        antigravity_cmd=args.antigravity_cmd,
+        antigravity_args=tuple(
+            args.antigravity_arg
+            if args.antigravity_arg is not None
+            else default_agent_args("antigravity", dangerous=args.dangerous_agent_permissions)
+        ),
+        antigravity_model=args.antigravity_model,
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -105,6 +105,7 @@ def _coder_workdir_guidance(
         "claude": config.claude_args,
         "codex": config.codex_args,
         "gemini": config.gemini_args,
+        "antigravity": config.antigravity_args,
     }[active_agent]
     dangerous_warning = ""
     if any(arg in dangerous_args for arg in active_args):

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 import time
@@ -21,6 +22,17 @@ class CommandResult:
     stdout: str
     stderr: str
     returncode: int
+
+
+# Matches ANSI/VT100 control sequences (CSI, OSC, charset selection) that a
+# program emits when it believes it is talking to a terminal. We run some agents
+# under a pseudo-terminal (see run_with_log use_pty), so we strip these from the
+# captured output before parsing it.
+_ANSI_RE = re.compile(r"\x1B\[[0-9;?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)|\x1B[()][AB0-2]")
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text).replace("\r", "")
 
 
 def tail_text(text: str, *, max_lines: int = 80) -> str:
@@ -82,6 +94,7 @@ class Runner:
         progress_interval_seconds: int,
         check: bool = True,
         env: Mapping[str, str] | None = None,
+        use_pty: bool = False,
     ) -> CommandResult:
         cmd = [str(a) for a in args]
         if self.dry_run:
@@ -90,6 +103,16 @@ class Runner:
 
         log_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_log_dir_ignored(log_path.parent)
+        if use_pty:
+            return self._run_with_log_pty(
+                cmd,
+                cwd=cwd,
+                log_path=log_path,
+                label=label,
+                progress_interval_seconds=progress_interval_seconds,
+                check=check,
+                env=env,
+            )
         started = time.monotonic()
         next_progress = started + progress_interval_seconds
         header = f"$ {' '.join(cmd)}\n\n"
@@ -140,5 +163,94 @@ class Runner:
             raise AgentLoopError(
                 f"Command failed with exit {returncode}: {' '.join(cmd)}\n"
                 f"log: {log_path}\n\nlast output:\n{tail_text(full_output)}"
+            )
+        return result
+
+    def _run_with_log_pty(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        label: str,
+        progress_interval_seconds: int,
+        check: bool,
+        env: Mapping[str, str] | None,
+    ) -> CommandResult:
+        """Run a command attached to a pseudo-terminal, logging and capturing output.
+
+        Some agents (notably Antigravity's `agy`) detect whether stdout is a TTY
+        and silently drop their final response when it is not (a pipe / file /
+        subprocess), see upstream antigravity-cli issue #76. Allocating a PTY makes
+        the agent emit normally; we strip the resulting ANSI control sequences from
+        the captured text before returning it.
+        """
+        import pty
+        import select
+
+        started = time.monotonic()
+        next_progress = started + progress_interval_seconds
+        header = f"$ {' '.join(cmd)}\n\n"
+        master_fd, slave_fd = pty.openpty()
+        chunks: list[bytes] = []
+        with log_path.open("wb") as log_file:
+            log_file.write(header.encode("utf-8"))
+            log_file.flush()
+            proc = subprocess.Popen(
+                cmd,
+                cwd=cwd,
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                close_fds=True,
+                start_new_session=True,
+                env={**os.environ, **env} if env is not None else None,
+            )
+            os.close(slave_fd)
+            try:
+                while True:
+                    ready, _, _ = select.select([master_fd], [], [], 1.0)
+                    if master_fd in ready:
+                        try:
+                            data = os.read(master_fd, 65536)
+                        except OSError:
+                            data = b""  # EIO once the slave side has fully closed
+                        if data:
+                            log_file.write(data)
+                            log_file.flush()
+                            chunks.append(data)
+                        elif proc.poll() is not None:
+                            break
+                    elif proc.poll() is not None:
+                        break
+                    now = time.monotonic()
+                    if now >= next_progress:
+                        elapsed = int(now - started)
+                        print(
+                            f"[agent-loop {datetime.now().strftime('%H:%M:%S')}] "
+                            f"{label} still running ({elapsed}s); log: {log_path}",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                        next_progress = now + progress_interval_seconds
+            except KeyboardInterrupt:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                raise
+            finally:
+                os.close(master_fd)
+            returncode = proc.wait()
+
+        raw = b"".join(chunks).decode("utf-8", errors="replace")
+        output = strip_ansi(raw)
+        result = CommandResult(cmd, cwd, output, "", returncode)
+        if check and returncode != 0:
+            raise AgentLoopError(
+                f"Command failed with exit {returncode}: {' '.join(cmd)}\n"
+                f"log: {log_path}\n\nlast output:\n{tail_text(output)}"
             )
         return result

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
-AgentName = Literal["claude", "codex", "gemini"]
+AgentName = Literal["claude", "codex", "gemini", "antigravity"]
 UsageMode = Literal["exact", "partial", "estimated"]
 
 NUMERIC_USAGE_FIELDS = (

--- a/src/coding_review_agent_loop/workdirs.py
+++ b/src/coding_review_agent_loop/workdirs.py
@@ -16,6 +16,7 @@ def agent_workdir(config: AgentLoopConfig, agent: AgentName) -> Path:
         "claude": config.claude_dir,
         "codex": config.codex_dir,
         "gemini": config.gemini_dir,
+        "antigravity": config.antigravity_dir,
     }[agent]
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -17788,6 +17788,29 @@ def test_gemini_failure_appends_migration_guidance(tmp_path, capsys, monkeypatch
     monkeypatch.setattr(gm, "date", _BeforeWindow)
     config = make_config(tmp_path, quiet=False)
     runner = FakeRunner(gemini_outputs=[{"stdout": "Error: quota exceeded", "returncode": 1}])
-    gm.BACKEND.run(runner, config, "Review", run_id="r")
+    result = gm.BACKEND.run(runner, config, "Review", run_id="r")
     err = capsys.readouterr().err
     assert "Antigravity" in err and "2026-06-18" in err
+    # The guidance must travel with the *returned* result (raw_output and text),
+    # since run_external classifies/persists failures from those, not stderr (#215).
+    assert "2026-06-18" in result.raw_output
+    assert "antigravity" in result.raw_output
+    assert result.raw_output.startswith("Error: quota exceeded")  # original error preserved
+    assert "2026-06-18" in result.text
+
+
+def test_gemini_success_does_not_append_migration_guidance(tmp_path, monkeypatch):
+    import coding_review_agent_loop.agents.gemini as gm
+    from datetime import date
+
+    class _BeforeWindow(date):
+        @classmethod
+        def today(cls):
+            return date(2026, 1, 1)
+
+    monkeypatch.setattr(gm, "date", _BeforeWindow)
+    config = make_config(tmp_path)
+    runner = FakeRunner(gemini_outputs=[("STATE: approved\n\nLGTM", 0)])
+    result = gm.BACKEND.run(runner, config, "Review", run_id="r")
+    assert "2026-06-18" not in result.raw_output  # no guidance on a clean success
+    assert "2026-06-18" not in result.text

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -199,6 +199,7 @@ class FakeRunner(Runner):
         claude_outputs=None,
         codex_outputs=None,
         gemini_outputs=None,
+        antigravity_outputs=None,
         issue_payload=None,
         issue_comments=None,
         pr_payload=None,
@@ -227,6 +228,7 @@ class FakeRunner(Runner):
         self.claude_outputs = list(claude_outputs or [])
         self.codex_outputs = list(codex_outputs or [])
         self.gemini_outputs = list(gemini_outputs or [])
+        self.antigravity_outputs = list(antigravity_outputs or [])
         self.issue_payload = {
             "number": 56,
             "state": "open",
@@ -491,6 +493,18 @@ class FakeRunner(Runner):
             self._maybe_advance_git_head_for_agent_pr(output)
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
+
+        if cmd[:1] == ["agy"]:
+            output = self._next_agent_output(self.antigravity_outputs)
+            if isinstance(output, dict):
+                stdout = output.get("stdout", "")
+                returncode = output.get("returncode", 0)
+            else:
+                stdout, returncode = output
+            self._maybe_write_public_response_file(cmd)
+            self._maybe_advance_git_head_for_agent_pr(stdout)
+            log_path.write_text(f"$ {' '.join(cmd)}\n\n{stdout}", encoding="utf-8")
+            return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
         return self.run(args, cwd=cwd, check=check)
 
@@ -11544,7 +11558,8 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, t
     assert config.codex_dir == default_agent_workdir("OWNER/REPO", "codex").resolve()
     assert config.claude_dir == default_agent_workdir("OWNER/REPO", "claude").resolve()
     assert config.gemini_dir == default_agent_workdir("OWNER/REPO", "gemini").resolve()
-    assert set(config.auto_agent_dirs) == {"claude", "codex", "gemini"}
+    assert config.antigravity_dir == default_agent_workdir("OWNER/REPO", "antigravity").resolve()
+    assert set(config.auto_agent_dirs) == {"claude", "codex", "gemini", "antigravity"}
     assert config.agent_memory_dir == (
         cache_home / "coding-review-agent-loop" / "repos" / "OWNER-REPO" / "memory"
     ).resolve()
@@ -11709,7 +11724,7 @@ def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):
 
     assert config.codex_dir == codex_dir
     assert config.claude_dir == default_agent_workdir("OWNER/REPO", "claude").resolve()
-    assert set(config.auto_agent_dirs) == {"claude", "gemini"}
+    assert set(config.auto_agent_dirs) == {"claude", "gemini", "antigravity"}
 
 
 def test_relative_log_dir_defaults_under_active_coder_workdir(tmp_path):
@@ -17579,3 +17594,150 @@ def test_run_validated_agent_deterministic_strip_skipped_when_ledger_incomplete(
 
     repair_mock.assert_not_called()
     assert "item-1" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Antigravity (agy) backend + Gemini retirement guidance (#215)
+# ---------------------------------------------------------------------------
+
+
+def test_antigravity_backend_command_and_prefers_response_file(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    runner = FakeRunner(
+        antigravity_outputs=[("stdout fallback text", 0)],
+        public_response_outputs=["response file text"],
+    )
+    config = make_config(
+        tmp_path,
+        antigravity_dir=agy_dir,
+        antigravity_cmd="agy",
+        antigravity_model="Gemini 3.1 Pro (High)",
+        antigravity_args=("--dangerously-skip-permissions",),
+    )
+    result = AntigravityBackend().run(runner, config, "Review this PR.", run_id="run-1")
+    cmd = runner.commands[-1][0]
+    assert cmd[0] == "agy"
+    assert "--print" in cmd
+    assert cmd[cmd.index("--model") + 1] == "Gemini 3.1 Pro (High)"
+    assert "--dangerously-skip-permissions" in cmd
+    assert result.text == "response file text"
+    assert result.session_id is None  # agy --print exposes no conversation id
+
+
+def test_antigravity_backend_stdout_fallback(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    runner = FakeRunner(antigravity_outputs=[("plain stdout review", 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    result = AntigravityBackend().run(runner, config, "Review this PR.", run_id="run-1")
+    assert result.text == "plain stdout review"
+    assert result.text_source == "stdout"
+
+
+def test_antigravity_backend_resume_uses_conversation(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    runner = FakeRunner(antigravity_outputs=[("ok", 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(runner, config, "x", session_id="conv-7", run_id="r")
+    cmd = runner.commands[-1][0]
+    assert cmd[cmd.index("--conversation") + 1] == "conv-7"
+
+
+def test_antigravity_registry():
+    from coding_review_agent_loop.agents.registry import (
+        agent_display_name,
+        agent_signature,
+        get_backend,
+    )
+    assert agent_display_name("antigravity") == "Antigravity"
+    assert agent_signature("antigravity") == "Google Antigravity"
+    assert get_backend("antigravity").name == "antigravity"
+
+
+def test_config_from_args_antigravity_defaults(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "123", "--repo", "OWNER/REPO",
+        "--coder", "antigravity", "--reviewer", "codex",
+        "--codex-dir", str(tmp_path / "codex"),
+        "--dangerous-agent-permissions",
+    ])
+    config = config_from_args(args, FakeRunner())
+    assert config.coder == "antigravity"
+    assert config.antigravity_cmd == "agy"
+    assert config.antigravity_model == "Gemini 3.1 Pro (High)"
+    assert config.antigravity_args == ("--dangerously-skip-permissions",)
+    assert config.antigravity_dir == default_agent_workdir("OWNER/REPO", "antigravity").resolve()
+    # antigravity is the coder -> primary/log dir lives under its checkout.
+    assert str(config.log_dir).startswith(str(config.antigravity_dir))
+
+
+def test_distinct_workdir_validation_covers_antigravity(tmp_path):
+    from coding_review_agent_loop.config import ensure_distinct_workdirs
+    shared = tmp_path / "shared"
+    config = make_config(
+        tmp_path,
+        coder="antigravity",
+        reviewer="codex",
+        allow_shared_dir=False,
+        antigravity_dir=shared,
+        codex_dir=shared,
+    )
+    with pytest.raises(AgentLoopError, match="same directory"):
+        ensure_distinct_workdirs(config)
+
+
+def test_gemini_retirement_signal():
+    from coding_review_agent_loop.agents.gemini import _gemini_retirement_signal
+    assert _gemini_retirement_signal("Error: quota exceeded")
+    assert _gemini_retirement_signal("PERMISSION_DENIED for this account")
+    assert _gemini_retirement_signal("request was unauthenticated")
+    assert not _gemini_retirement_signal("SyntaxError: invalid token")
+    assert not _gemini_retirement_signal("connection reset by peer")
+
+
+def test_gemini_date_advisory_fires_only_in_window(tmp_path, capsys, monkeypatch):
+    import coding_review_agent_loop.agents.gemini as gm
+    from datetime import date
+
+    class _NearCutoff(date):
+        @classmethod
+        def today(cls):
+            return date(2026, 6, 18)
+
+    class _BeforeWindow(date):
+        @classmethod
+        def today(cls):
+            return date(2026, 1, 1)
+
+    config = make_config(tmp_path, quiet=False)
+
+    monkeypatch.setattr(gm, "date", _NearCutoff)
+    gm.BACKEND.run(FakeRunner(gemini_outputs=[("ok", 0)]), config, "Review", run_id="r1")
+    assert "2026-06-18" in capsys.readouterr().err  # advisory fires near cutoff
+
+    monkeypatch.setattr(gm, "date", _BeforeWindow)
+    gm.BACKEND.run(FakeRunner(gemini_outputs=[("ok", 0)]), config, "Review", run_id="r2")
+    assert "Antigravity" not in capsys.readouterr().err  # no advisory long before cutoff
+
+
+def test_gemini_failure_appends_migration_guidance(tmp_path, capsys, monkeypatch):
+    import coding_review_agent_loop.agents.gemini as gm
+    from datetime import date
+
+    class _BeforeWindow(date):
+        @classmethod
+        def today(cls):
+            return date(2026, 1, 1)  # advisory off, so this isolates the failure path
+
+    monkeypatch.setattr(gm, "date", _BeforeWindow)
+    config = make_config(tmp_path, quiet=False)
+    runner = FakeRunner(gemini_outputs=[{"stdout": "Error: quota exceeded", "returncode": 1}])
+    gm.BACKEND.run(runner, config, "Review", run_id="r")
+    err = capsys.readouterr().err
+    assert "Antigravity" in err and "2026-06-18" in err

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -442,6 +442,7 @@ class FakeRunner(Runner):
         progress_interval_seconds,
         check=True,
         env=None,
+        use_pty=False,
     ):
         cmd, cwd_path = self._record_command(args, cwd)
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -17619,9 +17620,12 @@ def test_antigravity_backend_command_and_prefers_response_file(tmp_path):
     result = AntigravityBackend().run(runner, config, "Review this PR.", run_id="run-1")
     cmd = runner.commands[-1][0]
     assert cmd[0] == "agy"
-    assert "--print" in cmd
     assert cmd[cmd.index("--model") + 1] == "Gemini 3.1 Pro (High)"
     assert "--dangerously-skip-permissions" in cmd
+    # The prompt is the value of --print and must be the last argument (agy's
+    # --print/--prompt consumes the next token, not a trailing positional).
+    assert cmd[-2] == "--print"
+    assert "Review this PR." in cmd[-1]
     assert result.text == "response file text"
     assert result.session_id is None  # agy --print exposes no conversation id
 
@@ -17637,6 +17641,24 @@ def test_antigravity_backend_stdout_fallback(tmp_path):
     assert result.text_source == "stdout"
 
 
+def test_antigravity_backend_strips_public_response_marker(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    from coding_review_agent_loop.protocol import PUBLIC_RESPONSE_MARKER
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    stdout = (
+        "I will inspect the diff and run the tests.\n"
+        f"{PUBLIC_RESPONSE_MARKER}\n"
+        "STATE: approved\n\nLooks good to me."
+    )
+    runner = FakeRunner(antigravity_outputs=[(stdout, 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    result = AntigravityBackend().run(runner, config, "Review this PR.", run_id="run-1")
+    assert result.text == "STATE: approved\n\nLooks good to me."
+    assert result.text_source == "stdout_marker"
+    assert "I will inspect" not in result.text
+
+
 def test_antigravity_backend_resume_uses_conversation(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     agy_dir = tmp_path / "antigravity"
@@ -17646,6 +17668,34 @@ def test_antigravity_backend_resume_uses_conversation(tmp_path):
     AntigravityBackend().run(runner, config, "x", session_id="conv-7", run_id="r")
     cmd = runner.commands[-1][0]
     assert cmd[cmd.index("--conversation") + 1] == "conv-7"
+
+
+def test_runner_pty_reports_tty_and_strips_ansi(tmp_path):
+    """The real PTY path: the child sees a TTY and ANSI codes are stripped."""
+    import sys
+    from coding_review_agent_loop.runner import Runner, strip_ansi
+
+    assert strip_ansi("\x1b[31mred\x1b[0m\r\ndone") == "red\ndone"
+
+    program = (
+        "import sys\n"
+        "sys.stdout.write('istty=%s\\n' % sys.stdout.isatty())\n"
+        "sys.stdout.write('\\x1b[32mGREEN\\x1b[0m\\n')\n"
+    )
+    log_path = tmp_path / "logs" / "pty.log"
+    result = Runner().run_with_log(
+        [sys.executable, "-c", program],
+        cwd=tmp_path,
+        log_path=log_path,
+        label="PtyProbe",
+        progress_interval_seconds=999,
+        check=True,
+        use_pty=True,
+    )
+    assert "istty=True" in result.stdout
+    assert "GREEN" in result.stdout
+    assert "\x1b[" not in result.stdout  # ANSI stripped from captured output
+    assert result.returncode == 0
 
 
 def test_antigravity_registry():

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2710,3 +2710,71 @@ class TestRunReviewerUnavailable:
         assert output["state"] == "pending"
         assert output["pending_reviewers"] == ["Claude"]
         assert output["unavailable_reviewers"] == ["Gemini"]
+
+
+# ---------------------------------------------------------------------------
+# helpers — Antigravity (agy) agent in the skill (#215)
+# ---------------------------------------------------------------------------
+
+
+class TestAntigravitySkill:
+    def _last_json(self, stdout: str) -> dict:
+        start = stdout.rfind("\n{")
+        if start < 0:
+            start = stdout.find("{")
+        return json.loads(stdout[start:].strip())
+
+    def test_run_external_antigravity_dry_run_plan_review_stub(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "out.md"
+            result = _run(
+                "helpers.run_external",
+                "--agent", "antigravity", "--role", "reviewer", "--flow", "plan",
+                "--prompt-file", _write_tmp("review it"),
+                "--output", str(out), "--workdir", tmpdir,
+                "--dry-run",
+            )
+            assert result.returncode == 0
+            val = _run(
+                "helpers.validate_response", "--file", str(out), "--kind", "plan_review",
+                check=False,
+            )
+            assert val.returncode == 0, f"{out.read_text()}\n{val.stderr}"
+
+    def test_run_plan_round_antigravity_external_coder_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            result = _run(
+                "helpers.skill_runner", "run-plan-round",
+                "--issue", "9991", "--repo", "test/skill-repo",
+                "--coder", "antigravity", "--reviewers", "codex",
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            output = self._last_json(result.stdout)
+            assert "state" in output
+            repair_dir = _REPAIR_BASE / "9991-r1-antigravity-coder"
+            manifest = json.loads((repair_dir / "manifest.json").read_text(encoding="utf-8"))
+            assert manifest["role"] == "coder"
+            assert manifest["agent"] == "antigravity"
+
+    def test_antigravity_reviewer_display_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            plan = tmppath / "plan.md"
+            plan.write_text(_VALID_PLAN_STATE, encoding="utf-8")
+            result = _run(
+                "helpers.skill_runner", "run-plan-round",
+                "--issue", "9990", "--repo", "test/skill-repo",
+                "--plan-file", str(plan), "--reviewers", "antigravity",
+                "--dry-run",
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            output = self._last_json(result.stdout)
+            assert "Antigravity" in output["approved_reviewers"]


### PR DESCRIPTION
Closes #215. Google retires **Gemini CLI consumer access** (free / Google AI Pro /
Ultra) on **2026-06-18**. This adds an `antigravity` agent backend driving the
`agy` CLI as the migration path, coexisting with the existing `gemini` backend
(purely additive — default `claude`/`codex`/`gemini` paths are unchanged).

## Backend (`agents/antigravity.py`)

`agy` is an autonomous, Claude-Code-style coding agent, not a plain prompt→text
CLI. Driving it reliably needs three things (all verified end-to-end against real
`agy` v1.0.8):

1. **Arg order.** The prompt is the *value* of `--print` (`--prompt` is its alias),
   **not** a trailing positional. So the invocation is
   `agy --model "<model>" --dangerously-skip-permissions … --print "<prompt>"`
   with the prompt last.
2. **PTY.** `agy --print` detects a non-terminal stdout and silently drops its
   final response under a pipe / subprocess (upstream
   [antigravity-cli #76](https://github.com/google-antigravity/antigravity-cli/issues/76)).
   `Runner` gains a `use_pty` path that attaches the child to a pseudo-terminal
   and strips ANSI from the captured output; this backend opts in.
3. **Output isolation.** As an agent, `agy` narrates tool use before its answer.
   The backend asks for the public-response marker (same convention as the
   `gemini` backend) and keeps only what follows it, in addition to the
   response-file path. In practice `agy` honors the response file directly.

**Caveats (by design this increment):** `agy --print` exposes no conversation id,
so turns are **single-shot** (no cross-round session resume, `session_id=None`),
and it emits no token counts, so usage is **estimated**. Default model
`Gemini 3.1 Pro (High)` (configurable via `--antigravity-model`, names from
`agy models`).

## Wiring (cross-cutting, mechanical)

`AgentName` literal (base.py, usage.py); registry; comment_rendering signatures;
config (`antigravity_dir`/`_cmd`/`_args`/`_model` + every agent→dir map,
`_agent_dir_option`, distinct/ensure-workdir maps, `config_from_args`
defaults/primary-dir/auto-dirs); `workdirs.agent_workdir`;
`prompts._coder_workdir_guidance`; `cli.py` (`--coder`/`--reviewer` choices +
`--antigravity-cmd`/`-dir`/`-model`/`-arg`); `run_external.py` (`--agent` choice,
default cmd, `--model`, config, backend select); `prompt_builders.make_minimal_config`;
`skill_runner` (`--coder` choices; `agent_display_name` instead of the
`.capitalize()` hacks so `antigravity` → `Antigravity`).

## Gemini retirement guidance (#215 acceptance criteria 3–4)

`GeminiBackend.run` logs a **near/after-cutoff advisory** (when today ≥ 2026-06-18
− 14d) and, on a non-zero `gemini` exit whose output matches auth/quota/retirement
signatures, **appends migration guidance** pointing to antigravity / enterprise-
API-key paths (conservative: only on a gemini failure + those signatures). Docs
(README, SKILL.md, `docs/skill_mode.md`, `docs/local_agent_loop.md`) cover the
cutoff, that enterprise/API-key Gemini CLI remains supported, agy install/select,
and the caveats.

## Tests

Antigravity backend (command/arg order, response-file vs marker vs stdout,
`--conversation` resume), a **real PTY runner test** (child sees a TTY, ANSI is
stripped), registry display/signature, `config_from_args` defaults +
distinct-workdir validation, `_gemini_retirement_signal` + the date advisory
(monkeypatched date, in/out of window) + failure-path guidance,
`run_external --agent antigravity` dry-run stub, and skill `--coder antigravity`
/ `Antigravity` reviewer display. **Full suite: 861 passed.**

Verified live: real `agy` reviewed a planted bug and returned a clean
`STATE: blocking` review through the actual backend.

Plan approved on #215 (plan-r2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude
