### PR TITLE
Accept agy as antigravity agent alias

### DIFF
--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -115,7 +115,14 @@ def _build_dry_run_response(role: str, flow: str = "plan") -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run one external agent turn.")
-    parser.add_argument("--agent", required=True, choices=["codex", "gemini", "antigravity"])
+    from coding_review_agent_loop.agents.base import normalize_agent_name
+
+    parser.add_argument(
+        "--agent",
+        required=True,
+        type=normalize_agent_name,
+        choices=["codex", "gemini", "antigravity"],
+    )
     parser.add_argument("--prompt-file", required=True, help="Path to prompt text file.")
     antigravity_models = parser.add_mutually_exclusive_group()
     antigravity_models.add_argument(

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -106,7 +106,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from coding_review_agent_loop.agents.base import AgentName
+from coding_review_agent_loop.agents.base import AgentName, normalize_agent_name
 from coding_review_agent_loop.agents.registry import agent_display_name
 from coding_review_agent_loop.config import ensure_temp_checkout
 from coding_review_agent_loop.errors import AgentLoopError, UnknownPriorItemDispositionError
@@ -3953,7 +3953,8 @@ def main() -> None:
     p_plan.add_argument("--issue", type=int, required=True)
     p_plan.add_argument("--repo", required=True)
     p_plan.add_argument(
-        "--coder", choices=["claude", "codex", "gemini", "antigravity"], default="claude",
+        "--coder", type=normalize_agent_name,
+        choices=["claude", "codex", "gemini", "antigravity"], default="claude",
         help="Who writes the plan: 'claude' (default, host supplies --plan-file) or "
              "an external coder ('codex'/'gemini') run by the skill (reversed roles, #307).",
     )
@@ -3961,7 +3962,7 @@ def main() -> None:
         "--plan-file", default=None,
         help="Plan markdown file. Required for --coder claude; ignored for an external coder.",
     )
-    p_plan.add_argument("--reviewers", nargs="+", required=True)
+    p_plan.add_argument("--reviewers", type=normalize_agent_name, nargs="+", required=True)
     p_plan.add_argument("--workdir-codex", default=None)
     p_plan.add_argument("--workdir-gemini", default=None)
     p_plan.add_argument("--workdir", default=None)
@@ -3980,7 +3981,7 @@ def main() -> None:
     p_pr = subparsers.add_parser("run-pr-round", help="Run one PR review round.")
     p_pr.add_argument("--pr", type=int, required=True)
     p_pr.add_argument("--repo", required=True)
-    p_pr.add_argument("--reviewers", nargs="+", required=True)
+    p_pr.add_argument("--reviewers", type=normalize_agent_name, nargs="+", required=True)
     p_pr.add_argument("--head-sha", default=None)
     p_pr.add_argument("--workdir", default=None)
     p_pr.add_argument("--workdir-codex", default=None)
@@ -4052,7 +4053,8 @@ def main() -> None:
     p_impl.add_argument("--issue", type=int, required=True)
     p_impl.add_argument("--repo", required=True)
     p_impl.add_argument(
-        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
+        "--coder", type=normalize_agent_name,
+        choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that implements the plan (the host implements in-session).",
     )
     p_impl.add_argument("--plan-file", required=True, help="Approved plan to implement.")
@@ -4078,11 +4080,12 @@ def main() -> None:
     p_pr_fix.add_argument("--pr", type=int, required=True)
     p_pr_fix.add_argument("--repo", required=True)
     p_pr_fix.add_argument(
-        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
+        "--coder", type=normalize_agent_name,
+        choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that fixes the existing PR.",
     )
     p_pr_fix.add_argument(
-        "--reviewers", nargs="+", required=True,
+        "--reviewers", type=normalize_agent_name, nargs="+", required=True,
         help="Reviewer set used by the preceding run-pr-round; must match exactly.",
     )
     p_pr_fix.add_argument(
@@ -4105,7 +4108,8 @@ def main() -> None:
     p_impl_phase.add_argument("--issue", type=int, required=True)
     p_impl_phase.add_argument("--repo", required=True)
     p_impl_phase.add_argument(
-        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
+        "--coder", type=normalize_agent_name,
+        choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that decomposes and implements the first agent phase.",
     )
     p_impl_phase.add_argument("--plan-file", required=True, help="Approved plan to decompose and implement.")
@@ -4131,7 +4135,8 @@ def main() -> None:
     p_decompose.add_argument("--issue", type=int, required=True)
     p_decompose.add_argument("--repo", required=True)
     p_decompose.add_argument(
-        "--coder", choices=["codex", "gemini", "antigravity"], required=True,
+        "--coder", type=normalize_agent_name,
+        choices=["codex", "gemini", "antigravity"], required=True,
         help="External coder that decomposes the approved plan.",
     )
     p_decompose.add_argument("--plan-file", required=True, help="Approved plan to decompose.")
@@ -4154,11 +4159,12 @@ def main() -> None:
     )
     p_task.add_argument("--repo", required=True)
     p_task.add_argument(
-        "--coder", choices=["claude", "codex", "gemini", "antigravity"], default="claude",
+        "--coder", type=normalize_agent_name,
+        choices=["claude", "codex", "gemini", "antigravity"], default="claude",
         help="Host coder only for now; external coders are rejected in task mode (#307).",
     )
     p_task.add_argument("--plan-file", required=True)
-    p_task.add_argument("--reviewers", nargs="+", required=True)
+    p_task.add_argument("--reviewers", type=normalize_agent_name, nargs="+", required=True)
     p_task.add_argument("--workdir-codex", default=None)
     p_task.add_argument("--workdir-gemini", default=None)
     p_task.add_argument("--workdir", default=None)

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import tempfile
 import uuid
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from ..runner import Runner
 from ..usage import UsageMetadata
@@ -16,6 +16,11 @@ if TYPE_CHECKING:
 
 AgentName = Literal["claude", "codex", "gemini", "antigravity"]
 AgentTextSource = Literal["response_file", "stdout_marker", "stdout"]
+
+
+def normalize_agent_name(value: str) -> AgentName:
+    """Normalize input-only agent aliases to their canonical names."""
+    return cast(AgentName, "antigravity" if value == "agy" else value)
 
 
 @dataclass(frozen=True)

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from .agents.base import normalize_agent_name
 from .agents.registry import (
     agent_display_name,
     agent_signature,
@@ -93,12 +94,14 @@ def build_parser() -> argparse.ArgumentParser:
         )
         subparser.add_argument(
             "--coder",
+            type=normalize_agent_name,
             choices=("claude", "codex", "gemini", "antigravity"),
             default="claude",
             help="Agent that creates and fixes the PR (default: claude).",
         )
         subparser.add_argument(
             "--reviewer",
+            type=normalize_agent_name,
             choices=("claude", "codex", "gemini", "antigravity"),
             action="append",
             default=None,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -12871,6 +12871,37 @@ def test_config_accepts_gemini_as_coder_and_reviewer(tmp_path):
     assert config.gemini_dir == tmp_path / "gemini"
 
 
+@pytest.mark.parametrize(
+    ("coder", "reviewer"),
+    [
+        ("agy", "codex"),
+        ("codex", "agy"),
+        ("antigravity", "codex"),
+    ],
+)
+def test_config_normalizes_antigravity_agent_names(tmp_path, coder, reviewer):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        coder,
+        "--reviewer",
+        reviewer,
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.coder == ("antigravity" if coder == "agy" else coder)
+    assert config.reviewer == (
+        "antigravity" if reviewer == "agy" else reviewer,
+    )
+
+
 def test_config_rejects_duplicate_reviewers(tmp_path):
     parser = build_parser()
     args = parser.parse_args([
@@ -12882,6 +12913,25 @@ def test_config_rejects_duplicate_reviewers(tmp_path):
         "codex",
         "--reviewer",
         "codex",
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+
+    with pytest.raises(AgentLoopError, match="same agent more than once"):
+        config_from_args(args, FakeRunner())
+
+
+def test_config_rejects_alias_and_canonical_duplicate_reviewers(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--reviewer",
+        "agy",
+        "--reviewer",
+        "antigravity",
         "--codex-dir",
         str(tmp_path / "codex"),
     ])

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -3315,7 +3315,8 @@ class TestAntigravitySkill:
             )
             assert val.returncode == 0, f"{out.read_text()}\n{val.stderr}"
 
-    def test_run_plan_round_antigravity_external_coder_dry_run(self) -> None:
+    @pytest.mark.parametrize("coder", ["antigravity", "agy"])
+    def test_run_plan_round_antigravity_external_coder_dry_run(self, coder) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)
             _write_fake_gh(tmppath)
@@ -3323,7 +3324,7 @@ class TestAntigravitySkill:
             result = _run(
                 "helpers.skill_runner", "run-plan-round",
                 "--issue", "9991", "--repo", "test/skill-repo",
-                "--coder", "antigravity", "--reviewers", "codex",
+                "--coder", coder, "--reviewers", "codex",
                 "--antigravity-models", "Model A", "Model B",
                 "--dry-run",
                 env=env,
@@ -3346,7 +3347,7 @@ class TestAntigravitySkill:
             result = _run(
                 "helpers.skill_runner", "run-plan-round",
                 "--issue", "9990", "--repo", "test/skill-repo",
-                "--plan-file", str(plan), "--reviewers", "antigravity",
+                "--plan-file", str(plan), "--reviewers", "agy",
                 "--model", "Model X",
                 "--dry-run",
                 env=env,
@@ -3403,7 +3404,7 @@ class TestAntigravitySkill:
         prompt.write_text("review this", encoding="utf-8")
         monkeypatch.setattr(sys, "argv", [
             "run_external",
-            "--agent", "antigravity",
+            "--agent", "agy",
             "--prompt-file", str(prompt),
             "--output", str(output),
             "--workdir", str(tmp_path),
@@ -3414,6 +3415,7 @@ class TestAntigravitySkill:
         rex.main()
 
         config = captured["config"]
+        assert config.reviewer == ("antigravity",)
         assert config.antigravity_models == expected_models
         assert config.antigravity_quota_signatures == expected_signatures
 


### PR DESCRIPTION
## Summary
- normalize the input-only `agy` alias to canonical `antigravity`
- accept the alias across CLI, skill runner, and external runner agent arguments
- cover canonicalization, duplicate reviewers, artifacts, and backend config in tests

## Tests
- `python3 -m pytest tests/test_agent_loop.py -k 'normalizes_antigravity_agent_names or alias_and_canonical_duplicate_reviewers or config_from_args_antigravity_defaults'`
- `python3 -m pytest tests/test_skill_helpers.py -k 'run_plan_round_antigravity_external_coder_dry_run or antigravity_reviewer_display_name or run_external_resolves_antigravity_config'`
- `python3 -m pytest`

Fixes #373