### PR TITLE
Resolve PR and repository base branches dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ iteration pass:
 agent-loop pr 456 --repo OWNER/REPO
 ```
 
+When `--base` is omitted, `pr` mode uses the pull request's base branch.
+`issue` and `task` modes use the repository default branch. If PR metadata does
+not include a base branch, `pr` mode also falls back to the repository default.
+An explicit `--base BRANCH` always takes precedence.
+
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the
 detected `OWNER/REPO`. Pass `--repo` explicitly when running outside the target
@@ -233,7 +238,7 @@ repository.
 When `--claude-dir`, `--codex-dir`, or `--gemini-dir` is omitted for an active
 agent, the tool creates or reuses a repo-scoped temporary checkout such as
 `/tmp/coding-review-agent-loop/OWNER-REPO/codex/repo`. Existing clean temp
-checkouts are fetched and fast-forwarded on the base branch before the agent
+checkouts are fetched and fast-forwarded on the resolved base branch before the agent
 runs. Default temp checkouts are tool-owned and disposable; if one is dirty,
 the tool resets and cleans it before reuse. Explicit persistent directories are
 kept conservative: dirty explicit workdirs fail clearly, and existing git

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -349,7 +349,10 @@ by repo and agent:
 The tool prints the selected default workdirs. If a default checkout does not
 exist, it runs `gh repo clone OWNER/REPO <path>`. If it already exists and is a
 clean checkout for the requested repo, it fetches origin and fast-forwards the
-configured base branch. Default checkouts are tool-owned and disposable; if one
+resolved base branch. In `pr` mode the base defaults to the PR's base branch,
+then the repository default branch; in `issue` and `task` modes it defaults to
+the repository default branch. An explicit `--base` overrides these defaults.
+Default checkouts are tool-owned and disposable; if one
 is dirty, the tool logs the cleanup, runs `git reset --hard` and `git clean -fd`,
 then syncs the configured base branch. If a default checkout points at another
 repo or is not a git checkout, the command fails clearly instead of overwriting

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -58,7 +58,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     def add_common(subparser: argparse.ArgumentParser) -> None:
         subparser.add_argument("--repo", help="GitHub repo as owner/name. Defaults to gh repo view.")
-        subparser.add_argument("--base", default="main", help="PR base branch for new issue work.")
+        subparser.add_argument(
+            "--base",
+            default=None,
+            help=(
+                "Base branch override. Defaults to the PR base for `pr`, otherwise "
+                "the repository default branch."
+            ),
+        )
         subparser.add_argument(
             "--claude-dir",
             type=Path,

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -8,13 +8,13 @@ import shlex
 import shutil
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from .agents.base import AgentName
 from .agents.registry import default_agent_args
 from .errors import AgentLoopError
-from .github import PullRequestMetadata, detect_repo
+from .github import PullRequestMetadata, detect_repo, get_repo_default_branch
 from .logging import log
 from .runner import Runner
 from .workdirs import active_workdir, agent_workdir
@@ -28,7 +28,7 @@ class AgentLoopConfig:
     gemini_dir: Path
     coder: AgentName
     reviewer: tuple[AgentName, ...]
-    base: str
+    base: str | None
     max_rounds: int
     auto_merge: bool
     dry_run: bool
@@ -95,6 +95,50 @@ class AgentLoopConfig:
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
     return config.reviewer
+
+
+def github_bootstrap_cwd(config: AgentLoopConfig) -> Path:
+    candidates = (
+        active_workdir(config),
+        *(agent_workdir(config, reviewer) for reviewer in reviewers(config)),
+        Path.cwd(),
+    )
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    raise AgentLoopError("No existing directory is available for GitHub repository metadata queries.")
+
+
+def resolve_base_branch(
+    config: AgentLoopConfig,
+    runner: Runner,
+    *,
+    pr_metadata: PullRequestMetadata | None = None,
+    cwd: Path | None = None,
+) -> AgentLoopConfig:
+    explicit_base = (config.base or "").strip()
+    if explicit_base:
+        return config if explicit_base == config.base else replace(config, base=explicit_base)
+
+    if config.dry_run:
+        return replace(config, base="main")
+
+    pr_base = (pr_metadata.base_branch or "").strip() if pr_metadata is not None else ""
+    if pr_base:
+        return replace(config, base=pr_base)
+
+    default_branch = get_repo_default_branch(
+        runner,
+        config=config,
+        cwd=cwd or github_bootstrap_cwd(config),
+    )
+    if default_branch:
+        return replace(config, base=default_branch)
+
+    raise AgentLoopError(
+        f"Unable to resolve a base branch for {config.repo}. "
+        "Pass --base <branch> explicitly."
+    )
 
 
 def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
@@ -290,6 +334,10 @@ def _sync_base_branch(
     config: AgentLoopConfig,
     runner: Runner,
 ) -> None:
+    if not config.base:
+        raise AgentLoopError(
+            f"Base branch for {config.repo} was not resolved. Pass --base <branch> explicitly."
+        )
     if not path.is_dir():
         raise AgentLoopError(f"{label} does not exist or is not a directory: {path}")
 
@@ -589,7 +637,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         gemini_dir=gemini_dir,
         coder=args.coder,
         reviewer=configured_reviewers,
-        base=args.base,
+        base=getattr(args, "base", None),
         max_rounds=args.max_rounds,
         auto_merge=args.auto_merge,
         dry_run=args.dry_run,

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -102,6 +102,31 @@ def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
     return repo
 
 
+def get_repo_default_branch(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    cwd: Path,
+) -> str | None:
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "repo",
+            "view",
+            config.repo,
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ],
+        cwd=cwd,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def get_pr_state(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> str:
     """Return the PR state string ('OPEN', 'CLOSED', or 'MERGED').
 
@@ -223,6 +248,7 @@ def get_pr_review_context(
     *,
     config: AgentLoopConfig,
     pr_number: int,
+    cwd: Path | None = None,
 ) -> PullRequestReviewContext:
     if config.dry_run:
         return PullRequestReviewContext(
@@ -250,7 +276,7 @@ def get_pr_review_context(
             "--json",
             PR_REVIEW_CONTEXT_FIELDS,
         ],
-        cwd=active_workdir(config),
+        cwd=cwd or active_workdir(config),
     )
     data = json.loads(result.stdout or "{}")
     comments = _parse_issue_comments(data.get("comments"))

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -15,6 +15,8 @@ from .agents.registry import agent_display_name, run_agent_result
 from .config import (
     AgentLoopConfig,
     ensure_agent_workdirs,
+    github_bootstrap_cwd,
+    resolve_base_branch,
     reviewers,
     sync_coder_base_before_implementation,
     sync_coder_pr_before_validation,
@@ -2248,6 +2250,7 @@ def run_issue_loop(
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
     try:
+        config = resolve_base_branch(config, runner)
         ensure_agent_workdirs(config, runner)
         log(config, f"Validating issue #{issue_number}")
         validate_open_issue(runner, config=config, issue_number=issue_number)
@@ -2365,6 +2368,7 @@ def run_task_loop(
             raise AgentLoopError("Task text is empty; provide a non-empty description.")
         if max_clarification_rounds < 0:
             raise AgentLoopError("--max-clarification-rounds must be zero or positive.")
+        config = resolve_base_branch(config, runner)
         ensure_agent_workdirs(config, runner)
         memory = prepare_agent_memory(runner, config)
 
@@ -2492,6 +2496,19 @@ def run_pr_loop(
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
     try:
+        bootstrap_cwd = github_bootstrap_cwd(config)
+        initial_pr_context = get_pr_review_context(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            cwd=bootstrap_cwd,
+        )
+        config = resolve_base_branch(
+            config,
+            runner,
+            pr_metadata=initial_pr_context.metadata,
+            cwd=bootstrap_cwd,
+        )
         if not workdirs_ready:
             ensure_agent_workdirs(config, runner)
         log(config, f"Validating PR #{pr_number}")
@@ -2509,7 +2526,6 @@ def run_pr_loop(
             # Backward-compatible single-reviewer resume support: older callers
             # pass one reviewer session, so attach it to the first configured reviewer.
             reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
-        initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
         prefetched_pr_context: PullRequestReviewContext | None = None
         resumed_round = _resume_pr_round(
             initial_pr_context.comments,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -54,6 +54,7 @@ from coding_review_agent_loop.config import (
     default_agent_memory_dir,
     default_agent_workdir,
     default_cache_root,
+    resolve_base_branch,
 )
 from coding_review_agent_loop.comment_rendering import (
     _render_public_coder_followup_comment,
@@ -216,6 +217,8 @@ class FakeRunner(Runner):
         pr_check_runs_stderr="",
         pr_status_returncode=0,
         pr_status_stderr="",
+        repo_default_branch="main",
+        repo_default_branch_returncode=0,
         git_status="",
         git_remote="git@github.com:OWNER/REPO.git",
         git_inside=True,
@@ -269,6 +272,8 @@ class FakeRunner(Runner):
         self.pr_check_runs_stderr = pr_check_runs_stderr
         self.pr_status_returncode = pr_status_returncode
         self.pr_status_stderr = pr_status_stderr
+        self.repo_default_branch = repo_default_branch
+        self.repo_default_branch_returncode = repo_default_branch_returncode
         self.commands = []
         self.comments = []
         self.issues = []
@@ -596,6 +601,20 @@ class FakeRunner(Runner):
             if "--jq" in cmd and ".headRefOid" in cmd:
                 return CommandResult(cmd, cwd_path, "abc123\n", "", 0)
             return CommandResult(cmd, cwd_path, json_dumps(self.pr_payload), "", 0)
+
+        if cmd[:3] == ["gh", "repo", "view"] and "defaultBranchRef" in cmd:
+            stdout = (
+                f"{self.repo_default_branch}\n"
+                if self.repo_default_branch_returncode == 0 and self.repo_default_branch
+                else ""
+            )
+            return CommandResult(
+                cmd,
+                cwd_path,
+                stdout,
+                "",
+                self.repo_default_branch_returncode,
+            )
 
         if cmd[:3] == ["gh", "issue", "view"]:
             payload = {
@@ -11647,7 +11666,15 @@ def test_non_codex_loop_uses_active_workdir_for_github_and_tests(tmp_path):
         if cmd[:1] == ["gh"] or cmd == ["pytest", "tests/test_agent_loop.py"]
     ]
     assert github_or_test_cwds
-    assert set(github_or_test_cwds) == {config.claude_dir}
+    bootstrap_pr_queries = [
+        cwd
+        for cmd, cwd in runner.commands
+        if cmd[:3] == ["gh", "pr", "view"]
+        and "number,title,headRefName,baseRefName,headRefOid,url,body,comments,reviews" in cmd
+        and cwd != config.claude_dir
+    ]
+    assert bootstrap_pr_queries == [Path.cwd()]
+    assert set(github_or_test_cwds) == {Path.cwd(), config.claude_dir}
 
 
 def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, tmp_path):
@@ -11676,6 +11703,22 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, t
     assert config.agent_memory_dir == (
         cache_home / "coding-review-agent-loop" / "repos" / "OWNER-REPO" / "memory"
     ).resolve()
+
+
+def test_omitted_cli_base_is_preserved_for_runtime_resolution(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+
+    assert config_from_args(args, FakeRunner()).base is None
 
 
 def test_pre_review_tests_cli_defaults_on_and_can_be_disabled(tmp_path):
@@ -11979,6 +12022,127 @@ def test_clean_existing_auto_agent_dir_is_synced(tmp_path):
     assert ["git", "fetch", "origin"] in commands
     assert ["git", "switch", "main"] in commands
     assert ["git", "pull", "--ff-only", "origin", "main"] in commands
+
+
+def test_pr_loop_resolves_pr_base_before_workdir_setup(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"baseRefName": "develop"},
+    )
+    config = make_config(
+        tmp_path,
+        base=None,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    pr_context_index = command_index(runner.commands, ["gh", "pr", "view"])
+    switch_index = command_index(runner.commands, ["git", "switch", "develop"])
+    assert pr_context_index < switch_index
+    assert ["git", "pull", "--ff-only", "origin", "develop"] in commands
+    assert not any("origin/main" in arg for cmd in commands for arg in cmd)
+
+
+def test_pr_loop_explicit_base_overrides_pr_base_without_repo_default_query(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"baseRefName": "develop"},
+    )
+    config = make_config(
+        tmp_path,
+        base="release",
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["git", "switch", "release"] in commands
+    assert ["git", "switch", "develop"] not in commands
+    assert not any(
+        cmd[:3] == ["gh", "repo", "view"] and "defaultBranchRef" in cmd
+        for cmd in commands
+    )
+
+
+@pytest.mark.parametrize("pr_base", [None, "", "   "])
+def test_pr_loop_falls_back_to_repo_default_when_pr_base_is_missing(tmp_path, pr_base):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"baseRefName": pr_base},
+        repo_default_branch="develop",
+    )
+    config = make_config(
+        tmp_path,
+        base=None,
+        reviewer="codex",
+        auto_agent_dirs=("codex",),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    repo_query_index = command_index(runner.commands, ["gh", "repo", "view"])
+    switch_index = command_index(runner.commands, ["git", "switch", "develop"])
+    assert repo_query_index < switch_index
+
+
+@pytest.mark.parametrize("mode", ["issue", "task"])
+def test_issue_and_task_loops_use_repo_default_when_base_is_omitted(tmp_path, mode):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"baseRefName": "develop"},
+        repo_default_branch="develop",
+    )
+    config = make_config(
+        tmp_path,
+        base=None,
+        reviewer="codex",
+        auto_agent_dirs=("claude", "codex"),
+    )
+
+    if mode == "issue":
+        assert run_issue_loop(runner, issue_number=56, config=config) == 0
+    else:
+        assert run_task_loop(runner, task_text="Add /healthz endpoint.", config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert ["git", "switch", "develop"] in commands
+    assert not any("origin/main" in arg for cmd in commands for arg in cmd)
+
+
+def test_unresolved_base_metadata_produces_targeted_override_error(tmp_path):
+    runner = FakeRunner(
+        pr_payload={"baseRefName": None},
+        repo_default_branch=None,
+        repo_default_branch_returncode=1,
+    )
+    config = make_config(tmp_path, base=None, reviewer="codex")
+
+    with pytest.raises(
+        AgentLoopError,
+        match=r"Unable to resolve a base branch for OWNER/REPO.*--base <branch>",
+    ):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["git", "switch"] for cmd, _cwd in runner.commands)
+
+
+def test_dry_run_base_resolution_defaults_to_main_without_github_query(tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, base=None, dry_run=True)
+
+    resolved = resolve_base_branch(config, runner)
+
+    assert resolved.base == "main"
+    assert not any(cmd[:1] == ["gh"] for cmd, _cwd in runner.commands)
 
 
 def test_reviewer_checkout_is_refreshed_to_pr_head_before_review(tmp_path):


### PR DESCRIPTION
Fixes #351

## Summary
- preserve omitted `--base` values and resolve them at runtime
- prefer the PR base branch in `pr` mode, then fall back to the repository default branch
- use the repository default branch for omitted issue/task bases and keep explicit overrides authoritative
- bootstrap PR metadata before workdir setup, reuse that context, and provide a targeted unresolved-base error
- document the behavior and add regression coverage for ordering, fallback, overrides, dry-run, and workdir setup

## Tests
- `python3 -m pytest tests/test_agent_loop.py -q -k 'omitted_cli_base or resolves_pr_base_before_workdir_setup or explicit_base_overrides_pr_base or falls_back_to_repo_default_when_pr_base_is_missing or issue_and_task_loops_use_repo_default or unresolved_base_metadata or dry_run_base_resolution or clean_existing_auto_agent_dir_is_synced or omitted_agent_dirs_default'` (12 passed)
- `python3 -m pytest` (917 passed)
