### PR TITLE
Add skill-mode external PR fix command

### DIFF
--- a/.claude/commands/coding-review-agent-loop.md
+++ b/.claude/commands/coding-review-agent-loop.md
@@ -7,18 +7,18 @@ Parse the arguments to extract:
 - **flow** — `issue <N>` (maps to `--flow plan`) or `pr <N>` (maps to `--flow pr`)
 - **reviewers** — `--reviewers codex`, `gemini`, or both (default: gemini)
 - **plan-first** — present if the user passes `--plan-first` (only relevant for issue flow)
-- **coder** — `--coder claude` (default) or `--coder codex`
+- **coder** — `--coder claude` (default), `--coder codex`, `--coder gemini`, or
+  `--coder antigravity`
 
 If any required argument is missing, ask the user before proceeding.
 
 Then follow the orchestration steps in `SKILL.md` from Step 1.
 
-When `--coder codex` is parsed, follow the **Reversed roles** section of `SKILL.md`
-instead of the default Claude-as-coder flow: Codex handles Step 2 (plan writing)
-via `run_external --role coder`, and Claude performs Step 6 (review turn) directly
-in the session.  **Important**: pass `--reviewers claude` (not `codex`/`gemini`)
-in the `build-resume` Step 1 call so Claude's completed review is tracked correctly
-for resume.
+When an external `--coder` is parsed, follow the **Reversed roles** section of
+`SKILL.md` instead of the default Claude-as-coder flow. If an external-coder PR
+is blocked by `run-pr-round`, use `run-pr-fix --pr N --coder X --reviewers ...`
+with the same reviewer set and a push-capable PR-branch workdir, then re-run
+`run-pr-round` on the new head.
 
 Note: `task "<text>"` is not supported in skill mode. Direct the user to the
 headless CLI (`agent-loop task "..." --repo OWNER/REPO`) for task-based flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ which prompts you to read `SKILL.md` and start orchestration.
 - "Run the agent-loop skill for issue #123 in OWNER/REPO with gemini as reviewer"
 - "Start agent-loop plan-first for issue #42, reviewers: codex and gemini"
 - "Run agent-loop pr 99 in OWNER/REPO"
+- "Have codex fix the blocking review on PR #99 in OWNER/REPO"
 - "Resume the agent-loop skill for issue #123"
 
 In every case: read `SKILL.md`, gather the required inputs (repo, issue/PR

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ on which agents you use.
 Besides the headless `agent-loop` CLI, the repo ships a **Claude Code skill** that
 runs the same review loop directly inside an interactive Claude Code session
 (host Claude turns use your session instead of `claude -p`). It supports the
-reversed roles end to end — an external agent (Codex/Gemini) can plan, implement
-(one-shot, decompose, or by-phase), and the host (Claude) can review — and
-degrades gracefully if a reviewer's CLI fails. See [`SKILL.md`](SKILL.md) for the
-step-by-step instructions and [`docs/skill_mode.md`](docs/skill_mode.md) for the
-design overview.
+reversed roles end to end: an external agent (Codex/Gemini/Antigravity) can
+plan, implement (one-shot, decompose, or by-phase), address blocking PR review
+with `run-pr-fix`, and hand the PR back for re-review; the host (Claude) can
+review. See [`SKILL.md`](SKILL.md) for the step-by-step instructions and
+[`docs/skill_mode.md`](docs/skill_mode.md) for the design overview.
 
 ## Develop This Tool
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -134,7 +134,8 @@ python -m helpers.skill_runner run-implement-by-phase \
 ```
 
 Live runs require a push-capable `--workdir` (or `--workdir-codex` /
-`--workdir-gemini`). The command decomposes the approved parent plan using an
+`--workdir-gemini` / `--workdir-antigravity`). The command decomposes the
+approved parent plan using an
 `implement-by-phase` decomposition marker, creates or reuses child phase issues,
 and then inspects phase 1:
 
@@ -166,8 +167,22 @@ phase that would be implemented.
    The result shape matches plan rounds, plus the optional `tests` and
    `approved_followups` fields (see **Gates & guardrails**).
 2. Decide:
-   - `"blocking"` → fix the code, push, post a change-summary comment (template
-     below), and re-run. A new head SHA starts a new round automatically.
+   - `"blocking"` with a host-owned PR → fix the code, push, post a
+     change-summary comment (template below), and re-run. A new head SHA starts
+     a new round automatically.
+   - `"blocking"` with an external-coder PR → have that coder address the
+     settled blocking review and push to the same PR branch:
+     ```bash
+     python -m helpers.skill_runner run-pr-fix \
+       --pr PR_NUMBER --repo OWNER/REPO \
+       --coder codex \
+       --reviewers claude gemini \
+       --workdir /path/to/push-capable/pr-clone
+     ```
+     The PR must be open, `--reviewers` must exactly match the reviewer set used
+     by the previous `run-pr-round`, and `--workdir` must be a clean,
+     push-capable clone where the PR head branch can be checked out by name.
+     Re-run `run-pr-round` after the coder follow-up posts.
    - `"approved"` → check the test gate, then **stop at "ready to merge — human
      decision."** The skill never merges.
 
@@ -370,6 +385,12 @@ python -m helpers.skill_runner run-implement \
   --workdir <push-capable-clone> [--base main]
 # → prints {"pr": N, ...}; then:
 python -m helpers.skill_runner run-pr-round --pr N --repo OWNER/REPO --reviewers claude gemini
+# If that review blocks, let the same external coder push fixes:
+python -m helpers.skill_runner run-pr-fix \
+  --pr N --repo OWNER/REPO --coder codex --reviewers claude gemini \
+  --workdir <push-capable-clone>
+# Then re-review the new head:
+python -m helpers.skill_runner run-pr-round --pr N --repo OWNER/REPO --reviewers claude gemini
 ```
 
 This is **side-effecting**: the coder commits, pushes a branch, and opens a real
@@ -378,8 +399,12 @@ CLI's implement path — a real PR marker, the signed-human-requirements
 acknowledgement, in-workdir test reports, an advanced checkout HEAD, and that the
 PR is open and references the issue — before a `role: coder` PR comment is posted.
 It is **idempotent per plan** (the one-shot handoff marker): re-running returns the
-existing PR instead of opening a duplicate. A response that fails validation is
-non-retryable — fix the cause and re-run. `--dry-run` does no pushes/PRs.
+existing PR instead of opening another one. For PR-review fixes, use
+`run-pr-fix`; it is gated on a complete, current-head blocking `run-pr-round`
+and posts a `role: coder` follow-up for the new PR head after validating that
+the PR head and assigned checkout HEAD advanced.
+A response that fails validation is non-retryable — fix the cause and re-run.
+`--dry-run` does no pushes/PRs.
 
 ### Decompose an approved plan into phase issues
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -64,10 +64,14 @@ mirroring the CLI's `--coder` / `--reviewer` reversal — so an external agent
   plan and PR rounds); re-running the round then recomputes the final state.
 - **Implement, reversed**: after a plan is approved, an external coder implements
   it and opens a PR — see [Approved-plan execution helpers](#approved-plan-execution-helpers)
-  — which the host then reviews with `run-pr-round`.
+  — which the host then reviews with `run-pr-round`. If that review blocks,
+  `run-pr-fix --coder X --reviewers ... --workdir <push-capable clone>` sends the
+  same external coder back to the open PR branch, posts a coder follow-up for the
+  new head, and hands the PR back to `run-pr-round`.
 
-End to end: external coder plans → reviewers review → external coder implements
-(one-shot / decompose / by-phase) → host + external reviewers review the PR.
+End to end: external coder plans -> reviewers review -> external coder implements
+(one-shot / decompose / by-phase) -> host + external reviewers review the PR ->
+external coder fixes blocking PR review with `run-pr-fix` -> reviewers re-review.
 Merge stays a human decision.
 
 The external agent can be `codex`, `gemini`, or `antigravity` (the `agy` CLI —
@@ -88,6 +92,10 @@ has already been approved:
   `decompose-only`.
 - `run-implement-by-phase` decomposes with mode `implement-by-phase`, then
   implements phase 1 only when that phase is `agent-pr`.
+- `run-pr-fix` addresses a settled blocking PR review for an externally opened
+  PR. The target PR must be `OPEN`; `--reviewers` must exactly match the reviewer
+  set used by the prior `run-pr-round`; and `--workdir` must be a clean,
+  push-capable clone where the PR head branch can be checked out and pushed.
 
 Example:
 

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -19,14 +19,21 @@ from coding_review_agent_loop.config import AgentLoopConfig
 from coding_review_agent_loop.github import IssueContext, IssueComment
 from coding_review_agent_loop.memory import AgentMemoryContext
 from coding_review_agent_loop.prompts import (
+    build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
     build_plan_decomposition_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
     build_review_prompt,
+    build_same_pr_followup_prompt,
+    render_coder_human_requirements_prompt_context,
 )
 from coding_review_agent_loop.round_state import _deserialize_unresolved_item
+from coding_review_agent_loop.unresolved_items import (
+    _format_same_pr_unresolved_items,
+    _format_unresolved_items_for_coder,
+)
 
 
 def make_minimal_config(
@@ -214,6 +221,53 @@ def build_review_prompt_for_skill(
     if pr_diff:
         prompt += f"\n\n## PR diff\n\n```diff\n{pr_diff}\n```\n"
     return prompt
+
+
+def build_pr_fix_prompt_for_skill(
+    pr_number: int,
+    active_items_raw: list[dict],
+    review_round_number: int,
+    *,
+    repo: str,
+    coder: AgentName,
+    reviewers: Sequence[AgentName],
+    workdir: str,
+    issue_context: IssueContext | None = None,
+    human_requirements: Sequence | None = None,
+    same_pr_only: bool = False,
+    memory: AgentMemoryContext | None = None,
+) -> str:
+    """Build the external-coder PR-fix prompt from skill-mode ledger items."""
+    config = make_minimal_config(
+        repo, coder, tuple(reviewers), reviewer=coder, workdir=workdir,
+    )
+    unresolved = [_deserialize_unresolved_item(item) for item in active_items_raw]
+    human_requirements_context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+    )
+    if same_pr_only:
+        review_text = _format_same_pr_unresolved_items(unresolved)
+        return build_same_pr_followup_prompt(
+            pr_number,
+            review_round_number,
+            review_text,
+            config,
+            memory,
+            issue_context=issue_context,
+            human_requirements=human_requirements,
+            human_requirements_context=human_requirements_context,
+        )
+    review_text = _format_unresolved_items_for_coder(unresolved)
+    return build_followup_prompt(
+        pr_number,
+        review_round_number,
+        review_text,
+        config,
+        memory,
+        issue_context=issue_context,
+        human_requirements=human_requirements,
+        human_requirements_context=human_requirements_context,
+    )
 
 
 def build_plan_prompt_for_skill(

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -17,6 +17,18 @@ Subcommands:
     [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH]
     [--dry-run]
 
+  run-pr-fix
+    --pr N --repo OWNER/REPO
+    --coder {codex,gemini,antigravity}
+    --reviewers REVIEWER [REVIEWER ...]
+    --workdir PATH
+    [--dry-run]
+
+    Reversed roles: after an external coder's PR receives a settled blocking
+    skill-mode review, have the same external coder address the blocking items,
+    commit, and push to the existing PR branch. Requires an open PR and a
+    push-capable explicit workdir.
+
   retry-validate
     --repair-dir PATH
     [--dry-run]
@@ -603,13 +615,28 @@ def _fetch_issue_json(repo: str, issue: int, gh_cmd: str = "gh") -> dict:
 def _fetch_pr_json(repo: str, pr: int, gh_cmd: str = "gh") -> dict:
     result = subprocess.run(
         [gh_cmd, "pr", "view", str(pr), "--repo", repo,
-         "--json", "number,title,body,url,headRefOid"],
+         "--json", "number,title,body,url,headRefOid,headRefName,baseRefName,state"],
         capture_output=True, text=True, check=False,
     )
     if result.returncode != 0:
         print(f"skill_runner: gh pr view failed: {result.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
     return json.loads(result.stdout)
+
+
+_ISSUE_REFERENCE_RE = re.compile(r"(?:^|\s)(?:#|https://github\.com/[^/\s]+/[^/\s]+/issues/)(\d+)\b")
+
+
+def _linked_issue_number_from_pr(pr_info: dict) -> int | None:
+    body = str(pr_info.get("body") or "")
+    match = _ISSUE_REFERENCE_RE.search(body)
+    return int(match.group(1)) if match else None
+
+
+def _noop_pr_fix_result(pr: int, reason: str, **fields: object) -> dict:
+    result = {"state": "noop", "pr": pr, "reason": reason}
+    result.update(fields)
+    return result
 
 
 def _fetch_pr_diff(repo: str, pr: int, gh_cmd: str = "gh") -> str:
@@ -2439,6 +2466,93 @@ def _implementation_config(
     )
 
 
+def _pr_fix_gate(resume: dict, reviewers: list[str], current_head: str) -> tuple[bool, str]:
+    expected = {agent_display_name(r) for r in reviewers}  # type: ignore[arg-type]
+    completed_names = [str(name) for name in resume.get("completed_reviewer_names", [])]
+    completed = set(completed_names)
+    completed_data = list(resume.get("completed_reviewer_data", []))
+    subject = str(resume.get("current_plan_subject") or "")
+    if subject != current_head:
+        return False, "current PR head has not been reviewed; run run-pr-round first"
+    if len(completed_names) != len(reviewers) or completed != expected:
+        return False, "review round is incomplete or reviewer set does not match --reviewers"
+    if not completed_data:
+        return False, "reviewer data is unavailable for the current head; wait for run-pr-round/re-review"
+    if not any(record.get("state") == "blocking" for record in completed_data):
+        return False, "current head has no blocking review; no coder fix is needed"
+    return True, ""
+
+
+def _active_pr_fix_items(resume: dict) -> list[dict]:
+    items = _compute_next_prior_items(
+        list(resume.get("prior_items", [])),
+        list(resume.get("completed_reviewer_data", [])),
+        same_status="same-pr",
+        retain_future=True,
+    )
+    return [item for item in items if item.get("status") in {"blocking", "same-pr"}]
+
+
+def _run_git_capture(workdir: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", workdir, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _position_pr_fix_workdir(
+    *,
+    repo: str,
+    coder: str,
+    workdir: str,
+    branch: str,
+    head_sha: str,
+    dry_run: bool,
+) -> None:
+    from coding_review_agent_loop.config import validate_explicit_workdir
+    from helpers.prompt_builders import make_minimal_config
+
+    config = dataclasses.replace(
+        make_minimal_config(repo, coder, (coder,), reviewer=coder, workdir=workdir),  # type: ignore[arg-type]
+        dry_run=dry_run,
+        auto_agent_dirs=(),
+    )
+    runner = Runner(dry_run=dry_run)
+    path = Path(workdir)
+    if dry_run:
+        print(f"[dry-run] would validate {path} and check out PR branch {branch}")
+        return
+    if not branch:
+        raise AgentLoopError("PR head branch is unavailable; cannot position coder workdir.")
+    if not path.is_dir():
+        raise AgentLoopError(f"--workdir does not exist or is not a directory: {path}")
+    validate_explicit_workdir(path, "--workdir", config, runner)
+
+    def run(*git_args: str) -> subprocess.CompletedProcess[str]:
+        result = _run_git_capture(workdir, *git_args)
+        if result.returncode != 0:
+            raise AgentLoopError(
+                f"git {' '.join(git_args)} failed in {workdir}: {result.stderr.strip()}"
+            )
+        return result
+
+    run("fetch", "origin", f"+refs/heads/{branch}:refs/remotes/origin/{branch}")
+    local_exists = _run_git_capture(workdir, "show-ref", "--verify", "--quiet", f"refs/heads/{branch}").returncode == 0
+    if local_exists:
+        run("checkout", branch)
+        run("merge", "--ff-only", f"origin/{branch}")
+    else:
+        run("checkout", "-b", branch, "--track", f"origin/{branch}")
+    local_head = run("rev-parse", "HEAD").stdout.strip()
+    if head_sha and local_head != head_sha:
+        raise AgentLoopError(
+            f"--workdir HEAD is {local_head}, but PR head is {head_sha}; "
+            "refusing to run coder on a mispointed checkout."
+        )
+
+
 def _run_child_or_one_shot_implementation(
     *,
     issue: int,
@@ -2679,6 +2793,259 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
         f"run-pr-round --pr {result_json['pr']} --repo {repo} --reviewers claude gemini",
         file=sys.stderr,
     )
+
+
+# ---------------------------------------------------------------------------
+# run-pr-fix  (external coder addresses a settled blocking PR review) (#338)
+# ---------------------------------------------------------------------------
+
+def cmd_run_pr_fix(args: argparse.Namespace) -> None:
+    pr: int = args.pr
+    repo: str = args.repo
+    coder: str = args.coder
+    reviewers: list[str] = args.reviewers
+    dry_run: bool = args.dry_run
+
+    explicit_workdir = getattr(args, f"workdir_{coder}", None) or getattr(args, "workdir", None)
+    if not dry_run and not explicit_workdir:
+        print(
+            "skill_runner: run-pr-fix requires an explicit push-capable --workdir "
+            "(or --workdir-codex/--workdir-gemini/--workdir-antigravity) checked "
+            "out from the PR's repo.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    workdir = _workdir_for_agent(coder, args)
+
+    pr_info = _fetch_pr_json(repo, pr)
+    pr_state = str(pr_info.get("state") or "")
+    if pr_state != "OPEN":
+        print(json.dumps(_noop_pr_fix_result(
+            pr,
+            "PR is not open",
+            current_pr_state=pr_state or "unknown",
+        ), indent=2))
+        return
+
+    current_head = str(pr_info.get("headRefOid") or "")
+    pr_branch = str(pr_info.get("headRefName") or "")
+    resume = _build_resume(pr, repo, reviewers, flow="pr", head_sha=current_head, pr=pr)
+    _reconcile_pending_comment(resume, pr, repo, dry_run)
+    resume = _build_resume(pr, repo, reviewers, flow="pr", head_sha=current_head, pr=pr)
+
+    allowed, reason = _pr_fix_gate(resume, reviewers, current_head)
+    if not allowed:
+        print(json.dumps(_noop_pr_fix_result(
+            pr,
+            reason,
+            head_sha=current_head,
+            current_pr_state=pr_state,
+        ), indent=2))
+        return
+
+    active_items_raw = _active_pr_fix_items(resume)
+    if not active_items_raw:
+        print(json.dumps(_noop_pr_fix_result(
+            pr,
+            "settled blocking review has no active blocking or same-PR items",
+            head_sha=current_head,
+            current_pr_state=pr_state,
+        ), indent=2))
+        return
+
+    from coding_review_agent_loop.agents.registry import agent_signature
+    from coding_review_agent_loop.github import get_issue_context, get_pr_review_context
+    from coding_review_agent_loop.orchestrator import (
+        _merge_human_requirements,
+        _reconcile_human_requirements_ack_item,
+        _validate_coder_followup_response,
+    )
+    from coding_review_agent_loop.protocol import StructuredCoderFollowup
+    from coding_review_agent_loop.round_state import _serialize_unresolved_item
+    from coding_review_agent_loop.workdir_guard import (
+        validate_assigned_head_advanced,
+        validate_response_tests_within_workdir,
+        validate_test_commands_within_workdir,
+    )
+    from helpers.prompt_builders import build_pr_fix_prompt_for_skill, make_minimal_config
+    from coding_review_agent_loop.comment_rendering import _render_public_coder_followup_comment
+
+    config = dataclasses.replace(
+        make_minimal_config(repo, coder, tuple(reviewers), reviewer=coder, workdir=workdir),  # type: ignore[arg-type]
+        dry_run=dry_run,
+        auto_agent_dirs=(),
+    )
+    runner = Runner(dry_run=dry_run)
+    linked_issue = _linked_issue_number_from_pr(pr_info)
+    issue_context = (
+        get_issue_context(runner, config=config, issue_number=linked_issue)
+        if linked_issue is not None and not dry_run
+        else None
+    )
+    pr_context = get_pr_review_context(runner, config=config, pr_number=pr)
+    human_requirements = _merge_human_requirements(issue_context, pr_context)
+
+    same_pr_only = all(item.get("status") == "same-pr" for item in active_items_raw)
+    review_round_number = int(resume.get("round_number") or resume.get("completed_round_number") or 1)
+    prompt_text = build_pr_fix_prompt_for_skill(
+        pr,
+        active_items_raw,
+        review_round_number,
+        repo=repo,
+        coder=coder,  # type: ignore[arg-type]
+        reviewers=reviewers,  # type: ignore[arg-type]
+        workdir=workdir,
+        issue_context=issue_context,
+        human_requirements=human_requirements,
+        same_pr_only=same_pr_only,
+    )
+
+    if not dry_run:
+        _position_pr_fix_workdir(
+            repo=repo,
+            coder=coder,
+            workdir=workdir,
+            branch=pr_branch,
+            head_sha=current_head,
+            dry_run=False,
+        )
+    else:
+        _position_pr_fix_workdir(
+            repo=repo,
+            coder=coder,
+            workdir=workdir,
+            branch=pr_branch or "dry-run-branch",
+            head_sha=current_head,
+            dry_run=True,
+        )
+    assigned_head_before = _git_head(workdir)
+
+    with tempfile.TemporaryDirectory() as tmpstr:
+        tmpdir = Path(tmpstr)
+        prompt_file = tmpdir / "pr-fix-prompt.md"
+        raw_output = tmpdir / "pr-fix-raw.md"
+        rendered_output = tmpdir / "pr-fix-rendered.md"
+        tagged_output = tmpdir / "pr-fix-tagged.md"
+        prior_items_file = tmpdir / "pr-fix-prior-items.json"
+        compact_prior_file = tmpdir / "pr-fix-compact-prior.json"
+        usage_file = tmpdir / "pr-fix-usage.json"
+        _write_text(prompt_file, prompt_text)
+
+        _run_helper(
+            "helpers.run_external",
+            "--agent", coder,
+            "--role", "coder",
+            "--prompt-file", str(prompt_file),
+            "--output", str(raw_output),
+            "--workdir", workdir,
+            "--flow", "pr",
+            "--usage-output", str(usage_file),
+            *(["--dry-run"] if dry_run else []),
+        )
+        coder_output = raw_output.read_text(encoding="utf-8")
+        if re.search(r"<!--\s*AGENT_PR\s*:", coder_output):
+            raise AgentLoopError("run-pr-fix response attempted to open/report a new PR.")
+        try:
+            parsed = _validate_coder_followup_response(
+                coder_output,
+                unresolved_items=tuple(_deserialize_unresolved_item(item) for item in active_items_raw),
+                human_requirements=human_requirements,
+            )
+            if isinstance(parsed, StructuredCoderFollowup):
+                validate_test_commands_within_workdir(
+                    parsed.tests_run,
+                    assigned_workdir=Path(workdir),
+                )
+                public_comment = _render_public_coder_followup_comment(
+                    parsed,
+                    signature=agent_signature(coder, config, _model_used_from_usage(usage_file)),  # type: ignore[arg-type]
+                    prior_items=tuple(_deserialize_unresolved_item(item) for item in active_items_raw),
+                    config=config,
+                )
+                _write_text(rendered_output, public_comment)
+                raw_structured_arg = ["--raw-structured-coder-response-file", str(raw_output)]
+            else:
+                validate_response_tests_within_workdir(coder_output, assigned_workdir=Path(workdir))
+                _write_text(rendered_output, coder_output)
+                raw_structured_arg = []
+        except AgentLoopError as exc:
+            debug_dir = _REPAIR_BASE / f"{pr}-pr-fix-debug"
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(raw_output, debug_dir / "raw.md")
+            shutil.copy2(prompt_file, debug_dir / "prompt.md")
+            print(f"skill_runner: PR-fix response rejected: {exc}", file=sys.stderr)
+            print(f"skill_runner: raw response saved to {debug_dir}/raw.md", file=sys.stderr)
+            sys.exit(1)
+
+        after_info = _fetch_pr_json(repo, pr)
+        new_head = str(after_info.get("headRefOid") or "")
+        assigned_head_after = _git_head(workdir)
+        if not dry_run:
+            if str(after_info.get("state") or "") != "OPEN":
+                raise AgentLoopError(f"PR #{pr} is no longer open after coder run.")
+            if str(after_info.get("headRefName") or "") != pr_branch:
+                raise AgentLoopError("PR head branch changed during run-pr-fix; refusing to post.")
+            if not new_head or new_head == current_head:
+                raise AgentLoopError("Coder did not push a new PR head SHA; refusing to post follow-up.")
+            validate_assigned_head_advanced(
+                before_head=assigned_head_before,
+                after_head=assigned_head_after,
+                assigned_workdir=Path(workdir),
+            )
+        else:
+            new_head = new_head or "dry-run-new-head"
+
+        reconciled_items = _reconcile_human_requirements_ack_item(
+            tuple(_deserialize_unresolved_item(item) for item in active_items_raw),
+            coder_output=coder_output,
+            human_requirements=human_requirements,
+            source_round=review_round_number,
+        )
+        _write_json(prior_items_file, [_serialize_unresolved_item(item) for item in reconciled_items])
+        _write_json(compact_prior_file, list(resume.get("compact_prior_summaries", [])))
+
+        _run_helper(
+            "helpers.state_manager", "attach-metadata",
+            "--body-file", str(rendered_output),
+            "--output", str(tagged_output),
+            "--flow", "pr",
+            "--role", "coder",
+            "--agent", agent_display_name(coder),  # type: ignore[arg-type]
+            "--round-number", str(review_round_number + 1),
+            "--subject", str(new_head),
+            "--state", "blocking",
+            "--prior-items-file", str(prior_items_file),
+            "--usage-file", str(usage_file),
+            "--compact-prior-summaries-file", str(compact_prior_file),
+            *raw_structured_arg,
+        )
+        if not dry_run:
+            _run_helper(
+                "helpers.gh_ops", "post-issue-comment",
+                "--issue", str(pr), "--file", str(tagged_output), "--repo", repo,
+            )
+        else:
+            print(f"[dry-run] would post coder follow-up for PR #{pr}")
+
+        coder_usage: dict | None = None
+        if usage_file.exists():
+            try:
+                coder_usage = json.loads(usage_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                coder_usage = None
+
+    result_json: dict = {
+        "state": "blocking",
+        "pr": pr,
+        "previous_head_sha": current_head,
+        "head_sha": new_head,
+        "addressed_item_count": len(getattr(parsed, "addressed_items", ()) or ()),
+        "remaining_item_count": len(getattr(parsed, "remaining_items", ()) or ()),
+    }
+    usage = _aggregate_reviewer_usage([{"usage": coder_usage}] if coder_usage else [])
+    if usage is not None:
+        result_json["usage"] = usage
+    print(json.dumps(result_json, indent=2))
 
 
 # ---------------------------------------------------------------------------
@@ -3256,6 +3623,31 @@ def main() -> None:
     p_impl.add_argument("--workdir-gemini", default=None)
     p_impl.add_argument("--dry-run", action="store_true")
 
+    # run-pr-fix
+    p_pr_fix = subparsers.add_parser(
+        "run-pr-fix",
+        help="Reversed roles: an external coder addresses a settled blocking PR "
+             "review and pushes fixes to the existing PR branch (#338).",
+    )
+    p_pr_fix.add_argument("--pr", type=int, required=True)
+    p_pr_fix.add_argument("--repo", required=True)
+    p_pr_fix.add_argument(
+        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
+        help="External coder that fixes the existing PR.",
+    )
+    p_pr_fix.add_argument(
+        "--reviewers", nargs="+", required=True,
+        help="Reviewer set used by the preceding run-pr-round; must match exactly.",
+    )
+    p_pr_fix.add_argument(
+        "--workdir", default=None,
+        help="Explicit push-capable clone for the PR branch (required for a real run).",
+    )
+    p_pr_fix.add_argument("--workdir-codex", default=None)
+    p_pr_fix.add_argument("--workdir-gemini", default=None)
+    p_pr_fix.add_argument("--workdir-antigravity", default=None)
+    p_pr_fix.add_argument("--dry-run", action="store_true")
+
     # run-implement-by-phase
     p_impl_phase = subparsers.add_parser(
         "run-implement-by-phase",
@@ -3336,6 +3728,7 @@ def main() -> None:
         "retry-validate": cmd_retry_validate,
         "complete-host-review": cmd_complete_host_review,
         "run-implement": cmd_run_implement,
+        "run-pr-fix": cmd_run_pr_fix,
         "run-implement-by-phase": cmd_run_implement_by_phase,
         "run-decompose": cmd_run_decompose,
         "run-task-round": cmd_run_task_round,

--- a/helpers/state_manager.py
+++ b/helpers/state_manager.py
@@ -321,6 +321,17 @@ def cmd_attach_metadata(args: argparse.Namespace) -> None:
             print(f"state_manager: cannot read raw coder response file: {exc}", file=sys.stderr)
             sys.exit(1)
 
+    compact_prior_summaries: tuple[str, ...] = ()
+    if getattr(args, "compact_prior_summaries_file", None):
+        try:
+            raw_compact = json.loads(Path(args.compact_prior_summaries_file).read_text(encoding="utf-8"))
+            if not isinstance(raw_compact, list):
+                raise ValueError("expected a JSON array")
+            compact_prior_summaries = tuple(str(summary) for summary in raw_compact)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            print(f"state_manager: cannot read compact prior summaries file: {exc}", file=sys.stderr)
+            sys.exit(1)
+
     metadata = PostedRoundMetadata(
         flow=args.flow,
         role=args.role,
@@ -334,6 +345,7 @@ def cmd_attach_metadata(args: argparse.Namespace) -> None:
         canonical_plan=canonical_plan,
         usage=usage,
         raw_structured_coder_response=raw_structured_coder_response,
+        compact_prior_summaries=compact_prior_summaries,
     )
     augmented = _attach_round_metadata(body, metadata)
 
@@ -409,6 +421,8 @@ def main() -> None:
     p_meta.add_argument("--raw-structured-coder-response-file", default=None,
                         help="Raw structured coder response (plan_revision JSON) to persist in "
                              "AGENT_LOOP_META for reversed-roles revision rounds (#307).")
+    p_meta.add_argument("--compact-prior-summaries-file", default=None,
+                        help="JSON array of compact prior summaries to persist in AGENT_LOOP_META.")
     p_meta.add_argument("--canonical-plan-file", default=None,
                         help="Plan text file (written as canonical_plan for coder turns).")
 

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -363,6 +363,38 @@ class TestStateManager:
             _plan_text, resumed = result
             assert resumed.round_number == 1
 
+    def test_attach_metadata_persists_compact_prior_summaries(self) -> None:
+        body = _VALID_PLAN_STATE
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            body_file = Path(tmpdir) / "body.md"
+            body_file.write_text(body, encoding="utf-8")
+            compact_file = Path(tmpdir) / "compact.json"
+            compact_file.write_text(json.dumps(["summary one", "summary two"]), encoding="utf-8")
+            output_file = Path(tmpdir) / "tagged.md"
+
+            _run(
+                "helpers.state_manager",
+                "attach-metadata",
+                "--body-file", str(body_file),
+                "--output", str(output_file),
+                "--flow", "pr", "--role", "coder", "--agent", "Codex",
+                "--round-number", "2", "--state", "blocking",
+                "--subject", "abc123",
+                "--compact-prior-summaries-file", str(compact_file),
+            )
+
+            from coding_review_agent_loop.round_state import (
+                ROUND_RESUME_MARKER_RE,
+                _decode_round_metadata,
+            )
+
+            tagged = output_file.read_text(encoding="utf-8")
+            match = ROUND_RESUME_MARKER_RE.search(tagged)
+            assert match is not None
+            metadata = _decode_round_metadata(match.group("payload"))
+            assert metadata.compact_prior_summaries == ("summary one", "summary two")
+
     def test_attach_metadata_reviewer_found_by_resume(self) -> None:
         """Coder + reviewer comments both with AGENT_LOOP_META → resume finds completed reviewer."""
         plan_body = _VALID_PLAN_STATE
@@ -2081,6 +2113,202 @@ class TestValidateCoderImplementationResponse:
             _validate_coder_implementation_response(
                 bad, workdir="/tmp/wd", human_requirements=(),
             )
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — reverse implementation: run-pr-fix (#338)
+# ---------------------------------------------------------------------------
+
+def _pr_fix_item(status: str = "blocking") -> dict:
+    return {
+        "item_id": "item-1",
+        "reviewer": "Codex",
+        "source_round": 1,
+        "text": "Fix the broken behavior.",
+        "status": status,
+        "source_status": status,
+        "notes": [],
+    }
+
+
+def _pr_fix_resume(*, state: str = "blocking", reviewer_names: list[str] | None = None) -> dict:
+    names = ["Codex"] if reviewer_names is None else reviewer_names
+    return {
+        "round_number": 1,
+        "completed_round_number": 1,
+        "current_plan_subject": "head-old",
+        "prior_items": [],
+        "compact_prior_summaries": ["old summary"],
+        "completed_reviewer_names": names,
+        "completed_reviewer_data": [
+            {
+                "reviewer_name": names[0],
+                "state": state,
+                "dispositions": [],
+                "new_items": [_pr_fix_item()],
+            }
+        ] if names else [],
+    }
+
+
+def _structured_pr_fix_output() -> str:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "coder_followup",
+            "state": "blocking",
+            "summary": "Fixed the blocking item.",
+            "addressed_items": ["item-1"],
+            "remaining_items": [],
+            "addressed_item_notes": {"item-1": "Implemented the requested fix."},
+            "remaining_item_notes": {},
+            "tests_run": ["python3 -m pytest tests/test_skill_helpers.py -k run_pr_fix"],
+            "human_requirements": {
+                "addressed_ids": ["Requirement 1"],
+                "checked_discussion_directly": True,
+            },
+        }
+    ) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex\n"
+
+
+class TestRunPrFix:
+    def test_settled_gate_requires_current_subject_complete_blocking_review(self) -> None:
+        from helpers.skill_runner import _pr_fix_gate
+
+        assert _pr_fix_gate(_pr_fix_resume(), ["codex"], "head-old") == (True, "")
+        allowed, reason = _pr_fix_gate(_pr_fix_resume(state="approved"), ["codex"], "head-old")
+        assert not allowed and "no blocking" in reason
+        allowed, reason = _pr_fix_gate(_pr_fix_resume(reviewer_names=[]), ["codex"], "head-old")
+        assert not allowed and "reviewer set" in reason
+        allowed, reason = _pr_fix_gate(_pr_fix_resume(), ["codex"], "head-new")
+        assert not allowed and "run-pr-round" in reason
+
+    def test_empty_reviewer_data_noops_even_with_carried_prior_items(self) -> None:
+        from helpers.skill_runner import _pr_fix_gate
+
+        resume = _pr_fix_resume(reviewer_names=["Codex"])
+        resume["completed_reviewer_data"] = []
+        resume["prior_items"] = [_pr_fix_item()]
+        allowed, reason = _pr_fix_gate(resume, ["codex"], "head-old")
+        assert not allowed
+        assert "reviewer data is unavailable" in reason
+
+    def test_closed_pr_noops_before_resume_or_workdir(self, monkeypatch, capsys) -> None:
+        import helpers.skill_runner as sr
+
+        monkeypatch.setattr(sr, "_fetch_pr_json", lambda repo, pr: {
+            "number": pr, "state": "CLOSED", "headRefOid": "head-old",
+        })
+        monkeypatch.setattr(sr, "_build_resume", lambda *a, **k: pytest.fail("resume should not run"))
+        monkeypatch.setattr(sr, "_position_pr_fix_workdir", lambda *a, **k: pytest.fail("workdir should not mutate"))
+
+        args = types.SimpleNamespace(
+            pr=7, repo="o/r", coder="codex", reviewers=["codex"],
+            workdir="/tmp/wd", workdir_codex=None, dry_run=False,
+        )
+        sr.cmd_run_pr_fix(args)
+        output = json.loads(capsys.readouterr().out)
+        assert output["state"] == "noop"
+        assert output["current_pr_state"] == "CLOSED"
+
+    def test_success_posts_metadata_after_head_and_assigned_head_advance(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        import helpers.skill_runner as sr
+        from coding_review_agent_loop.github import (
+            IssueContext,
+            PullRequestMetadata,
+            PullRequestReviewContext,
+        )
+
+        pr_infos = iter([
+            {
+                "number": 7,
+                "state": "OPEN",
+                "headRefOid": "head-old",
+                "headRefName": "feature/pr",
+                "body": "Fixes #338",
+            },
+            {
+                "number": 7,
+                "state": "OPEN",
+                "headRefOid": "head-new",
+                "headRefName": "feature/pr",
+                "body": "Fixes #338",
+            },
+        ])
+        helper_calls: list[tuple[str, ...]] = []
+
+        def fake_run_helper(*args: str, check: bool = True):
+            helper_calls.append(args)
+            if args[:1] == ("helpers.run_external",):
+                out = Path(args[args.index("--output") + 1])
+                out.write_text(_structured_pr_fix_output(), encoding="utf-8")
+                usage = Path(args[args.index("--usage-output") + 1])
+                usage.write_text(json.dumps({"agent": "codex", "returncode": 0}), encoding="utf-8")
+            elif args[:2] == ("helpers.state_manager", "attach-metadata"):
+                body = Path(args[args.index("--body-file") + 1]).read_text(encoding="utf-8")
+                out = Path(args[args.index("--output") + 1])
+                out.write_text(body + "\n<!-- AGENT_LOOP_META: test -->\n", encoding="utf-8")
+                assert "--raw-structured-coder-response-file" in args
+                assert "--compact-prior-summaries-file" in args
+            elif args[:2] == ("helpers.gh_ops", "post-issue-comment"):
+                posted = Path(args[args.index("--file") + 1]).read_text(encoding="utf-8")
+                assert "AGENT_LOOP_META" in posted
+            return subprocess.CompletedProcess(args, 0)
+
+        monkeypatch.setattr(sr, "_fetch_pr_json", lambda repo, pr: next(pr_infos))
+        monkeypatch.setattr(sr, "_build_resume", lambda *a, **k: _pr_fix_resume())
+        monkeypatch.setattr(sr, "_reconcile_pending_comment", lambda *a, **k: None)
+        monkeypatch.setattr(sr, "_position_pr_fix_workdir", lambda **kwargs: None)
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+
+        seen = {"count": 0}
+        def fake_git_head(workdir: str) -> str:
+            seen["count"] += 1
+            return "head-old" if seen["count"] == 1 else "head-new"
+        monkeypatch.setattr(sr, "_git_head", fake_git_head)
+
+        import coding_review_agent_loop.github as gh
+        monkeypatch.setattr(gh, "get_issue_context", lambda runner, config, issue_number: IssueContext(
+            number=issue_number,
+            repo="o/r",
+            title="Issue",
+            body="Body",
+            url=None,
+            comments=(),
+            human_requirements=(_human_req(),),
+        ))
+        monkeypatch.setattr(gh, "get_pr_review_context", lambda runner, config, pr_number: PullRequestReviewContext(
+            metadata=PullRequestMetadata(
+                number=pr_number,
+                repo="o/r",
+                title="PR",
+                head_branch="feature/pr",
+                base_branch="main",
+                head_sha="head-old",
+                url=None,
+            ),
+            comments=(),
+            human_requirements=(),
+        ))
+
+        args = types.SimpleNamespace(
+            pr=7,
+            repo="o/r",
+            coder="codex",
+            reviewers=["codex"],
+            workdir=str(tmp_path),
+            workdir_codex=None,
+            dry_run=False,
+        )
+        sr.cmd_run_pr_fix(args)
+        output = json.loads(capsys.readouterr().out)
+        assert output["state"] == "blocking"
+        assert output["previous_head_sha"] == "head-old"
+        assert output["head_sha"] == "head-new"
+        assert output["addressed_item_count"] == 1
+        assert any(call[:2] == ("helpers.gh_ops", "post-issue-comment") for call in helper_calls)
 
     def test_missing_pr_marker_rejected(self) -> None:
         from coding_review_agent_loop.errors import AgentLoopError


### PR DESCRIPTION
## Summary

- Add skill-mode `run-pr-fix` for external coders to address settled blocking PR reviews and push to the existing PR branch.
- Gate PR fixes on open PR state, current-head settled blocking reviewer data, exact reviewer set, active items, workdir branch positioning, and head advancement.
- Persist raw structured coder responses and compact prior summaries, and document the reverse-roles PR-fix loop.

Fixes #338

## Tests

- `python3 -m py_compile helpers/skill_runner.py helpers/prompt_builders.py helpers/state_manager.py`
- `python3 -m pytest tests/test_skill_helpers.py -k 'RunPrFix or state_manager or Prompt'`
- `python3 -m pytest`
