### PR TITLE
Auto-detect Codex model from rollout sessions

### DIFF
--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -21,6 +22,15 @@ from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
+
+
+_CODEX_THREAD_ID_RE = re.compile(r"[0-9a-fA-F-]+")
+_CODEX_REASONING_EFFORT_KEYS = (
+    "effort",
+    "reasoning_effort",
+    "model_reasoning_effort",
+)
+
 
 def _normalize_codex_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
@@ -102,6 +112,97 @@ def _codex_model_label(config: AgentLoopConfig) -> str | None:
     if config.codex_reasoning_effort:
         return f"{config.codex_model} ({config.codex_reasoning_effort})"
     return config.codex_model
+
+
+def _extract_codex_thread_id(raw: str) -> str | None:
+    for line in raw.splitlines():
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(event, dict) or event.get("type") != "thread.started":
+            continue
+        thread_id = event.get("thread_id")
+        if isinstance(thread_id, str):
+            thread_id = thread_id.strip()
+            if _CODEX_THREAD_ID_RE.fullmatch(thread_id):
+                return thread_id
+    return None
+
+
+def _codex_session_root() -> Path:
+    codex_home = os.environ.get("CODEX_HOME")
+    return Path(codex_home).expanduser() if codex_home else Path.home() / ".codex"
+
+
+def _find_codex_rollout(thread_id: str) -> Path | None:
+    if not _CODEX_THREAD_ID_RE.fullmatch(thread_id):
+        return None
+    sessions_root = _codex_session_root() / "sessions"
+    try:
+        matches = list(sessions_root.glob(f"**/rollout-*-{thread_id}.jsonl"))
+    except OSError:
+        return None
+
+    newest: tuple[int, str, Path] | None = None
+    for path in matches:
+        try:
+            candidate = (path.stat().st_mtime_ns, str(path), path)
+        except OSError:
+            continue
+        if newest is None or candidate > newest:
+            newest = candidate
+    return newest[2] if newest is not None else None
+
+
+def _model_record_containers(record: dict[object, object]) -> tuple[dict[object, object], ...]:
+    containers = [record]
+    for key in ("payload", "turn", "turn_context"):
+        value = record.get(key)
+        if isinstance(value, dict):
+            containers.append(value)
+    return tuple(containers)
+
+
+def _read_codex_rollout_model(rollout_path: Path) -> str | None:
+    model: str | None = None
+    effort: str | None = None
+    try:
+        with rollout_path.open(encoding="utf-8") as rollout:
+            for line in rollout:
+                try:
+                    record = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                for container in _model_record_containers(record):
+                    candidate = container.get("model")
+                    if not isinstance(candidate, str) or not candidate.strip():
+                        continue
+                    model = candidate.strip()
+                    effort = None
+                    for key in _CODEX_REASONING_EFFORT_KEYS:
+                        candidate_effort = container.get(key)
+                        if isinstance(candidate_effort, str) and candidate_effort.strip():
+                            effort = candidate_effort.strip()
+                            break
+    except (OSError, UnicodeError):
+        return None
+
+    if model is None:
+        return None
+    return f"{model} ({effort})" if effort else model
+
+
+def _detect_codex_model(raw: str) -> str | None:
+    thread_id = _extract_codex_thread_id(raw)
+    if thread_id is None:
+        return None
+    rollout_path = _find_codex_rollout(thread_id)
+    if rollout_path is None:
+        return None
+    return _read_codex_rollout_model(rollout_path)
 
 
 def _read_codex_message_file(output_path: Path) -> str | None:
@@ -190,6 +291,7 @@ class CodexBackend:
             response_file_text = read_public_response_file(response_path)
             message_text = _read_codex_message_file(Path(output_path)) or result.stdout
             usage, raw_usage = _extract_codex_usage(result.stdout)
+            model_used = _codex_model_label(config) or _detect_codex_model(result.stdout)
             log(config, f"Codex finished; log: {log_path}")
             return AgentResult(
                 text=response_file_text or message_text,
@@ -201,7 +303,7 @@ class CodexBackend:
                 returncode=result.returncode,
                 usage=usage,
                 raw_usage=raw_usage,
-                model_used=_codex_model_label(config),
+                model_used=model_used,
             )
         finally:
             try:

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -146,7 +146,7 @@ def build_parser() -> argparse.ArgumentParser:
             default="",
             help=(
                 "Codex reasoning effort (e.g. low/medium/high) to run and stamp in the "
-                "signature. Requires --codex-model (codex does not report its model). "
+                "signature. Requires --codex-model because rollout detection is best-effort. "
                 "Mutually exclusive with model_reasoning_effort via --codex-arg."
             ),
         )

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -214,11 +214,12 @@ def ensure_no_model_arg_conflicts(config: AgentLoopConfig) -> None:
         )
     if config.codex_reasoning_effort and not config.codex_model:
         # The declared flags exist to stamp the signature, which needs the model
-        # name; codex does not report its model, so effort alone can't be labeled.
+        # name. Rollout-file detection is best-effort, so effort alone cannot
+        # reliably be labeled.
         raise AgentLoopError(
             "--codex-reasoning-effort requires --codex-model so the signature can "
-            "name the model (codex does not report its model). To set effort without "
-            "stamping the signature, use --codex-arg -c model_reasoning_effort=... instead."
+            "reliably name the model. To set effort without stamping the signature, "
+            "use --codex-arg -c model_reasoning_effort=... instead."
         )
     if config.gemini_model and _args_have_model_flag(config.gemini_args):
         raise AgentLoopError(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1743,6 +1743,159 @@ def test_codex_backend_dry_run_sets_message_text_without_response_file(tmp_path)
     assert result.text == "dry run stdout"
 
 
+def _write_codex_rollout(
+    codex_home: Path,
+    thread_id: str,
+    records: list[object],
+    *,
+    name_prefix: str = "rollout-2026-06-18T12-00-00",
+) -> Path:
+    rollout_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "06"
+        / "18"
+        / f"{name_prefix}-{thread_id}.jsonl"
+    )
+    rollout_path.parent.mkdir(parents=True, exist_ok=True)
+    rollout_path.write_text(
+        "\n".join(
+            record if isinstance(record, str) else json.dumps(record)
+            for record in records
+        ),
+        encoding="utf-8",
+    )
+    return rollout_path
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        ({"payload": {"model": "gpt-5.5"}}, "gpt-5.5"),
+        (
+            {"type": "turn_context", "payload": {"model": "gpt-5.5", "effort": "high"}},
+            "gpt-5.5 (high)",
+        ),
+        (
+            {"turn": {"model": "gpt-5.5", "model_reasoning_effort": "medium"}},
+            "gpt-5.5 (medium)",
+        ),
+    ],
+)
+def test_codex_backend_detects_model_from_rollout(tmp_path, monkeypatch, record, expected):
+    thread_id = "019ed9d8-1111-7222-8333-444444444444"
+    codex_home = tmp_path / "codex-home"
+    _write_codex_rollout(codex_home, thread_id, [record])
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": "last message text",
+                "stdout": json.dumps({"type": "thread.started", "thread_id": thread_id}),
+            }
+        ]
+    )
+    config = make_config(tmp_path)
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.model_used == expected
+
+
+def test_codex_backend_declared_model_takes_precedence_over_rollout(tmp_path, monkeypatch):
+    thread_id = "019ed9d8-1111-7222-8333-444444444444"
+    codex_home = tmp_path / "codex-home"
+    _write_codex_rollout(
+        codex_home,
+        thread_id,
+        [{"payload": {"model": "gpt-5.5", "effort": "high"}}],
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": "last message text",
+                "stdout": json.dumps({"type": "thread.started", "thread_id": thread_id}),
+            }
+        ]
+    )
+    config = make_config(
+        tmp_path,
+        codex_model="gpt-5.4",
+        codex_reasoning_effort="medium",
+    )
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.model_used == "gpt-5.4 (medium)"
+
+
+@pytest.mark.parametrize(
+    ("stdout", "records"),
+    [
+        ("not json", [{"payload": {"model": "gpt-5.5"}}]),
+        (
+            json.dumps(
+                {
+                    "type": "thread.started",
+                    "thread_id": "019ed9d8-1111-7222-8333-444444444444",
+                }
+            ),
+            None,
+        ),
+        (
+            json.dumps(
+                {
+                    "type": "thread.started",
+                    "thread_id": "019ed9d8-1111-7222-8333-444444444444",
+                }
+            ),
+            ["not json", {"payload": {"model": ""}}, {"payload": {"model": 55}}],
+        ),
+    ],
+)
+def test_codex_backend_missing_or_invalid_rollout_model_falls_back_to_none(
+    tmp_path,
+    monkeypatch,
+    stdout,
+    records,
+):
+    thread_id = "019ed9d8-1111-7222-8333-444444444444"
+    codex_home = tmp_path / "codex-home"
+    if records is not None:
+        _write_codex_rollout(codex_home, thread_id, records)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": "last message text", "stdout": stdout}]
+    )
+    config = make_config(tmp_path)
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.model_used is None
+
+
+def test_codex_backend_invalid_rollout_falls_back_to_declared_model(tmp_path, monkeypatch):
+    thread_id = "019ed9d8-1111-7222-8333-444444444444"
+    codex_home = tmp_path / "codex-home"
+    _write_codex_rollout(codex_home, thread_id, ["not json"])
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runner = FakeRunner(
+        codex_outputs=[
+            {
+                "public_response": "last message text",
+                "stdout": json.dumps({"type": "thread.started", "thread_id": thread_id}),
+            }
+        ]
+    )
+    config = make_config(tmp_path, codex_model="gpt-5.4")
+
+    result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
+
+    assert result.model_used == "gpt-5.4"
+
+
 def test_parse_agent_state_accepts_html_marker():
     assert parse_agent_state("looks fine\n<!-- AGENT_STATE: approved -->") == "approved"
     assert parse_agent_state("needs work\n<!-- agent_state: BLOCKING -->") == "blocking"


### PR DESCRIPTION
## Summary
- parse Codex thread IDs from JSONL stdout and locate the matching rollout session under `$CODEX_HOME` or `~/.codex`
- derive the model and optional reasoning effort without failing the agent run when rollout data is missing or malformed
- preserve explicit `--codex-model` precedence and update related CLI guidance
- add backend coverage for detection, effort labels, precedence, and graceful fallbacks

## Tests
- `python3 -m pytest tests/test_agent_loop.py -k "codex_backend or extract_codex_usage or normalize_codex_usage"`
- `python3 -m pytest`

Fixes #357