### PR TITLE
Handle missing agent CLIs gracefully

### DIFF
--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -594,10 +594,38 @@ def _resolve_agent_memory_dir(value: Path | None, *, repo: str, primary_dir: Pat
     return (primary_dir / value).resolve()
 
 
+def preflight_agent_commands(
+    args: argparse.Namespace,
+    runner: Runner,
+    configured_reviewers: tuple[AgentName, ...],
+) -> None:
+    """Validate configured agent CLIs before repository or workdir operations."""
+    if args.dry_run:
+        return
+
+    command_options = {
+        "claude": (args.claude_cmd, "--claude-cmd"),
+        "codex": (args.codex_cmd, "--codex-cmd"),
+        "gemini": (args.gemini_cmd, "--gemini-cmd"),
+        "antigravity": (args.antigravity_cmd, "--antigravity-cmd"),
+    }
+    configured_agents = dict.fromkeys((args.coder, *configured_reviewers))
+    for agent in configured_agents:
+        command, override_flag = command_options[agent]
+        resolved = shutil.which(command)
+        if resolved is None:
+            raise AgentLoopError(
+                f"{command} CLI not found on PATH; install it or pass "
+                f"{override_flag} <path>."
+            )
+        runner.remember_agent_command(command, resolved, override_flag)
+
+
 def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfig:
     configured_reviewers = tuple(args.reviewer or ["codex"])
     if len(set(configured_reviewers)) != len(configured_reviewers):
         raise AgentLoopError("--reviewer cannot include the same agent more than once.")
+    preflight_agent_commands(args, runner, configured_reviewers)
 
     detect_dir = args.codex_dir.resolve() if args.codex_dir is not None else Path.cwd().resolve()
     repo = args.repo or detect_repo(runner, detect_dir, args.gh_cmd)

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Callable, Mapping, Sequence, TypeVar
 
 from .errors import AgentLoopError
 
@@ -29,6 +30,9 @@ class CommandResult:
 # under a pseudo-terminal (see run_with_log use_pty), so we strip these from the
 # captured output before parsing it.
 _ANSI_RE = re.compile(r"\x1B\[[0-9;?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)|\x1B[()][AB0-2]")
+_SPAWN_ATTEMPTS = 3
+_SPAWN_RETRY_BACKOFF_SECONDS = 2
+_SpawnResult = TypeVar("_SpawnResult")
 
 
 def strip_ansi(text: str) -> str:
@@ -49,6 +53,58 @@ def ensure_log_dir_ignored(log_dir: Path) -> None:
 class Runner:
     def __init__(self, *, dry_run: bool = False):
         self.dry_run = dry_run
+        self._resolved_commands: dict[str, str] = {}
+        self._command_override_flags: dict[str, str] = {}
+
+    def remember_agent_command(
+        self,
+        command: str,
+        resolved_path: str,
+        override_flag: str,
+    ) -> None:
+        """Retain preflight evidence for a later spawn-time PATH race."""
+        self._resolved_commands[command] = resolved_path
+        self._command_override_flags[command] = override_flag
+
+    def _missing_command_error(self, command: str) -> AgentLoopError:
+        override_flag = self._command_override_flags.get(command)
+        if override_flag is None:
+            command_name = Path(command).name
+            override_flag = f"--{command_name}-cmd"
+        return AgentLoopError(
+            f"{command} CLI not found on PATH; install it or pass "
+            f"{override_flag} <path>."
+        )
+
+    @staticmethod
+    def _is_dangling_symlink(path: str | None) -> bool:
+        return bool(path and os.path.islink(path) and not os.path.exists(path))
+
+    def _spawn_with_retry(
+        self,
+        cmd: list[str],
+        spawn_attempt: Callable[[], _SpawnResult],
+    ) -> _SpawnResult:
+        command = cmd[0]
+        resolved = shutil.which(command)
+        if resolved is not None:
+            self._resolved_commands[command] = resolved
+
+        for attempt in range(1, _SPAWN_ATTEMPTS + 1):
+            try:
+                return spawn_attempt()
+            except FileNotFoundError as exc:
+                current = shutil.which(command)
+                if current is not None:
+                    self._resolved_commands[command] = current
+                candidate = current or self._resolved_commands.get(command)
+                if not self._is_dangling_symlink(candidate):
+                    raise self._missing_command_error(command) from exc
+                if attempt == _SPAWN_ATTEMPTS:
+                    raise self._missing_command_error(command) from exc
+                time.sleep(_SPAWN_RETRY_BACKOFF_SECONDS)
+
+        raise AssertionError("spawn retry loop exited unexpectedly")
 
     def run(
         self,
@@ -122,14 +178,17 @@ class Runner:
             # stderr=subprocess.STDOUT merges stderr into the log file.
             # All agent backends (Claude, Codex, Gemini) use run_with_log,
             # so stderr capture is uniform across them (issue #266).
-            proc = subprocess.Popen(
+            proc = self._spawn_with_retry(
                 cmd,
-                cwd=cwd,
-                stdin=subprocess.DEVNULL,
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env={**os.environ, **env} if env is not None else None,
+                lambda: subprocess.Popen(
+                    cmd,
+                    cwd=cwd,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env={**os.environ, **env} if env is not None else None,
+                ),
             )
             try:
                 while True:
@@ -191,21 +250,36 @@ class Runner:
         started = time.monotonic()
         next_progress = started + progress_interval_seconds
         header = f"$ {' '.join(cmd)}\n\n"
-        master_fd, slave_fd = pty.openpty()
         chunks: list[bytes] = []
         with log_path.open("wb") as log_file:
             log_file.write(header.encode("utf-8"))
             log_file.flush()
-            proc = subprocess.Popen(
-                cmd,
-                cwd=cwd,
-                stdin=slave_fd,
-                stdout=slave_fd,
-                stderr=slave_fd,
-                close_fds=True,
-                start_new_session=True,
-                env={**os.environ, **env} if env is not None else None,
-            )
+            allocated_fds: tuple[int, int] | None = None
+
+            def spawn_pty() -> subprocess.Popen[bytes]:
+                nonlocal allocated_fds
+                master_fd, slave_fd = pty.openpty()
+                allocated_fds = (master_fd, slave_fd)
+                try:
+                    return subprocess.Popen(
+                        cmd,
+                        cwd=cwd,
+                        stdin=slave_fd,
+                        stdout=slave_fd,
+                        stderr=slave_fd,
+                        close_fds=True,
+                        start_new_session=True,
+                        env={**os.environ, **env} if env is not None else None,
+                    )
+                except BaseException:
+                    os.close(master_fd)
+                    os.close(slave_fd)
+                    allocated_fds = None
+                    raise
+
+            proc = self._spawn_with_retry(cmd, spawn_pty)
+            assert allocated_fds is not None
+            master_fd, slave_fd = allocated_fds
             os.close(slave_fd)
             try:
                 while True:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -174,7 +174,7 @@ from unittest.mock import MagicMock, patch
 
 
 @pytest.fixture(autouse=True)
-def _no_real_repair(request):
+def _no_real_repair():
     """Prevent attempt_repair from calling the real Gemini CLI in all tests.
 
     Tests that explicitly test repair behaviour patch the orchestrator-level
@@ -187,16 +187,21 @@ def _no_real_repair(request):
 
 
 @pytest.fixture(autouse=True)
-def _no_real_repair(request):
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
+def _agent_commands_available(monkeypatch):
+    """Keep config tests independent of agent CLIs installed on the test host."""
+    import coding_review_agent_loop.config as config_module
 
-    Tests that explicitly test repair behaviour patch the orchestrator-level
-    import themselves, which takes precedence over this fixture.  Unit tests
-    for attempt_repair itself patch subprocess.run directly, so they are
-    unaffected here.
-    """
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
+    real_which = config_module.shutil.which
+
+    def which(command):
+        resolved = real_which(command)
+        if resolved is not None:
+            return resolved
+        if command in {"claude", "codex", "gemini", "agy"}:
+            return f"/mock/bin/{command}"
+        return None
+
+    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 class FakeRunner(Runner):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,8 +1,10 @@
 import base64
 import datetime
 import json
+import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -12035,6 +12037,126 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, t
     ).resolve()
 
 
+@pytest.mark.parametrize(
+    ("coder", "reviewer", "missing_command", "override_flag"),
+    [
+        ("claude", "codex", "missing-claude", "--claude-cmd"),
+        ("claude", "gemini", "missing-gemini", "--gemini-cmd"),
+    ],
+)
+def test_config_preflight_rejects_missing_agent_before_repo_detection(
+    monkeypatch,
+    coder,
+    reviewer,
+    missing_command,
+    override_flag,
+):
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--coder",
+        coder,
+        "--reviewer",
+        reviewer,
+        f"--{coder}-cmd",
+        missing_command if override_flag == f"--{coder}-cmd" else coder,
+        f"--{reviewer}-cmd",
+        missing_command if override_flag == f"--{reviewer}-cmd" else reviewer,
+    ])
+    detection_calls = []
+    monkeypatch.setattr(
+        "coding_review_agent_loop.config.detect_repo",
+        lambda *call_args: detection_calls.append(call_args),
+    )
+    monkeypatch.setattr(
+        "coding_review_agent_loop.config.shutil.which",
+        lambda command: None if command == missing_command else f"/bin/{command}",
+    )
+
+    with pytest.raises(
+        AgentLoopError,
+        match=rf"{missing_command} CLI not found on PATH.*{override_flag}",
+    ):
+        config_from_args(args, Runner())
+
+    assert detection_calls == []
+
+
+def test_config_preflight_checks_only_unique_configured_agents(monkeypatch, tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "codex",
+        "--reviewer",
+        "codex",
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+    checked = []
+
+    def fake_which(command):
+        checked.append(command)
+        return f"/bin/{command}"
+
+    monkeypatch.setattr("coding_review_agent_loop.config.shutil.which", fake_which)
+
+    config = config_from_args(args, Runner())
+
+    assert config.coder == "codex"
+    assert checked == ["codex"]
+
+
+def test_config_preflight_accepts_custom_absolute_command(tmp_path):
+    command = tmp_path / "custom-codex"
+    command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    command.chmod(0o755)
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--coder",
+        "codex",
+        "--reviewer",
+        "codex",
+        "--codex-cmd",
+        str(command),
+    ])
+
+    config = config_from_args(args, Runner())
+
+    assert config.codex_cmd == str(command)
+
+
+def test_config_preflight_skips_dry_run_command_preview(monkeypatch):
+    parser = build_parser()
+    args = parser.parse_args([
+        "task",
+        "Fix the bug",
+        "--repo",
+        "OWNER/REPO",
+        "--dry-run",
+        "--claude-cmd",
+        "missing-claude",
+        "--codex-cmd",
+        "missing-codex",
+    ])
+    monkeypatch.setattr(
+        "coding_review_agent_loop.config.shutil.which",
+        lambda command: pytest.fail(f"unexpected preflight for {command}"),
+    )
+
+    config = config_from_args(args, Runner(dry_run=True))
+
+    assert config.dry_run is True
+
+
 def test_omitted_cli_base_is_preserved_for_runtime_resolution(tmp_path):
     parser = build_parser()
     args = parser.parse_args([
@@ -18712,6 +18834,130 @@ def test_runner_pty_reports_tty_and_strips_ansi(tmp_path):
     assert "GREEN" in result.stdout
     assert "\x1b[" not in result.stdout  # ANSI stripped from captured output
     assert result.returncode == 0
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_retries_dangling_symlink_spawn_and_recovers(
+    monkeypatch,
+    tmp_path,
+    use_pty,
+):
+    import coding_review_agent_loop.runner as runner_module
+
+    missing_target = tmp_path / "updating-agent-target"
+    command = tmp_path / "agent"
+    command.symlink_to(missing_target)
+    runner = Runner()
+    runner.remember_agent_command(str(command), str(command), "--codex-cmd")
+    original_popen = runner_module.subprocess.Popen
+    popen_calls = []
+    sleep_calls = []
+
+    def flaky_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        if len(popen_calls) == 1:
+            raise FileNotFoundError(str(command))
+        return original_popen(*args, **kwargs)
+
+    def restore_command(delay):
+        sleep_calls.append(delay)
+        command.unlink()
+        command.symlink_to(sys.executable)
+
+    monkeypatch.setattr(runner_module.subprocess, "Popen", flaky_popen)
+    monkeypatch.setattr(runner_module.time, "sleep", restore_command)
+
+    result = runner.run_with_log(
+        [str(command), "-c", "print('recovered')"],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / f"retry-{use_pty}.log",
+        label="Retry probe",
+        progress_interval_seconds=999,
+        use_pty=use_pty,
+    )
+
+    assert result.returncode == 0
+    assert "recovered" in result.stdout
+    assert len(popen_calls) == 2
+    assert sleep_calls[0] == 2
+    assert all(delay == 1 for delay in sleep_calls[1:])
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_dangling_symlink_spawn_retry_is_bounded(
+    monkeypatch,
+    tmp_path,
+    use_pty,
+):
+    import coding_review_agent_loop.runner as runner_module
+
+    command = tmp_path / "agent"
+    command.symlink_to(tmp_path / "missing-target")
+    runner = Runner()
+    runner.remember_agent_command(str(command), str(command), "--codex-cmd")
+    popen_calls = []
+    sleep_calls = []
+
+    def missing_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        raise FileNotFoundError(str(command))
+
+    monkeypatch.setattr(runner_module.subprocess, "Popen", missing_popen)
+    monkeypatch.setattr(
+        runner_module.time,
+        "sleep",
+        lambda delay: sleep_calls.append(delay),
+    )
+
+    with pytest.raises(
+        AgentLoopError,
+        match=r"CLI not found on PATH.*--codex-cmd",
+    ):
+        runner.run_with_log(
+            [str(command), "--version"],
+            cwd=tmp_path,
+            log_path=tmp_path / "logs" / f"bounded-{use_pty}.log",
+            label="Bounded retry probe",
+            progress_interval_seconds=999,
+            use_pty=use_pty,
+        )
+
+    assert len(popen_calls) == 3
+    assert sleep_calls == [2, 2]
+
+
+def test_runner_missing_command_without_dangling_evidence_does_not_retry(
+    monkeypatch,
+    tmp_path,
+):
+    import coding_review_agent_loop.runner as runner_module
+
+    popen_calls = []
+    sleep_calls = []
+
+    def missing_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        raise FileNotFoundError("missing-agent")
+
+    monkeypatch.setattr(runner_module.shutil, "which", lambda command: None)
+    monkeypatch.setattr(runner_module.subprocess, "Popen", missing_popen)
+    monkeypatch.setattr(
+        runner_module.time,
+        "sleep",
+        lambda delay: sleep_calls.append(delay),
+    )
+
+    with pytest.raises(AgentLoopError, match="missing-agent CLI not found on PATH"):
+        Runner().run_with_log(
+            ["missing-agent", "--version"],
+            cwd=tmp_path,
+            log_path=tmp_path / "logs" / "missing.log",
+            label="Missing probe",
+            progress_interval_seconds=999,
+        )
+
+    assert len(popen_calls) == 1
+    assert sleep_calls == []
 
 
 def test_antigravity_registry():


### PR DESCRIPTION
## Summary

- preflight configured coder and reviewer commands before repository detection or agent work
- convert spawn-time missing executables into actionable `AgentLoopError` messages
- retry only when a cached/current executable candidate is a dangling symlink, with three bounded attempts and PTY descriptor cleanup
- preserve dry-run command previews and add focused regular/PTY coverage

## Tests

- `python3 -m pytest tests/test_agent_loop.py -k 'config_preflight or runner_retries_dangling or runner_dangling_symlink or runner_missing_command_without_dangling or runner_pty_reports_tty'`
- `python3 -m pytest`

Fixes #363