### PR TITLE
Fix: instruct reviewers not to defer on pending CI

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1598,6 +1598,7 @@ Treat the GitHub PR checks block in the volatile tail as authoritative for curre
 Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
+Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
@@ -1974,6 +1975,7 @@ Treat the GitHub PR checks block above as authoritative for current CI state.
 Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
+Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9308,6 +9308,13 @@ def test_review_prompt_includes_failing_github_check_status(tmp_path):
     assert "- Failing checks: tests/test_security.py (failure)" in prompt
 
 
+@pytest.mark.parametrize("compact_context", [False, True])
+def test_review_prompt_includes_no_ci_wait_instruction(tmp_path, compact_context):
+    config = make_config(tmp_path)
+    prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact_context)
+    assert "Do not defer your review to wait for CI" in prompt
+
+
 def test_review_prompt_mentions_branch_protection_forbidden_when_checks_exist(tmp_path):
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],


### PR DESCRIPTION
## Summary

- Adds "Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings." to both the standard and compact-context PR review prompt paths in `prompts.py`
- Prevents Antigravity (and other reviewers) from interpreting a pending GitHub CI check as a reason to skip the review entirely — the observed failure was Antigravity producing a single line ("I will wait for the sitemap tests to complete.") and ending its turn

## Test plan

- [ ] 789 tests pass (`pytest tests/test_agent_loop.py`)
- [ ] `test_review_prompt_includes_no_ci_wait_instruction[compact_context=False]` — asserts instruction is in the standard prompt path
- [ ] `test_review_prompt_includes_no_ci_wait_instruction[compact_context=True]` — asserts instruction is in the compact-context prompt path

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)