### PR TITLE
Fix Claude primary model attribution

### DIFF
--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -45,13 +45,22 @@ def _normalize_claude_usage(payload: object) -> UsageMetadata | None:
 
 
 def _extract_claude_model(data: dict) -> str | None:
-    """Model id Claude reported running (`model`, else a `modelUsage` key)."""
+    """Model id Claude reported running (`model`, else primary `modelUsage` key)."""
     model = data.get("model")
     if isinstance(model, str) and model:
         return model
     model_usage = data.get("modelUsage")
     if isinstance(model_usage, dict) and model_usage:
-        return next(iter(model_usage))
+        def output_tokens(model_id: str) -> int:
+            usage = model_usage.get(model_id)
+            if not isinstance(usage, dict):
+                return 0
+            return coerce_int(usage.get("outputTokens")) or 0
+
+        return max(
+            model_usage,
+            key=output_tokens,
+        )
     return None
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1278,6 +1278,37 @@ def test_parse_claude_output_extracts_model_from_model_usage():
     assert model == "claude-sonnet-4-6"
 
 
+def test_parse_claude_output_extracts_primary_model_from_model_usage():
+    raw = json.dumps({
+        "result": "Reviewed.",
+        "modelUsage": {
+            "claude-haiku-4-5-20251001": {"inputTokens": 4750, "outputTokens": 20},
+            "claude-sonnet-4-6": {
+                "inputTokens": 18,
+                "outputTokens": 8263,
+                "cacheReadInputTokens": 715975,
+            },
+        },
+    })
+    text, sid, usage, raw_usage, model = _parse_claude_output(raw)
+    assert text == "Reviewed."
+    assert model == "claude-sonnet-4-6"
+
+
+def test_parse_claude_output_prefers_top_level_model_over_model_usage():
+    raw = json.dumps({
+        "result": "Reviewed.",
+        "model": "claude-opus-4-1",
+        "modelUsage": {
+            "claude-haiku-4-5-20251001": {"outputTokens": 20},
+            "claude-sonnet-4-6": {"outputTokens": 8263},
+        },
+    })
+    text, sid, usage, raw_usage, model = _parse_claude_output(raw)
+    assert text == "Reviewed."
+    assert model == "claude-opus-4-1"
+
+
 def test_parse_gemini_output_extracts_json_response():
     raw = json.dumps({
         "response": "Reviewed.\n<!-- AGENT_STATE: approved -->",


### PR DESCRIPTION
## Summary
- choose the Claude modelUsage entry with the most outputTokens when no top-level model is reported
- keep top-level model precedence intact
- add regression coverage for mixed Claude modelUsage payloads

Fixes #344

## Tests
- python3 -m pytest tests/test_agent_loop.py -k claude_output
- python3 -m pytest