### PR TITLE
docs: skill vs CLI comparison + agy agent-name alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,12 @@ coder/reviewer turns run in *your* interactive session instead of `claude -p`, w
 Rule of thumb: **CLI for fire-and-forget through merge; the skill when you want to
 participate, use your session model, or avoid the `claude -p` model/binary gotchas.**
 
-Keeping the skill also hedges a real risk: programmatic `claude -p` usage could be billed
-or restricted differently in the future (such a change was announced once, then reversed).
-The skill runs Claude turns as ordinary interactive-session usage, sidestepping that.
+Keeping the skill also **reduces reliance on programmatic `claude -p`** for Claude turns —
+useful if `claude -p` is ever billed or restricted differently (such a change was announced
+once, then reversed). Whether interactive-session usage is actually treated differently
+from `claude -p` depends on Anthropic's current terms and product behavior; see the billing
+note in [`SKILL.md`](SKILL.md). This is about reducing the `claude -p` dependency, not a
+guaranteed billing outcome.
 
 ## Develop This Tool
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ much they automate**. (External agents — Codex/Gemini/Antigravity — run as s
 either way; the difference is only the Claude turns.)
 
 **Use the CLI (`agent-loop`) for hands-off automation.** It's a closed-loop driver: it
-loops to approval, implements, runs the test/CI gate, waits for CI, and can `--auto-merge`.
+loops to approval and implements, and — when configured — runs a test gate
+(`--test-command`) and, with `--auto-merge`, waits for CI (`wait_for_ci`) and merges.
+Without those flags it runs no test gate and does not poll/merge (pending checks stop the
+run).
 It runs without an interactive session (cron/CI/scripts). Claude turns run as isolated
 `claude -p` subprocesses — which means a Claude turn uses the Claude CLI's *default* model
 unless you pass `--claude-model`, and it depends on the `claude` binary being on `PATH`.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Currently supported local agent CLIs:
 - Gemini CLI via `gemini`
 - Antigravity CLI via `agy` (first-class backend; also the Gemini CLI migration path — see below)
 
-The `agy` backend is supported in every role the other external agents support — `--coder antigravity` and `--reviewer antigravity` — and in skill mode (`--coder antigravity` / `--reviewers antigravity`).
+The `agy` backend is supported in every role the other external agents support — `--coder antigravity` and `--reviewer antigravity` — and in skill mode (`--coder antigravity` / `--reviewers antigravity`). `agy` is also accepted as an alias for `antigravity` in these flags (e.g. `--coder agy`, `--reviewer agy`, skill `--reviewers agy`, `run_external --agent agy`); it is normalized to the canonical `antigravity` internally.
 
 ### Gemini CLI → Antigravity migration
 
@@ -126,6 +126,32 @@ plan, implement (one-shot, decompose, or by-phase), address blocking PR review
 with `run-pr-fix`, and hand the PR back for re-review; the host (Claude) can
 review. See [`SKILL.md`](SKILL.md) for the step-by-step instructions and
 [`docs/skill_mode.md`](docs/skill_mode.md) for the design overview.
+
+### Skill vs CLI — which to use
+
+Both drive the same review loop; they differ in **how Claude's own turns run** and **how
+much they automate**. (External agents — Codex/Gemini/Antigravity — run as subprocesses
+either way; the difference is only the Claude turns.)
+
+**Use the CLI (`agent-loop`) for hands-off automation.** It's a closed-loop driver: it
+loops to approval, implements, runs the test/CI gate, waits for CI, and can `--auto-merge`.
+It runs without an interactive session (cron/CI/scripts). Claude turns run as isolated
+`claude -p` subprocesses — which means a Claude turn uses the Claude CLI's *default* model
+unless you pass `--claude-model`, and it depends on the `claude` binary being on `PATH`.
+
+**Use the skill (inside a Claude Code session) for high-touch / oversight.** Claude's
+coder/reviewer turns run in *your* interactive session instead of `claude -p`, which:
+- uses **your session model** (e.g. Opus) for Claude turns — no `--claude-model` needed;
+- **doesn't depend on the `claude` binary** (immune to "claude not found" / mid-update races);
+- lets you **watch and steer** each round (plans, reviews, clarifications);
+- keeps PR **merge a human decision** — the skill never auto-merges or waits on CI.
+
+Rule of thumb: **CLI for fire-and-forget through merge; the skill when you want to
+participate, use your session model, or avoid the `claude -p` model/binary gotchas.**
+
+Keeping the skill also hedges a real risk: programmatic `claude -p` usage could be billed
+or restricted differently in the future (such a change was announced once, then reversed).
+The skill runs Claude turns as ordinary interactive-session usage, sidestepping that.
 
 ## Develop This Tool
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,8 +10,10 @@ GitHub operations go through `gh`.
 **Skill vs the `agent-loop` CLI (when to use which):** use the skill when you want to
 participate/oversee, want Claude turns on your **session model** (e.g. Opus, no
 `--claude-model` needed), or want to avoid the `claude -p` model/binary gotchas; use the
-CLI for hands-off automation through CI-wait and `--auto-merge`. The skill never
-auto-merges (merge stays a human decision). Keeping the skill also reduces reliance on
+CLI for hands-off automation — optionally a `--test-command` gate and, with
+`--auto-merge`, CI-wait + merge (both are configuration-dependent; without them the CLI
+runs no gate and won't poll/merge). The skill never auto-merges (merge stays a human
+decision). Keeping the skill also reduces reliance on
 `claude -p` for Claude turns if it is ever billed/restricted differently (announced once,
 then reversed) — whether interactive-session usage is treated differently depends on
 Anthropic's current terms and product behavior (see the "Billing and terms note" below),

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,10 +11,12 @@ GitHub operations go through `gh`.
 participate/oversee, want Claude turns on your **session model** (e.g. Opus, no
 `--claude-model` needed), or want to avoid the `claude -p` model/binary gotchas; use the
 CLI for hands-off automation through CI-wait and `--auto-merge`. The skill never
-auto-merges (merge stays a human decision). Keeping the skill also hedges the chance that
-programmatic `claude -p` usage is billed/restricted differently in future (announced once,
-then reversed). See the "Skill vs CLI — which to use" section in [`README.md`](README.md)
-for the full comparison.
+auto-merges (merge stays a human decision). Keeping the skill also reduces reliance on
+`claude -p` for Claude turns if it is ever billed/restricted differently (announced once,
+then reversed) — whether interactive-session usage is treated differently depends on
+Anthropic's current terms and product behavior (see the "Billing and terms note" below),
+so this is about reducing the dependency, not a guaranteed billing outcome. See the
+"Skill vs CLI — which to use" section in [`README.md`](README.md) for the full comparison.
 
 ## Prerequisites
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,15 @@ Claude (you, the host) performs coder/plan turns using your active session conte
 External agents (Codex, Gemini) are invoked via their local CLIs as subprocesses.
 GitHub operations go through `gh`.
 
+**Skill vs the `agent-loop` CLI (when to use which):** use the skill when you want to
+participate/oversee, want Claude turns on your **session model** (e.g. Opus, no
+`--claude-model` needed), or want to avoid the `claude -p` model/binary gotchas; use the
+CLI for hands-off automation through CI-wait and `--auto-merge`. The skill never
+auto-merges (merge stays a human decision). Keeping the skill also hedges the chance that
+programmatic `claude -p` usage is billed/restricted differently in future (announced once,
+then reversed). See the "Skill vs CLI — which to use" section in [`README.md`](README.md)
+for the full comparison.
+
 ## Prerequisites
 
 - `gh` authenticated and configured.
@@ -57,7 +66,8 @@ resume model, and the same posture: **merge is always a human decision.** For an
 mode, you need `OWNER/REPO` and the reviewer set (`codex`, `gemini`, and/or
 `antigravity` — the `agy` CLI, the migration path for Gemini CLI consumer access
 that Google retires on 2026-06-18). `antigravity` works wherever an external
-coder/reviewer does (`--coder antigravity` / `--reviewers antigravity ...`).
+coder/reviewer does (`--coder antigravity` / `--reviewers antigravity ...`); `agy` is
+accepted as an alias (e.g. `--coder agy` / `--reviewers agy`), normalized to `antigravity`.
 With no override, it uses the ordered fallback chain `Gemini 3.1 Pro (High)` →
 `Gemini 3.5 Flash (High)`. Use `--model MODEL` for the legacy single-model
 override or `--antigravity-models MODEL [MODEL ...]` for a custom ordered chain;


### PR DESCRIPTION
Docs-only.

## Skill vs CLI — which to use
Adds a comparison section to README (with a pointer from SKILL.md): **CLI** for hands-off automation through CI-wait/`--auto-merge`; **skill** for oversight, Claude turns on your **session model** (no `--claude-model` needed), and avoiding the `claude -p` model/binary gotchas (the haiku-misattribution and 'claude not found' issues we hit recently). Also records that keeping the skill **hedges a possible future `claude -p` billing/restriction change** (announced once, then reversed) — the skill runs Claude turns as ordinary interactive-session usage.

## agy alias
Documents that `agy` is accepted as an alias for the `antigravity` agent name in `--coder`/`--reviewer(s)` (CLI + skill) and `run_external --agent` (per #375), normalized to the canonical `antigravity`.

Docs only — no code/tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude