### PR TITLE
Dedupe antigravity quota-signatures default + confirm task-round forwarding (#347, #348, #350)

### DIFF
--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -229,7 +229,12 @@ def main() -> None:
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     from coding_review_agent_loop.agents.codex import CodexBackend
     from coding_review_agent_loop.agents.gemini import GeminiBackend
-    from coding_review_agent_loop.config import AgentLoopConfig, AgentName, ensure_temp_checkout
+    from coding_review_agent_loop.config import (
+        DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES,
+        AgentLoopConfig,
+        AgentName,
+        ensure_temp_checkout,
+    )
     from coding_review_agent_loop.transient import is_transient_agent_output
     from coding_review_agent_loop.usage import estimate_usage
 
@@ -244,7 +249,7 @@ def main() -> None:
     antigravity_quota_signatures = (
         tuple(args.antigravity_quota_signatures)
         if args.antigravity_quota_signatures is not None
-        else ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")
+        else DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES
     )
 
     # Build a minimal config sufficient for backend.run()

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -1297,6 +1297,9 @@ def cmd_run_task_round(args: argparse.Namespace) -> None:
         print(f"reusing issue #{issue} for task {key[:12]}")
 
     args.issue = issue
+    # Delegates with the full args namespace, so options added to p_task via
+    # _add_antigravity_options (--antigravity-models / --antigravity-quota-signatures,
+    # --model) are forwarded intact to the plan round and on to run_external (#347).
     cmd_run_plan_round(args)
 
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -13,6 +13,7 @@ from .agents.registry import (
     agent_signature,
 )
 from .config import (
+    DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES,
     AgentLoopConfig,
     config_from_args,
     ensure_agent_workdirs,
@@ -129,7 +130,7 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument(
             "--antigravity-quota-signatures",
             nargs="+",
-            default=["quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"],
+            default=list(DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES),
             help="Output substrings that trigger model fallback (default: quota, rate limit, etc).",
         )
         subparser.add_argument(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -19,6 +19,17 @@ from .logging import log
 from .runner import Runner
 from .workdirs import active_workdir, agent_workdir
 
+# Single source of truth for the Antigravity quota-exhaustion fallback signatures
+# (#348, #350). The dataclass field default, config_from_args, the CLI flag default,
+# and helpers/run_external.py all derive from this so the default can't drift.
+DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES: tuple[str, ...] = (
+    "quota",
+    "rate limit",
+    "resource exhausted",
+    "RESOURCE_EXHAUSTED",
+    "429",
+)
+
 
 @dataclass(frozen=True)
 class AgentLoopConfig:
@@ -66,7 +77,7 @@ class AgentLoopConfig:
     antigravity_args: tuple[str, ...] = ()
     antigravity_model: str | None = None
     antigravity_models: tuple[str, ...] = ()
-    antigravity_quota_signatures: tuple[str, ...] = ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")
+    antigravity_quota_signatures: tuple[str, ...] = DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES
     # Declared model / reasoning effort for the dynamic signature (#332). Empty
     # means "not declared" (the agent runs its own default and the signature
     # falls back to the generic provider name). antigravity always has a model.
@@ -670,7 +681,10 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ),
         antigravity_model=args.antigravity_model,
         antigravity_models=tuple(args.antigravity_models) if getattr(args, "antigravity_models", None) is not None else (),
-        antigravity_quota_signatures=tuple(getattr(args, "antigravity_quota_signatures", ["quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"])),
+        antigravity_quota_signatures=tuple(
+            getattr(args, "antigravity_quota_signatures", None)
+            or DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES
+        ),
         codex_model=getattr(args, "codex_model", ""),
         codex_reasoning_effort=getattr(args, "codex_reasoning_effort", ""),
         gemini_model=getattr(args, "gemini_model", ""),

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18133,6 +18133,19 @@ def test_config_from_args_antigravity_defaults(tmp_path):
     assert str(config.log_dir).startswith(str(config.antigravity_dir))
 
 
+def test_antigravity_quota_signatures_default_single_source(tmp_path):
+    """The quota-signatures default comes from one constant — no drift across the
+    dataclass field, the CLI flag, and config_from_args (#348, #350)."""
+    from coding_review_agent_loop.config import DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES as DEFAULT
+    # dataclass field default
+    assert make_config(tmp_path).antigravity_quota_signatures == DEFAULT
+    # CLI flag default and config_from_args both derive from the constant
+    parser = build_parser()
+    args = parser.parse_args(["pr", "123", "--repo", "OWNER/REPO", "--codex-dir", str(tmp_path / "codex")])
+    assert tuple(args.antigravity_quota_signatures) == DEFAULT
+    assert config_from_args(args, FakeRunner()).antigravity_quota_signatures == DEFAULT
+
+
 def test_cli_rejects_both_antigravity_model_flags():
     parser = build_parser()
     with pytest.raises(SystemExit):

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -3214,6 +3214,32 @@ class TestAntigravitySkill:
 # ---------------------------------------------------------------------------
 
 
+def test_run_task_round_forwards_antigravity_options():
+    """run-task-round applies _add_antigravity_options and delegates the full args
+    namespace to the plan round, so the antigravity model/chain/quota options forward
+    to run_external (#347)."""
+    import argparse
+    import helpers.skill_runner as sr
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    p_task = sub.add_parser("run-task-round")
+    sr._add_antigravity_options(p_task)
+
+    args = parser.parse_args([
+        "run-task-round",
+        "--antigravity-models", "Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)",
+        "--antigravity-quota-signatures", "quota", "429",
+    ])
+    assert sr._run_external_antigravity_args(args) == (
+        "--antigravity-models", "Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)",
+        "--antigravity-quota-signatures", "quota", "429",
+    )
+    # Legacy single-model override forwards as --model.
+    legacy = parser.parse_args(["run-task-round", "--model", "Gemini 3.1 Pro (High)"])
+    assert sr._run_external_antigravity_args(legacy) == ("--model", "Gemini 3.1 Pro (High)")
+
+
 def test_model_used_from_usage_sidecar(tmp_path):
     import helpers.skill_runner as sr
     sidecar = tmp_path / "agent-usage.json"


### PR DESCRIPTION
Addresses three small follow-ups from the #340 antigravity work.

## Quota-signatures default dedup — closes #348 and #350

#348 and #350 are the **same root cause**: the antigravity quota-exhaustion
signature default tuple was hardcoded in **four** places —
`AgentLoopConfig.antigravity_quota_signatures` field default, `config_from_args`,
the `--antigravity-quota-signatures` CLI flag default, and `run_external.py`'s
fallback — so they could drift silently.

Fix: a single `DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES` constant in `config.py`; all
four sites now derive from it.

## Task-round arg forwarding — closes #347

`run-task-round` delegates to `cmd_run_plan_round` with the full args namespace, and
`p_task` applies `_add_antigravity_options`, so `--antigravity-models` /
`--antigravity-quota-signatures` / `--model` forward to `run_external`. Added a code
comment at the delegation and a test asserting the parse→convert chain (chain form +
legacy `--model`).

## Tests

- Single-source default: the dataclass field, the CLI flag default, and
  `config_from_args` all equal `DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES`.
- Task-round forwarding via `_add_antigravity_options` + `_run_external_antigravity_args`.
- Full suite: **919 passed.**

Scope note: deliberately limited to the quota-signatures default (the filed
concern). The antigravity *model-chain* default has the same duplication pattern but
no filed issue — left out to keep this focused; happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude
