### PR TITLE
fix: add --workdir-antigravity to subcommand parsers and fix stale coder help text

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -101,7 +101,7 @@ These are the building blocks; the modes sequence them.
      --issue ISSUE --repo OWNER/REPO \
      --plan-file /tmp/agent-loop-skill/{session-id}/plan-r{N}.md \
      --reviewers codex gemini \
-     [--workdir-codex /path/to/checkout] [--workdir-gemini /path/to/checkout]
+     [--workdir-codex /path/to/checkout] [--workdir-gemini /path/to/checkout] [--workdir-antigravity /path/to/checkout]
    ```
    It prints a JSON result:
    ```json
@@ -180,7 +180,7 @@ phase that would be implemented.
    ```bash
    python -m helpers.skill_runner run-pr-round \
      --pr PR_NUMBER --repo OWNER/REPO --reviewers codex gemini \
-     [--head-sha SHA] [--workdir-codex /path/to/checkout] [--workdir-gemini /path/to/checkout] \
+     [--head-sha SHA] [--workdir-codex /path/to/checkout] [--workdir-gemini /path/to/checkout] [--workdir-antigravity /path/to/checkout] \
      [--test-command "pytest -q"] [--test-workdir .] \
      [--approved-followups summarize|issue]
    ```

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -7,14 +7,14 @@ Subcommands:
     --issue N --repo OWNER/REPO
     --plan-file PATH
     --reviewers REVIEWER [REVIEWER ...]
-    [--workdir-codex PATH] [--workdir-gemini PATH] [--workdir PATH]
+    [--workdir-codex PATH] [--workdir-gemini PATH] [--workdir-antigravity PATH] [--workdir PATH]
     [--dry-run]
 
   run-pr-round
     --pr N --repo OWNER/REPO
     --reviewers REVIEWER [REVIEWER ...]
     [--head-sha SHA]
-    [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH]
+    [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH] [--workdir-antigravity PATH]
     [--dry-run]
 
   run-pr-fix
@@ -50,9 +50,9 @@ Subcommands:
 
   run-implement
     --issue N --repo OWNER/REPO
-    --coder {codex,gemini}
+    --coder {codex,gemini,antigravity}
     --plan-file PATH
-    [--base BRANCH] [--workdir PATH] [--dry-run]
+    [--base BRANCH] [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH] [--workdir-antigravity PATH] [--dry-run]
 
     Reversed roles: an external coder implements an approved plan and opens a PR
     (validated for the PR marker, human-requirements ack, in-workdir tests, an
@@ -62,9 +62,9 @@ Subcommands:
 
   run-implement-by-phase
     --issue N --repo OWNER/REPO
-    --coder {codex,gemini}
+    --coder {codex,gemini,antigravity}
     --plan-file PATH
-    [--base BRANCH] [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH]
+    [--base BRANCH] [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH] [--workdir-antigravity PATH]
     [--dry-run]
 
     Reversed roles: decompose an approved plan into child phase issues, then
@@ -73,9 +73,9 @@ Subcommands:
 
   run-decompose
     --issue N --repo OWNER/REPO
-    --coder {codex,gemini}
+    --coder {codex,gemini,antigravity}
     --plan-file PATH
-    [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH]
+    [--workdir PATH] [--workdir-codex PATH] [--workdir-gemini PATH] [--workdir-antigravity PATH]
     [--dry-run]
 
     Reversed roles: an external coder decomposes an approved plan into child
@@ -3112,7 +3112,7 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
     if not dry_run and not explicit_workdir:
         print(
             "skill_runner: run-implement requires an explicit push-capable "
-            "--workdir (or --workdir-codex/--workdir-gemini); the external coder "
+            "--workdir (or --workdir-codex/--workdir-gemini/--workdir-antigravity); the external coder "
             "commits, pushes a branch, and opens a PR there.",
             file=sys.stderr,
         )
@@ -3758,7 +3758,7 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
     if not dry_run and not explicit_workdir:
         print(
             "skill_runner: run-implement-by-phase requires an explicit push-capable "
-            "--workdir (or --workdir-codex/--workdir-gemini); the external coder "
+            "--workdir (or --workdir-codex/--workdir-gemini/--workdir-antigravity); the external coder "
             "commits, pushes a branch, and opens a PR for the first agent phase there.",
             file=sys.stderr,
         )
@@ -3958,7 +3958,7 @@ def main() -> None:
         "--coder", type=normalize_agent_name,
         choices=["claude", "codex", "gemini", "antigravity"], default="claude",
         help="Who writes the plan: 'claude' (default, host supplies --plan-file) or "
-             "an external coder ('codex'/'gemini') run by the skill (reversed roles, #307).",
+             "an external coder ('codex'/'gemini'/'antigravity') run by the skill (reversed roles, #307).",
     )
     p_plan.add_argument(
         "--plan-file", default=None,
@@ -3967,6 +3967,7 @@ def main() -> None:
     p_plan.add_argument("--reviewers", type=normalize_agent_name, nargs="+", required=True)
     p_plan.add_argument("--workdir-codex", default=None)
     p_plan.add_argument("--workdir-gemini", default=None)
+    p_plan.add_argument("--workdir-antigravity", default=None)
     p_plan.add_argument("--workdir", default=None)
     p_plan_mem = p_plan.add_mutually_exclusive_group()
     p_plan_mem.add_argument("--agent-memory", dest="agent_memory", action="store_true", default=True,
@@ -3988,6 +3989,7 @@ def main() -> None:
     p_pr.add_argument("--workdir", default=None)
     p_pr.add_argument("--workdir-codex", default=None)
     p_pr.add_argument("--workdir-gemini", default=None)
+    p_pr.add_argument("--workdir-antigravity", default=None)
     p_pr.add_argument(
         "--test-command",
         default=None,
@@ -4070,6 +4072,7 @@ def main() -> None:
     )
     p_impl.add_argument("--workdir-codex", default=None)
     p_impl.add_argument("--workdir-gemini", default=None)
+    p_impl.add_argument("--workdir-antigravity", default=None)
     p_impl.add_argument("--dry-run", action="store_true")
     _add_antigravity_options(p_impl)
 
@@ -4125,6 +4128,7 @@ def main() -> None:
     )
     p_impl_phase.add_argument("--workdir-codex", default=None)
     p_impl_phase.add_argument("--workdir-gemini", default=None)
+    p_impl_phase.add_argument("--workdir-antigravity", default=None)
     p_impl_phase.add_argument("--dry-run", action="store_true")
     _add_antigravity_options(p_impl_phase)
 
@@ -4145,6 +4149,7 @@ def main() -> None:
     p_decompose.add_argument("--workdir", default=None)
     p_decompose.add_argument("--workdir-codex", default=None)
     p_decompose.add_argument("--workdir-gemini", default=None)
+    p_decompose.add_argument("--workdir-antigravity", default=None)
     p_decompose.add_argument("--dry-run", action="store_true")
     _add_antigravity_options(p_decompose)
 
@@ -4173,6 +4178,7 @@ def main() -> None:
     p_task.add_argument("--reviewers", type=normalize_agent_name, nargs="+", required=True)
     p_task.add_argument("--workdir-codex", default=None)
     p_task.add_argument("--workdir-gemini", default=None)
+    p_task.add_argument("--workdir-antigravity", default=None)
     p_task.add_argument("--workdir", default=None)
     p_task_mem = p_task.add_mutually_exclusive_group()
     p_task_mem.add_argument("--agent-memory", dest="agent_memory", action="store_true", default=True,

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1568,7 +1568,8 @@ class TestRunTaskRound:
     def _task_args(self, **over):
         base = dict(task="do X", task_file=None, repo="o/r", coder="codex",
                     plan_file=None, reviewers=["codex"], workdir=None,
-                    workdir_codex=None, workdir_gemini=None, gemini_cmd="gemini",
+                    workdir_codex=None, workdir_gemini=None, workdir_antigravity=None,
+                    gemini_cmd="gemini",
                     antigravity_models=None, antigravity_quota_signatures=None,
                     model=None, dry_run=False)
         base.update(over)
@@ -2895,6 +2896,7 @@ class TestRunDecompose:
             workdir=str(tmp_path),
             workdir_codex=None,
             workdir_gemini=None,
+            workdir_antigravity=None,
             dry_run=False,
         ))
 
@@ -2950,6 +2952,7 @@ class TestRunDecompose:
             workdir=str(tmp_path),
             workdir_codex=None,
             workdir_gemini=None,
+            workdir_antigravity=None,
             dry_run=False,
         ))
 
@@ -2996,6 +2999,7 @@ class TestRunImplementByPhase:
             workdir=str(tmp_path),
             workdir_codex=None,
             workdir_gemini=None,
+            workdir_antigravity=None,
             base="main",
             dry_run=dry_run,
         )
@@ -3335,7 +3339,7 @@ class TestRunReviewerUnavailable:
             issue=1, repo="o/r", reviewers=["gemini", "claude"],
             coder="claude", plan_file=str(plan), dry_run=True,
             agent_memory=False, refresh_agent_memory=False,
-            workdir=str(tmp_path), workdir_codex=None, workdir_gemini=None,
+            workdir=str(tmp_path), workdir_codex=None, workdir_gemini=None, workdir_antigravity=None,
         ))
 
         out = capsys.readouterr().out
@@ -3630,3 +3634,98 @@ def test_render_response_coder_followup_stamps_model_signature():
     assert result.returncode == 0, result.stderr
     rendered = Path(out).read_text(encoding="utf-8")
     assert "Google Antigravity: Gemini 3.1 Pro (High)" in rendered
+
+
+# ---------------------------------------------------------------------------
+# helpers/skill_runner.py — --workdir-antigravity parser parity (#374)
+# ---------------------------------------------------------------------------
+
+class TestWorkdirAntigravityParser:
+    """
+    Verify that --workdir-antigravity is accepted by all six affected subcommands.
+    Each test patches sys.argv with the minimum required arguments plus
+    --workdir-antigravity /tmp/agy, stubs out the dispatched command handler to
+    capture the parsed namespace, calls main(), and asserts the stored value.
+    """
+
+    def _run(self, monkeypatch, argv, cmd_attr, captured):
+        import helpers.skill_runner as sr
+        monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.setattr(sr, cmd_attr, lambda args: captured.update(vars(args)))
+        sr.main()
+
+    def test_run_plan_round_accepts_workdir_antigravity(self, monkeypatch):
+        import helpers.skill_runner as sr
+        captured = {}
+        self._run(
+            monkeypatch,
+            ["sr", "run-plan-round", "--issue", "1", "--repo", "o/r",
+             "--plan-file", "/dev/null", "--reviewers", "codex",
+             "--workdir-antigravity", "/tmp/agy"],
+            "cmd_run_plan_round",
+            captured,
+        )
+        assert captured.get("workdir_antigravity") == "/tmp/agy"
+
+    def test_run_pr_round_accepts_workdir_antigravity(self, monkeypatch):
+        import helpers.skill_runner as sr
+        captured = {}
+        self._run(
+            monkeypatch,
+            ["sr", "run-pr-round", "--pr", "1", "--repo", "o/r",
+             "--reviewers", "codex", "--workdir-antigravity", "/tmp/agy"],
+            "cmd_run_pr_round",
+            captured,
+        )
+        assert captured.get("workdir_antigravity") == "/tmp/agy"
+
+    def test_run_implement_accepts_workdir_antigravity(self, monkeypatch):
+        import helpers.skill_runner as sr
+        captured = {}
+        self._run(
+            monkeypatch,
+            ["sr", "run-implement", "--issue", "1", "--repo", "o/r",
+             "--coder", "codex", "--plan-file", "/dev/null",
+             "--workdir-antigravity", "/tmp/agy"],
+            "cmd_run_implement",
+            captured,
+        )
+        assert captured.get("workdir_antigravity") == "/tmp/agy"
+
+    def test_run_implement_by_phase_accepts_workdir_antigravity(self, monkeypatch):
+        import helpers.skill_runner as sr
+        captured = {}
+        self._run(
+            monkeypatch,
+            ["sr", "run-implement-by-phase", "--issue", "1", "--repo", "o/r",
+             "--coder", "codex", "--plan-file", "/dev/null",
+             "--workdir-antigravity", "/tmp/agy"],
+            "cmd_run_implement_by_phase",
+            captured,
+        )
+        assert captured.get("workdir_antigravity") == "/tmp/agy"
+
+    def test_run_decompose_accepts_workdir_antigravity(self, monkeypatch):
+        import helpers.skill_runner as sr
+        captured = {}
+        self._run(
+            monkeypatch,
+            ["sr", "run-decompose", "--issue", "1", "--repo", "o/r",
+             "--coder", "codex", "--plan-file", "/dev/null",
+             "--workdir-antigravity", "/tmp/agy"],
+            "cmd_run_decompose",
+            captured,
+        )
+        assert captured.get("workdir_antigravity") == "/tmp/agy"
+
+    def test_run_task_round_accepts_workdir_antigravity(self, monkeypatch):
+        import helpers.skill_runner as sr
+        captured = {}
+        self._run(
+            monkeypatch,
+            ["sr", "run-task-round", "--task", "do X", "--repo", "o/r",
+             "--reviewers", "codex", "--workdir-antigravity", "/tmp/agy"],
+            "cmd_run_task_round",
+            captured,
+        )
+        assert captured.get("workdir_antigravity") == "/tmp/agy"


### PR DESCRIPTION
## Summary

- **#374**: Add `--workdir-antigravity` to six subcommand parsers that had `--workdir-codex`/`--workdir-gemini` but not `--workdir-antigravity` (`run-plan-round`, `run-pr-round`, `run-implement`, `run-implement-by-phase`, `run-decompose`, `run-task-round`). Also updates error messages in `run-implement` and `run-implement-by-phase` and the SKILL.md option listings.
- **#378**: Fix `p_plan --coder` help string from `('codex'/'gemini')` to `('codex'/'gemini'/'antigravity')`, and update the module docstring `{codex,gemini}` for `run-implement`, `run-implement-by-phase`, and `run-decompose`.

## Test plan

- [ ] `TestWorkdirAntigravityParser` (6 new tests): each patches `sys.argv` + stubs the dispatch handler, calls `main()`, asserts `workdir_antigravity == "/tmp/agy"` — covers all six parsers at the argparse level
- [ ] Updated `_task_args` helper and `SimpleNamespace` calls in `TestRunDecompose` and `TestRunImplementByPhase` for namespace consistency
- [ ] Full test suite: 950 passed

Closes #374, closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)