### PR TITLE
Fix: write GEMINI.md single-shot rule to agy workdir before each --print run

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -23,7 +23,6 @@ emits no token usage (usage falls back to the estimated path).
 
 from __future__ import annotations
 
-import fcntl
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -149,6 +148,7 @@ class AntigravityBackend:
                 " and wait for the result in this same turn before writing your response.\n\n"
                 "---\n\n"
             )
+            import fcntl  # Unix-only; imported here so the module loads on Windows
             lock_file = lock_path.open("a+")
             try:
                 fcntl.flock(lock_file, fcntl.LOCK_EX)

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -107,15 +107,13 @@ class AntigravityBackend:
             log_path = agent_log_path(config, "antigravity", run_id=run_id)
             log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
             # agy reads GEMINI.md from the workdir as high-priority system context before
-            # the model sees the prompt. Injecting a single-shot session rule here
-            # prevents agy from spawning background execution tasks (which cause it to
-            # end the --print turn without writing a response). The file is restored
-            # to its original state in the finally block so the workdir is unchanged.
+            # the model sees the prompt. Injecting a single-shot session rule prevents
+            # agy from spawning background execution tasks (which cause it to end the
+            # --print turn without a response). Cleanup strips only the injected prefix
+            # rather than restoring a snapshot, so any file changes the agent makes
+            # during a coder turn are preserved. Each agent gets its own dedicated
+            # workdir so concurrent GEMINI.md writes cannot occur in normal operation.
             gemini_md_path = config.antigravity_dir / "GEMINI.md"
-            try:
-                original_gemini_md: str | None = gemini_md_path.read_text(encoding="utf-8")
-            except FileNotFoundError:
-                original_gemini_md = None
             single_shot_instruction = (
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"
@@ -125,8 +123,12 @@ class AntigravityBackend:
                 " and wait for the result in this same turn before writing your response.\n\n"
                 "---\n\n"
             )
+            try:
+                existing = gemini_md_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                existing = None
             gemini_md_path.write_text(
-                single_shot_instruction + (original_gemini_md or ""),
+                single_shot_instruction + (existing or ""),
                 encoding="utf-8",
             )
             try:
@@ -141,10 +143,18 @@ class AntigravityBackend:
                     use_pty=True,
                 )
             finally:
-                if original_gemini_md is None:
-                    gemini_md_path.unlink(missing_ok=True)
-                else:
-                    gemini_md_path.write_text(original_gemini_md, encoding="utf-8")
+                # Strip only our injected prefix from whatever the file contains now,
+                # preserving any changes the agent made to the content that followed it.
+                if gemini_md_path.exists():
+                    current = gemini_md_path.read_text(encoding="utf-8")
+                    if current.startswith(single_shot_instruction):
+                        remainder = current[len(single_shot_instruction):]
+                        if remainder:
+                            gemini_md_path.write_text(remainder, encoding="utf-8")
+                        else:
+                            gemini_md_path.unlink()
+                    # else: agent rewrote the file entirely — leave it as-is
+                # else: agent deleted the file — leave it deleted (intentional change)
             log(config, f"Antigravity ({model}) finished; log: {log_path}")
 
             if result.returncode != 0:

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -23,6 +23,7 @@ emits no token usage (usage falls back to the estimated path).
 
 from __future__ import annotations
 
+import fcntl
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -110,10 +111,12 @@ class AntigravityBackend:
             # the model sees the prompt. Injecting a single-shot session rule prevents
             # agy from spawning background execution tasks (which cause it to end the
             # --print turn without a response). Cleanup strips only the injected prefix
-            # rather than restoring a snapshot, so any file changes the agent makes
-            # during a coder turn are preserved. Each agent gets its own dedicated
-            # workdir so concurrent GEMINI.md writes cannot occur in normal operation.
+            # rather than restoring a snapshot, so file changes made during a coder turn
+            # are preserved. An exclusive flock on GEMINI.md.lock serializes the entire
+            # inject→run→strip sequence across concurrent processes sharing the same
+            # default per-repo workdir.
             gemini_md_path = config.antigravity_dir / "GEMINI.md"
+            lock_path = config.antigravity_dir / "GEMINI.md.lock"
             single_shot_instruction = (
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"
@@ -123,38 +126,44 @@ class AntigravityBackend:
                 " and wait for the result in this same turn before writing your response.\n\n"
                 "---\n\n"
             )
+            lock_file = lock_path.open("a+")
             try:
-                existing = gemini_md_path.read_text(encoding="utf-8")
-            except FileNotFoundError:
-                existing = None
-            gemini_md_path.write_text(
-                single_shot_instruction + (existing or ""),
-                encoding="utf-8",
-            )
-            try:
-                result = runner.run_with_log(
-                    args,
-                    cwd=config.antigravity_dir,
-                    log_path=log_path,
-                    label=f"Antigravity ({model})",
-                    progress_interval_seconds=config.progress_interval_seconds,
-                    check=False,
-                    env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
-                    use_pty=True,
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                try:
+                    existing = gemini_md_path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    existing = None
+                gemini_md_path.write_text(
+                    single_shot_instruction + (existing or ""),
+                    encoding="utf-8",
                 )
+                try:
+                    result = runner.run_with_log(
+                        args,
+                        cwd=config.antigravity_dir,
+                        log_path=log_path,
+                        label=f"Antigravity ({model})",
+                        progress_interval_seconds=config.progress_interval_seconds,
+                        check=False,
+                        env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+                        use_pty=True,
+                    )
+                finally:
+                    # Strip only our injected prefix from whatever the file contains now,
+                    # preserving any changes the agent made to the content that followed it.
+                    if gemini_md_path.exists():
+                        current = gemini_md_path.read_text(encoding="utf-8")
+                        if current.startswith(single_shot_instruction):
+                            remainder = current[len(single_shot_instruction):]
+                            if remainder:
+                                gemini_md_path.write_text(remainder, encoding="utf-8")
+                            else:
+                                gemini_md_path.unlink()
+                        # else: agent rewrote the file entirely — leave it as-is
+                    # else: agent deleted the file — leave it deleted (intentional change)
             finally:
-                # Strip only our injected prefix from whatever the file contains now,
-                # preserving any changes the agent made to the content that followed it.
-                if gemini_md_path.exists():
-                    current = gemini_md_path.read_text(encoding="utf-8")
-                    if current.startswith(single_shot_instruction):
-                        remainder = current[len(single_shot_instruction):]
-                        if remainder:
-                            gemini_md_path.write_text(remainder, encoding="utf-8")
-                        else:
-                            gemini_md_path.unlink()
-                    # else: agent rewrote the file entirely — leave it as-is
-                # else: agent deleted the file — leave it deleted (intentional change)
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+                lock_file.close()
             log(config, f"Antigravity ({model}) finished; log: {log_path}")
 
             if result.returncode != 0:

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -106,16 +106,45 @@ class AntigravityBackend:
             args += ["--print", prompt_text]
             log_path = agent_log_path(config, "antigravity", run_id=run_id)
             log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
-            result = runner.run_with_log(
-                args,
-                cwd=config.antigravity_dir,
-                log_path=log_path,
-                label=f"Antigravity ({model})",
-                progress_interval_seconds=config.progress_interval_seconds,
-                check=False,
-                env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
-                use_pty=True,
+            # agy reads GEMINI.md from the workdir as high-priority system context before
+            # the model sees the prompt. Injecting a single-shot session rule here
+            # prevents agy from spawning background execution tasks (which cause it to
+            # end the --print turn without writing a response). The file is restored
+            # to its original state in the finally block so the workdir is unchanged.
+            gemini_md_path = config.antigravity_dir / "GEMINI.md"
+            try:
+                original_gemini_md: str | None = gemini_md_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                original_gemini_md = None
+            single_shot_instruction = (
+                "# Agent Loop Single-Shot Session\n\n"
+                "You are running in a single-shot, non-interactive `agy --print` session"
+                " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
+                "**Do NOT spawn background execution tasks or subagents.** If you need to"
+                " run tests or shell commands, run them synchronously using your shell tool"
+                " and wait for the result in this same turn before writing your response.\n\n"
+                "---\n\n"
             )
+            gemini_md_path.write_text(
+                single_shot_instruction + (original_gemini_md or ""),
+                encoding="utf-8",
+            )
+            try:
+                result = runner.run_with_log(
+                    args,
+                    cwd=config.antigravity_dir,
+                    log_path=log_path,
+                    label=f"Antigravity ({model})",
+                    progress_interval_seconds=config.progress_interval_seconds,
+                    check=False,
+                    env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+                    use_pty=True,
+                )
+            finally:
+                if original_gemini_md is None:
+                    gemini_md_path.unlink(missing_ok=True)
+                else:
+                    gemini_md_path.write_text(original_gemini_md, encoding="utf-8")
             log(config, f"Antigravity ({model}) finished; log: {log_path}")
 
             if result.returncode != 0:

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -43,6 +43,28 @@ if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
 
+def _git_lock_path(workdir: Path) -> Path:
+    """Return GEMINI.md.lock inside the git metadata dir, following linked-worktree .git files.
+
+    In a linked worktree .git is a file containing ``gitdir: <relative-path>``.
+    mkdir-ing that path would raise NotADirectoryError.  We resolve the pointer
+    and place the lock in the real git dir so git add never sees it.  If no git
+    dir can be found (test tmp dirs without a .git) we create .git/ and use it.
+    """
+    git_path = workdir / ".git"
+    if git_path.is_dir():
+        return git_path / "GEMINI.md.lock"
+    if git_path.is_file():
+        content = git_path.read_text(encoding="utf-8", errors="replace").strip()
+        if content.startswith("gitdir:"):
+            gitdir = (workdir / content[len("gitdir:"):].strip()).resolve()
+            if gitdir.is_dir():
+                return gitdir / "GEMINI.md.lock"
+    # No .git directory yet (e.g. test tmp dirs) — create it.
+    git_path.mkdir(parents=True, exist_ok=True)
+    return git_path / "GEMINI.md.lock"
+
+
 def _with_public_response_marker_instruction(prompt: str) -> str:
     return f"""{prompt}
 
@@ -112,15 +134,12 @@ class AntigravityBackend:
             # agy from spawning background execution tasks (which cause it to end the
             # --print turn without a response). Cleanup strips only the injected prefix
             # rather than restoring a snapshot, so file changes made during a coder turn
-            # are preserved. An exclusive flock on GEMINI.md.lock serializes the entire
+            # are preserved. An exclusive flock on the lock file (resolved by
+            # _git_lock_path into git metadata, not the worktree) serializes the entire
             # inject→run→strip sequence across concurrent processes sharing the same
             # default per-repo workdir.
             gemini_md_path = config.antigravity_dir / "GEMINI.md"
-            # Lock lives in .git/ (git metadata) so it is never staged or committed
-            # by a coder-role agy run, and agy itself ignores .git/. mkdir is a
-            # no-op in production (where .git/ always exists) and creates it in tests.
-            lock_path = config.antigravity_dir / ".git" / "GEMINI.md.lock"
-            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            lock_path = _git_lock_path(config.antigravity_dir)
             single_shot_instruction = (
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -116,7 +116,11 @@ class AntigravityBackend:
             # inject→run→strip sequence across concurrent processes sharing the same
             # default per-repo workdir.
             gemini_md_path = config.antigravity_dir / "GEMINI.md"
-            lock_path = config.antigravity_dir / "GEMINI.md.lock"
+            # Lock lives in .git/ (git metadata) so it is never staged or committed
+            # by a coder-role agy run, and agy itself ignores .git/. mkdir is a
+            # no-op in production (where .git/ always exists) and creates it in tests.
+            lock_path = config.antigravity_dir / ".git" / "GEMINI.md.lock"
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
             single_shot_instruction = (
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1598,6 +1598,7 @@ Treat the GitHub PR checks block in the volatile tail as authoritative for curre
 Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
+Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
@@ -1974,6 +1975,7 @@ Treat the GitHub PR checks block above as authoritative for current CI state.
 Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
+Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9308,6 +9308,13 @@ def test_review_prompt_includes_failing_github_check_status(tmp_path):
     assert "- Failing checks: tests/test_security.py (failure)" in prompt
 
 
+@pytest.mark.parametrize("compact_context", [False, True])
+def test_review_prompt_includes_no_ci_wait_instruction(tmp_path, compact_context):
+    config = make_config(tmp_path)
+    prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact_context)
+    assert "Do not defer your review to wait for CI" in prompt
+
+
 def test_review_prompt_mentions_branch_protection_forbidden_when_checks_exist(tmp_path):
     runner = FakeRunner(
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18445,6 +18445,8 @@ def test_antigravity_backend_writes_gemini_md_single_shot_instruction(tmp_path):
     assert "Do NOT spawn background execution tasks" in captured[0]
     # prefix is stripped → file deleted (no remaining content after it)
     assert not (agy_dir / "GEMINI.md").exists()
+    # Lock file must not appear in the worktree root (it lives in .git/ only)
+    assert not (agy_dir / "GEMINI.md.lock").exists()
 
 
 def test_antigravity_backend_preserves_existing_gemini_md_during_and_after_run(tmp_path):
@@ -18545,7 +18547,9 @@ def test_antigravity_backend_gemini_md_lock_serializes_concurrent_access(tmp_pat
     config = make_config(tmp_path, antigravity_dir=agy_dir)
 
     order: list[str] = []
-    lock_path = agy_dir / "GEMINI.md.lock"
+    # Lock lives in .git/ to avoid polluting the worktree
+    lock_path = agy_dir / ".git" / "GEMINI.md.lock"
+    (agy_dir / ".git").mkdir(parents=True, exist_ok=True)
 
     # Thread A: pre-acquires the exclusive lock, records "A-holds", sleeps briefly,
     # records "A-releases", then releases the lock. This simulates another process

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18533,6 +18533,76 @@ def test_antigravity_backend_cleans_up_gemini_md_on_exception(tmp_path):
     assert "Do NOT spawn" not in after
 
 
+def test_antigravity_backend_gemini_md_lock_serializes_concurrent_access(tmp_path):
+    """flock on GEMINI.md.lock prevents a second run from starting until the first
+    completes its inject→run→strip sequence."""
+    import fcntl
+    import threading
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+
+    order: list[str] = []
+    lock_path = agy_dir / "GEMINI.md.lock"
+
+    # Thread A: pre-acquires the exclusive lock, records "A-holds", sleeps briefly,
+    # records "A-releases", then releases the lock. This simulates another process
+    # holding the lock while running agy.
+    lock_acquired = threading.Event()
+    lock_released = threading.Event()
+
+    def hold_lock():
+        lf = lock_path.open("a+")
+        fcntl.flock(lf, fcntl.LOCK_EX)
+        order.append("A-holds")
+        lock_acquired.set()
+        lock_released.wait()
+        order.append("A-releases")
+        fcntl.flock(lf, fcntl.LOCK_UN)
+        lf.close()
+
+    t = threading.Thread(target=hold_lock, daemon=True)
+    t.start()
+    lock_acquired.wait()
+
+    # Thread B (main): tries to run AntigravityBackend — should block on LOCK_EX
+    # until Thread A releases.
+    run_started = threading.Event()
+
+    class RecordingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            order.append("B-run")
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    def run_backend():
+        AntigravityBackend().run(
+            RecordingRunner(antigravity_outputs=[("ok", 0)]),
+            config,
+            "Review.",
+            run_id="r1",
+        )
+        order.append("B-done")
+
+    backend_thread = threading.Thread(target=run_backend, daemon=True)
+    backend_thread.start()
+
+    # Give the backend thread a moment to block on the lock, then release it.
+    import time
+    time.sleep(0.05)
+    lock_released.set()
+    t.join(timeout=5)
+    backend_thread.join(timeout=10)
+
+    # A-holds must precede B-run and A-releases must precede B-run
+    assert "A-holds" in order
+    assert "A-releases" in order
+    assert "B-run" in order
+    assert order.index("A-holds") < order.index("B-run")
+    assert order.index("A-releases") < order.index("B-run")
+
+
 def test_antigravity_backend_strips_public_response_marker(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     from coding_review_agent_loop.protocol import PUBLIC_RESPONSE_MARKER

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18607,6 +18607,33 @@ def test_antigravity_backend_gemini_md_lock_serializes_concurrent_access(tmp_pat
     assert order.index("A-releases") < order.index("B-run")
 
 
+def test_antigravity_module_imports_without_fcntl():
+    """Antigravity module must import cleanly even when fcntl is unavailable (Windows)."""
+    import importlib
+    import sys
+
+    # Remove any cached import of the module under test
+    mods_to_remove = [k for k in sys.modules if "antigravity" in k]
+    for m in mods_to_remove:
+        del sys.modules[m]
+
+    # Simulate a platform without fcntl by hiding it
+    original = sys.modules.pop("fcntl", None)
+    sys.modules["fcntl"] = None  # type: ignore[assignment]
+    try:
+        import coding_review_agent_loop.agents.antigravity as mod
+        assert hasattr(mod, "AntigravityBackend")
+    finally:
+        if original is not None:
+            sys.modules["fcntl"] = original
+        else:
+            sys.modules.pop("fcntl", None)
+        # Re-remove so later tests get a clean import
+        for k in list(sys.modules):
+            if "antigravity" in k:
+                del sys.modules[k]
+
+
 def test_antigravity_backend_git_lock_path_follows_linked_worktree(tmp_path):
     """_git_lock_path resolves a file-form .git marker (linked worktree) to the real
     git dir instead of trying to mkdir the .git file."""

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18607,6 +18607,28 @@ def test_antigravity_backend_gemini_md_lock_serializes_concurrent_access(tmp_pat
     assert order.index("A-releases") < order.index("B-run")
 
 
+def test_antigravity_backend_git_lock_path_follows_linked_worktree(tmp_path):
+    """_git_lock_path resolves a file-form .git marker (linked worktree) to the real
+    git dir instead of trying to mkdir the .git file."""
+    from coding_review_agent_loop.agents.antigravity import _git_lock_path
+
+    agy_dir = tmp_path / "worktree"
+    agy_dir.mkdir()
+    real_git_dir = tmp_path / "repo.git" / "worktrees" / "wt"
+    real_git_dir.mkdir(parents=True)
+
+    # Simulate the .git file that git worktree add creates
+    (agy_dir / ".git").write_text(
+        f"gitdir: {real_git_dir}\n", encoding="utf-8"
+    )
+
+    lock = _git_lock_path(agy_dir)
+    assert lock.parent == real_git_dir
+    assert lock.name == "GEMINI.md.lock"
+    # Must not attempt to mkdir over the .git file
+    assert (agy_dir / ".git").is_file()
+
+
 def test_antigravity_backend_strips_public_response_marker(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     from coding_review_agent_loop.protocol import PUBLIC_RESPONSE_MARKER

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18443,10 +18443,11 @@ def test_antigravity_backend_writes_gemini_md_single_shot_instruction(tmp_path):
 
     assert captured, "run_with_log was not called"
     assert "Do NOT spawn background execution tasks" in captured[0]
-    assert not (agy_dir / "GEMINI.md").exists()  # cleaned up
+    # prefix is stripped → file deleted (no remaining content after it)
+    assert not (agy_dir / "GEMINI.md").exists()
 
 
-def test_antigravity_backend_preserves_and_restores_existing_gemini_md(tmp_path):
+def test_antigravity_backend_preserves_existing_gemini_md_during_and_after_run(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
 
     agy_dir = tmp_path / "antigravity"
@@ -18466,14 +18467,42 @@ def test_antigravity_backend_preserves_and_restores_existing_gemini_md(tmp_path)
     AntigravityBackend().run(runner, config, "Review this PR.", run_id="r1")
 
     assert captured, "run_with_log was not called"
-    # Instruction was prepended during the run
+    # Instruction was prepended before the original content during the run
     assert "Do NOT spawn background execution tasks" in captured[0]
     assert "My project rules" in captured[0]
     assert captured[0].index("Do NOT spawn") < captured[0].index("My project rules")
-    # Original content fully restored after the run
-    restored = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
-    assert restored == original_content
-    assert "Do NOT spawn" not in restored
+    # Prefix stripped after the run → original content remains
+    after = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
+    assert after == original_content
+    assert "Do NOT spawn" not in after
+
+
+def test_antigravity_backend_preserves_agent_edits_to_gemini_md(tmp_path):
+    """Agent (coder role) edits the content after our prefix — preserved after run."""
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    original_content = "# Original rules\n"
+    (agy_dir / "GEMINI.md").write_text(original_content, encoding="utf-8")
+
+    class EditingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            # Simulate agent appending to the file after the injected prefix
+            gemini_md = cwd / "GEMINI.md"
+            current = gemini_md.read_text(encoding="utf-8")
+            gemini_md.write_text(current + "# New agent-added rules\n", encoding="utf-8")
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    runner = EditingRunner(antigravity_outputs=[("ok", 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(runner, config, "Review this PR.", run_id="r1")
+
+    after = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
+    # Original content and agent's new content both present; our prefix stripped
+    assert "Original rules" in after
+    assert "New agent-added rules" in after
+    assert "Do NOT spawn" not in after
 
 
 def test_antigravity_backend_cleans_up_gemini_md_on_exception(tmp_path):
@@ -18486,21 +18515,22 @@ def test_antigravity_backend_cleans_up_gemini_md_on_exception(tmp_path):
         def run_with_log(self, args, *, cwd, **kwargs):
             raise RuntimeError("subprocess failed")
 
-    # Sub-test A: no pre-existing GEMINI.md — file is removed after exception
+    # Sub-test A: no pre-existing GEMINI.md — prefix stripped → file deleted
     runner = RaisingRunner()
     config = make_config(tmp_path, antigravity_dir=agy_dir)
     with pytest.raises(RuntimeError):
         AntigravityBackend().run(runner, config, "Review this PR.", run_id="r1")
     assert not (agy_dir / "GEMINI.md").exists()
 
-    # Sub-test B: pre-existing GEMINI.md — original content is restored after exception
+    # Sub-test B: pre-existing GEMINI.md — prefix stripped, original content restored
     original_content = "# Existing rules\n"
     (agy_dir / "GEMINI.md").write_text(original_content, encoding="utf-8")
     runner2 = RaisingRunner()
     with pytest.raises(RuntimeError):
         AntigravityBackend().run(runner2, config, "Review this PR.", run_id="r2")
-    restored = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
-    assert restored == original_content
+    after = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
+    assert after == original_content
+    assert "Do NOT spawn" not in after
 
 
 def test_antigravity_backend_strips_public_response_marker(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18424,6 +18424,85 @@ def test_antigravity_backend_ignores_partial_response_file_on_fallback(tmp_path)
     assert result.model_used == "ModelB"
 
 
+def test_antigravity_backend_writes_gemini_md_single_shot_instruction(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    captured: list[str] = []
+
+    class CapturingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            gemini_md = cwd / "GEMINI.md"
+            captured.append(gemini_md.read_text(encoding="utf-8") if gemini_md.exists() else "")
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    runner = CapturingRunner(antigravity_outputs=[("ok", 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(runner, config, "Review this PR.", run_id="r1")
+
+    assert captured, "run_with_log was not called"
+    assert "Do NOT spawn background execution tasks" in captured[0]
+    assert not (agy_dir / "GEMINI.md").exists()  # cleaned up
+
+
+def test_antigravity_backend_preserves_and_restores_existing_gemini_md(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    original_content = "# My project rules\nUse tabs.\n"
+    (agy_dir / "GEMINI.md").write_text(original_content, encoding="utf-8")
+    captured: list[str] = []
+
+    class CapturingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            gemini_md = cwd / "GEMINI.md"
+            captured.append(gemini_md.read_text(encoding="utf-8") if gemini_md.exists() else "")
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    runner = CapturingRunner(antigravity_outputs=[("ok", 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(runner, config, "Review this PR.", run_id="r1")
+
+    assert captured, "run_with_log was not called"
+    # Instruction was prepended during the run
+    assert "Do NOT spawn background execution tasks" in captured[0]
+    assert "My project rules" in captured[0]
+    assert captured[0].index("Do NOT spawn") < captured[0].index("My project rules")
+    # Original content fully restored after the run
+    restored = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
+    assert restored == original_content
+    assert "Do NOT spawn" not in restored
+
+
+def test_antigravity_backend_cleans_up_gemini_md_on_exception(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+
+    class RaisingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            raise RuntimeError("subprocess failed")
+
+    # Sub-test A: no pre-existing GEMINI.md — file is removed after exception
+    runner = RaisingRunner()
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    with pytest.raises(RuntimeError):
+        AntigravityBackend().run(runner, config, "Review this PR.", run_id="r1")
+    assert not (agy_dir / "GEMINI.md").exists()
+
+    # Sub-test B: pre-existing GEMINI.md — original content is restored after exception
+    original_content = "# Existing rules\n"
+    (agy_dir / "GEMINI.md").write_text(original_content, encoding="utf-8")
+    runner2 = RaisingRunner()
+    with pytest.raises(RuntimeError):
+        AntigravityBackend().run(runner2, config, "Review this PR.", run_id="r2")
+    restored = (agy_dir / "GEMINI.md").read_text(encoding="utf-8")
+    assert restored == original_content
+
+
 def test_antigravity_backend_strips_public_response_marker(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     from coding_review_agent_loop.protocol import PUBLIC_RESPONSE_MARKER


### PR DESCRIPTION
## Summary

- `agy` reads `GEMINI.md` from its working directory as high-priority system context loaded before the model sees any prompt text
- Injects a "Do NOT spawn background execution tasks or subagents" rule into `GEMINI.md` immediately before each `agy --print` invocation in `AntigravityBackend.run()`
- Restores or deletes the file in a `try/finally` block so the workdir is left unchanged regardless of success or exception
- If a `GEMINI.md` already exists in the workdir (e.g. project rules), its content is preserved by prepending the instruction and restoring the original after the run

## Root cause

`agy` is an interactive agent with a background subagent system. When it decides to run tests in `--print` mode, it ends the current turn expecting a follow-up interactive turn — but there is none, so the session closes without a response. Prompt-level instructions were insufficient because agy's background task dispatch fires before the model processes user-turn text. `GEMINI.md` is loaded as system context and enforces the constraint earlier.

## Test plan

- [ ] 792 tests pass (`pytest tests/test_agent_loop.py`)
- [ ] `test_antigravity_backend_writes_gemini_md_single_shot_instruction` — captured content contains instruction; file cleaned up after run
- [ ] `test_antigravity_backend_preserves_and_restores_existing_gemini_md` — instruction prepended during run; original restored after
- [ ] `test_antigravity_backend_cleans_up_gemini_md_on_exception` — new file deleted and pre-existing file restored when run_with_log raises

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)