### PR TITLE
fix: reword Antigravity output marker instruction to require response before turn ends

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -55,8 +55,14 @@ GitHub, print this exact line immediately before it:
 
 {PUBLIC_RESPONSE_MARKER}
 
-Only content after that line will be posted to GitHub. Do not print the marker
-until you are done with all internal reasoning, tool use, and review work.
+Only content after that line will be posted to GitHub. Run any verification
+steps (tests, file inspection) before you are ready to finalize. When you are
+ready to submit your review: print this marker, output the structured JSON
+response, then end your turn immediately — no further tool calls, narration, or
+output after the response. If background work is still pending, print the marker
+and response now without waiting; do not defer to a background task result. A
+turn that ends without printing this marker results in an empty response and a
+review failure.
 """
 
 

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -109,6 +109,8 @@ the response file. For structured plan revisions only, if signed human
 requirements are present, place `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` and the
 `### Human requirements` section after the JSON object and before the
 `AGENT_PLAN_STATE` footer.
+You MUST write this file before your turn ends. A turn that ends without
+writing this file results in a review failure.
 """
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18786,3 +18786,27 @@ def test_render_public_agent_comment_stamps_model_for_every_kind():
     ]
 
     assert all(comment.endswith(f"-- Google Antigravity: {model}") for comment in rendered)
+
+
+# ---------------------------------------------------------------------------
+# Antigravity prompt — turn-end requirement (#385)
+# ---------------------------------------------------------------------------
+
+
+def test_antigravity_prompt_includes_terminal_response_instruction():
+    from coding_review_agent_loop.agents.antigravity import _with_public_response_marker_instruction
+    composed = _with_public_response_marker_instruction("BASE PROMPT")
+    assert "end your turn immediately" in composed
+    assert "do not defer to a background task result" in composed
+
+
+def test_antigravity_prompt_excludes_old_wait_instruction():
+    from coding_review_agent_loop.agents.antigravity import _with_public_response_marker_instruction
+    composed = _with_public_response_marker_instruction("BASE PROMPT")
+    assert "Do not print the marker until you are done with all internal reasoning" not in composed
+
+
+def test_base_response_file_instruction_includes_must_write_before_turn_ends(tmp_path):
+    from coding_review_agent_loop.agents.base import with_public_response_file_instruction
+    composed = with_public_response_file_instruction("BASE PROMPT", tmp_path / "response.md")
+    assert "before your turn ends" in composed


### PR DESCRIPTION
## Summary

- Replaces "Do not print the marker until you are done with all internal reasoning, tool use, and review work" with explicit "print marker → output response → end turn immediately — no further tool calls, narration, or output" sequencing
- Adds "do not defer to a background task result" to handle the specific case where Antigravity launches a background test command and ends the turn waiting for it
- Adds a must-write-before-turn-ends note to the shared response-file instruction in `base.py`

## Root cause

Antigravity (Gemini 3.5 Flash via `agy`) consistently ended turns empty when reviewing complex PRs: it would run `pytest` in the background, then end with "I will wait for the test command to execute and complete", never printing the public-response marker or writing the response file. The old instruction's "don't print until done" wording actively encouraged this.

## Test plan

- [ ] `test_antigravity_prompt_includes_terminal_response_instruction`: asserts new "end your turn immediately" and "do not defer to a background task result" wording is present
- [ ] `test_antigravity_prompt_excludes_old_wait_instruction`: asserts old "Do not print the marker until you are done with all internal reasoning" is absent
- [ ] `test_base_response_file_instruction_includes_must_write_before_turn_ends`: asserts base instruction includes "before your turn ends"
- [ ] Full suite: 947 passed

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)