### PR TITLE
config: make Gemini 3.5 Flash the primary antigravity default

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -34,8 +34,8 @@ DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES: tuple[str, ...] = (
 # legacy antigravity_model nor an explicit antigravity_models chain is given. Named
 # for discoverability/symmetry with DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES.
 DEFAULT_ANTIGRAVITY_MODELS: tuple[str, ...] = (
-    "Gemini 3.1 Pro (High)",
     "Gemini 3.5 Flash (High)",
+    "Gemini 3.1 Pro (High)",
 )
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18429,7 +18429,7 @@ def test_config_from_args_antigravity_defaults(tmp_path):
     assert config.coder == "antigravity"
     assert config.antigravity_cmd == "agy"
     assert config.antigravity_model is None
-    assert config.antigravity_models == ("Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)")
+    assert config.antigravity_models == ("Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)")
     assert config.antigravity_quota_signatures == ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")
     assert config.antigravity_args == ("--dangerously-skip-permissions",)
     assert config.antigravity_dir == default_agent_workdir("OWNER/REPO", "antigravity").resolve()
@@ -18588,7 +18588,7 @@ def test_agent_signature_uses_configured_model(tmp_path):
     config = make_config(tmp_path, codex_model="gpt-5.2-codex", codex_reasoning_effort="high")
     assert agent_signature("codex", config) == "OpenAI Codex: gpt-5.2-codex (high)"
     # antigravity model is always declared (effort already embedded).
-    assert agent_signature("antigravity", config) == "Google Antigravity: Gemini 3.1 Pro (High)"
+    assert agent_signature("antigravity", config) == "Google Antigravity: Gemini 3.5 Flash (High)"
     # gemini with no declared model falls back to the generic signature.
     assert agent_signature("gemini", make_config(tmp_path)) == "Google Gemini"
 

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -3361,7 +3361,7 @@ class TestAntigravitySkill:
         [
             (
                 (),
-                ("Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)"),
+                ("Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)"),
                 ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"),
             ),
             (("--model", "Model X"), ("Model X",), ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")),
@@ -3372,7 +3372,7 @@ class TestAntigravitySkill:
             ),
             (
                 ("--antigravity-quota-signatures", "Quota Hit", "429"),
-                ("Gemini 3.1 Pro (High)", "Gemini 3.5 Flash (High)"),
+                ("Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)"),
                 ("Quota Hit", "429"),
             ),
         ],


### PR DESCRIPTION
## Summary

- Swaps `DEFAULT_ANTIGRAVITY_MODELS` in `config.py` so `Gemini 3.5 Flash (High)` runs first and `Gemini 3.1 Pro (High)` is the quota-exhaustion fallback.
- Updates the three test assertions that encoded the old literal order (`test_config_from_args_antigravity_defaults`, `test_agent_signature_uses_configured_model`, `test_run_external_resolves_antigravity_config`).
- 938 tests pass.

## Motivation

User feedback: Gemini 3.5 Flash catches more review issues in practice than Gemini 3.1 Pro.

## Test plan

- [ ] `tests/test_agent_loop.py` and `tests/test_skill_helpers.py` — 938 passed (verified locally)
- [ ] No docs changes (out of scope per issue)

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)