### PR TITLE
Render structured coder plan_state comments

### DIFF
--- a/helpers/render_response.py
+++ b/helpers/render_response.py
@@ -7,7 +7,7 @@ Usage:
     [--reviewer REVIEWER] \\
     [--context-file PATH]
 
-Kinds: pr_review, plan_review, coder_followup, plan_revision
+Kinds: pr_review, plan_review, coder_followup, plan_revision, plan_state
 
 Exit 0 on success; exit 1 with diagnostic on failure.
 """
@@ -28,6 +28,7 @@ from coding_review_agent_loop.protocol import (
     parse_pr_review,
     parse_plan_review,
     validate_structured_coder_followup,
+    validate_structured_plan_state,
     validate_structured_plan_revision,
 )
 from coding_review_agent_loop.round_state import _deserialize_unresolved_item
@@ -49,7 +50,7 @@ def main() -> None:
     parser.add_argument(
         "--kind",
         required=True,
-        choices=["pr_review", "plan_review", "coder_followup", "plan_revision"],
+        choices=["pr_review", "plan_review", "coder_followup", "plan_revision", "plan_state"],
     )
     parser.add_argument("--output", required=True, help="Path to write rendered markdown.")
     parser.add_argument("--reviewer", default="Codex", help="Reviewer display name.")
@@ -117,6 +118,17 @@ def main() -> None:
                 raw_text=text,
                 model_used=model_used,
             )
+        elif args.kind == "plan_state":
+            parsed = validate_structured_plan_state(text)
+            if parsed is None:
+                rendered = text
+            else:
+                rendered = render_public_agent_comment(
+                    kind="plan_state",
+                    parsed=parsed,
+                    agent=args.reviewer,
+                    model_used=model_used,
+                )
         else:
             print(f"render_response: unknown kind {args.kind}", file=sys.stderr)
             sys.exit(1)

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -1390,7 +1390,25 @@ def _complete_coder_turn(
 
     if kind == "plan_state":
         canonical_text = raw_text
-        public_file = raw_output
+        from coding_review_agent_loop.protocol import validate_structured_plan_state
+
+        parsed_plan = validate_structured_plan_state(raw_text)
+        if parsed_plan is None:
+            public_file = raw_output
+        else:
+            coder_model = _model_used_from_usage(usage_file)
+            public_file = work_dir / "coder-public.md"
+            _run_helper(
+                "helpers.render_response",
+                "--file", str(raw_output),
+                "--kind", "plan_state",
+                "--reviewer", coder_cap,
+                "--output", str(public_file),
+                *(["--model", coder_model] if coder_model else []),
+            )
+            raw_structured_file = work_dir / "coder-raw-structured.json"
+            _write_text(raw_structured_file, raw_text)
+            raw_structured_args = ["--raw-structured-coder-response-file", str(raw_structured_file)]
     else:
         from coding_review_agent_loop.comment_rendering import render_canonical_plan_revision
         from coding_review_agent_loop.protocol import validate_structured_plan_revision

--- a/helpers/state_manager.py
+++ b/helpers/state_manager.py
@@ -419,8 +419,8 @@ def main() -> None:
     p_meta.add_argument("--usage-file", default=None,
                         help="JSON file with external-agent usage to persist in AGENT_LOOP_META (#308).")
     p_meta.add_argument("--raw-structured-coder-response-file", default=None,
-                        help="Raw structured coder response (plan_revision JSON) to persist in "
-                             "AGENT_LOOP_META for reversed-roles revision rounds (#307).")
+                        help="Raw structured coder response JSON to persist in "
+                             "AGENT_LOOP_META for reversed-roles coder rounds (#307).")
     p_meta.add_argument("--compact-prior-summaries-file", default=None,
                         help="JSON array of compact prior summaries to persist in AGENT_LOOP_META.")
     p_meta.add_argument("--canonical-plan-file", default=None,

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -20,6 +20,7 @@ from .protocol import (
     ParsedReview,
     ReviewItemDisposition,
     StructuredCoderFollowup,
+    StructuredPlanState,
     StructuredPlanRevision,
     UnresolvedReviewItem,
     review_freeform_summary_text,
@@ -478,10 +479,33 @@ def _render_public_plan_revision_comment(
     return "\n\n".join(section for section in sections if section)
 
 
+def _render_public_plan_state_comment(
+    parsed_plan: StructuredPlanState,
+    *,
+    agent: str,
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
+) -> str:
+    sections = [
+        "## Plan",
+        parsed_plan.summary.strip(),
+        "\n".join(["### Plan steps", render_canonical_plan_steps(parsed_plan.plan_steps)]),
+        f"<!-- AGENT_PLAN_STATE: {parsed_plan.state} -->",
+        f"-- {_comment_signature(agent, config, model_used)}",
+    ]
+    return "\n\n".join(section for section in sections if section)
+
+
 def render_public_agent_comment(
     *,
     kind: str,
-    parsed: ParsedReview | ParsedPlanReview | StructuredCoderFollowup | StructuredPlanRevision,
+    parsed: (
+        ParsedReview
+        | ParsedPlanReview
+        | StructuredCoderFollowup
+        | StructuredPlanRevision
+        | StructuredPlanState
+    ),
     agent: str,
     config: AgentLoopConfig | None = None,
     model_used: str | None = None,
@@ -537,6 +561,15 @@ def render_public_agent_comment(
             parsed,
             prior_items=prior_items,
             raw_text=raw_text,
+            agent=agent,
+            config=config,
+            model_used=model_used,
+        )
+    if kind == "plan_state":
+        if not isinstance(parsed, StructuredPlanState):
+            raise AgentLoopError("render_public_agent_comment expected StructuredPlanState.")
+        return _render_public_plan_state_comment(
+            parsed,
             agent=agent,
             config=config,
             model_used=model_used,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -77,6 +77,7 @@ from .protocol import (
     PUBLIC_RESPONSE_MARKER,
     ReviewItemDisposition,
     StructuredCoderFollowup,
+    StructuredPlanState,
     StructuredPlanRevision,
     UnresolvedReviewItem,
     human_requirements_resolved,
@@ -92,6 +93,7 @@ from .protocol import (
     normalize_response_file_structured_text,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
+    validate_structured_plan_state,
     validate_structured_plan_revision,
 )
 from .protocol import parse_review
@@ -1575,12 +1577,26 @@ def _run_plan_first_loop(
                 f"{coder_name}'s questions:\n{plan_output}"
             )
         current_plan = plan_output
+        public_plan_output = plan_output
+        raw_structured_coder_response: str | None = None
+        canonical_plan: str | None = None
+        structured_plan = validate_structured_plan_state(plan_output)
+        if isinstance(structured_plan, StructuredPlanState):
+            raw_structured_coder_response = plan_output
+            canonical_plan = plan_output
+            public_plan_output = render_public_agent_comment(
+                kind="plan_state",
+                parsed=structured_plan,
+                agent=config.coder,
+                config=config,
+                model_used=plan_response.model_used,
+            )
         post_issue_comment(
             runner,
             config=config,
             issue_number=issue_number,
             body=_attach_round_metadata(
-                plan_output,
+                public_plan_output,
                 PostedRoundMetadata(
                     flow="plan",
                     role="coder",
@@ -1588,6 +1604,8 @@ def _run_plan_first_loop(
                     round_number=1,
                     subject=_plan_subject(current_plan),
                     prior_items=(),
+                    canonical_plan=canonical_plan,
+                    raw_structured_coder_response=raw_structured_coder_response,
                     compact_prior_summaries=tuple(compact_prior_summaries),
                 ),
             ),

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -206,6 +206,15 @@ class StructuredPlanRevision:
 
 
 @dataclass(frozen=True)
+class StructuredPlanState:
+    schema_version: int
+    kind: str
+    state: str
+    summary: str
+    plan_steps: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class ParsedHumanRequirementsAcknowledgement:
     marker_present: bool
     section_present: bool
@@ -772,6 +781,21 @@ def _extract_structured_plan_revision_payload(text: str) -> dict[str, object] | 
     )
 
 
+def _extract_structured_plan_state_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    return _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=PLAN_STATE_RE,
+        state_marker_name="AGENT_PLAN_STATE",
+        context_label="Structured plan state",
+    )
+
+
 def _extract_structured_coder_followup_payload(text: str) -> dict[str, object] | None:
     text, _status = normalize_response_file_structured_text(text)
     extracted = _extract_json_object_prefix(text)
@@ -1239,6 +1263,37 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         summary=summary,
         prior_plan_item_dispositions=dispositions,
         plan_steps=plan_steps,
+    )
+
+
+def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
+    payload = _extract_structured_plan_state_payload(text)
+    if payload is None:
+        return None
+    if "schema_version" in payload:
+        _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "plan_state":
+        raise AgentLoopError("Structured response kind mismatch: expected `plan_state`.")
+    _expect_exact_keys(
+        payload,
+        context="plan_state",
+        required={"kind", "summary", "plan_steps"},
+        optional={"schema_version", "state"},
+    )
+    if "state" in payload:
+        _expect_state(payload["state"], context="plan_state.state")
+    return StructuredPlanState(
+        schema_version=int(payload.get("schema_version", 1)),
+        kind="plan_state",
+        state=parse_plan_state(text),
+        summary=_expect_non_empty_string(payload["summary"], context="plan_state.summary"),
+        plan_steps=_expect_string_list(
+            payload["plan_steps"],
+            context="plan_state.plan_steps",
+            item_context="plan_state.plan_steps",
+            min_length=1,
+        ),
     )
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -158,6 +158,7 @@ from coding_review_agent_loop.protocol import (
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
     validate_structured_human_requirements_acknowledgement,
+    validate_structured_plan_state,
     validate_structured_plan_revision,
 )
 from coding_review_agent_loop.workdir_guard import (
@@ -804,6 +805,28 @@ def structured_plan_revision(
         )
         + human_requirements
         + "\n<!-- AGENT_PLAN_STATE: blocking -->\n"
+        + f"-- {reviewer}"
+    )
+
+
+def structured_plan_state(
+    *,
+    state: str = "approved",
+    summary: str = "Implementation plan.",
+    plan_steps: list[str] | None = None,
+    reviewer: str = "Anthropic Claude",
+) -> str:
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_state",
+                "state": state,
+                "summary": summary,
+                "plan_steps": plan_steps or ["Update the code.", "Run the relevant tests."],
+            }
+        )
+        + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n"
         + f"-- {reviewer}"
     )
 
@@ -4852,6 +4875,39 @@ def test_render_canonical_plan_revision_and_public_comment():
         + "\n\n<!-- AGENT_PLAN_STATE: blocking -->\n\n-- OpenAI Codex"
     )
     assert '"kind": "plan_revision"' not in public
+
+
+def test_render_structured_plan_state_to_public_markdown():
+    raw = (
+        json.dumps(
+            {
+                "kind": "plan_state",
+                "summary": "Plan the renderer fix.",
+                "plan_steps": ["Detect structured plan_state.", "Render public markdown."],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Antigravity"
+    )
+    parsed = validate_structured_plan_state(raw)
+
+    assert parsed is not None
+    public = render_public_agent_comment(
+        kind="plan_state",
+        parsed=parsed,
+        agent="antigravity",
+        model_used="Gemini 3.1 Pro (High)",
+    )
+
+    assert public == (
+        "## Plan\n\n"
+        "Plan the renderer fix.\n\n"
+        "### Plan steps\n"
+        "1. Detect structured plan_state.\n"
+        "2. Render public markdown.\n\n"
+        "<!-- AGENT_PLAN_STATE: approved -->\n\n"
+        "-- Google Antigravity: Gemini 3.1 Pro (High)"
+    )
+    assert '"kind": "plan_state"' not in public
 
 
 def test_render_public_coder_followup_comment():
@@ -12809,6 +12865,58 @@ def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     config = make_config(tmp_path)
 
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+
+def test_issue_loop_structured_plan_state_public_comment_renders_markdown_and_preserves_metadata(tmp_path):
+    raw_structured_plan = structured_plan_state(
+        summary="Plan the issue fix.",
+        plan_steps=["Update the renderer.", "Add regression tests."],
+        reviewer="Google Antigravity",
+    )
+    runner = FakeRunner(
+        antigravity_outputs=[raw_structured_plan],
+        codex_outputs=[structured_plan_review(summary="Plan looks sound.")],
+    )
+    config = make_config(tmp_path, coder="antigravity", reviewer="codex")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    public_comment = runner.comments[0]
+    assert public_comment.startswith("## Plan")
+    assert "### Plan steps\n1. Update the renderer.\n2. Add regression tests." in public_comment
+    assert '"kind": "plan_state"' not in _strip_round_metadata(public_comment)
+
+    raw_comment = runner.issue_comments[0]["body"]
+    match = re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", raw_comment)
+    assert match is not None
+    metadata = _decode_round_metadata(match.group("payload"))
+    assert metadata.canonical_plan == raw_structured_plan
+    assert metadata.raw_structured_coder_response == raw_structured_plan
+
+
+def test_issue_loop_markdown_plan_state_public_comment_passes_through(tmp_path):
+    markdown_plan = "Initial markdown plan.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+    runner = FakeRunner(
+        claude_outputs=[markdown_plan],
+        codex_outputs=[structured_plan_review(summary="Plan looks sound.")],
+    )
+    config = make_config(tmp_path, reviewer="codex")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    raw_comment = runner.issue_comments[0]["body"]
+    metadata_match = re.search(
+        r"\n?<!--\s*AGENT_LOOP_META:\s*[A-Za-z0-9+/=_-]+\s*-->\n?",
+        raw_comment,
+    )
+    assert metadata_match is not None
+    assert raw_comment.replace(metadata_match.group(0), "\n").strip() == markdown_plan
+    metadata = _decode_round_metadata(
+        re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", raw_comment)
+        .group("payload")
+    )
+    assert metadata.canonical_plan is None
+    assert metadata.raw_structured_coder_response is None
 
 
 def test_issue_loop_plan_revision_stores_raw_structured_metadata(tmp_path):

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1731,6 +1731,79 @@ class TestRetryValidateCoder:
             assert output["role"] == "coder"
             assert output["agent"] == "Codex"
 
+    def test_retry_validate_structured_coder_plan_state_renders_public_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            repair_dir = self._make_coder_repair_dir(tmppath)
+            raw_plan = (
+                json.dumps(
+                    {
+                        "kind": "plan_state",
+                        "summary": "Plan the renderer fix.",
+                        "plan_steps": ["Detect structured plan_state.", "Render markdown."],
+                    }
+                )
+                + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Codex"
+            )
+            (repair_dir / "raw.md").write_text(raw_plan, encoding="utf-8")
+
+            result = _run(
+                "helpers.skill_runner", "retry-validate",
+                "--repair-dir", str(repair_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+
+            assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+            tagged = (repair_dir / "coder-tagged.md").read_text(encoding="utf-8")
+            from coding_review_agent_loop.round_state import _strip_round_metadata
+
+            public = _strip_round_metadata(tagged)
+            assert public.startswith("## Plan")
+            assert "### Plan steps\n1. Detect structured plan_state.\n2. Render markdown." in public
+            assert '"kind": "plan_state"' not in public
+
+            from coding_review_agent_loop.round_state import ROUND_RESUME_MARKER_RE, _decode_round_metadata
+
+            match = ROUND_RESUME_MARKER_RE.search(tagged)
+            assert match is not None
+            metadata = _decode_round_metadata(match.group("payload"))
+            assert metadata.canonical_plan == raw_plan
+            assert metadata.raw_structured_coder_response == raw_plan
+
+    def test_retry_validate_markdown_coder_plan_state_passes_through(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            repair_dir = self._make_coder_repair_dir(tmppath)
+
+            result = _run(
+                "helpers.skill_runner", "retry-validate",
+                "--repair-dir", str(repair_dir),
+                "--dry-run",
+                env=env,
+                check=False,
+            )
+
+            assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+            tagged = (repair_dir / "coder-tagged.md").read_text(encoding="utf-8")
+            from coding_review_agent_loop.round_state import ROUND_RESUME_MARKER_RE
+
+            match = ROUND_RESUME_MARKER_RE.search(tagged)
+            assert match is not None
+            original_prefix, original_suffix = _VALID_PLAN_STATE.strip().split(
+                "<!-- AGENT_PLAN_STATE: approved -->",
+                1,
+            )
+            assert tagged[: match.start()].rstrip() == original_prefix.rstrip()
+            assert tagged[match.end() :].strip() == (
+                "<!-- AGENT_PLAN_STATE: approved -->" + original_suffix
+            ).strip()
+
     def test_retry_validate_coder_invalid_plan_state_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)


### PR DESCRIPTION
## Summary
- render structured coder `plan_state` JSON as public markdown comments
- preserve raw structured plan_state in round metadata/canonical plan for resume and review ledgers
- cover both headless orchestrator and skill-mode external coder paths

Fixes #336

## Tests
- python3 -m pytest