### PR TITLE
Allow external coders in task rounds

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -255,6 +255,18 @@ stdin) for longer descriptions; `--dry-run` previews the issue it would create
 without creating it. From there, continue **exactly as issue mode** from the
 Plan-loop onward (including the optional Implement step + PR-loop).
 
+Task mode accepts the same coder roles as issue mode. The host coder remains the
+default and requires `--plan-file`. To have an external coder produce the plan,
+pass `--coder codex|gemini|antigravity` (or `agy`) and omit `--plan-file`:
+
+```bash
+python -m helpers.skill_runner run-task-round \
+  --task "Add a --verbose flag to the CLI" \
+  --repo OWNER/REPO \
+  --coder codex \
+  --reviewers gemini
+```
+
 ---
 
 ## Gates & guardrails
@@ -338,11 +350,12 @@ Every phase is re-runnable; if a session ends mid-arc, just re-invoke:
 
 ## Reversed roles (external coder, #307)
 
-`run-plan-round` can run with an **external coder** (Codex or Gemini writes the
-plan) instead of the host. Pass `--coder codex|gemini` and **omit** `--plan-file`
-— the skill generates the plan via `run_external --role coder`, validates it,
-attaches `--role coder --agent Codex|Gemini`, and posts it, then runs the
-configured reviewers:
+`run-plan-round` and `run-task-round` can run with an **external coder** (Codex,
+Gemini, or Antigravity writes the plan) instead of the host. Pass
+`--coder codex|gemini|antigravity` (or `agy`) and **omit** `--plan-file` — the
+skill generates the plan via `run_external --role coder`, validates it, attaches
+the coder role and agent metadata, and posts it, then runs the configured
+reviewers:
 
 ```bash
 python -m helpers.skill_runner run-plan-round \
@@ -455,8 +468,6 @@ hash + `decompose-only` mode; re-running the same plan returns the recorded chil
 issues instead of creating duplicates. `--dry-run` still exercises the
 decomposition parser and prints the child-issue preview JSON, but it does not
 create issues or post comments.
-
-`run-task-round` stays host-coder only.
 
 ---
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -1503,13 +1503,15 @@ def _create_task_issue(repo: str, task_text: str, task_key: str, gh_cmd: str = "
 def cmd_run_task_round(args: argparse.Namespace) -> None:
     repo: str = args.repo
     dry_run: bool = args.dry_run
-    if getattr(args, "coder", "claude") != "claude":
-        print(
-            "skill_runner: run-task-round supports only --coder claude (host coder) for now; "
-            "external coders are available via run-plan-round (#307).",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    coder: str = getattr(args, "coder", "claude")
+    if coder == "claude":
+        if not args.plan_file:
+            print("skill_runner: run-task-round --coder claude requires --plan-file", file=sys.stderr)
+            sys.exit(1)
+        plan_file = Path(args.plan_file)
+        if not plan_file.exists():
+            print(f"skill_runner: plan file not found: {plan_file}", file=sys.stderr)
+            sys.exit(1)
     task_text = _resolve_task_text(args)
     key = _task_key(task_text)
     issue = _lookup_task_issue(repo, key)
@@ -4161,9 +4163,13 @@ def main() -> None:
     p_task.add_argument(
         "--coder", type=normalize_agent_name,
         choices=["claude", "codex", "gemini", "antigravity"], default="claude",
-        help="Host coder only for now; external coders are rejected in task mode (#307).",
+        help="Who writes the plan: 'claude' (default, host supplies --plan-file) or "
+             "an external coder ('codex'/'gemini'/'antigravity') run by the skill.",
     )
-    p_task.add_argument("--plan-file", required=True)
+    p_task.add_argument(
+        "--plan-file", default=None,
+        help="Plan markdown file. Required for --coder claude; ignored for an external coder.",
+    )
     p_task.add_argument("--reviewers", type=normalize_agent_name, nargs="+", required=True)
     p_task.add_argument("--workdir-codex", default=None)
     p_task.add_argument("--workdir-gemini", default=None)

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1566,9 +1566,11 @@ class TestRunTaskRound:
         assert sr._lookup_task_issue("o/r", "key123") is None
 
     def _task_args(self, **over):
-        base = dict(task="do X", task_file=None, repo="o/r", plan_file="/tmp/p.md",
-                    reviewers=["codex"], workdir=None, workdir_codex=None,
-                    workdir_gemini=None, dry_run=False)
+        base = dict(task="do X", task_file=None, repo="o/r", coder="codex",
+                    plan_file=None, reviewers=["codex"], workdir=None,
+                    workdir_codex=None, workdir_gemini=None, gemini_cmd="gemini",
+                    antigravity_models=None, antigravity_quota_signatures=None,
+                    model=None, dry_run=False)
         base.update(over)
         return _argparse.Namespace(**base)
 
@@ -1578,19 +1580,76 @@ class TestRunTaskRound:
         created = {"n": 0}
         monkeypatch.setattr(sr, "_create_task_issue", lambda *a, **k: created.__setitem__("n", created["n"] + 1) or 999)
         seen = {}
-        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.__setitem__("issue", args.issue))
-        sr.cmd_run_task_round(self._task_args())
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.update(vars(args)))
+        sr.cmd_run_task_round(self._task_args(
+            coder="antigravity",
+            antigravity_models=["Model A", "Model B"],
+            antigravity_quota_signatures=["quota", "429"],
+        ))
         assert created["n"] == 0          # did not create a duplicate
         assert seen["issue"] == 77        # delegated with the reused issue
+        assert seen["coder"] == "antigravity"
+        assert seen["antigravity_models"] == ["Model A", "Model B"]
+        assert seen["antigravity_quota_signatures"] == ["quota", "429"]
 
     def test_task_round_creates_when_absent(self, monkeypatch) -> None:
         import helpers.skill_runner as sr
         monkeypatch.setattr(sr, "_lookup_task_issue", lambda repo, key: None)
         monkeypatch.setattr(sr, "_create_task_issue", lambda repo, text, key: 123)
         seen = {}
-        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.__setitem__("issue", args.issue))
-        sr.cmd_run_task_round(self._task_args())
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.update(vars(args)))
+        sr.cmd_run_task_round(self._task_args(
+            coder="gemini", gemini_cmd="/opt/gemini", workdir_gemini="/tmp/gemini-workdir",
+        ))
         assert seen["issue"] == 123
+        assert seen["coder"] == "gemini"
+        assert seen["gemini_cmd"] == "/opt/gemini"
+        assert seen["workdir_gemini"] == "/tmp/gemini-workdir"
+
+    @pytest.mark.parametrize("coder", [None, "claude"])
+    def test_task_round_claude_requires_plan_before_issue_lookup(
+        self, monkeypatch, capsys, coder,
+    ) -> None:
+        import helpers.skill_runner as sr
+        looked_up = {"n": 0}
+        monkeypatch.setattr(
+            sr, "_lookup_task_issue",
+            lambda repo, key: looked_up.__setitem__("n", looked_up["n"] + 1),
+        )
+        args = self._task_args(coder="claude", plan_file=None)
+        if coder is None:
+            del args.coder
+        with pytest.raises(SystemExit):
+            sr.cmd_run_task_round(args)
+        assert looked_up["n"] == 0
+        assert "requires --plan-file" in capsys.readouterr().err
+
+    def test_task_round_claude_requires_existing_plan_before_issue_lookup(
+        self, monkeypatch, capsys, tmp_path,
+    ) -> None:
+        import helpers.skill_runner as sr
+        looked_up = {"n": 0}
+        monkeypatch.setattr(
+            sr, "_lookup_task_issue",
+            lambda repo, key: looked_up.__setitem__("n", looked_up["n"] + 1),
+        )
+        missing = tmp_path / "missing.md"
+        with pytest.raises(SystemExit):
+            sr.cmd_run_task_round(self._task_args(coder="claude", plan_file=str(missing)))
+        assert looked_up["n"] == 0
+        assert f"plan file not found: {missing}" in capsys.readouterr().err
+
+    def test_task_round_claude_delegation_unchanged(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+        plan = tmp_path / "plan.md"
+        plan.write_text("plan", encoding="utf-8")
+        monkeypatch.setattr(sr, "_lookup_task_issue", lambda repo, key: 77)
+        seen = {}
+        monkeypatch.setattr(sr, "cmd_run_plan_round", lambda args: seen.update(vars(args)))
+        sr.cmd_run_task_round(self._task_args(coder="claude", plan_file=str(plan)))
+        assert seen["issue"] == 77
+        assert seen["coder"] == "claude"
+        assert seen["plan_file"] == str(plan)
 
     def test_task_round_dry_run_creates_nothing(self, monkeypatch, capsys) -> None:
         import helpers.skill_runner as sr
@@ -1941,19 +2000,22 @@ class TestExternalCoderRun:
         assert result.returncode != 0
         assert "requires --plan-file" in result.stderr
 
-    def test_run_task_round_rejects_external_coder(self) -> None:
-        result = _run(
-            "helpers.skill_runner", "run-task-round",
-            "--task", "do a thing",
-            "--repo", "test/skill-repo",
-            "--coder", "codex",
-            "--plan-file", "/tmp/does-not-matter.md",
-            "--reviewers", "codex",
-            "--dry-run",
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "only --coder claude" in result.stderr
+    def test_run_task_round_external_coder_dry_run_without_plan_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = os.environ.copy()
+            env["XDG_STATE_HOME"] = tmpdir
+            result = _run(
+                "helpers.skill_runner", "run-task-round",
+                "--task", "do a thing",
+                "--repo", "test/skill-repo",
+                "--coder", "codex",
+                "--reviewers", "codex",
+                "--dry-run",
+                env=env,
+            )
+        assert result.returncode == 0, result.stderr
+        output = json.loads(result.stdout)
+        assert output["would_create_issue"] is True
 
 
 class TestRetryValidateCoder:


### PR DESCRIPTION
## Summary

- allow `run-task-round` to delegate Codex, Gemini, and Antigravity coders through the existing plan-round flow
- require and validate `--plan-file` only for the default Claude host coder before scratch-issue lookup or creation
- update task-mode documentation and regression coverage for parsing, delegation, dry-run previews, and Claude behavior

## Tests

- `python3 -m pytest tests/test_skill_helpers.py -k 'RunTaskRound or run_task_round'` (19 passed)
- `python3 -m pytest` (947 passed)

Fixes #371
