### PR TITLE
fix: remove prose disposition heading from structured review prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,13 @@ edit files, push, or open a PR during planning. Reviewers approve or block with
 ### Future follow-ups
 ```
 
-When earlier plan issues remain open, reviewers must also include
-`### Prior unresolved plan item dispositions` and disposition every carried item
-exactly once with `resolved`, `still blocking`, `same-plan`, or `future
-follow-up`. `Future follow-ups` are accepted only in approved plan reviews and
-are reconciled with the final approved plan instead of reopening planning. If
+When earlier plan issues remain open, reviewers encode prior item dispositions
+in the JSON `prior_plan_item_dispositions` array using `"resolved"`,
+`"blocking"`, `"same-plan"`, or `"future"` (with a `"note"`). The orchestrator
+renders those as a `### Prior unresolved plan item dispositions` section in the
+public GitHub comment; reviewers do not add that section themselves. `"future"`
+dispositions are accepted only in approved plan reviews and are reconciled with
+the final approved plan instead of reopening planning. If
 `--approved-followups=issue` or `fix-and-issue` is enabled and implementation
 will continue after approval, those plan-stage future follow-ups are filed as
 separate issues before implementation starts. If implementation continues but

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -199,12 +199,14 @@ same planning round. Plan reviews use explicit sections:
 ### Future follow-ups
 ```
 
-If earlier blocking or same-plan items are still open, reviewers must also add
-`### Prior unresolved plan item dispositions` and disposition every carried
-item exactly once. Use `same-plan` for required current-plan refinements,
-reserve `future follow-up` for approved plan reviews only, and expect approved
-future follow-ups to be reconciled with the final approved plan instead of
-reopening planning. In `--approved-followups=issue` and `fix-and-issue` modes,
+If earlier blocking or same-plan items are still open, reviewers encode prior
+item dispositions in the JSON `prior_plan_item_dispositions` array using
+`"resolved"`, `"blocking"`, `"same-plan"`, or `"future"` (with a `"note"`).
+The orchestrator renders a `### Prior unresolved plan item dispositions` section
+in the public GitHub comment; reviewers do not add that section themselves. Use
+`"same-plan"` for required current-plan refinements; `"future"` is accepted only
+in approved plan reviews and the approved future follow-ups are reconciled with
+the final approved plan instead of reopening planning. In `--approved-followups=issue` and `fix-and-issue` modes,
 when implementation will continue after approval, plan-stage future follow-ups
 are filed as separate issues before implementation starts. If implementation
 continues but issue filing is disabled, they are summarized inline with a note

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -901,19 +901,17 @@ def build_plan_review_prompt(
         requirement_label="signed human issue requirements",
     )
     if unresolved_items:
-        unresolved_items_guidance = """Because prior unresolved plan items exist, include this exact section in your review:
+        unresolved_items_guidance = """Prior unresolved plan items are present. Disposition every listed item
+in the JSON `prior_plan_item_dispositions` array — do not add a separate prose section
+or bullet list for prior items outside the JSON object. Valid `disposition` values:
+- `"resolved"` — item is fixed in this revision.
+- `"blocking"` — item is still a blocking plan problem; include it in `blocking_plan_issues`.
+- `"same-plan"` — item needs to be incorporated before implementation; include it in `same_plan_followups`.
+- `"future"` — deferred; must include a `"note"` field; only valid when approving.
 
-### Prior unresolved plan item dispositions
-
-Use one bullet per listed item and cover every item exactly once. Allowed forms:
-- [item-id] resolved
-- [item-id] still blocking
-- [item-id] same-plan
-- [item-id] future follow-up: brief reason
-
-Only use `future follow-up` when returning `approved`. If a current-plan item still needs to be fixed before implementation starts, keep it as `still blocking` or `same-plan` instead of downgrading it.
-For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later plan changes, or now belongs back in same-plan/blocking work.
-Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
+Only use `"future"` when returning `approved`. If a plan item still needs to be fixed
+before implementation starts, use `"blocking"` or `"same-plan"` instead. For any prior
+item already marked `"future"`, explicitly re-evaluate.
 """
     else:
         unresolved_items_guidance = ""
@@ -1019,19 +1017,17 @@ def _build_compact_plan_review_prompt(
         requirement_label="signed human issue requirements",
     )
     if unresolved_items:
-        unresolved_items_guidance = """Because prior unresolved plan items exist, include this exact section in your review:
+        unresolved_items_guidance = """Prior unresolved plan items are present. Disposition every listed item
+in the JSON `prior_plan_item_dispositions` array — do not add a separate prose section
+or bullet list for prior items outside the JSON object. Valid `disposition` values:
+- `"resolved"` — item is fixed in this revision.
+- `"blocking"` — item is still a blocking plan problem; include it in `blocking_plan_issues`.
+- `"same-plan"` — item needs to be incorporated before implementation; include it in `same_plan_followups`.
+- `"future"` — deferred; must include a `"note"` field; only valid when approving.
 
-### Prior unresolved plan item dispositions
-
-Use one bullet per listed item and cover every item exactly once. Allowed forms:
-- [item-id] resolved
-- [item-id] still blocking
-- [item-id] same-plan
-- [item-id] future follow-up: brief reason
-
-Only use `future follow-up` when returning `approved`. If a current-plan item still needs to be fixed before implementation starts, keep it as `still blocking` or `same-plan` instead of downgrading it.
-For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later plan changes, or now belongs back in same-plan/blocking work.
-Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
+Only use `"future"` when returning `approved`. If a plan item still needs to be fixed
+before implementation starts, use `"blocking"` or `"same-plan"` instead. For any prior
+item already marked `"future"`, explicitly re-evaluate.
 """
     else:
         unresolved_items_guidance = ""
@@ -1654,19 +1650,18 @@ def _build_compact_pr_review_prompt(
     human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
     non_future_items = [item for item in unresolved_items if item.status != "future"]
     if non_future_items:
-        unresolved_items_guidance = """Because prior unresolved items exist, include this exact section in your review:
+        unresolved_items_guidance = """Prior unresolved items are present. Disposition every listed
+item in the JSON `prior_item_dispositions` array — do not add a separate prose section
+or bullet list for prior items outside the JSON object. Valid `disposition` values:
+- `"resolved"` — item is fixed in this PR.
+- `"blocking"` — item is still a merge-blocking problem; include it in `blocking_items`.
+- `"same-pr"` — item needs to be fixed before merge; include it in `same_pr_followups`.
+- `"future"` — deferred; must include a `"note"` field; only valid when approving.
 
-### Prior unresolved item dispositions
-
-Use one bullet per listed item and cover every item exactly once. Allowed forms:
-- [item-id] resolved
-- [item-id] still blocking
-- [item-id] same-pr
-- [item-id] future follow-up: brief reason
-
-Only use `future follow-up` when returning `approved`. If an item should still be fixed before merge, keep it as `still blocking` or `same-pr` instead of downgrading it.
-For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later commits, or now belongs back in same-PR/blocking work.
-Contradictory forms like `same-pr: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
+Only use `"future"` when returning `approved`. If an item should still be fixed before
+merge, use `"blocking"` or `"same-pr"` instead. For any prior item already marked
+`"future"`, explicitly re-evaluate: `"resolved"`, still `"future"`, or back to
+`"blocking"`/`"same-pr"`.
 """
     else:
         unresolved_items_guidance = ""
@@ -1856,19 +1851,18 @@ def build_review_prompt(
     human_requirements_guidance = _human_requirements_review_guidance(human_requirements)
     unresolved_items_block = _format_unresolved_review_items(unresolved_items)
     if unresolved_items:
-        unresolved_items_guidance = """Because prior unresolved items exist, include this exact section in your review:
+        unresolved_items_guidance = """Prior unresolved items are present. Disposition every listed
+item in the JSON `prior_item_dispositions` array — do not add a separate prose section
+or bullet list for prior items outside the JSON object. Valid `disposition` values:
+- `"resolved"` — item is fixed in this PR.
+- `"blocking"` — item is still a merge-blocking problem; include it in `blocking_items`.
+- `"same-pr"` — item needs to be fixed before merge; include it in `same_pr_followups`.
+- `"future"` — deferred; must include a `"note"` field; only valid when approving.
 
-### Prior unresolved item dispositions
-
-Use one bullet per listed item and cover every item exactly once. Allowed forms:
-- [item-id] resolved
-- [item-id] still blocking
-- [item-id] same-pr
-- [item-id] future follow-up: brief reason
-
-Only use `future follow-up` when returning `approved`. If an item should still be fixed before merge, keep it as `still blocking` or `same-pr` instead of downgrading it.
-For any prior item that was already marked `future`, explicitly choose whether it remains valid future work, was resolved by later commits, or now belongs back in same-PR/blocking work.
-Contradictory forms like `same-pr: none`, `still blocking: none`, and `future follow-up: none` are invalid; use `resolved` if the item is no longer active.
+Only use `"future"` when returning `approved`. If an item should still be fixed before
+merge, use `"blocking"` or `"same-pr"` instead. For any prior item already marked
+`"future"`, explicitly re-evaluate: `"resolved"`, still `"future"`, or back to
+`"blocking"`/`"same-pr"`.
 """
     else:
         unresolved_items_guidance = ""

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4443,10 +4443,13 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "Prior unresolved review items from earlier rounds" in prompt
     assert "[item-1] blocking from Anthropic Claude in round 1" in prompt
     assert "[item-2] same-pr from OpenAI Codex in round 1" in prompt
-    assert "### Prior unresolved item dispositions" in prompt
-    assert "- [item-id] resolved" in prompt
-    assert "Only use `future follow-up` when returning `approved`." in prompt
-    assert "Contradictory forms like `same-pr: none`, `still blocking: none`, and `future follow-up: none` are invalid" in prompt
+    assert "### Prior unresolved item dispositions" not in prompt
+    assert 'Disposition every listed\nitem in the JSON `prior_item_dispositions` array' in prompt
+    assert '"resolved"' in prompt
+    assert '"blocking"' in prompt
+    assert '"same-pr"' in prompt
+    assert '"future"' in prompt
+    assert "do not add a separate prose section" in prompt
     assert "Only items listed under `Prior unresolved review items from earlier rounds`" in prompt
     assert "same-round findings from\nother reviewers appear elsewhere in the PR discussion" in prompt
     assert "Same-PR follow-ups may appear only in blocking reviews." in prompt
@@ -4455,6 +4458,38 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "After the JSON object, include only:" in prompt
     assert "Use this mandatory structured PR review format" in prompt
     assert "Markdown fallback" not in prompt
+
+
+def test_compact_review_prompt_excludes_prose_disposition_heading(tmp_path):
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    prompt = build_review_prompt(
+        77,
+        2,
+        config,
+        reviewer="codex",
+        compact_context=True,
+        pr_metadata=PullRequestMetadata(
+            number=77,
+            repo="OWNER/REPO",
+            title="Improve review prompt context",
+            head_branch="feature/review-context",
+            base_branch="main",
+            head_sha="abc123",
+            url="https://github.com/OWNER/REPO/pull/77",
+        ),
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Needs a regression test before merge.",
+                status="blocking",
+            ),
+        ),
+    )
+    assert "### Prior unresolved item dispositions" not in prompt
+    assert 'Disposition every listed\nitem in the JSON `prior_item_dispositions` array' in prompt
+    assert "do not add a separate prose section" in prompt
 
 
 def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
@@ -4514,11 +4549,14 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
         ),
     )
 
-    assert "### Prior unresolved plan item dispositions" in prompt
+    assert "### Prior unresolved plan item dispositions" not in prompt
     assert "[item-1] blocking from Anthropic Claude in round 1" in prompt
     assert "[item-2] same-plan from Google Gemini in round 1" in prompt
-    assert "Only use `future follow-up` when returning `approved`." in prompt
-    assert "Contradictory forms like `same-plan: none`, `still blocking: none`, and `future follow-up: none` are invalid" in prompt
+    assert 'Disposition every listed item\nin the JSON `prior_plan_item_dispositions` array' in prompt
+    assert '"resolved"' in prompt
+    assert '"blocking"' in prompt
+    assert '"same-plan"' in prompt
+    assert "do not add a separate prose section" in prompt
     assert "Only items listed under `Prior unresolved plan items from earlier rounds`" in prompt
     assert "same-round findings from other\nreviewers appear elsewhere in the issue discussion" in prompt
     assert "Same-plan\nfollow-ups are small current-plan refinements" in prompt
@@ -4533,6 +4571,30 @@ def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_pat
     assert '"prior_plan_item_dispositions"' in prompt
     assert "Use this mandatory structured JSON response format" in prompt
     assert "markdown compatibility" not in prompt.lower()
+
+
+def test_compact_plan_review_prompt_excludes_prose_disposition_heading(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_plan_review_prompt(
+        56,
+        2,
+        "Fix the caching layer.",
+        config,
+        reviewer="codex",
+        compact_context=True,
+        unresolved_items=(
+            UnresolvedReviewItem(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                source_round=1,
+                text="Define exact plan-review headings.",
+                status="blocking",
+            ),
+        ),
+    )
+    assert "### Prior unresolved plan item dispositions" not in prompt
+    assert 'Disposition every listed item\nin the JSON `prior_plan_item_dispositions` array' in prompt
+    assert "do not add a separate prose section" in prompt
 
 
 def test_plan_revision_prompt_includes_unresolved_ledger_and_required_dispositions(tmp_path):


### PR DESCRIPTION
## Summary

- All four `unresolved_items_guidance` blocks (PR full/compact, plan full/compact) in `prompts.py` told reviewers to add a `### Prior unresolved item dispositions` prose section — but all four functions build **structured JSON** prompts where the parser rejects any prose between the JSON and the footer. The prose instruction directly contradicted the no-prose rule, causing schema validation failures (observed: Claude adding the section, triggering "Structured PR review may not include prose between the JSON object and the AGENT_STATE footer.").
- Replace all four blocks with JSON-appropriate guidance that retains the semantic rules (valid disposition values, when `"future"` is allowed, re-evaluation semantics) but uses the JSON `prior_item_dispositions` / `prior_plan_item_dispositions` arrays instead of a prose section.
- Update `README.md` and `docs/local_agent_loop.md` to describe JSON-array dispositions, noting the rendered heading appears in GitHub comments generated by the orchestrator, not in reviewer response files.
- Update two existing tests; add two new compact-path tests. 944 tests pass.

## Test plan

- [ ] `test_review_prompt_includes_prior_unresolved_items_and_disposition_instructions` — updated, passes
- [ ] `test_plan_review_prompt_includes_structured_sections_and_prior_items` — updated, passes
- [ ] `test_compact_review_prompt_excludes_prose_disposition_heading` — new, passes
- [ ] `test_compact_plan_review_prompt_excludes_prose_disposition_heading` — new, passes
- [ ] Full suite: 944 passed

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)