### PR TITLE
Fix workdir guard for script tag regexes

### DIFF
--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -11,7 +11,7 @@ from .errors import AgentLoopError
 
 
 TEST_SECTION_RE = re.compile(r"(?im)^\s*tests(?:\s+run)?\s*:\s*(?P<body>.*)$")
-ABSOLUTE_PATH_RE = re.compile(r"(?<![\w.-])/(?:[^\s`'\"|;&)<>]+)")
+ABSOLUTE_PATH_RE = re.compile(r"(?<![\w.\\<>-])/(?:[^\s`'\"|;&)<>]+)")
 HOME_PATH_RE = re.compile(r"(?<![\w.-])(?:~|\$HOME)/(?:[^\s`'\"|;&)<>]+)")
 WINDOWS_PATH_RE = re.compile(r"(?<![\w.-])[A-Za-z]:\\[^\s`'\"|;&)<>]+")
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -919,6 +919,18 @@ def test_workdir_guard_accepts_assigned_absolute_path(tmp_path):
     )
 
 
+def test_workdir_guard_accepts_javascript_regex_closing_script_tag(tmp_path):
+    assigned = tmp_path / "codex" / "repo"
+    assigned.mkdir(parents=True)
+
+    validate_test_commands_within_workdir(
+        (
+            r"""node -e "const fs=require('fs'); const html=fs.readFileSync('server/static/index.html','utf8'); const scripts=[...html.matchAll(/<script(?![^>]*\\bsrc=)[^>]*>([\\s\\S]*?)<\\/script>/gi)].map(m=>m[1]); scripts.forEach((code,i)=>{ try { new Function(code); } catch(e) { console.error('script '+i+' parse failed'); throw e; } }); console.log(scripts.length+' inline scripts parsed');" (failed: naive regex matched non-code text)""",
+        ),
+        assigned_workdir=assigned,
+    )
+
+
 def test_workdir_guard_accepts_relative_test_commands(tmp_path):
     assigned = tmp_path / "claude" / "repo"
     assigned.mkdir(parents=True)


### PR DESCRIPTION
Summary:
- Ignore absolute-path regex matches that are part of HTML/JS closing-tag regex syntax.
- Add a regression test for the reported inline script parser command.

Tests:
- python3 -m pytest tests/test_agent_loop.py -k workdir_guard
- python3 -m pytest

Fixes #341