### PR TITLE
Dynamic model-specific agent signatures (#332)

### DIFF
--- a/helpers/render_response.py
+++ b/helpers/render_response.py
@@ -22,6 +22,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.comment_rendering import (
+    _public_reviewer_name,
     _render_public_pr_review_comment,
     _render_public_plan_review_comment,
     _render_public_coder_followup_comment,
@@ -100,13 +101,19 @@ def main() -> None:
             if parsed is None:
                 print("render_response: coder_followup did not parse", file=sys.stderr)
                 sys.exit(1)
-            rendered = _render_public_coder_followup_comment(parsed)
+            signature = _public_reviewer_name(args.reviewer, None, model_used)
+            rendered = _render_public_coder_followup_comment(
+                parsed, signature=signature, prior_items=prior_items
+            )
         elif args.kind == "plan_revision":
             parsed = validate_structured_plan_revision(text)
             if parsed is None:
                 print("render_response: plan_revision did not parse", file=sys.stderr)
                 sys.exit(1)
-            rendered = _render_public_plan_revision_comment(parsed, prior_items=prior_items)
+            signature = _public_reviewer_name(args.reviewer, None, model_used)
+            rendered = _render_public_plan_revision_comment(
+                parsed, prior_items=prior_items, raw_text=text, signature=signature
+            )
         else:
             print(f"render_response: unknown kind {args.kind}", file=sys.stderr)
             sys.exit(1)

--- a/helpers/render_response.py
+++ b/helpers/render_response.py
@@ -57,7 +57,13 @@ def main() -> None:
     parser.add_argument("--output", required=True, help="Path to write rendered markdown.")
     parser.add_argument("--reviewer", default="Codex", help="Reviewer display name.")
     parser.add_argument("--context-file", default=None, help="Optional JSON context file.")
+    parser.add_argument(
+        "--model",
+        default="",
+        help="Model the agent actually ran, stamped into the signature (#332).",
+    )
     args = parser.parse_args()
+    model_used = args.model or None
 
     try:
         text = Path(args.file).read_text(encoding="utf-8")
@@ -77,6 +83,7 @@ def main() -> None:
                 human_requirements_resolved_flag=False,
                 prior_items=prior_items,
                 dispositions=parsed.dispositions,
+                model_used=model_used,
             )
         elif args.kind == "plan_review":
             parsed = parse_plan_review(text, reviewer=args.reviewer)
@@ -86,6 +93,7 @@ def main() -> None:
                 human_requirements_resolved_flag=False,
                 prior_items=prior_items,
                 dispositions=parsed.dispositions,
+                model_used=model_used,
             )
         elif args.kind == "coder_followup":
             parsed = validate_structured_coder_followup(text)

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -341,6 +341,8 @@ def main() -> None:
                     "session_id": result.session_id,
                     "returncode": result.returncode,
                     "usage": usage.to_dict(),
+                    # Model that actually ran, for the dynamic signature (#332).
+                    "model_used": result.model_used,
                 }, indent=2),
                 encoding="utf-8",
             )

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -814,6 +814,15 @@ def _complete_reviewer_turn(
         )
 
     # --- Render ---
+    # The model the reviewer actually ran is in run_external's usage sidecar (#332);
+    # pass it so the rendered signature reads e.g. "Google Antigravity: Gemini 3.1 Pro (High)".
+    reviewer_model = ""
+    _usage_path = work_dir / f"{agent}-usage.json"
+    if _usage_path.exists():
+        try:
+            reviewer_model = json.loads(_usage_path.read_text(encoding="utf-8")).get("model_used") or ""
+        except (OSError, json.JSONDecodeError):
+            reviewer_model = ""
     _run_helper(
         "helpers.render_response",
         "--file", str(raw_output),
@@ -821,6 +830,7 @@ def _complete_reviewer_turn(
         "--reviewer", agent_cap,
         "--context-file", str(context_file),
         "--output", str(rendered_output),
+        *(["--model", reviewer_model] if reviewer_model else []),
     )
 
     # --- Parse review JSON for metadata ---

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -355,6 +355,20 @@ def _workdir_for_agent(agent: str, args: argparse.Namespace) -> str:
     return str(tmp)
 
 
+def _model_used_from_usage(usage_file: Path) -> str:
+    """Model the agent ran, read from run_external's usage sidecar (#332).
+
+    Returns "" when the sidecar is missing/unreadable or carries no model, so the
+    signature falls back to the generic provider name.
+    """
+    if usage_file.exists():
+        try:
+            return json.loads(usage_file.read_text(encoding="utf-8")).get("model_used") or ""
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return ""
+    return ""
+
+
 def _agent_memory_dir(repo: str) -> Path:
     slug = repo.replace("/", "-").replace(":", "-")
     state_home = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
@@ -816,13 +830,7 @@ def _complete_reviewer_turn(
     # --- Render ---
     # The model the reviewer actually ran is in run_external's usage sidecar (#332);
     # pass it so the rendered signature reads e.g. "Google Antigravity: Gemini 3.1 Pro (High)".
-    reviewer_model = ""
-    _usage_path = work_dir / f"{agent}-usage.json"
-    if _usage_path.exists():
-        try:
-            reviewer_model = json.loads(_usage_path.read_text(encoding="utf-8")).get("model_used") or ""
-        except (OSError, json.JSONDecodeError):
-            reviewer_model = ""
+    reviewer_model = _model_used_from_usage(work_dir / f"{agent}-usage.json")
     _run_helper(
         "helpers.render_response",
         "--file", str(raw_output),
@@ -1371,12 +1379,16 @@ def _complete_coder_turn(
                 f"skill_runner: raw response at: {raw_output}"
             )
         prior_items = [_deserialize_unresolved_item(i) for i in next_prior_items_raw]
+        # The coder's actual model is in run_external's usage sidecar (#332); stamp it
+        # so a skill-mode plan revision is signed e.g. "-- Google Antigravity: Gemini
+        # 3.1 Pro (High)" rather than the bare provider name.
+        coder_model = _model_used_from_usage(usage_file)
         canonical_text = render_canonical_plan_revision(parsed, prior_items)
         public_body = _render_public_plan_revision_comment(
             parsed,
             prior_items=prior_items,
             raw_text=raw_text,
-            signature=agent_signature(coder),  # type: ignore[arg-type]
+            signature=agent_signature(coder, None, coder_model or None),  # type: ignore[arg-type]
         )
         public_file = work_dir / "coder-public.md"
         _write_text(public_file, public_body)

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -128,6 +128,10 @@ class AntigravityBackend:
             returncode=result.returncode,
             usage=None,
             raw_usage=None,
+            # The model we requested is the model that ran (single-shot, no
+            # server-side substitution); the signature stamps it (#332). #333's
+            # fallback chain will override this with the model that answered.
+            model_used=config.antigravity_model or None,
         )
 
 

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -30,6 +30,11 @@ class AgentResult:
     returncode: int = 0
     usage: UsageMetadata | None = None
     raw_usage: object | None = None
+    # Human-readable label of the model that actually produced this result (e.g.
+    # "Gemini 3.1 Pro (High)", "claude-sonnet-4-6"). Ground truth for the dynamic
+    # signature (#332); None when the backend could not determine it. The
+    # antigravity fallback chain (#333) sets this to the model that answered.
+    model_used: str | None = None
 
 
 class AgentBackend(Protocol):

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -44,8 +44,21 @@ def _normalize_claude_usage(payload: object) -> UsageMetadata | None:
     )
 
 
-def _parse_claude_output(raw: str) -> tuple[str, str | None, UsageMetadata | None, object | None]:
-    """Extract (text, session_id) from Claude's --output-format json response."""
+def _extract_claude_model(data: dict) -> str | None:
+    """Model id Claude reported running (`model`, else a `modelUsage` key)."""
+    model = data.get("model")
+    if isinstance(model, str) and model:
+        return model
+    model_usage = data.get("modelUsage")
+    if isinstance(model_usage, dict) and model_usage:
+        return next(iter(model_usage))
+    return None
+
+
+def _parse_claude_output(
+    raw: str,
+) -> tuple[str, str | None, UsageMetadata | None, object | None, str | None]:
+    """Extract (text, session_id, usage, raw_usage, model) from Claude json output."""
     try:
         data = json.loads(raw)
         if isinstance(data, dict):
@@ -55,10 +68,16 @@ def _parse_claude_output(raw: str) -> tuple[str, str | None, UsageMetadata | Non
             raw_usage = data.get("usage")
             if raw_usage is None and isinstance(data.get("result_message"), dict):
                 raw_usage = data["result_message"].get("usage")
-            return text, data.get("session_id"), _normalize_claude_usage(raw_usage), raw_usage
+            return (
+                text,
+                data.get("session_id"),
+                _normalize_claude_usage(raw_usage),
+                raw_usage,
+                _extract_claude_model(data),
+            )
     except (json.JSONDecodeError, ValueError):
         pass
-    return raw, None, None, None
+    return raw, None, None, None, None
 
 
 class ClaudeBackend:
@@ -82,6 +101,10 @@ class ClaudeBackend:
     ) -> AgentResult:
         response_path = public_response_path(config, "claude")
         args = [config.claude_cmd, "--print", "--output-format", "json", *config.claude_args]
+        # Pin the model when declared (#332); conflict validation guarantees this is
+        # not also passed via --claude-arg --model.
+        if config.claude_model:
+            args += ["--model", config.claude_model]
         if session_id:
             args += ["--resume", session_id]
         args.append(with_public_response_file_instruction(prompt, response_path))
@@ -97,7 +120,7 @@ class ClaudeBackend:
             env={"AGENT_LOOP_WORKDIR": str(config.claude_dir.resolve())},
         )
         log(config, f"Claude finished; log: {log_path}")
-        message_text, new_session_id, usage, raw_usage = _parse_claude_output(result.stdout)
+        message_text, new_session_id, usage, raw_usage, model_detected = _parse_claude_output(result.stdout)
         response_file_text = read_public_response_file(response_path)
         return AgentResult(
             text=response_file_text or message_text,
@@ -110,6 +133,9 @@ class ClaudeBackend:
             returncode=result.returncode,
             usage=usage,
             raw_usage=raw_usage,
+            # Ground truth from Claude's own output; falls back to config.claude_model
+            # at signature time when detection is unavailable (e.g. non-JSON output).
+            model_used=model_detected,
         )
 
 

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -82,6 +82,28 @@ def _extract_codex_usage(raw: str) -> tuple[UsageMetadata | None, object | None]
     return None, last_usage
 
 
+def _codex_model_args(config: AgentLoopConfig) -> list[str]:
+    """CLI args to pin codex's model/effort when declared (#332).
+
+    Conflict validation guarantees these are not also passed via --codex-arg, so
+    no duplicate flags. The reasoning-effort value is TOML, hence the quotes.
+    """
+    args: list[str] = []
+    if config.codex_model:
+        args += ["--model", config.codex_model]
+    if config.codex_reasoning_effort:
+        args += ["-c", f'model_reasoning_effort="{config.codex_reasoning_effort}"']
+    return args
+
+
+def _codex_model_label(config: AgentLoopConfig) -> str | None:
+    if not config.codex_model:
+        return None
+    if config.codex_reasoning_effort:
+        return f"{config.codex_model} ({config.codex_reasoning_effort})"
+    return config.codex_model
+
+
 def _read_codex_message_file(output_path: Path) -> str | None:
     try:
         text = output_path.read_text(encoding="utf-8")
@@ -124,6 +146,7 @@ class CodexBackend:
                     "exec",
                     "--cd",
                     str(config.codex_dir),
+                    *_codex_model_args(config),
                     *config.codex_args,
                     prompt,
                 ],
@@ -138,6 +161,7 @@ class CodexBackend:
                 message_text=result.stdout,
                 log_path=log_path,
                 returncode=result.returncode,
+                model_used=_codex_model_label(config),
             )
 
         with tempfile.NamedTemporaryFile("r", encoding="utf-8", delete=False) as handle:
@@ -152,6 +176,7 @@ class CodexBackend:
                     "--json",
                     "--output-last-message",
                     output_path,
+                    *_codex_model_args(config),
                     *config.codex_args,
                     prompt_with_response_file,
                 ],
@@ -176,6 +201,7 @@ class CodexBackend:
                 returncode=result.returncode,
                 usage=usage,
                 raw_usage=raw_usage,
+                model_used=_codex_model_label(config),
             )
         finally:
             try:

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -215,6 +215,10 @@ class GeminiBackend:
             ),
             *config.gemini_args,
         ]
+        # Pin the model when declared (#332); conflict validation guarantees this is
+        # not also passed via --gemini-arg --model.
+        if config.gemini_model:
+            args += ["--model", config.gemini_model]
         if session_id:
             args += ["--resume", session_id]
         result = runner.run_with_log(
@@ -255,6 +259,7 @@ class GeminiBackend:
             returncode=result.returncode,
             usage=usage,
             raw_usage=raw_usage,
+            model_used=config.gemini_model or None,
         )
 
 

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -34,8 +34,45 @@ def agent_display_name(agent: AgentName) -> str:
     return get_backend(agent).display_name
 
 
-def agent_signature(agent: AgentName) -> str:
-    return get_backend(agent).signature
+def _configured_model_label(agent: AgentName, config: AgentLoopConfig | None) -> str | None:
+    """The model label declared in config for `agent`, or None if not declared.
+
+    Codex appends its reasoning effort; antigravity's model string already embeds
+    effort (e.g. "Gemini 3.1 Pro (High)"), so it is used verbatim.
+    """
+    if config is None:
+        return None
+    if agent == "antigravity":
+        return config.antigravity_model or None
+    if agent == "codex":
+        model = config.codex_model
+        if not model:
+            return None
+        effort = config.codex_reasoning_effort
+        return f"{model} ({effort})" if effort else model
+    if agent == "gemini":
+        return config.gemini_model or None
+    if agent == "claude":
+        return config.claude_model or None
+    return None
+
+
+def agent_signature(
+    agent: AgentName,
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
+) -> str:
+    """Build the `-- {signature}` label for `agent`.
+
+    Precedence: the model that actually ran (`model_used`, ground truth) > the
+    model declared in config > the generic provider signature. When no model is
+    known, returns the generic signature unchanged so existing output is stable.
+    """
+    base = get_backend(agent).signature
+    label = model_used or _configured_model_label(agent, config)
+    if not label:
+        return base
+    return f"{base}: {label}"
 
 
 def default_agent_args(agent: AgentName, *, dangerous: bool) -> tuple[str, ...]:

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -112,6 +112,35 @@ def build_parser() -> argparse.ArgumentParser:
             default="Gemini 3.1 Pro (High)",
             help="Antigravity (agy) model, as shown by `agy models` (default: 'Gemini 3.1 Pro (High)').",
         )
+        subparser.add_argument(
+            "--codex-model",
+            default="",
+            help=(
+                "Codex model to run and stamp in the signature (#332). Mutually "
+                "exclusive with passing --model via --codex-arg."
+            ),
+        )
+        subparser.add_argument(
+            "--codex-reasoning-effort",
+            default="",
+            help=(
+                "Codex reasoning effort (e.g. low/medium/high) to run and stamp in the "
+                "signature. Mutually exclusive with model_reasoning_effort via --codex-arg."
+            ),
+        )
+        subparser.add_argument(
+            "--gemini-model",
+            default="",
+            help="Gemini model to run and stamp in the signature. Mutually exclusive with --gemini-arg --model.",
+        )
+        subparser.add_argument(
+            "--claude-model",
+            default="",
+            help=(
+                "Claude model to run (CLI mode) / declare for the signature (host mode). "
+                "Mutually exclusive with --claude-arg --model."
+            ),
+        )
         subparser.add_argument("--gh-cmd", default="gh")
         subparser.add_argument(
             "--dangerous-agent-permissions",

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -125,7 +125,8 @@ def build_parser() -> argparse.ArgumentParser:
             default="",
             help=(
                 "Codex reasoning effort (e.g. low/medium/high) to run and stamp in the "
-                "signature. Mutually exclusive with model_reasoning_effort via --codex-arg."
+                "signature. Requires --codex-model (codex does not report its model). "
+                "Mutually exclusive with model_reasoning_effort via --codex-arg."
             ),
         )
         subparser.add_argument(

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from .errors import AgentLoopError
 from .agents.registry import agent_display_name, agent_signature
@@ -25,9 +26,15 @@ from .protocol import (
 )
 from .unresolved_items import HUMAN_REQUIREMENTS_ACK_ITEM_ID
 
+if TYPE_CHECKING:
+    from .config import AgentLoopConfig
+
 ITEM_SUMMARY_LIMIT = 100
-PUBLIC_REVIEWER_NAME_BY_DISPLAY = {
-    agent_display_name(agent): agent_signature(agent)
+# Reverse map display-name -> agent. agent_display_name is config-independent, so
+# this is safe to build at import; the signature itself is resolved per-call via
+# agent_signature(agent, config) so it can reflect the configured model (#332).
+_AGENT_BY_DISPLAY_NAME = {
+    agent_display_name(agent): agent
     for agent in ("claude", "codex", "gemini", "antigravity")
 }
 
@@ -55,11 +62,23 @@ def _item_label_status(item: UnresolvedReviewItem) -> str:
     return item.source_status or item.status
 
 
-def _public_reviewer_name(name: str) -> str:
-    return PUBLIC_REVIEWER_NAME_BY_DISPLAY.get(name, name)
+def _public_reviewer_name(
+    name: str,
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
+) -> str:
+    agent = _AGENT_BY_DISPLAY_NAME.get(name)
+    if agent is None:
+        return name
+    # `model_used` is the producing agent's actual model (footers). Prior-item
+    # attributions pass model_used=None and use the configured model (or the
+    # generic signature when nothing is declared) — no cross-agent leakage.
+    return agent_signature(agent, config, model_used)
 
 
-def _format_unresolved_item_label(item: UnresolvedReviewItem) -> str:
+def _format_unresolved_item_label(
+    item: UnresolvedReviewItem, config: AgentLoopConfig | None = None
+) -> str:
     summary = _normalize_item_summary(item.text)
     status = _item_label_status(item)
     if item.item_id == HUMAN_REQUIREMENTS_ACK_ITEM_ID:
@@ -71,7 +90,7 @@ def _format_unresolved_item_label(item: UnresolvedReviewItem) -> str:
         "future": "Future follow-up",
     }
     phrase = phrases.get(status, "Unresolved item")
-    reviewer_name = _public_reviewer_name(item.reviewer)
+    reviewer_name = _public_reviewer_name(item.reviewer, config)
     return f"{phrase} from {reviewer_name}, round {item.source_round}: {summary}"
 
 
@@ -94,6 +113,7 @@ def _render_prior_dispositions_section(
     heading: str,
     prior_items: Sequence[UnresolvedReviewItem],
     dispositions: Sequence[ReviewItemDisposition],
+    config: AgentLoopConfig | None = None,
 ) -> str:
     item_by_id = {item.item_id: item for item in prior_items}
     lines = [heading]
@@ -105,7 +125,7 @@ def _render_prior_dispositions_section(
                 f"allowed IDs: {sorted(item_by_id)}"
             )
         lines.append(
-            f"- [{disposition.item_id}] {_format_unresolved_item_label(item)}"
+            f"- [{disposition.item_id}] {_format_unresolved_item_label(item, config)}"
             f" -> {_render_disposition_status(disposition)}"
         )
     return "\n".join(lines)
@@ -176,6 +196,7 @@ def render_canonical_plan_steps(plan_steps: Sequence[str]) -> str:
 def render_canonical_plan_revision(
     parsed_revision: StructuredPlanRevision,
     prior_items: Sequence[UnresolvedReviewItem],
+    config: AgentLoopConfig | None = None,
 ) -> str:
     sections = [parsed_revision.summary.strip()]
     if prior_items or parsed_revision.prior_plan_item_dispositions:
@@ -184,6 +205,7 @@ def render_canonical_plan_revision(
                 heading="### Prior plan item dispositions",
                 prior_items=prior_items,
                 dispositions=parsed_revision.prior_plan_item_dispositions,
+                config=config,
             )
         )
     else:
@@ -206,6 +228,7 @@ def _render_public_review_comment(
     prior_items: Sequence[UnresolvedReviewItem],
     dispositions: Sequence[ReviewItemDisposition],
     new_items: Sequence[UnresolvedReviewItem],
+    config: AgentLoopConfig | None = None,
 ) -> str:
     rendered = body
     if prior_items:
@@ -221,6 +244,7 @@ def _render_public_review_comment(
                 heading=heading,
                 prior_items=prior_items,
                 dispositions=dispositions,
+                config=config,
             ),
         )
     return rendered
@@ -233,6 +257,8 @@ def _render_public_pr_review_comment(
     human_requirements_resolved_flag: bool,
     prior_items: Sequence[UnresolvedReviewItem],
     dispositions: Sequence[ReviewItemDisposition],
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
 ) -> str:
     sections: list[str] = [f"**Review verdict:** {parsed_review.state.title()}"]
     if parsed_review.summary and parsed_review.summary.strip() != "Review complete.":
@@ -270,13 +296,14 @@ def _render_public_pr_review_comment(
                 heading="### Prior unresolved item dispositions",
                 prior_items=prior_items,
                 dispositions=dispositions,
+                config=config,
             )
         )
     footer: list[str] = []
     if human_requirements_resolved_flag:
         footer.append("<!-- HUMAN_REQUIREMENTS_RESOLVED -->")
     footer.append(f"<!-- AGENT_STATE: {parsed_review.state} -->")
-    footer.append(f"-- {_public_reviewer_name(reviewer)}")
+    footer.append(f"-- {_public_reviewer_name(reviewer, config, model_used)}")
     return "\n\n".join(section for section in sections if section) + (
         ("\n\n" if sections else "") + "\n".join(footer)
     )
@@ -289,6 +316,8 @@ def _render_public_plan_review_comment(
     prior_items: Sequence[UnresolvedReviewItem],
     dispositions: Sequence[ReviewItemDisposition],
     human_requirements_resolved_flag: bool = False,
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
 ) -> str:
     sections: list[str] = [f"**Review verdict:** {parsed_review.state.title()}"]
     if parsed_review.summary and parsed_review.summary.strip() != "Plan review complete.":
@@ -326,6 +355,7 @@ def _render_public_plan_review_comment(
                 heading="### Prior unresolved plan item dispositions",
                 prior_items=prior_items,
                 dispositions=dispositions,
+                config=config,
             )
         )
     footer: list[str] = []
@@ -334,7 +364,7 @@ def _render_public_plan_review_comment(
     footer.extend(
         [
             f"<!-- AGENT_PLAN_STATE: {parsed_review.state} -->",
-            f"-- {_public_reviewer_name(reviewer)}",
+            f"-- {_public_reviewer_name(reviewer, config, model_used)}",
         ]
     )
     return "\n\n".join(section for section in sections if section) + (
@@ -347,6 +377,7 @@ def _render_public_coder_followup_comment(
     *,
     signature: str,
     prior_items: Sequence[UnresolvedReviewItem] = (),
+    config: AgentLoopConfig | None = None,
 ) -> str:
     item_by_id = {item.item_id: item for item in prior_items}
 
@@ -355,7 +386,7 @@ def _render_public_coder_followup_comment(
         if item is None:
             lines = [f"- {item_id}: Item context unavailable in current round metadata."]
         else:
-            lines = [f"- {item_id}: {_format_unresolved_item_label(item)}"]
+            lines = [f"- {item_id}: {_format_unresolved_item_label(item, config)}"]
         if note:
             lines.append(f"  - {note_label}: {note}")
         elif placeholder:
@@ -424,8 +455,9 @@ def _render_public_plan_revision_comment(
     prior_items: Sequence[UnresolvedReviewItem],
     raw_text: str,
     signature: str,
+    config: AgentLoopConfig | None = None,
 ) -> str:
-    sections = ["## Revised plan", render_canonical_plan_revision(parsed_revision, prior_items)]
+    sections = ["## Revised plan", render_canonical_plan_revision(parsed_revision, prior_items, config)]
     human_requirements_block = _extract_plan_revision_human_requirements_block(raw_text)
     if human_requirements_block:
         sections.append(human_requirements_block)

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -65,10 +65,18 @@ class AgentLoopConfig:
     antigravity_cmd: str = "agy"
     antigravity_args: tuple[str, ...] = ()
     antigravity_model: str = "Gemini 3.1 Pro (High)"
+    # Declared model / reasoning effort for the dynamic signature (#332). Empty
+    # means "not declared" (the agent runs its own default and the signature
+    # falls back to the generic provider name). antigravity always has a model.
+    codex_model: str = ""
+    codex_reasoning_effort: str = ""
+    gemini_model: str = ""
+    claude_model: str = ""
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
             object.__setattr__(self, "reviewer", (self.reviewer,))
+        ensure_no_model_arg_conflicts(self)
         if self.planning_context_mode not in {"full", "compact"}:
             raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")
         if self.pr_review_context_mode not in {"full", "compact"}:
@@ -97,6 +105,48 @@ def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
                     f"{left_option} and {right_option} point to the same directory. "
                     "Use separate clones/worktrees, or pass --allow-shared-dir explicitly."
                 )
+
+
+def _args_have_model_flag(args: tuple[str, ...]) -> bool:
+    return any(a == "--model" or a.startswith("--model=") for a in args)
+
+
+def _args_have_reasoning_effort(args: tuple[str, ...]) -> bool:
+    return any("model_reasoning_effort" in a for a in args)
+
+
+def ensure_no_model_arg_conflicts(config: AgentLoopConfig) -> None:
+    """Reject declaring a model/effort both via the dedicated flag and a freeform arg.
+
+    The dynamic signature (#332) must match the model that actually ran. Passing a
+    model/effort both as a declared value and as a freeform `--*-arg` would emit
+    duplicate CLI flags (tool/version-dependent precedence) and risk a signature
+    that disagrees with the run, so we fail fast with a clear message. Note
+    ``antigravity_model`` is always declared, so any ``--antigravity-arg --model``
+    is always a conflict.
+    """
+    if _args_have_model_flag(config.antigravity_args):
+        raise AgentLoopError(
+            "--antigravity-arg --model conflicts with the always-declared antigravity "
+            "model; set the model via --antigravity-model only."
+        )
+    if config.codex_model and _args_have_model_flag(config.codex_args):
+        raise AgentLoopError(
+            "--codex-arg --model conflicts with --codex-model; use --codex-model only."
+        )
+    if config.codex_reasoning_effort and _args_have_reasoning_effort(config.codex_args):
+        raise AgentLoopError(
+            "--codex-arg model_reasoning_effort conflicts with --codex-reasoning-effort; "
+            "use --codex-reasoning-effort only."
+        )
+    if config.gemini_model and _args_have_model_flag(config.gemini_args):
+        raise AgentLoopError(
+            "--gemini-arg --model conflicts with --gemini-model; use --gemini-model only."
+        )
+    if config.claude_model and _args_have_model_flag(config.claude_args):
+        raise AgentLoopError(
+            "--claude-arg --model conflicts with --claude-model; use --claude-model only."
+        )
 
 
 def default_agent_workdir(repo: str, agent: AgentName) -> Path:
@@ -553,6 +603,10 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
             else default_agent_args("antigravity", dangerous=args.dangerous_agent_permissions)
         ),
         antigravity_model=args.antigravity_model,
+        codex_model=getattr(args, "codex_model", ""),
+        codex_reasoning_effort=getattr(args, "codex_reasoning_effort", ""),
+        gemini_model=getattr(args, "gemini_model", ""),
+        claude_model=getattr(args, "claude_model", ""),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -139,6 +139,14 @@ def ensure_no_model_arg_conflicts(config: AgentLoopConfig) -> None:
             "--codex-arg model_reasoning_effort conflicts with --codex-reasoning-effort; "
             "use --codex-reasoning-effort only."
         )
+    if config.codex_reasoning_effort and not config.codex_model:
+        # The declared flags exist to stamp the signature, which needs the model
+        # name; codex does not report its model, so effort alone can't be labeled.
+        raise AgentLoopError(
+            "--codex-reasoning-effort requires --codex-model so the signature can "
+            "name the model (codex does not report its model). To set effort without "
+            "stamping the signature, use --codex-arg -c model_reasoning_effort=... instead."
+        )
     if config.gemini_model and _args_have_model_flag(config.gemini_args):
         raise AgentLoopError(
             "--gemini-arg --model conflicts with --gemini-model; use --gemini-model only."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -118,7 +118,6 @@ from .checks import (
 )
 from .comment_rendering import (
     ITEM_SUMMARY_LIMIT,
-    PUBLIC_REVIEWER_NAME_BY_DISPLAY,
     _append_before_trailing_metadata,
     _format_unresolved_item_label,
     _extract_plan_revision_human_requirements_block,
@@ -293,6 +292,9 @@ class ValidatedAgentResponse:
     session_id: str | None
     marker_value: object
     usage: UsageMetadata | None = None
+    # Model the agent actually ran, for the dynamic signature (#332). Carried from
+    # AgentResult.model_used so the orchestrator render sites can stamp it.
+    model_used: str | None = None
 
 
 def _parse_absolute_reset_seconds(
@@ -962,6 +964,7 @@ def _run_validated_agent(
                             session_id=result.session_id,
                             marker_value=marker_value,
                             usage=usage,
+                            model_used=result.model_used,
                         )
                 if (
                     repair_expected_kind == "plan_revision"
@@ -998,6 +1001,7 @@ def _run_validated_agent(
                             session_id=result.session_id,
                             marker_value=marker_value,
                             usage=usage,
+                            model_used=result.model_used,
                         )
                 if (
                     use_repair
@@ -1054,6 +1058,7 @@ def _run_validated_agent(
                                             session_id=result.session_id,
                                             marker_value=marker_value,
                                             usage=usage,
+                                            model_used=result.model_used,
                                         )
                         except AgentLoopError:
                             pass
@@ -1069,6 +1074,7 @@ def _run_validated_agent(
                                 session_id=result.session_id,
                                 marker_value=marker_value,
                                 usage=usage,
+                                model_used=result.model_used,
                             )
                 if (
                     use_repair
@@ -1102,6 +1108,7 @@ def _run_validated_agent(
                                 session_id=result.session_id,
                                 marker_value=marker_value,
                                 usage=usage,
+                                model_used=result.model_used,
                             )
                 if (
                     use_repair
@@ -1158,6 +1165,7 @@ def _run_validated_agent(
                                 session_id=result.session_id,
                                 marker_value=marker_value,
                                 usage=usage,
+                                model_used=result.model_used,
                             )
             else:
                 if usage_record is not None:
@@ -1167,6 +1175,7 @@ def _run_validated_agent(
                     session_id=result.session_id,
                     marker_value=marker_value,
                     usage=usage,
+                    model_used=result.model_used,
                 )
 
         if should_retry:
@@ -1634,6 +1643,9 @@ def _run_plan_first_loop(
             resumed_record = resumed_by_name.get(reviewer_name)
             if resumed_record is not None:
                 review_output = resumed_record.body
+                # Resumed from a posted comment: the model is not recorded, so the
+                # signature falls back to the configured model (#332).
+                review_model_used = None
                 structured_review = parse_structured_plan_review(
                     review_output,
                     reviewer=reviewer_name,
@@ -1695,6 +1707,7 @@ def _run_plan_first_loop(
                     ledger_incomplete=round_ledger_incomplete,
                 )
                 review_output = review_response.text
+                review_model_used = review_response.model_used
                 reviewer_session_ids[reviewer] = review_response.session_id
                 parsed_review = review_response.marker_value
                 assert isinstance(parsed_review, ParsedPlanReview)
@@ -1769,6 +1782,8 @@ def _run_plan_first_loop(
                             human_requirements_resolved_flag=human_requirements_resolved(
                                 review_output
                             ),
+                            config=config,
+                            model_used=review_model_used,
                         ),
                         PostedRoundMetadata(
                             flow="plan",
@@ -2161,13 +2176,16 @@ def _run_plan_first_loop(
         raw_structured_coder_response: str | None = None
         if isinstance(plan_response.marker_value, StructuredPlanRevision):
             raw_structured_coder_response = plan_response.text
-            canonical_plan = render_canonical_plan_revision(plan_response.marker_value, must_fix_items)
+            canonical_plan = render_canonical_plan_revision(
+                plan_response.marker_value, must_fix_items, config
+            )
             current_plan = canonical_plan
             public_comment = _render_public_plan_revision_comment(
                 plan_response.marker_value,
                 prior_items=must_fix_items,
                 raw_text=plan_response.text,
-                signature=agent_signature(config.coder),
+                signature=agent_signature(config.coder, config, plan_response.model_used),
+                config=config,
             )
         else:
             current_plan = plan_response.text
@@ -2558,6 +2576,7 @@ def run_pr_loop(
                 resumed_record = resumed_by_name.get(reviewer_name)
                 if resumed_record is not None:
                     review_output = resumed_record.body
+                    review_model_used = None
                     reparsed_review = parse_review(review_output, reviewer=reviewer_name)
                     parsed_review = ParsedReview(
                         state=resumed_record.metadata.state or parse_agent_state(review_output),
@@ -2625,6 +2644,7 @@ def run_pr_loop(
                         ledger_incomplete=round_ledger_incomplete,
                     )
                     review_output = review_response.text
+                    review_model_used = review_response.model_used
                     reviewer_session_ids[reviewer] = review_response.session_id
                     parsed_review = review_response.marker_value
                     assert isinstance(parsed_review, ParsedReview)
@@ -2709,6 +2729,8 @@ def run_pr_loop(
                                     ),
                                     prior_items=prior_unresolved_items,
                                     dispositions=parsed_review.dispositions,
+                                    config=config,
+                                    model_used=review_model_used,
                                 ),
                                 PostedRoundMetadata(
                                     flow="pr",
@@ -2754,6 +2776,8 @@ def run_pr_loop(
                                 ),
                                 prior_items=prior_unresolved_items,
                                 dispositions=parsed_review.dispositions,
+                                config=config,
+                                model_used=review_model_used,
                             ),
                             PostedRoundMetadata(
                                 flow="pr",
@@ -3060,8 +3084,9 @@ def run_pr_loop(
                 raw_structured_coder_response = coder_output
                 public_comment = _render_public_coder_followup_comment(
                     coder_response.marker_value,
-                    signature=agent_signature(config.coder),
+                    signature=agent_signature(config.coder, config, coder_response.model_used),
                     prior_items=tuple(unresolved_items),
+                    config=config,
                 )
             else:
                 validate_response_tests_within_workdir(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -776,7 +776,7 @@ def build_issue_prompt(
     issue_context: IssueContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     human_requirements_context = _issue_human_requirements_prompt_context(
         issue_context,
         requirement_scope="implementation requirements",
@@ -819,7 +819,7 @@ def build_issue_plan_prompt(
     issue_context: IssueContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     human_requirements_context = _issue_human_requirements_prompt_context(
         issue_context,
         requirement_scope="planning requirements",
@@ -888,7 +888,7 @@ def build_plan_review_prompt(
             compact_tail=compact_tail,
         )
     coder_name = agent_display_name(config.coder)
-    reviewer_signature = agent_signature(reviewer)
+    reviewer_signature = agent_signature(reviewer, config)
     reviewer_group = format_agent_list(reviewers(config))
     unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
     human_requirements_block = _issue_human_requirements_block(
@@ -1007,7 +1007,7 @@ def _build_compact_plan_review_prompt(
 ) -> str:
     coder_name = agent_display_name(config.coder)
     reviewer_name = agent_display_name(reviewer)
-    reviewer_signature = agent_signature(reviewer)
+    reviewer_signature = agent_signature(reviewer, config)
     reviewer_group = format_agent_list(reviewers(config))
     human_requirements_block = _issue_human_requirements_block(
         issue_context,
@@ -1094,7 +1094,7 @@ def build_plan_decomposition_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
 ) -> str:
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     human_requirements_block = _issue_human_requirements_block(
         issue_context,
         requirement_scope="decomposition requirements",
@@ -1184,7 +1184,7 @@ def build_plan_revision_prompt(
             compact_tail=compact_tail,
         )
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     unresolved_items_block = _format_unresolved_plan_items(unresolved_items)
     human_requirements_context = _issue_human_requirements_prompt_context(
         issue_context,
@@ -1282,7 +1282,7 @@ def _build_compact_plan_revision_prompt(
     compact_tail: CompactPlanTailContext | None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     human_requirements_context = _issue_human_requirements_prompt_context(
         issue_context,
         requirement_scope="planning requirements",
@@ -1347,7 +1347,7 @@ def build_issue_implementation_prompt(
     issue_context: IssueContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     human_requirements_context = _issue_human_requirements_prompt_context(
         issue_context,
         requirement_scope="implementation requirements",
@@ -1394,7 +1394,7 @@ def build_task_prompt(
     memory: AgentMemoryContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     return f"""You have been given a free-form task to implement in {config.repo}.
 
 Task:
@@ -1433,7 +1433,7 @@ def build_task_clarification_prompt(
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
 ) -> str:
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     qa_blocks = "\n\n".join(
         f"Round {idx + 1} questions from you:\n{questions}\n\n"
         f"Round {idx + 1} answers from the user:\n{answers}"
@@ -1649,7 +1649,7 @@ def _build_compact_pr_review_prompt(
     compact_tail: CompactPrReviewTailContext | None,
 ) -> str:
     reviewer_name = agent_display_name(reviewer)
-    reviewer_signature = agent_signature(reviewer)
+    reviewer_signature = agent_signature(reviewer, config)
     checks_block = f"{format_pr_checks(pr_checks)}\n" if pr_checks is not None else ""
     human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
     non_future_items = [item for item in unresolved_items if item.status != "future"]
@@ -1819,7 +1819,7 @@ def build_review_prompt(
     compact_coder_tests_run: Sequence[str] | None = None,
 ) -> str:
     coder_name = agent_display_name(config.coder)
-    reviewer_signature = agent_signature(reviewer)
+    reviewer_signature = agent_signature(reviewer, config)
     reviewer_group = format_agent_list(reviewers(config))
     metadata = pr_metadata or PullRequestMetadata(
         number=pr_number,
@@ -2066,7 +2066,7 @@ def build_followup_prompt(
     human_requirements_context: CoderHumanRequirementsPromptContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     if human_requirements_context is None:
         human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
     return f"""{reviewer_name} reviewed pull request #{pr_number} in {config.repo} and found blocking issues.
@@ -2111,7 +2111,7 @@ def build_same_pr_followup_prompt(
     human_requirements_context: CoderHumanRequirementsPromptContext | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
-    coder_signature = agent_signature(config.coder)
+    coder_signature = agent_signature(config.coder, config)
     if human_requirements_context is None:
         human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
     return f"""{reviewer_name} requested same-PR follow-ups on pull request #{pr_number} in {config.repo}.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -17869,6 +17869,16 @@ def test_config_rejects_model_arg_conflicts(tmp_path):
             make_config(tmp_path, **kwargs)
 
 
+def test_config_rejects_codex_effort_without_model(tmp_path):
+    # Effort alone can't be stamped (codex doesn't report its model), so it requires
+    # an explicit --codex-model.
+    with pytest.raises(AgentLoopError, match="requires --codex-model"):
+        make_config(tmp_path, codex_reasoning_effort="high")
+    # With a model it's accepted.
+    config = make_config(tmp_path, codex_model="gpt-5", codex_reasoning_effort="high")
+    assert config.codex_reasoning_effort == "high"
+
+
 def test_config_allows_declared_model_without_conflict(tmp_path):
     config = make_config(tmp_path, codex_model="gpt-5", gemini_model="g", claude_model="c")
     assert config.codex_model == "gpt-5"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1228,29 +1228,39 @@ def test_validate_pr_migration_topology_blocks_non_literal_changed_metadata(tmp_
 
 def test_parse_claude_output_extracts_text_and_session_id():
     raw = json.dumps({"result": "Hello.", "session_id": "abc123"})
-    text, sid, usage, raw_usage = _parse_claude_output(raw)
+    text, sid, usage, raw_usage, model = _parse_claude_output(raw)
     assert text == "Hello."
     assert sid == "abc123"
     assert usage is None
     assert raw_usage is None
+    assert model is None
 
 
 def test_parse_claude_output_falls_back_on_plain_text():
     raw = "plain response"
-    text, sid, usage, raw_usage = _parse_claude_output(raw)
+    text, sid, usage, raw_usage, model = _parse_claude_output(raw)
     assert text == "plain response"
     assert sid is None
     assert usage is None
     assert raw_usage is None
+    assert model is None
 
 
 def test_parse_claude_output_falls_back_on_non_string_result():
     raw = json.dumps({"result": 42, "session_id": "abc"})
-    text, sid, usage, raw_usage = _parse_claude_output(raw)
+    text, sid, usage, raw_usage, model = _parse_claude_output(raw)
     assert text == raw  # non-string result → fall back to raw
     assert sid == "abc"
     assert usage is None
     assert raw_usage is None
+    assert model is None
+
+
+def test_parse_claude_output_extracts_model_from_model_usage():
+    raw = json.dumps({"result": "Hi.", "modelUsage": {"claude-sonnet-4-6": {"outputTokens": 5}}})
+    text, sid, usage, raw_usage, model = _parse_claude_output(raw)
+    assert text == "Hi."
+    assert model == "claude-sonnet-4-6"
 
 
 def test_parse_gemini_output_extracts_json_response():
@@ -17814,3 +17824,94 @@ def test_gemini_success_does_not_append_migration_guidance(tmp_path, monkeypatch
     result = gm.BACKEND.run(runner, config, "Review", run_id="r")
     assert "2026-06-18" not in result.raw_output  # no guidance on a clean success
     assert "2026-06-18" not in result.text
+
+
+# ---------------------------------------------------------------------------
+# Dynamic model-specific signatures (#332)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_signature_generic_without_config():
+    from coding_review_agent_loop.agents.registry import agent_signature
+    assert agent_signature("codex") == "OpenAI Codex"
+    assert agent_signature("antigravity") == "Google Antigravity"
+
+
+def test_agent_signature_uses_configured_model(tmp_path):
+    from coding_review_agent_loop.agents.registry import agent_signature
+    config = make_config(tmp_path, codex_model="gpt-5.2-codex", codex_reasoning_effort="high")
+    assert agent_signature("codex", config) == "OpenAI Codex: gpt-5.2-codex (high)"
+    # antigravity model is always declared (effort already embedded).
+    assert agent_signature("antigravity", config) == "Google Antigravity: Gemini 3.1 Pro (High)"
+    # gemini with no declared model falls back to the generic signature.
+    assert agent_signature("gemini", make_config(tmp_path)) == "Google Gemini"
+
+
+def test_agent_signature_model_used_overrides_config(tmp_path):
+    from coding_review_agent_loop.agents.registry import agent_signature
+    config = make_config(tmp_path, antigravity_model="Gemini 3.1 Pro (High)")
+    # #333 fallback: the model that actually ran wins over the configured one.
+    assert (
+        agent_signature("antigravity", config, "Gemini 3.5 Flash (High)")
+        == "Google Antigravity: Gemini 3.5 Flash (High)"
+    )
+
+
+def test_config_rejects_model_arg_conflicts(tmp_path):
+    for kwargs in (
+        {"codex_model": "gpt-5", "codex_args": ("--model", "other")},
+        {"codex_reasoning_effort": "high", "codex_args": ("-c", 'model_reasoning_effort="low"')},
+        {"gemini_model": "g", "gemini_args": ("--model", "other")},
+        {"claude_model": "c", "claude_args": ("--model", "other")},
+        {"antigravity_args": ("--model", "x")},
+    ):
+        with pytest.raises(AgentLoopError, match="conflicts with"):
+            make_config(tmp_path, **kwargs)
+
+
+def test_config_allows_declared_model_without_conflict(tmp_path):
+    config = make_config(tmp_path, codex_model="gpt-5", gemini_model="g", claude_model="c")
+    assert config.codex_model == "gpt-5"
+    assert config.gemini_model == "g"
+    assert config.claude_model == "c"
+
+
+def test_codex_backend_passes_model_and_effort(tmp_path):
+    from coding_review_agent_loop.agents.codex import CodexBackend
+    runner = FakeRunner(codex_outputs=[("STATE: approved\n\nok", 0)])
+    config = make_config(tmp_path, codex_model="gpt-5.2-codex", codex_reasoning_effort="high")
+    result = CodexBackend().run(runner, config, "Review", run_id="r")
+    cmd = runner.commands[-1][0]
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.2-codex"
+    assert 'model_reasoning_effort="high"' in cmd
+    assert result.model_used == "gpt-5.2-codex (high)"
+
+
+def test_gemini_backend_passes_model_and_sets_model_used(tmp_path):
+    import coding_review_agent_loop.agents.gemini as gm
+    runner = FakeRunner(gemini_outputs=[("STATE: approved\n\nok", 0)])
+    config = make_config(tmp_path, gemini_model="gemini-3.5-flash")
+    result = gm.BACKEND.run(runner, config, "Review", run_id="r")
+    cmd = runner.commands[-1][0]
+    assert cmd[cmd.index("--model") + 1] == "gemini-3.5-flash"
+    assert result.model_used == "gemini-3.5-flash"
+
+
+def test_claude_backend_passes_model_when_declared(tmp_path):
+    from coding_review_agent_loop.agents.claude import ClaudeBackend
+    runner = FakeRunner(claude_outputs=[("STATE: approved\n\nok", 0)])
+    config = make_config(tmp_path, claude_model="opus")
+    ClaudeBackend().run(runner, config, "Review", run_id="r")
+    cmd = runner.commands[-1][0]
+    assert cmd[cmd.index("--model") + 1] == "opus"
+
+
+def test_public_reviewer_name_config_aware_no_leakage(tmp_path):
+    from coding_review_agent_loop.comment_rendering import _public_reviewer_name
+    config = make_config(tmp_path, codex_model="gpt-5", antigravity_model="Gemini 3.1 Pro (High)")
+    assert _public_reviewer_name("Codex", config) == "OpenAI Codex: gpt-5"
+    assert _public_reviewer_name("Antigravity", config) == "Google Antigravity: Gemini 3.1 Pro (High)"
+    # No declared model → generic; unknown display name → passthrough.
+    assert _public_reviewer_name("Claude", config) == "Anthropic Claude"
+    assert _public_reviewer_name("Codex") == "OpenAI Codex"
+    assert _public_reviewer_name("Somebody") == "Somebody"

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2778,3 +2778,59 @@ class TestAntigravitySkill:
             assert result.returncode == 0, result.stderr
             output = self._last_json(result.stdout)
             assert "Antigravity" in output["approved_reviewers"]
+
+
+# ---------------------------------------------------------------------------
+# render_response --model stamps the dynamic signature (#332)
+# ---------------------------------------------------------------------------
+
+
+def test_render_response_plan_revision_stamps_model_signature():
+    revision = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "Revised plan.",
+            "prior_plan_item_dispositions": [],
+            "plan_steps": ["Step A"],
+        }
+    ) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Google Antigravity\n"
+    path = _write_tmp(revision)
+    ctx = _write_tmp(json.dumps({"prior_items": [], "current_round_items": []}), suffix=".json")
+    out = _write_tmp("", suffix=".md")
+    result = _run(
+        "helpers.render_response",
+        "--file", path, "--kind", "plan_revision",
+        "--reviewer", "Antigravity", "--context-file", ctx,
+        "--output", out, "--model", "Gemini 3.1 Pro (High)",
+    )
+    assert result.returncode == 0, result.stderr
+    rendered = Path(out).read_text(encoding="utf-8")
+    assert "Google Antigravity: Gemini 3.1 Pro (High)" in rendered
+
+
+def test_render_response_coder_followup_stamps_model_signature():
+    followup = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "coder_followup",
+            "state": "approved",
+            "summary": "Addressed feedback.",
+            "addressed_items": [],
+            "remaining_items": [],
+            "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+        }
+    ) + "\n<!-- AGENT_STATE: approved -->\n-- Google Antigravity\n"
+    path = _write_tmp(followup)
+    ctx = _write_tmp(json.dumps({"prior_items": [], "current_round_items": []}), suffix=".json")
+    out = _write_tmp("", suffix=".md")
+    result = _run(
+        "helpers.render_response",
+        "--file", path, "--kind", "coder_followup",
+        "--reviewer", "Antigravity", "--context-file", ctx,
+        "--output", out, "--model", "Gemini 3.1 Pro (High)",
+    )
+    assert result.returncode == 0, result.stderr
+    rendered = Path(out).read_text(encoding="utf-8")
+    assert "Google Antigravity: Gemini 3.1 Pro (High)" in rendered

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2785,6 +2785,18 @@ class TestAntigravitySkill:
 # ---------------------------------------------------------------------------
 
 
+def test_model_used_from_usage_sidecar(tmp_path):
+    import helpers.skill_runner as sr
+    sidecar = tmp_path / "agent-usage.json"
+    assert sr._model_used_from_usage(sidecar) == ""  # missing file
+    sidecar.write_text(json.dumps({"model_used": "Gemini 3.1 Pro (High)"}), encoding="utf-8")
+    assert sr._model_used_from_usage(sidecar) == "Gemini 3.1 Pro (High)"
+    sidecar.write_text(json.dumps({"usage": {}}), encoding="utf-8")  # no model_used key
+    assert sr._model_used_from_usage(sidecar) == ""
+    sidecar.write_text("not json", encoding="utf-8")  # unreadable
+    assert sr._model_used_from_usage(sidecar) == ""
+
+
 def test_render_response_plan_revision_stamps_model_signature():
     revision = json.dumps(
         {


### PR DESCRIPTION
Closes #332. Makes the `-- {signature}` footer carry the **model, version, and
effort** that produced each comment, e.g.:

- `Google Antigravity: Gemini 3.1 Pro (High)`
- `OpenAI Codex: gpt-5.x-codex (high)`
- `Anthropic Claude: claude-sonnet-4-6`

## Design

Source of truth is the **model that actually ran** (`model_used`), falling back to
a **configured/declared** model, then to today's **generic** signature — so output
is byte-identical to today when nothing is declared.

- `AgentResult.model_used` + `ValidatedAgentResponse.model_used` carry the model
  through the CLI runtime path to every orchestrator render site (plan-review,
  pr-review, plan-revision, coder-followup).
- `agent_signature(agent, config=None, model_used=None)`: precedence
  `model_used` > configured > generic base.
- New config + flags: `--codex-model` / `--codex-reasoning-effort`,
  `--gemini-model`, `--claude-model`. Backends pass `--model` (and codex
  `-c model_reasoning_effort`) and set `model_used`; Claude also auto-detects from
  `modelUsage` in CLI-mode JSON.
- **Conflict validation:** declaring a model/effort both via the dedicated flag and
  a freeform `--*-arg` is rejected with a clear error (antigravity's model is always
  declared, so `--antigravity-arg --model` always conflicts) — guarantees the
  stamped signature matches what ran.
- `comment_rendering` threads `config`/`model_used` through all render + prior-item
  attribution sites; the all-agents reviewer-name map is **config-only with no
  cross-agent leakage** (a Codex run can't relabel Claude entries).
- `prompts.py` footer-instruction signatures are config-aware.
- **Skill path:** `run_external` writes `model_used` to its usage sidecar;
  `skill_runner` reads it and passes `render_response --model`, so skill-mode
  signatures (the primary antigravity path) show the model too.

## Availability (verified from logs + vendor docs)

Only antigravity (config) and Claude-CLI (`modelUsage`) self-report a model; Codex
omits it from `exec --json` (openai/codex#14736) and Gemini doesn't surface it — so
those are **declared** (and passed to the CLI), not scraped. Effort: codex via
config; antigravity embedded in the model string; Claude has none (thinking is
encrypted).

## Tests

Signature precedence (model_used > config > generic), conflict validation for all
four agents, per-agent `model_used` + CLI flag passthrough (codex model+effort,
gemini, claude), and `_public_reviewer_name` config-awareness + no-leakage.
**Full suite: 872 passed.**

This **blocks #333** (antigravity quota fallback), which will populate `model_used`
with the model that answered after a Pro→Flash fallback so the signature stays
truthful.

Plan approved on #332 (plan-r6, 6 rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude
