### PR TITLE
Fix skill Antigravity fallback chain

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -58,6 +58,12 @@ mode, you need `OWNER/REPO` and the reviewer set (`codex`, `gemini`, and/or
 `antigravity` — the `agy` CLI, the migration path for Gemini CLI consumer access
 that Google retires on 2026-06-18). `antigravity` works wherever an external
 coder/reviewer does (`--coder antigravity` / `--reviewers antigravity ...`).
+With no override, it uses the ordered fallback chain `Gemini 3.1 Pro (High)` →
+`Gemini 3.5 Flash (High)`. Use `--model MODEL` for the legacy single-model
+override or `--antigravity-models MODEL [MODEL ...]` for a custom ordered chain;
+the two model options are mutually exclusive. Customize fallback detection with
+`--antigravity-quota-signatures SIGNATURE [SIGNATURE ...]`. These options are
+available on every skill command that can invoke an external agent.
 
 ---
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -76,9 +76,15 @@ Merge stays a human decision.
 
 The external agent can be `codex`, `gemini`, or `antigravity` (the `agy` CLI —
 the migration path for Gemini CLI consumer access, which Google retires on
-2026-06-18; pick its model with `--antigravity-model`, default `Gemini 3.1 Pro
-(High)`). Antigravity turns are single-shot (no cross-round session resume) and
-report estimated token usage.
+2026-06-18). With no override, Antigravity uses the ordered fallback chain
+`Gemini 3.1 Pro (High)` → `Gemini 3.5 Flash (High)`. Use `--model MODEL` for the
+legacy single-model override or `--antigravity-models MODEL [MODEL ...]` for a
+custom ordered chain; these options are mutually exclusive. Use
+`--antigravity-quota-signatures SIGNATURE [SIGNATURE ...]` to customize the
+output signatures that trigger fallback. These options are available on plan,
+task, PR-review, implementation, decomposition, phased implementation, and
+PR-fix commands. Antigravity turns are single-shot (no cross-round session
+resume) and report estimated token usage.
 
 ## Approved-plan execution helpers
 

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -117,10 +117,22 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run one external agent turn.")
     parser.add_argument("--agent", required=True, choices=["codex", "gemini", "antigravity"])
     parser.add_argument("--prompt-file", required=True, help="Path to prompt text file.")
-    parser.add_argument(
+    antigravity_models = parser.add_mutually_exclusive_group()
+    antigravity_models.add_argument(
         "--model", default=None,
-        help="Model override (antigravity only; as shown by `agy models`). "
-             "Defaults to 'Gemini 3.1 Pro (High)'.",
+        help="Legacy single-model override (antigravity only; as shown by `agy models`).",
+    )
+    antigravity_models.add_argument(
+        "--antigravity-models",
+        nargs="+",
+        default=None,
+        help="Ordered Antigravity model fallback chain.",
+    )
+    parser.add_argument(
+        "--antigravity-quota-signatures",
+        nargs="+",
+        default=None,
+        help="Output signatures that trigger fallback to the next Antigravity model.",
     )
     parser.add_argument("--output", required=True, help="Path to write the agent response.")
     parser.add_argument("--workdir", required=True, help="Working directory for the agent.")
@@ -224,7 +236,16 @@ def main() -> None:
     agent_name: AgentName = args.agent
     default_cmds = {"codex": "codex", "gemini": "gemini", "antigravity": "agy"}
     cmd = args.cmd or default_cmds[agent_name]
-    antigravity_model = args.model or "Gemini 3.1 Pro (High)"
+    antigravity_models = (
+        (args.model,)
+        if args.model is not None
+        else tuple(args.antigravity_models or ())
+    )
+    antigravity_quota_signatures = (
+        tuple(args.antigravity_quota_signatures)
+        if args.antigravity_quota_signatures is not None
+        else ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")
+    )
 
     # Build a minimal config sufficient for backend.run()
     import tempfile
@@ -250,8 +271,8 @@ def main() -> None:
         antigravity_cmd=cmd if agent_name == "antigravity" else "agy",
         antigravity_args=("--dangerously-skip-permissions",),
         antigravity_model=None,
-        antigravity_models=(antigravity_model,),
-        antigravity_quota_signatures=("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"),
+        antigravity_models=antigravity_models,
+        antigravity_quota_signatures=antigravity_quota_signatures,
         gh_cmd="gh",
         claude_args=(),
         codex_args=("--dangerously-bypass-approvals-and-sandbox",),

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -367,6 +367,45 @@ def _workdir_for_agent(agent: str, args: argparse.Namespace) -> str:
     return str(tmp)
 
 
+def _add_antigravity_options(parser: argparse.ArgumentParser) -> None:
+    """Add Antigravity model-chain overrides shared by external-agent commands."""
+    models = parser.add_mutually_exclusive_group()
+    models.add_argument(
+        "--model",
+        default=None,
+        help="Legacy single-model Antigravity override.",
+    )
+    models.add_argument(
+        "--antigravity-models",
+        nargs="+",
+        default=None,
+        help="Ordered Antigravity model fallback chain.",
+    )
+    parser.add_argument(
+        "--antigravity-quota-signatures",
+        nargs="+",
+        default=None,
+        help="Output signatures that trigger fallback to the next Antigravity model.",
+    )
+
+
+def _run_external_antigravity_args(args: argparse.Namespace) -> tuple[str, ...]:
+    """Convert skill-runner Antigravity options to run_external arguments."""
+    result: list[str] = []
+    model = getattr(args, "model", None)
+    models = getattr(args, "antigravity_models", None)
+    quota_signatures = getattr(args, "antigravity_quota_signatures", None)
+    if model is not None:
+        result.extend(("--model", model))
+    elif models is not None:
+        result.append("--antigravity-models")
+        result.extend(models)
+    if quota_signatures is not None:
+        result.append("--antigravity-quota-signatures")
+        result.extend(quota_signatures)
+    return tuple(result)
+
+
 def _model_used_from_usage(usage_file: Path) -> str:
     """Model the agent ran, read from run_external's usage sidecar (#332).
 
@@ -1030,6 +1069,7 @@ def _run_reviewer(
     workdir: str,
     dry_run: bool,
     tmpdir: Path,
+    external_args: tuple[str, ...] = (),
     item_id_offset: int = 0,
 ) -> dict:
     """Run one reviewer turn; return {reviewer_name, state, blocking_items, new_items}."""
@@ -1060,6 +1100,7 @@ def _run_reviewer(
         "--repo", repo,
         "--flow", flow,
         "--usage-output", str(usage_file),
+        *external_args,
         *(["--dry-run"] if dry_run else []),
         check=False,
     )
@@ -1586,6 +1627,7 @@ def _run_external_coder_phase(
             "--repo", repo,
             "--flow", "plan",
             "--usage-output", str(usage_file),
+            *_run_external_antigravity_args(args),
             *(["--dry-run"] if dry_run else []),
         )
 
@@ -1919,6 +1961,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
                 workdir=workdir,
                 dry_run=dry_run,
                 tmpdir=tmpdir,
+                external_args=_run_external_antigravity_args(args),
                 item_id_offset=item_id_offset,
             )
             if record["state"] == "unavailable":
@@ -2136,6 +2179,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                 workdir=workdir,
                 dry_run=dry_run,
                 tmpdir=tmpdir,
+                external_args=_run_external_antigravity_args(args),
                 item_id_offset=item_id_offset,
             )
             if record["state"] == "unavailable":
@@ -2585,6 +2629,7 @@ def _run_child_or_one_shot_implementation(
     runner: Runner,
     post_one_shot_handoff: bool,
     one_shot_mode: str = "implement-one-shot",
+    external_args: tuple[str, ...] = (),
 ) -> dict:
     from coding_review_agent_loop.config import sync_coder_base_before_implementation
     from coding_review_agent_loop.decomposition import (
@@ -2635,6 +2680,7 @@ def _run_child_or_one_shot_implementation(
             "--workdir", str(workdir),
             "--flow", "pr",
             "--usage-output", str(usage_file),
+            *external_args,
             *(["--dry-run"] if dry_run else []),
         )
         coder_output = raw_output.read_text(encoding="utf-8")
@@ -2804,6 +2850,7 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
         runner=runner,
         post_one_shot_handoff=True,
         one_shot_mode=mode,
+        external_args=_run_external_antigravity_args(args),
     )
     print(json.dumps(result_json, indent=2))
     print(
@@ -2957,6 +3004,7 @@ def cmd_run_pr_fix(args: argparse.Namespace) -> None:
             "--workdir", workdir,
             "--flow", "pr",
             "--usage-output", str(usage_file),
+            *_run_external_antigravity_args(args),
             *(["--dry-run"] if dry_run else []),
         )
         coder_output = raw_output.read_text(encoding="utf-8")
@@ -3233,6 +3281,7 @@ def _run_decomposition_for_skill(
             "--repo", repo,
             "--flow", "decompose",
             "--usage-output", str(usage_file),
+            *_run_external_antigravity_args(args),
             *(["--dry-run"] if dry_run else []),
         )
         coder_output = raw_output.read_text(encoding="utf-8")
@@ -3426,6 +3475,7 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
             config=impl_config,
             runner=impl_runner,
             post_one_shot_handoff=False,
+            external_args=_run_external_antigravity_args(args),
         )
         result_json.update({
             "state": "would-implement",
@@ -3502,6 +3552,7 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
         config=impl_config,
         runner=impl_runner,
         post_one_shot_handoff=False,
+        external_args=_run_external_antigravity_args(args),
     )
     result_json.update({
         "state": "implemented",
@@ -3552,6 +3603,7 @@ def main() -> None:
     p_plan.add_argument("--refresh-agent-memory", action="store_true",
                         help="Regenerate the agent-memory cache before this round.")
     p_plan.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_plan)
 
     # run-pr-round
     p_pr = subparsers.add_parser("run-pr-round", help="Run one PR review round.")
@@ -3591,6 +3643,7 @@ def main() -> None:
     p_pr.add_argument("--refresh-agent-memory", action="store_true",
                       help="Regenerate the agent-memory cache before this round.")
     p_pr.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_pr)
 
     # retry-validate
     p_retry = subparsers.add_parser(
@@ -3641,6 +3694,7 @@ def main() -> None:
     p_impl.add_argument("--workdir-codex", default=None)
     p_impl.add_argument("--workdir-gemini", default=None)
     p_impl.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_impl)
 
     # run-pr-fix
     p_pr_fix = subparsers.add_parser(
@@ -3666,6 +3720,7 @@ def main() -> None:
     p_pr_fix.add_argument("--workdir-gemini", default=None)
     p_pr_fix.add_argument("--workdir-antigravity", default=None)
     p_pr_fix.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_pr_fix)
 
     # run-implement-by-phase
     p_impl_phase = subparsers.add_parser(
@@ -3691,6 +3746,7 @@ def main() -> None:
     p_impl_phase.add_argument("--workdir-codex", default=None)
     p_impl_phase.add_argument("--workdir-gemini", default=None)
     p_impl_phase.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_impl_phase)
 
     # run-decompose
     p_decompose = subparsers.add_parser(
@@ -3709,6 +3765,7 @@ def main() -> None:
     p_decompose.add_argument("--workdir-codex", default=None)
     p_decompose.add_argument("--workdir-gemini", default=None)
     p_decompose.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_decompose)
 
     # run-task-round
     p_task = subparsers.add_parser(
@@ -3739,6 +3796,7 @@ def main() -> None:
     p_task.add_argument("--refresh-agent-memory", action="store_true",
                         help="Regenerate the agent-memory cache before this round.")
     p_task.add_argument("--dry-run", action="store_true")
+    _add_antigravity_options(p_task)
 
     args = parser.parse_args()
     dispatch = {

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2373,6 +2373,8 @@ class TestRunPrFix:
             reviewers=["codex"],
             workdir=str(tmp_path),
             workdir_codex=None,
+            antigravity_models=["Model A", "Model B"],
+            antigravity_quota_signatures=["Quota Hit", "429"],
             dry_run=False,
         )
         sr.cmd_run_pr_fix(args)
@@ -2382,6 +2384,11 @@ class TestRunPrFix:
         assert output["head_sha"] == "head-new"
         assert output["addressed_item_count"] == 1
         assert any(call[:2] == ("helpers.gh_ops", "post-issue-comment") for call in helper_calls)
+        external_call = next(call for call in helper_calls if call[:1] == ("helpers.run_external",))
+        assert external_call[external_call.index("--antigravity-models") + 1:] == (
+            "Model A", "Model B",
+            "--antigravity-quota-signatures", "Quota Hit", "429",
+        )
 
     def test_missing_pr_marker_rejected(self) -> None:
         from coding_review_agent_loop.errors import AgentLoopError
@@ -2410,8 +2417,9 @@ class TestRunImplement:
             result = _run(
                 "helpers.skill_runner", "run-implement",
                 "--issue", "9992", "--repo", "test/skill-repo",
-                "--coder", "codex", "--plan-file", str(plan),
+                "--coder", "antigravity", "--plan-file", str(plan),
                 "--workdir", str(tmppath), "--base", "release-x",
+                "--antigravity-models", "Model A", "Model B",
                 "--dry-run",
                 env=env,
             )
@@ -3051,6 +3059,7 @@ class TestAntigravitySkill:
                 "helpers.skill_runner", "run-plan-round",
                 "--issue", "9991", "--repo", "test/skill-repo",
                 "--coder", "antigravity", "--reviewers", "codex",
+                "--antigravity-models", "Model A", "Model B",
                 "--dry-run",
                 env=env,
             )
@@ -3073,12 +3082,131 @@ class TestAntigravitySkill:
                 "helpers.skill_runner", "run-plan-round",
                 "--issue", "9990", "--repo", "test/skill-repo",
                 "--plan-file", str(plan), "--reviewers", "antigravity",
+                "--model", "Model X",
                 "--dry-run",
                 env=env,
             )
             assert result.returncode == 0, result.stderr
             output = self._last_json(result.stdout)
             assert "Antigravity" in output["approved_reviewers"]
+
+    @pytest.mark.parametrize(
+        ("extra_args", "expected_models", "expected_signatures"),
+        [
+            (
+                (),
+                ("Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)"),
+                ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"),
+            ),
+            (("--model", "Model X"), ("Model X",), ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")),
+            (
+                ("--antigravity-models", "Model A", "Model B"),
+                ("Model A", "Model B"),
+                ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"),
+            ),
+            (
+                ("--antigravity-quota-signatures", "Quota Hit", "429"),
+                ("Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)"),
+                ("Quota Hit", "429"),
+            ),
+        ],
+    )
+    def test_run_external_resolves_antigravity_config(
+        self,
+        monkeypatch,
+        tmp_path,
+        extra_args,
+        expected_models,
+        expected_signatures,
+    ) -> None:
+        import helpers.run_external as rex
+        from coding_review_agent_loop.agents.base import AgentResult
+
+        captured = {}
+
+        class FakeBackend:
+            def run(self, runner, config, prompt):
+                captured["config"] = config
+                return AgentResult(text="review complete", returncode=0)
+
+        monkeypatch.setattr(
+            "coding_review_agent_loop.agents.antigravity.AntigravityBackend",
+            FakeBackend,
+        )
+        prompt = tmp_path / "prompt.md"
+        output = tmp_path / "output.md"
+        prompt.write_text("review this", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", [
+            "run_external",
+            "--agent", "antigravity",
+            "--prompt-file", str(prompt),
+            "--output", str(output),
+            "--workdir", str(tmp_path),
+            "--max-retries", "0",
+            *extra_args,
+        ])
+
+        rex.main()
+
+        config = captured["config"]
+        assert config.antigravity_models == expected_models
+        assert config.antigravity_quota_signatures == expected_signatures
+
+    def test_run_external_rejects_single_model_and_chain_together(self, tmp_path) -> None:
+        result = _run(
+            "helpers.run_external",
+            "--agent", "antigravity",
+            "--prompt-file", _write_tmp("review it"),
+            "--output", str(tmp_path / "out.md"),
+            "--workdir", str(tmp_path),
+            "--model", "Model X",
+            "--antigravity-models", "Model A", "Model B",
+            "--dry-run",
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "not allowed with argument" in result.stderr
+
+    @pytest.mark.parametrize(
+        ("namespace", "expected"),
+        [
+            (types.SimpleNamespace(), ()),
+            (types.SimpleNamespace(model="Model X"), ("--model", "Model X")),
+            (
+                types.SimpleNamespace(antigravity_models=["Model A", "Model B"]),
+                ("--antigravity-models", "Model A", "Model B"),
+            ),
+            (
+                types.SimpleNamespace(
+                    antigravity_models=["Model A", "Model B"],
+                    antigravity_quota_signatures=["Quota Hit", "429"],
+                ),
+                (
+                    "--antigravity-models", "Model A", "Model B",
+                    "--antigravity-quota-signatures", "Quota Hit", "429",
+                ),
+            ),
+        ],
+    )
+    def test_skill_runner_converts_antigravity_options(self, namespace, expected) -> None:
+        from helpers.skill_runner import _run_external_antigravity_args
+
+        assert _run_external_antigravity_args(namespace) == expected
+
+    def test_skill_runner_rejects_single_model_and_chain_together(self) -> None:
+        result = _run(
+            "helpers.skill_runner", "run-plan-round",
+            "--issue", "1",
+            "--repo", "o/r",
+            "--plan-file", _write_tmp(_VALID_PLAN_STATE),
+            "--reviewers", "antigravity",
+            "--model", "Model X",
+            "--antigravity-models", "Model A", "Model B",
+            "--dry-run",
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "not allowed with argument" in result.stderr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #340

Skill mode now preserves the default Antigravity Pro-to-Flash fallback chain when no model override is supplied. It also supports ordered model-chain and quota-signature overrides across reviewer, planning, implementation, decomposition, phased implementation, and PR-fix paths.

Tests:
- `python3 -m pytest tests/test_skill_helpers.py -q`
- `python3 -m pytest -q`