### PR TITLE
Add automatic skill structured-response recovery

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -294,7 +294,11 @@ Plan-loop onward (including the optional Implement step + PR-loop).
   is re-attempted on the next run (or drop it from `--reviewers` to proceed). A
   round with an unavailable reviewer is never reported `approved`: its `state` is
   `incomplete` (or `blocking`/`pending` if those apply first). A genuinely
-  malformed-but-content-bearing review still uses the `retry-validate` repair path.
+  malformed-but-content-bearing structured output is first recovered automatically
+  when possible. The skill applies its safe reviewer normalizers, envelope cleanup,
+  known-ledger unknown-disposition stripping, plan-revision human-requirements
+  acknowledgement reconstruction, and finally a Gemini format-repair pass. Only
+  genuinely unrecoverable output falls back to `retry-validate`.
 - **Round states.** `approved` (all configured reviewers signed off) · `blocking`
   (a reviewer reported must-fix items) · `pending` (a host `claude` review handoff
   is outstanding — complete it with `complete-host-review`) · `incomplete` (a
@@ -344,10 +348,16 @@ discriminate them): you just re-run the command until it returns
   plan is carried forward for reviewers);
 - **round complete, all approved** → returns `approved`.
 
-If a coder turn produces a malformed plan, the raw response is saved to a repair
-dir (manifest `role: coder`); fix `raw.md` and recover with
-`retry-validate --repair-dir <dir>` (no re-run of the agent), then re-run
-`run-plan-round`.
+Structured reviewer responses, round-N `plan_revision` responses, and
+`run-pr-fix` `coder_followup` responses use the same automatic recovery order:
+safe deterministic normalization, envelope normalization, known-ledger
+disposition cleanup, context-specific acknowledgement reconstruction, then a
+Gemini format-repair pass. Pass `--gemini-cmd PATH` to the round/fix command to
+select the Gemini executable used both for Gemini agent turns and repair. The
+agent's original output is saved before recovery. If every recovery stage fails,
+fix the preserved repair-dir `raw.md` with
+`retry-validate --repair-dir <dir>` (or inspect the PR-fix debug directory), then
+re-run the parent command.
 
 ### Host-as-reviewer (Claude reviews the plan or PR)
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -143,10 +143,21 @@ of the following, in precedence order:
 review — an agent/tooling failure such as an empty or malformed-tool-call
 response, *not* a fixable malformed review — the round does **not** abort. That
 reviewer is marked unavailable, the remaining reviewers still run, and a round is
-never falsely reported `approved`. A genuinely malformed-but-content-bearing
-review instead uses the `retry-validate` repair path. (The classifier is
+never falsely reported `approved`. A malformed-but-content-bearing structured
+review is recovered automatically when possible: safe skill normalization,
+envelope normalization, deterministic unknown-prior-item stripping against the
+complete carried ledger, and then Gemini format repair. The classifier is
 conservative: only known tooling-failure signatures or truly-empty output count
-as unavailable.)
+as unavailable.
+
+The same automatic recovery pipeline covers external-coder `plan_revision`
+responses and `run-pr-fix` `coder_followup` responses. Plan revisions may also
+recover one unique, independently valid signed-human-requirements
+acknowledgement from the external agent's captured response evidence. Use
+`--gemini-cmd PATH` to configure both Gemini agent invocations and the final
+repair pass. The original response is saved before recovery; `retry-validate`
+repair directories and PR-fix debug directories remain the final fallback for
+genuinely unrecoverable output.
 
 ## Session state
 

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 import tempfile
+import dataclasses
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -302,6 +303,7 @@ def build_plan_revision_prompt_for_skill(
     previous_plan: str,
     reviewer_feedback: str,
     prior_items_raw: list[dict],
+    human_requirements: Sequence | None = None,
     memory: AgentMemoryContext | None = None,
 ) -> str:
     """Build the round-N+1 coder (plan revision) prompt for an external coder (#307).
@@ -313,6 +315,11 @@ def build_plan_revision_prompt_for_skill(
         repo, coder, tuple(reviewers), reviewer=coder, workdir=workdir,
     )
     issue_context = _make_issue_context(issue_dict)
+    if human_requirements:
+        issue_context = dataclasses.replace(
+            issue_context,
+            human_requirements=tuple(human_requirements),
+        )
     unresolved = [_deserialize_unresolved_item(item) for item in prior_items_raw]
     return build_plan_revision_prompt(
         issue_context.number,

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -179,6 +179,12 @@ def main() -> None:
         help="Write the agent's token usage (JSON) to this path for external-agent "
              "cost tracking (#308). Skipped in --dry-run.",
     )
+    parser.add_argument(
+        "--response-evidence-output",
+        default=None,
+        help="Write response_file_text/message_text evidence needed for deterministic "
+             "structured-response recovery. Skipped in --dry-run.",
+    )
     args = parser.parse_args()
 
     if args.max_retries < 0:
@@ -358,6 +364,18 @@ def main() -> None:
     assert result is not None  # loop either set result or exited
     output_path.write_text(result.text, encoding="utf-8")
     print(f"agent result written to {output_path}")
+
+    if args.response_evidence_output:
+        try:
+            Path(args.response_evidence_output).write_text(
+                json.dumps({
+                    "response_file_text": result.response_file_text,
+                    "message_text": result.message_text,
+                }, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"run_external: could not write response evidence: {exc}", file=sys.stderr)
 
     # External-agent usage for cost tracking (#308). Advisory — never fail the run.
     if args.usage_output:

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -101,6 +101,7 @@ import subprocess
 import sys
 import tempfile
 import types
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -108,7 +109,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from coding_review_agent_loop.agents.base import AgentName
 from coding_review_agent_loop.agents.registry import agent_display_name
 from coding_review_agent_loop.config import ensure_temp_checkout
-from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.errors import AgentLoopError, UnknownPriorItemDispositionError
 from coding_review_agent_loop.followups import (
     _approved_followup_from_unresolved_item,
     _publish_approved_followups,
@@ -126,7 +127,16 @@ from coding_review_agent_loop.round_state import (
     _serialize_unresolved_item,
     _serialize_disposition,
 )
-from coding_review_agent_loop.unresolved_items import apply_item_dispositions
+from coding_review_agent_loop.unresolved_items import (
+    HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+    apply_item_dispositions,
+)
+from coding_review_agent_loop.repair import (
+    attempt_envelope_normalization,
+    attempt_repair,
+    strip_unknown_prior_item_dispositions,
+)
+from helpers.validate_response import validate_response_text
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -310,6 +320,184 @@ def _normalize_raw_response(text: str) -> str:
     return json_text.rstrip() + "\n" + prefix + state_and_sig.rstrip() + "\n"
 
 
+def _response_evidence_texts(evidence: dict[str, object] | None) -> list[str]:
+    if not evidence:
+        return []
+    texts: list[str] = []
+    for key in ("response_file_text", "message_text"):
+        value = evidence.get(key)
+        if isinstance(value, str) and value.strip() and value not in texts:
+            texts.append(value)
+    return texts
+
+
+def _recover_plan_revision_human_ack(
+    candidate: str,
+    *,
+    response_evidence: dict[str, object] | None,
+    surfaced_requirement_ids: Sequence[str],
+    requires_direct_discussion_ack: bool,
+    validate: Callable[[str], object],
+) -> tuple[str, object] | None:
+    """Reattach exactly one independently-valid acknowledgement evidence block."""
+    if not surfaced_requirement_ids and not requires_direct_discussion_ack:
+        return None
+
+    from coding_review_agent_loop.protocol import (
+        HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+        PLAN_STATE_RE,
+        parse_human_requirements_acknowledgement,
+        validate_human_requirements_acknowledgement,
+    )
+
+    stripped = candidate.lstrip()
+    try:
+        payload, json_end = json.JSONDecoder().raw_decode(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or payload.get("kind") != "plan_revision":
+        return None
+    trailing = stripped[json_end:].lstrip()
+    footer_match = PLAN_STATE_RE.search(trailing)
+    if footer_match is None or trailing[:footer_match.start()].strip():
+        return None
+    footer_and_signature = trailing[footer_match.start():].strip()
+
+    valid_blocks: list[str] = []
+    for evidence_text in _response_evidence_texts(response_evidence):
+        lines = evidence_text.splitlines()
+        for index, line in enumerate(lines):
+            if HUMAN_REQUIREMENTS_ADDRESSED_MARKER not in line:
+                continue
+            block_lines = [line.strip()]
+            section_seen = False
+            for next_line in lines[index + 1:]:
+                stripped_line = next_line.strip()
+                if section_seen and (
+                    PLAN_STATE_RE.match(stripped_line)
+                    or re.match(r"^--\s+\S", stripped_line)
+                    or next_line.lstrip().startswith("{")
+                ):
+                    break
+                block_lines.append(next_line.rstrip())
+                if re.match(r"^\s*###\s+Human requirements\s*$", next_line, re.I):
+                    section_seen = True
+            block = "\n".join(block_lines).strip()
+            parsed = parse_human_requirements_acknowledgement(block)
+            if not parsed.marker_present or not parsed.section_present:
+                continue
+            try:
+                validate_human_requirements_acknowledgement(
+                    block,
+                    surfaced_requirement_ids=surfaced_requirement_ids,
+                    requires_direct_discussion_ack=requires_direct_discussion_ack,
+                )
+            except AgentLoopError:
+                continue
+            if block not in valid_blocks:
+                valid_blocks.append(block)
+
+    if len(valid_blocks) != 1:
+        return None
+    recovered = f"{stripped[:json_end].rstrip()}\n{valid_blocks[0]}\n{footer_and_signature}"
+    try:
+        parsed = validate(recovered)
+    except AgentLoopError:
+        return None
+    return recovered, parsed
+
+
+def _recover_structured_response(
+    original_text: str,
+    *,
+    expected_kind: str,
+    validate: Callable[[str], object],
+    allowed_prior_item_ids: Sequence[str] = (),
+    ledger_complete: bool = True,
+    unresolved_item_ids: Sequence[str] = (),
+    surfaced_requirement_ids: Sequence[str] = (),
+    requires_direct_discussion_ack: bool = False,
+    reviewer_requirement_ids: Sequence[str] = (),
+    response_evidence: dict[str, object] | None = None,
+    gemini_cmd: str = "gemini",
+    reviewer_normalization: bool = False,
+) -> tuple[str, object]:
+    """Run deterministic-to-Gemini recovery without mutating the saved raw artifact."""
+    candidate = original_text
+    if reviewer_normalization:
+        candidate = _normalize_disposition_values(_normalize_raw_response(candidate))
+
+    try:
+        return candidate, validate(candidate)
+    except AgentLoopError as first_error:
+        last_error: AgentLoopError = first_error
+
+    normalized = attempt_envelope_normalization(candidate, expected_kind=expected_kind)
+    if normalized is not None:
+        try:
+            return normalized, validate(normalized)
+        except UnknownPriorItemDispositionError as exc:
+            last_error = exc
+            if ledger_complete:
+                stripped = strip_unknown_prior_item_dispositions(
+                    normalized,
+                    allowed_ids=frozenset(allowed_prior_item_ids),
+                    expected_kind=expected_kind,
+                )
+                if stripped is not None:
+                    try:
+                        return stripped, validate(stripped)
+                    except AgentLoopError as strip_error:
+                        last_error = strip_error
+        except AgentLoopError as exc:
+            last_error = exc
+
+    if isinstance(last_error, UnknownPriorItemDispositionError) and ledger_complete:
+        stripped = strip_unknown_prior_item_dispositions(
+            candidate,
+            allowed_ids=frozenset(allowed_prior_item_ids),
+            expected_kind=expected_kind,
+        )
+        if stripped is not None:
+            try:
+                return stripped, validate(stripped)
+            except AgentLoopError as exc:
+                last_error = exc
+
+    if expected_kind == "plan_revision":
+        recovered_ack = _recover_plan_revision_human_ack(
+            candidate,
+            response_evidence=response_evidence,
+            surfaced_requirement_ids=surfaced_requirement_ids,
+            requires_direct_discussion_ack=requires_direct_discussion_ack,
+            validate=validate,
+        )
+        if recovered_ack is not None:
+            return recovered_ack
+
+    repair_kwargs: dict[str, object] = {
+        "expected_kind": expected_kind,
+        "allowed_prior_item_ids": tuple(allowed_prior_item_ids),
+    }
+    if expected_kind == "coder_followup":
+        repair_kwargs["unresolved_item_ids"] = tuple(unresolved_item_ids)
+        repair_kwargs["surfaced_requirement_ids"] = tuple(surfaced_requirement_ids)
+    if expected_kind in {"plan_review", "pr_review"}:
+        repair_kwargs["reviewer_requirement_ids"] = tuple(reviewer_requirement_ids)
+    if isinstance(last_error, UnknownPriorItemDispositionError):
+        repair_kwargs.update({
+            "unknown_prior_item_ids": last_error.unknown_ids,
+            "same_round_context": last_error.same_round_description,
+        })
+    repaired = attempt_repair(candidate, gemini_cmd, **repair_kwargs)
+    if repaired is not None:
+        try:
+            return repaired, validate(repaired)
+        except AgentLoopError as exc:
+            last_error = exc
+    raise last_error
+
+
 def _save_raw_to_repair_dir(
     *,
     agent: str,
@@ -325,6 +513,7 @@ def _save_raw_to_repair_dir(
     raw_output: Path,
     context_file: Path,
     prior_items_file: Path,
+    gemini_cmd: str = "gemini",
 ) -> Path:
     """Copy raw response + context to a stable repair dir before normalization/validation."""
     repair_dir = _REPAIR_BASE / f"{issue}-r{new_round_number}-{agent}"
@@ -337,7 +526,7 @@ def _save_raw_to_repair_dir(
         "issue": issue, "repo": repo,
         "new_round_number": new_round_number, "round_subject": round_subject,
         "item_id_offset": item_id_offset, "validate_kind": validate_kind,
-        "dry_run": dry_run,
+        "dry_run": dry_run, "gemini_cmd": gemini_cmd,
     }
     (repair_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return repair_dir
@@ -386,6 +575,15 @@ def _add_antigravity_options(parser: argparse.ArgumentParser) -> None:
         nargs="+",
         default=None,
         help="Output signatures that trigger fallback to the next Antigravity model.",
+    )
+
+
+def _add_gemini_cmd_option(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--gemini-cmd",
+        default="gemini",
+        help="Gemini CLI executable used for Gemini turns and automatic repair "
+             "(default: gemini).",
     )
 
 
@@ -860,6 +1058,9 @@ def _complete_reviewer_turn(
     raw_output: Path,
     context_file: Path,
     work_dir: Path,
+    auto_recover: bool = False,
+    response_evidence: dict[str, object] | None = None,
+    gemini_cmd: str = "gemini",
 ) -> dict:
     """Normalize, validate, render, parse, mint IDs, attach metadata, and post.
 
@@ -874,24 +1075,44 @@ def _complete_reviewer_turn(
 
     _write_json(prior_items_file, next_prior_items_raw)
 
-    # --- Normalize ---
     raw_text = raw_output.read_text(encoding="utf-8")
-    raw_text = _normalize_raw_response(raw_text)
-    raw_text = _normalize_disposition_values(raw_text)
-    raw_output.write_text(raw_text, encoding="utf-8")
-
-    # --- Validate ---
-    result = _run_helper_capture(
-        "helpers.validate_response",
-        "--file", str(raw_output),
-        "--kind", validate_kind,
-        "--context-file", str(context_file),
+    context = json.loads(context_file.read_text(encoding="utf-8"))
+    validate = lambda text: validate_response_text(
+        text,
+        kind=validate_kind,
+        reviewer=str(context.get("reviewer", agent_cap)),
+        prior_items=list(context.get("prior_items", [])),
+        current_round_items=list(context.get("current_round_items", [])),
+        human_requirements=list(context.get("human_requirements", [])),
     )
-    if result.returncode != 0:
+    try:
+        if auto_recover:
+            raw_text, _ = _recover_structured_response(
+                raw_text,
+                expected_kind=validate_kind,
+                validate=validate,
+                allowed_prior_item_ids=[
+                    str(item.get("item_id"))
+                    for item in context.get("prior_items", [])
+                    if isinstance(item, dict) and item.get("item_id")
+                ],
+                reviewer_requirement_ids=[
+                    f"Requirement {index}"
+                    for index, _ in enumerate(context.get("human_requirements", []), start=1)
+                ],
+                response_evidence=response_evidence,
+                gemini_cmd=gemini_cmd,
+                reviewer_normalization=True,
+            )
+        else:
+            raw_text = _normalize_disposition_values(_normalize_raw_response(raw_text))
+            validate(raw_text)
+        raw_output.write_text(raw_text, encoding="utf-8")
+    except (AgentLoopError, ValueError) as exc:
         raise _ValidationError(
-            f"skill_runner: {agent} review validation failed: {result.stderr.strip()}\n"
+            f"skill_runner: {agent} review validation failed: {exc}\n"
             f"skill_runner: raw response at: {raw_output}"
-        )
+        ) from exc
 
     # --- Render ---
     # The model the reviewer actually ran is in run_external's usage sidecar (#332);
@@ -1071,6 +1292,7 @@ def _run_reviewer(
     tmpdir: Path,
     external_args: tuple[str, ...] = (),
     item_id_offset: int = 0,
+    gemini_cmd: str = "gemini",
 ) -> dict:
     """Run one reviewer turn; return {reviewer_name, state, blocking_items, new_items}."""
     agent_cap = agent_display_name(agent)  # type: ignore[arg-type]
@@ -1091,6 +1313,7 @@ def _run_reviewer(
     # the validation + agent-unavailable classification below decide whether to skip
     # this reviewer and continue.
     usage_file = tmpdir / f"{agent}-usage.json"
+    evidence_file = tmpdir / f"{agent}-response-evidence.json"
     _run_helper(
         "helpers.run_external",
         "--agent", agent,
@@ -1100,6 +1323,8 @@ def _run_reviewer(
         "--repo", repo,
         "--flow", flow,
         "--usage-output", str(usage_file),
+        "--response-evidence-output", str(evidence_file),
+        *(["--cmd", gemini_cmd] if agent == "gemini" else []),
         *external_args,
         *(["--dry-run"] if dry_run else []),
         check=False,
@@ -1116,10 +1341,17 @@ def _run_reviewer(
         round_subject=round_subject, item_id_offset=item_id_offset,
         validate_kind=validate_kind, dry_run=dry_run,
         raw_output=raw_output, context_file=context_file,
-        prior_items_file=prior_items_file,
+        prior_items_file=prior_items_file, gemini_cmd=gemini_cmd,
     )
 
+    response_evidence = None
+    if evidence_file.exists():
+        try:
+            response_evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            response_evidence = None
     try:
+        original_text = raw_output.read_text(encoding="utf-8")
         return _complete_reviewer_turn(
             agent=agent, agent_cap=agent_cap, flow=flow,
             validate_kind=validate_kind, issue=issue, repo=repo,
@@ -1128,6 +1360,9 @@ def _run_reviewer(
             item_id_offset=item_id_offset, dry_run=dry_run,
             raw_output=raw_output, context_file=context_file,
             work_dir=tmpdir,
+            auto_recover=_is_agent_unavailable_output(original_text) is None,
+            response_evidence=response_evidence,
+            gemini_cmd=gemini_cmd,
         )
     except _ValidationError as exc:
         # Distinguish an agent/CLI failure (no usable review -> skip this reviewer
@@ -1159,9 +1394,11 @@ def _run_reviewer(
         print(str(exc), file=sys.stderr)
         print(f"skill_runner: raw response saved to: {repair_dir}/raw.md", file=sys.stderr)
         dry_run_flag = " --dry-run" if dry_run else ""
+        gemini_flag = f" --gemini-cmd {shlex.quote(gemini_cmd)}" if gemini_cmd != "gemini" else ""
         print(
             f"skill_runner: fix raw.md, then run: "
-            f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}{dry_run_flag}",
+            f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}"
+            f"{gemini_flag}{dry_run_flag}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1373,6 +1610,8 @@ def _save_coder_raw_to_repair_dir(
     dry_run: bool,
     raw_output: Path,
     usage_file: Path,
+    response_evidence_file: Path | None = None,
+    gemini_cmd: str = "gemini",
 ) -> Path:
     """Copy the coder's raw response + context to a stable repair dir.
 
@@ -1385,12 +1624,14 @@ def _save_coder_raw_to_repair_dir(
     _write_json(repair_dir / "prior_items.json", next_prior_items_raw)
     if usage_file.exists():
         shutil.copy2(usage_file, repair_dir / "coder-usage.json")
+    if response_evidence_file is not None and response_evidence_file.exists():
+        shutil.copy2(response_evidence_file, repair_dir / "response-evidence.json")
     manifest = {
         "role": "coder",
         "agent": coder, "agent_cap": coder_cap, "flow": "plan",
         "issue": issue, "repo": repo,
         "new_round_number": new_round_number, "kind": kind,
-        "dry_run": dry_run,
+        "dry_run": dry_run, "gemini_cmd": gemini_cmd,
     }
     (repair_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return repair_dir
@@ -1409,6 +1650,11 @@ def _complete_coder_turn(
     raw_output: Path,
     work_dir: Path,
     usage_file: Path,
+    auto_recover: bool = False,
+    response_evidence: dict[str, object] | None = None,
+    gemini_cmd: str = "gemini",
+    surfaced_requirement_ids: Sequence[str] = (),
+    requires_direct_discussion_ack: bool = False,
 ) -> dict:
     """Validate, render, canonicalize, attach (role coder), and post a coder plan.
 
@@ -1419,16 +1665,51 @@ def _complete_coder_turn(
     ``{plan_text, subject, usage}`` (``plan_text`` is the canonical plan reviewers
     will review).
     """
-    result = _run_helper_capture(
-        "helpers.validate_response", "--file", str(raw_output), "--kind", kind,
-    )
-    if result.returncode != 0:
-        raise _ValidationError(
-            f"skill_runner: {coder_cap} {kind} validation failed: {result.stderr.strip()}\n"
-            f"skill_runner: raw response at: {raw_output}"
-        )
-
     raw_text = raw_output.read_text(encoding="utf-8")
+    def validate(text: str) -> object:
+        parsed = validate_response_text(
+            text,
+            kind=kind,
+            prior_items=next_prior_items_raw,
+        )
+        if kind == "plan_revision" and (
+            surfaced_requirement_ids or requires_direct_discussion_ack
+        ):
+            from coding_review_agent_loop.protocol import (
+                validate_human_requirements_acknowledgement,
+            )
+
+            validate_human_requirements_acknowledgement(
+                text,
+                surfaced_requirement_ids=surfaced_requirement_ids,
+                requires_direct_discussion_ack=requires_direct_discussion_ack,
+            )
+        return parsed
+    try:
+        if auto_recover and kind == "plan_revision":
+            raw_text, _ = _recover_structured_response(
+                raw_text,
+                expected_kind=kind,
+                validate=validate,
+                allowed_prior_item_ids=[
+                    str(item.get("item_id"))
+                    for item in next_prior_items_raw
+                    if item.get("item_id")
+                ],
+                surfaced_requirement_ids=surfaced_requirement_ids,
+                requires_direct_discussion_ack=requires_direct_discussion_ack,
+                response_evidence=response_evidence,
+                gemini_cmd=gemini_cmd,
+            )
+        else:
+            validate(raw_text)
+        raw_output.write_text(raw_text, encoding="utf-8")
+    except (AgentLoopError, ValueError) as exc:
+        raise _ValidationError(
+            f"skill_runner: {coder_cap} {kind} validation failed: {exc}\n"
+            f"skill_runner: raw response at: {raw_output}"
+        ) from exc
+
     canonical_file = work_dir / "coder-canonical.md"
     raw_structured_args: list[str] = []
 
@@ -1553,6 +1834,7 @@ def _run_external_coder_phase(
     """
     issue: int = args.issue
     repo: str = args.repo
+    gemini_cmd = getattr(args, "gemini_cmd", "gemini")
     phase_info = _external_coder_phase(resume, reviewers)
     phase = phase_info["phase"]
 
@@ -1592,6 +1874,19 @@ def _run_external_coder_phase(
     workdir = _workdir_for_agent(coder, args)
     issue_dict = _fetch_issue_json(repo, issue)
     coder_cap = agent_display_name(coder)  # type: ignore[arg-type]
+    human_requirements: Sequence[object] = ()
+    if not dry_run:
+        from coding_review_agent_loop.github import get_issue_context
+        from helpers.prompt_builders import make_minimal_config
+
+        issue_config = make_minimal_config(
+            repo, coder, tuple(reviewers), reviewer=coder, workdir=workdir,
+        )
+        human_requirements = get_issue_context(
+            Runner(dry_run=False),
+            config=issue_config,
+            issue_number=issue,
+        ).human_requirements
 
     if phase == "coder-round-1":
         next_prior_items_raw: list[dict] = []
@@ -1609,15 +1904,20 @@ def _run_external_coder_phase(
             previous_plan=str(resume.get("current_plan", "")),
             reviewer_feedback=_aggregate_blocking_feedback(resume),
             prior_items_raw=next_prior_items_raw,
+            human_requirements=human_requirements,
             memory=memory,
         )
         kind = "plan_revision"
+
+    from coding_review_agent_loop.prompts import render_coder_human_requirements_prompt_context
+    human_context = render_coder_human_requirements_prompt_context(human_requirements)
 
     with tempfile.TemporaryDirectory() as tmpstr:
         tmpdir = Path(tmpstr)
         prompt_file = tmpdir / "coder-prompt.md"
         raw_output = tmpdir / "coder-plan-raw.md"
         usage_file = tmpdir / "coder-usage.json"
+        evidence_file = tmpdir / "coder-response-evidence.json"
         _write_text(prompt_file, prompt_text)
 
         _run_helper(
@@ -1630,6 +1930,8 @@ def _run_external_coder_phase(
             "--repo", repo,
             "--flow", "plan",
             "--usage-output", str(usage_file),
+            "--response-evidence-output", str(evidence_file),
+            *(["--cmd", gemini_cmd] if coder == "gemini" else []),
             *_run_external_antigravity_args(args),
             *(["--dry-run"] if dry_run else []),
         )
@@ -1650,8 +1952,16 @@ def _run_external_coder_phase(
             new_round_number=new_round_number, kind=kind,
             next_prior_items_raw=next_prior_items_raw, dry_run=dry_run,
             raw_output=raw_output, usage_file=usage_file,
+            response_evidence_file=evidence_file,
+            gemini_cmd=gemini_cmd,
         )
 
+        response_evidence = None
+        if evidence_file.exists():
+            try:
+                response_evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                response_evidence = None
         try:
             completed = _complete_coder_turn(
                 coder=coder, coder_cap=coder_cap, issue=issue, repo=repo,
@@ -1659,13 +1969,22 @@ def _run_external_coder_phase(
                 next_prior_items_raw=next_prior_items_raw, kind=kind,
                 dry_run=dry_run, raw_output=raw_output, work_dir=tmpdir,
                 usage_file=usage_file,
+                auto_recover=True, response_evidence=response_evidence,
+                gemini_cmd=gemini_cmd,
+                surfaced_requirement_ids=human_context.surfaced_requirement_ids,
+                requires_direct_discussion_ack=human_context.requires_direct_discussion_ack,
             )
         except _ValidationError as exc:
             print(str(exc), file=sys.stderr)
             dry_run_flag = " --dry-run" if dry_run else ""
+            gemini_flag = (
+                f" --gemini-cmd {shlex.quote(gemini_cmd)}"
+                if gemini_cmd != "gemini" else ""
+            )
             print(
                 f"skill_runner: fix raw.md, then run: "
-                f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}{dry_run_flag}",
+                f"python -m helpers.skill_runner retry-validate --repair-dir {repair_dir}"
+                f"{gemini_flag}{dry_run_flag}",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -1966,6 +2285,7 @@ def cmd_run_plan_round(args: argparse.Namespace) -> None:
                 tmpdir=tmpdir,
                 external_args=_run_external_antigravity_args(args),
                 item_id_offset=item_id_offset,
+                gemini_cmd=getattr(args, "gemini_cmd", "gemini"),
             )
             if record["state"] == "unavailable":
                 # Agent/CLI failure: skip this reviewer for the round (re-attempted
@@ -2184,6 +2504,7 @@ def cmd_run_pr_round(args: argparse.Namespace) -> None:
                 tmpdir=tmpdir,
                 external_args=_run_external_antigravity_args(args),
                 item_id_offset=item_id_offset,
+                gemini_cmd=getattr(args, "gemini_cmd", "gemini"),
             )
             if record["state"] == "unavailable":
                 # Agent/CLI failure: skip this reviewer for the round (re-attempted
@@ -2303,6 +2624,9 @@ def cmd_retry_validate(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     manifest = json.loads((repair_dir / "manifest.json").read_text(encoding="utf-8"))
+    gemini_cmd = str(
+        manifest.get("gemini_cmd") or getattr(args, "gemini_cmd", None) or "gemini"
+    )
 
     # Reversed-roles coder repair: a malformed external coder plan_state/plan_revision
     # is recoverable here, distinct from the reviewer completion path below (#307).
@@ -2323,6 +2647,7 @@ def cmd_retry_validate(args: argparse.Namespace) -> None:
                 next_prior_items_raw=next_prior_items_raw, kind=kind,
                 dry_run=args.dry_run, raw_output=repair_dir / "raw.md",
                 work_dir=repair_dir, usage_file=repair_dir / "coder-usage.json",
+                gemini_cmd=gemini_cmd,
             )
         except _ValidationError as exc:
             print(str(exc), file=sys.stderr)
@@ -2363,6 +2688,7 @@ def cmd_retry_validate(args: argparse.Namespace) -> None:
             item_id_offset=item_id_offset, dry_run=dry_run,
             raw_output=raw_output, context_file=context_file,
             work_dir=repair_dir,
+            gemini_cmd=gemini_cmd,
         )
     except _ValidationError as exc:
         print(str(exc), file=sys.stderr)
@@ -2873,6 +3199,7 @@ def cmd_run_pr_fix(args: argparse.Namespace) -> None:
     coder: str = args.coder
     reviewers: list[str] = args.reviewers
     dry_run: bool = args.dry_run
+    gemini_cmd = getattr(args, "gemini_cmd", "gemini")
 
     explicit_workdir = getattr(args, f"workdir_{coder}", None) or getattr(args, "workdir", None)
     if not dry_run and not explicit_workdir:
@@ -2929,6 +3256,7 @@ def cmd_run_pr_fix(args: argparse.Namespace) -> None:
         _validate_coder_followup_response,
     )
     from coding_review_agent_loop.protocol import StructuredCoderFollowup
+    from coding_review_agent_loop.prompts import render_coder_human_requirements_prompt_context
     from coding_review_agent_loop.round_state import _serialize_unresolved_item
     from coding_review_agent_loop.workdir_guard import (
         validate_assigned_head_advanced,
@@ -2996,6 +3324,7 @@ def cmd_run_pr_fix(args: argparse.Namespace) -> None:
         prior_items_file = tmpdir / "pr-fix-prior-items.json"
         compact_prior_file = tmpdir / "pr-fix-compact-prior.json"
         usage_file = tmpdir / "pr-fix-usage.json"
+        evidence_file = tmpdir / "pr-fix-response-evidence.json"
         _write_text(prompt_file, prompt_text)
 
         _run_helper(
@@ -3007,18 +3336,60 @@ def cmd_run_pr_fix(args: argparse.Namespace) -> None:
             "--workdir", workdir,
             "--flow", "pr",
             "--usage-output", str(usage_file),
+            "--response-evidence-output", str(evidence_file),
+            *(["--cmd", gemini_cmd] if coder == "gemini" else []),
             *_run_external_antigravity_args(args),
             *(["--dry-run"] if dry_run else []),
         )
         coder_output = raw_output.read_text(encoding="utf-8")
+        debug_dir = _REPAIR_BASE / f"{pr}-pr-fix-debug"
+        debug_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(raw_output, debug_dir / "raw.md")
+        shutil.copy2(prompt_file, debug_dir / "prompt.md")
+        _write_json(debug_dir / "manifest.json", {
+            "role": "coder",
+            "kind": "coder_followup",
+            "agent": coder,
+            "repo": repo,
+            "pr": pr,
+            "gemini_cmd": gemini_cmd,
+            "unresolved_item_ids": [
+                str(item.get("item_id")) for item in active_items_raw if item.get("item_id")
+            ],
+        })
         if re.search(r"<!--\s*AGENT_PR\s*:", coder_output):
             raise AgentLoopError("run-pr-fix response attempted to open/report a new PR.")
+        response_evidence = None
+        if evidence_file.exists():
+            try:
+                response_evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                response_evidence = None
+        human_context = render_coder_human_requirements_prompt_context(human_requirements)
+        unresolved_items = tuple(
+            _deserialize_unresolved_item(item) for item in active_items_raw
+        )
+        validate_followup = lambda text: _validate_coder_followup_response(
+            text,
+            unresolved_items=unresolved_items,
+            human_requirements=human_requirements,
+        )
         try:
-            parsed = _validate_coder_followup_response(
+            coder_output, parsed = _recover_structured_response(
                 coder_output,
-                unresolved_items=tuple(_deserialize_unresolved_item(item) for item in active_items_raw),
-                human_requirements=human_requirements,
+                expected_kind="coder_followup",
+                validate=validate_followup,
+                unresolved_item_ids=[
+                    item.item_id
+                    for item in unresolved_items
+                    if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+                ],
+                surfaced_requirement_ids=human_context.surfaced_requirement_ids,
+                requires_direct_discussion_ack=human_context.requires_direct_discussion_ack,
+                response_evidence=response_evidence,
+                gemini_cmd=gemini_cmd,
             )
+            raw_output.write_text(coder_output, encoding="utf-8")
             if isinstance(parsed, StructuredCoderFollowup):
                 validate_test_commands_within_workdir(
                     parsed.tests_run,
@@ -3039,10 +3410,6 @@ def cmd_run_pr_fix(args: argparse.Namespace) -> None:
                 _write_text(rendered_output, coder_output)
                 raw_structured_arg = []
         except AgentLoopError as exc:
-            debug_dir = _REPAIR_BASE / f"{pr}-pr-fix-debug"
-            debug_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(raw_output, debug_dir / "raw.md")
-            shutil.copy2(prompt_file, debug_dir / "prompt.md")
             print(f"skill_runner: PR-fix response rejected: {exc}", file=sys.stderr)
             print(f"skill_runner: raw response saved to {debug_dir}/raw.md", file=sys.stderr)
             sys.exit(1)
@@ -3606,6 +3973,7 @@ def main() -> None:
     p_plan.add_argument("--refresh-agent-memory", action="store_true",
                         help="Regenerate the agent-memory cache before this round.")
     p_plan.add_argument("--dry-run", action="store_true")
+    _add_gemini_cmd_option(p_plan)
     _add_antigravity_options(p_plan)
 
     # run-pr-round
@@ -3646,6 +4014,7 @@ def main() -> None:
     p_pr.add_argument("--refresh-agent-memory", action="store_true",
                       help="Regenerate the agent-memory cache before this round.")
     p_pr.add_argument("--dry-run", action="store_true")
+    _add_gemini_cmd_option(p_pr)
     _add_antigravity_options(p_pr)
 
     # retry-validate
@@ -3658,6 +4027,7 @@ def main() -> None:
         help="Path to repair dir written by skill_runner on validation failure.",
     )
     p_retry.add_argument("--dry-run", action="store_true")
+    _add_gemini_cmd_option(p_retry)
 
     # complete-host-review
     p_host = subparsers.add_parser(
@@ -3723,6 +4093,7 @@ def main() -> None:
     p_pr_fix.add_argument("--workdir-gemini", default=None)
     p_pr_fix.add_argument("--workdir-antigravity", default=None)
     p_pr_fix.add_argument("--dry-run", action="store_true")
+    _add_gemini_cmd_option(p_pr_fix)
     _add_antigravity_options(p_pr_fix)
 
     # run-implement-by-phase
@@ -3799,6 +4170,7 @@ def main() -> None:
     p_task.add_argument("--refresh-agent-memory", action="store_true",
                         help="Regenerate the agent-memory cache before this round.")
     p_task.add_argument("--dry-run", action="store_true")
+    _add_gemini_cmd_option(p_task)
     _add_antigravity_options(p_task)
 
     args = parser.parse_args()

--- a/helpers/validate_response.py
+++ b/helpers/validate_response.py
@@ -44,6 +44,9 @@ from coding_review_agent_loop.round_state import _deserialize_unresolved_item
 from coding_review_agent_loop.github import HumanReviewRequirement
 
 
+_KINDS = ("plan_state", "plan_review", "pr_review", "coder_followup", "plan_revision")
+
+
 def _load_context(path: str | None) -> dict[str, object]:
     """Load optional context JSON file."""
     if path is None:
@@ -79,13 +82,89 @@ def _deserialize_human_requirements(raw: list[object]) -> list[HumanReviewRequir
     return result
 
 
+def validate_response_text(
+    text: str,
+    *,
+    kind: str,
+    reviewer: str = "Codex",
+    prior_items: list[object] | tuple[object, ...] = (),
+    current_round_items: list[object] | tuple[object, ...] = (),
+    human_requirements: list[object] | tuple[object, ...] = (),
+) -> object:
+    """Validate response text with the same context used by the helper CLI.
+
+    ``prior_items``/``current_round_items`` and ``human_requirements`` may contain
+    either their runtime dataclasses or their serialized dictionary forms.  The
+    original ``AgentLoopError`` subclass is intentionally allowed to propagate so
+    callers can apply type-specific deterministic recovery.
+    """
+    if kind not in _KINDS:
+        raise ValueError(f"Unsupported response kind: {kind}")
+
+    deserialized_prior = [
+        _deserialize_unresolved_item(item) if isinstance(item, dict) else item
+        for item in prior_items
+    ]
+    deserialized_current = [
+        _deserialize_unresolved_item(item) if isinstance(item, dict) else item
+        for item in current_round_items
+    ]
+    deserialized_requirements = [
+        _deserialize_human_requirements([item])[0] if isinstance(item, dict) else item
+        for item in human_requirements
+        if not isinstance(item, dict) or item
+    ]
+
+    if kind == "plan_state":
+        return parse_plan_state(text)
+    if kind == "plan_review":
+        return _validate_plan_review_response(
+            text,
+            reviewer=reviewer,
+            unresolved_items=deserialized_prior,
+            current_round_items=deserialized_current,
+        )
+    if kind == "pr_review":
+        return _validate_review_response(
+            text,
+            reviewer=reviewer,
+            unresolved_items=deserialized_prior,
+            current_round_items=deserialized_current,
+        )
+    if kind == "coder_followup":
+        return _validate_coder_followup_response(
+            text,
+            unresolved_items=deserialized_prior,
+            human_requirements=deserialized_requirements or None,
+        )
+
+    parsed = validate_structured_plan_revision(text)
+    if parsed is None:
+        raise AgentLoopError("Response did not parse as a structured plan_revision.")
+    allowed_ids = {item.item_id for item in deserialized_prior}
+    unknown = {
+        disposition.item_id
+        for disposition in parsed.prior_plan_item_dispositions
+    } - allowed_ids
+    if unknown:
+        raise UnknownPriorItemDispositionError(
+            unknown_ids=tuple(sorted(unknown)),
+            allowed_ids=tuple(sorted(allowed_ids)),
+            same_round_description=(
+                "Same-round findings are informational only and must not be "
+                "dispositioned as prior carried items."
+            ),
+        )
+    return parsed
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Validate an agent response file.")
     parser.add_argument("--file", required=True, help="Path to the response file.")
     parser.add_argument(
         "--kind",
         required=True,
-        choices=["plan_state", "plan_review", "pr_review", "coder_followup", "plan_revision"],
+        choices=_KINDS,
         help="Kind of response to validate.",
     )
     parser.add_argument(
@@ -110,49 +189,14 @@ def main() -> None:
 
     kind = args.kind
     try:
-        if kind == "plan_state":
-            parse_plan_state(text)
-        elif kind == "plan_review":
-            _validate_plan_review_response(
-                text,
-                reviewer=reviewer,
-                unresolved_items=prior_items,
-                current_round_items=current_round_items,
-            )
-        elif kind == "pr_review":
-            _validate_review_response(
-                text,
-                reviewer=reviewer,
-                unresolved_items=prior_items,
-                current_round_items=current_round_items,
-            )
-        elif kind == "coder_followup":
-            _validate_coder_followup_response(
-                text,
-                unresolved_items=prior_items,
-                human_requirements=human_requirements or None,
-            )
-        elif kind == "plan_revision":
-            parsed = validate_structured_plan_revision(text)
-            if parsed is None:
-                raise AgentLoopError("Response did not parse as a structured plan_revision.")
-            # Validate that dispositions only reference known prior item IDs,
-            # matching the check in the headless orchestrator's _validate_plan_revision_response.
-            if prior_items:
-                allowed_ids = {item.item_id for item in prior_items}
-                unknown = {
-                    disposition.item_id
-                    for disposition in parsed.prior_plan_item_dispositions
-                } - allowed_ids
-                if unknown:
-                    raise UnknownPriorItemDispositionError(
-                        unknown_ids=tuple(sorted(unknown)),
-                        allowed_ids=tuple(sorted(allowed_ids)),
-                        same_round_description=(
-                            "Same-round findings are informational only and must not be "
-                            "dispositioned as prior carried items."
-                        ),
-                    )
+        validate_response_text(
+            text,
+            kind=kind,
+            reviewer=reviewer,
+            prior_items=prior_items,
+            current_round_items=current_round_items,
+            human_requirements=human_requirements,
+        )
     except AgentLoopError as exc:
         print(f"validation failed: {kind}: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -254,6 +254,32 @@ class TestValidateResponse:
         )
         assert "validation passed: plan_revision" in result.stdout
 
+    def test_callable_validator_preserves_unknown_prior_item_error_type(self) -> None:
+        from coding_review_agent_loop.errors import UnknownPriorItemDispositionError
+        from helpers.validate_response import validate_response_text
+
+        review = json.dumps({
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "blocking",
+            "summary": "Blocking.",
+            "blocking_plan_issues": ["Fix it."],
+            "same_plan_followups": [],
+            "future_followups": [],
+            "prior_plan_item_dispositions": [
+                {"item_id": "item-unknown", "disposition": "resolved"}
+            ],
+        }) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex\n"
+
+        with pytest.raises(UnknownPriorItemDispositionError) as exc_info:
+            validate_response_text(
+                review,
+                kind="plan_review",
+                reviewer="Codex",
+                prior_items=[],
+            )
+        assert exc_info.value.unknown_ids == ("item-unknown",)
+
 
 # ---------------------------------------------------------------------------
 # helpers/state_manager.py  (session round-trip + attach-metadata)
@@ -886,6 +912,212 @@ class TestRetryValidate:
             assert output["blocking_items"][0]["text"] == "Address the followup from last round."
 
 
+class TestStructuredSkillRecovery:
+    @staticmethod
+    def _prior_item(item_id: str = "item-1") -> dict:
+        return {
+            "item_id": item_id,
+            "reviewer": "Codex",
+            "source_round": 1,
+            "text": "Fix the issue.",
+            "status": "blocking",
+            "source_status": "blocking",
+            "notes": [],
+        }
+
+    def test_reviewer_envelope_and_unknown_item_are_recovered(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        from helpers.validate_response import validate_response_text
+
+        raw = json.dumps({
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "blocking",
+            "summary": "One issue remains.",
+            "blocking_plan_issues": ["Still broken."],
+            "same_plan_followups": [],
+            "future_followups": [],
+            "prior_plan_item_dispositions": [
+                {"item_id": "item-1", "disposition": "blocking"},
+                {"item_id": "item-invented", "disposition": "resolved"},
+            ],
+        }) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex\ntrailing prose"
+        original = raw
+        monkeypatch.setattr(sr, "attempt_repair", lambda *a, **k: pytest.fail("repair not needed"))
+        validate = lambda text: validate_response_text(
+            text,
+            kind="plan_review",
+            reviewer="Codex",
+            prior_items=[self._prior_item()],
+        )
+
+        recovered, parsed = sr._recover_structured_response(
+            raw,
+            expected_kind="plan_review",
+            validate=validate,
+            allowed_prior_item_ids=["item-1"],
+            reviewer_normalization=True,
+        )
+
+        assert raw == original
+        assert "item-invented" not in recovered
+        assert parsed.state == "blocking"
+
+    def test_custom_gemini_command_reaches_repair(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        from helpers.validate_response import validate_response_text
+
+        seen: dict[str, object] = {}
+        repaired = _VALID_PLAN_REVIEW_DRY
+
+        def fake_repair(raw, gemini_cmd, **kwargs):
+            seen.update({"raw": raw, "gemini_cmd": gemini_cmd, "kwargs": kwargs})
+            return repaired
+
+        monkeypatch.setattr(sr, "attempt_repair", fake_repair)
+        validate = lambda text: validate_response_text(
+            text, kind="plan_review", reviewer="Codex",
+        )
+        recovered, _ = sr._recover_structured_response(
+            "malformed review",
+            expected_kind="plan_review",
+            validate=validate,
+            gemini_cmd="/opt/bin/gemini-custom",
+            reviewer_normalization=True,
+        )
+
+        assert recovered == repaired
+        assert seen["gemini_cmd"] == "/opt/bin/gemini-custom"
+        assert seen["kwargs"]["expected_kind"] == "plan_review"
+
+    def test_plan_revision_ack_reconstructed_from_unique_evidence(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        from coding_review_agent_loop.protocol import validate_human_requirements_acknowledgement
+        from helpers.validate_response import validate_response_text
+
+        raw = json.dumps({
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "Revised.",
+            "prior_plan_item_dispositions": [
+                {"item_id": "item-1", "disposition": "resolved"}
+            ],
+            "plan_steps": ["Implement the fix."],
+        }) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex"
+        acknowledgement = (
+            "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+            "### Human requirements\n\n"
+            "- Requirement 1: preserved the required behavior."
+        )
+        monkeypatch.setattr(sr, "attempt_repair", lambda *a, **k: pytest.fail("repair not needed"))
+
+        def validate(text):
+            parsed = validate_response_text(
+                text,
+                kind="plan_revision",
+                prior_items=[self._prior_item()],
+            )
+            validate_human_requirements_acknowledgement(
+                text,
+                surfaced_requirement_ids=("Requirement 1",),
+                requires_direct_discussion_ack=False,
+            )
+            return parsed
+
+        recovered, _ = sr._recover_structured_response(
+            raw,
+            expected_kind="plan_revision",
+            validate=validate,
+            allowed_prior_item_ids=["item-1"],
+            surfaced_requirement_ids=["Requirement 1"],
+            response_evidence={"message_text": f"notes\n{acknowledgement}\n-- Codex"},
+        )
+        assert acknowledgement in recovered
+
+    def test_plan_revision_ambiguous_ack_evidence_falls_through(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        from coding_review_agent_loop.errors import AgentLoopError
+        from coding_review_agent_loop.protocol import validate_human_requirements_acknowledgement
+        from helpers.validate_response import validate_response_text
+
+        raw = json.dumps({
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "Revised.",
+            "prior_plan_item_dispositions": [
+                {"item_id": "item-1", "disposition": "resolved"}
+            ],
+            "plan_steps": ["Implement the fix."],
+        }) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex"
+        first = (
+            "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n### Human requirements\n"
+            "- Requirement 1: first explanation."
+        )
+        second = (
+            "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n### Human requirements\n"
+            "- Requirement 1: different explanation."
+        )
+        monkeypatch.setattr(sr, "attempt_repair", lambda *a, **k: None)
+
+        def validate(text):
+            parsed = validate_response_text(
+                text, kind="plan_revision", prior_items=[self._prior_item()],
+            )
+            validate_human_requirements_acknowledgement(
+                text,
+                surfaced_requirement_ids=("Requirement 1",),
+                requires_direct_discussion_ack=False,
+            )
+            return parsed
+
+        with pytest.raises(AgentLoopError, match="signed human requirements"):
+            sr._recover_structured_response(
+                raw,
+                expected_kind="plan_revision",
+                validate=validate,
+                allowed_prior_item_ids=["item-1"],
+                surfaced_requirement_ids=["Requirement 1"],
+                response_evidence={"message_text": f"{first}\n-- Codex\n{second}\n-- Codex"},
+            )
+
+    def test_coder_followup_envelope_recovery(self, monkeypatch) -> None:
+        import helpers.skill_runner as sr
+        from helpers.validate_response import validate_response_text
+
+        raw = json.dumps({
+            "schema_version": 1,
+            "kind": "coder_followup",
+            "state": "approved",
+            "summary": "Fixed.",
+            "addressed_items": ["item-1"],
+            "remaining_items": [],
+            "addressed_item_notes": {"item-1": "Implemented."},
+            "remaining_item_notes": {},
+            "human_requirements": {
+                "addressed_ids": [],
+                "checked_discussion_directly": False,
+            },
+            "tests_run": [],
+        }) + "\n<!-- AGENT_STATE: approved -->\n-- Codex\nextra"
+        monkeypatch.setattr(sr, "attempt_repair", lambda *a, **k: pytest.fail("repair not needed"))
+        validate = lambda text: validate_response_text(
+            text,
+            kind="coder_followup",
+            prior_items=[self._prior_item()],
+        )
+
+        recovered, parsed = sr._recover_structured_response(
+            raw,
+            expected_kind="coder_followup",
+            validate=validate,
+            unresolved_item_ids=["item-1"],
+        )
+        assert recovered.endswith("-- Codex")
+        assert parsed.state == "approved"
+
+
 # ---------------------------------------------------------------------------
 # helpers/run_external.py  retry loop (in-process, monkeypatched backend)
 # ---------------------------------------------------------------------------
@@ -991,6 +1223,39 @@ class TestRunExternalRetries:
         )
         assert exit_code == 1
         assert "Invalid stream" in Path(output_path).read_text(encoding="utf-8")
+
+    def test_writes_minimal_response_evidence_sidecar(self, monkeypatch, tmp_path) -> None:
+        import helpers.run_external as rex
+        from coding_review_agent_loop.agents.base import AgentResult
+
+        class FakeBackend:
+            def run(self, runner, config, prompt):
+                return AgentResult(
+                    text="public",
+                    response_file_text="public",
+                    message_text="captured acknowledgement",
+                )
+
+        monkeypatch.setattr("coding_review_agent_loop.agents.codex.CodexBackend", FakeBackend)
+        prompt = tmp_path / "prompt.md"
+        output = tmp_path / "output.md"
+        evidence = tmp_path / "evidence.json"
+        prompt.write_text("Review this.", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", [
+            "run_external",
+            "--agent", "codex",
+            "--prompt-file", str(prompt),
+            "--output", str(output),
+            "--workdir", str(tmp_path),
+            "--response-evidence-output", str(evidence),
+        ])
+
+        rex.main()
+
+        assert json.loads(evidence.read_text(encoding="utf-8")) == {
+            "response_file_text": "public",
+            "message_text": "captured acknowledgement",
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- expose callable context-aware response validation while preserving typed validation errors
- automatically recover reviewer, plan-revision, and PR-fix coder-followup structured responses through deterministic normalization and Gemini repair
- preserve original repair/debug artifacts, add response evidence capture, and support configurable/persisted `--gemini-cmd`
- document the recovery order and extend skill helper coverage

## Tests

- `python3 -m pytest tests/test_skill_helpers.py -q`
- `python3 -m pytest`
- `python3 -m py_compile helpers/validate_response.py helpers/run_external.py helpers/prompt_builders.py helpers/skill_runner.py`
- `git diff --check`

Fixes #356