### PR TITLE
Extract DEFAULT_ANTIGRAVITY_MODELS constant for the default fallback chain

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -30,6 +30,14 @@ DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES: tuple[str, ...] = (
     "429",
 )
 
+# Default Antigravity model fallback chain, applied in __post_init__ when neither a
+# legacy antigravity_model nor an explicit antigravity_models chain is given. Named
+# for discoverability/symmetry with DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES.
+DEFAULT_ANTIGRAVITY_MODELS: tuple[str, ...] = (
+    "Gemini 3.1 Pro (High)",
+    "Gemini 3.5 Flash (High)",
+)
+
 
 @dataclass(frozen=True)
 class AgentLoopConfig:
@@ -94,7 +102,7 @@ class AgentLoopConfig:
         if self.antigravity_model is not None:
             object.__setattr__(self, "antigravity_models", (self.antigravity_model,))
         elif not self.antigravity_models:
-            object.__setattr__(self, "antigravity_models", ("Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)"))
+            object.__setattr__(self, "antigravity_models", DEFAULT_ANTIGRAVITY_MODELS)
         if any(not m.strip() for m in self.antigravity_models):
             raise AgentLoopError("antigravity_models chain cannot be empty or contain blank entries.")
         ensure_no_model_arg_conflicts(self)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18146,6 +18146,16 @@ def test_antigravity_quota_signatures_default_single_source(tmp_path):
     assert config_from_args(args, FakeRunner()).antigravity_quota_signatures == DEFAULT
 
 
+def test_antigravity_models_default_chain_from_constant(tmp_path):
+    """The default model fallback chain resolves from the named constant when
+    neither a legacy model nor an explicit chain is given."""
+    from coding_review_agent_loop.config import DEFAULT_ANTIGRAVITY_MODELS
+    assert make_config(tmp_path).antigravity_models == DEFAULT_ANTIGRAVITY_MODELS
+    parser = build_parser()
+    args = parser.parse_args(["pr", "123", "--repo", "OWNER/REPO", "--codex-dir", str(tmp_path / "codex")])
+    assert config_from_args(args, FakeRunner()).antigravity_models == DEFAULT_ANTIGRAVITY_MODELS
+
+
 def test_cli_rejects_both_antigravity_model_flags():
     parser = build_parser()
     with pytest.raises(SystemExit):


### PR DESCRIPTION
Small readability refactor: the default Antigravity model fallback chain literal lived inline in `AgentLoopConfig.__post_init__`. Extract it to a named `DEFAULT_ANTIGRAVITY_MODELS` constant in `config.py`, for discoverability and symmetry with `DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES`.

Note: this is **not** a drift fix — #337's sentinel design (`antigravity_models` default `()`, chain applied once in `__post_init__`) already kept the chain single-sourced. This is purely making that single source a named constant.

Adds a test asserting the resolved default chain comes from the constant. Full suite: 920 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude