### PR TITLE
Fix: prohibit test execution in Antigravity reviewer turns

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -143,9 +143,15 @@ class AntigravityBackend:
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"
                 " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
-                "**Do NOT spawn background execution tasks or subagents.** If you need to"
-                " run tests or shell commands, run them synchronously using your shell tool"
-                " and wait for the result in this same turn before writing your response.\n\n"
+                "**Do NOT spawn background execution tasks or subagents under any"
+                " circumstances.**\n\n"
+                "**For code review tasks: DO NOT run tests, shell commands, or compile"
+                " code.** Review by reading files and the PR diff only. Tests are CI's"
+                " responsibility; your job is to read code and identify issues. If you find"
+                " yourself about to run `pytest`, `npm test`, `go test`, or any other"
+                " command — stop and write your review from code inspection alone.\n\n"
+                "For non-review tasks that require shell commands, run them synchronously"
+                " in this same turn before writing your response.\n\n"
                 "---\n\n"
             )
             import fcntl  # Unix-only; imported here so the module loads on Windows

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1599,6 +1599,7 @@ Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
 Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
+DO NOT run tests, shell commands, or compile code. Review by reading files and the PR diff only. If you find yourself about to execute `pytest`, `npm test`, or any other command — stop. Write your review from code inspection alone.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
@@ -1976,6 +1977,7 @@ Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
 Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
+DO NOT run tests, shell commands, or compile code. Review by reading files and the PR diff only. If you find yourself about to execute `pytest`, `npm test`, or any other command — stop. Write your review from code inspection alone.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9313,6 +9313,7 @@ def test_review_prompt_includes_no_ci_wait_instruction(tmp_path, compact_context
     config = make_config(tmp_path)
     prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact_context)
     assert "Do not defer your review to wait for CI" in prompt
+    assert "DO NOT run tests, shell commands, or compile code" in prompt
 
 
 def test_review_prompt_mentions_branch_protection_forbidden_when_checks_exist(tmp_path):


### PR DESCRIPTION
## Summary

- Strengthens the GEMINI.md single-shot instruction to explicitly prohibit test/shell execution during **code review** tasks (the prior wording said "run them synchronously" which inadvertently permitted it)
- Adds the same constraint to `build_review_prompt` (both compact and full context paths) so the instruction appears in the prompt text as well as GEMINI.md system context
- Adds assertion to `test_review_prompt_includes_no_ci_wait_instruction` covering the new prompt text

## Root cause

The previous GEMINI.md instruction had a fallback: *"If you need to run tests or shell commands, run them synchronously."* agy was reading this as permission to run tests — just synchronously. This still triggered agy's background-task dispatch and resulted in deferred turns. The fix removes the loophole for review tasks and makes the constraint explicit: read files and the PR diff, nothing else.

## Test plan

- [x] 796 tests pass (`pytest tests/test_agent_loop.py`)
- [x] `test_review_prompt_includes_no_ci_wait_instruction` now asserts `DO NOT run tests, shell commands, or compile code` in both compact and full context

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)