### PR TITLE
Inject toolPermission:strict for Antigravity reviewer runs (#400)

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -34,6 +34,7 @@ from .base import (
     read_public_response_file,
     with_public_response_file_instruction,
 )
+from ..errors import AgentLoopError
 from ..logging import agent_log_path, log
 from ..protocol import PUBLIC_RESPONSE_MARKER
 from ..runner import Runner
@@ -88,6 +89,26 @@ review failure.
 """
 
 
+_REVIEWER_SETTINGS_INJECTION = {
+    "toolPermission": "strict",
+    "permissions": {
+        "allow": [
+            "command(ls)",
+            "command(cat)",
+            "command(which)",
+            "command(echo)",
+            "command(file)",
+            "command(head)",
+        ]
+    },
+}
+
+
+def _antigravity_settings_path() -> Path:
+    """Return ~/.gemini/antigravity-cli/settings.json (patchable in tests)."""
+    return Path.home() / ".gemini" / "antigravity-cli" / "settings.json"
+
+
 def _strip_public_response_marker(raw: str) -> tuple[str, AgentTextSource]:
     if PUBLIC_RESPONSE_MARKER not in raw:
         return raw, "stdout"
@@ -112,13 +133,17 @@ class AntigravityBackend:
         prompt: str,
         session_id: str | None = None,
         run_id: str | None = None,
+        role: str | None = None,
     ) -> AgentResult:
+        import json, fcntl  # Unix-only (fcntl); imported here so the module loads on Windows
         for i, model in enumerate(config.antigravity_models):
             response_path = public_response_path(config, "antigravity")
             prompt_text = _with_public_response_marker_instruction(
                 with_public_response_file_instruction(prompt, response_path)
             )
             args = [config.antigravity_cmd, "--model", model, *config.antigravity_args]
+            if role == "reviewer":
+                args = [a for a in args if a != "--dangerously-skip-permissions"]
             # agy resumes by conversation id (not gemini's --resume). agy --print does
             # not surface a conversation id in plain output, so in practice session_id
             # is None and turns are single-shot; honor it if a caller ever supplies one.
@@ -138,7 +163,7 @@ class AntigravityBackend:
             # inject→run→strip sequence across concurrent processes sharing the same
             # default per-repo workdir.
             gemini_md_path = config.antigravity_dir / "GEMINI.md"
-            lock_path = _git_lock_path(config.antigravity_dir)
+            gemini_lock_path = _git_lock_path(config.antigravity_dir)
             single_shot_instruction = (
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"
@@ -154,45 +179,106 @@ class AntigravityBackend:
                 " in this same turn before writing your response.\n\n"
                 "---\n\n"
             )
-            import fcntl  # Unix-only; imported here so the module loads on Windows
-            lock_file = lock_path.open("a+")
+            settings_path = _antigravity_settings_path()
+            settings_lock_path = settings_path.with_suffix(".json.lock")
+            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            settings_lock = settings_lock_path.open("a+")
             try:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-                try:
-                    existing = gemini_md_path.read_text(encoding="utf-8")
-                except FileNotFoundError:
-                    existing = None
-                gemini_md_path.write_text(
-                    single_shot_instruction + (existing or ""),
-                    encoding="utf-8",
-                )
-                try:
-                    result = runner.run_with_log(
-                        args,
-                        cwd=config.antigravity_dir,
-                        log_path=log_path,
-                        label=f"Antigravity ({model})",
-                        progress_interval_seconds=config.progress_interval_seconds,
-                        check=False,
-                        env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
-                        use_pty=True,
-                    )
-                finally:
-                    # Strip only our injected prefix from whatever the file contains now,
-                    # preserving any changes the agent made to the content that followed it.
-                    if gemini_md_path.exists():
-                        current = gemini_md_path.read_text(encoding="utf-8")
-                        if current.startswith(single_shot_instruction):
-                            remainder = current[len(single_shot_instruction):]
-                            if remainder:
-                                gemini_md_path.write_text(remainder, encoding="utf-8")
-                            else:
-                                gemini_md_path.unlink()
-                        # else: agent rewrote the file entirely — leave it as-is
-                    # else: agent deleted the file — leave it deleted (intentional change)
+                fcntl.flock(settings_lock, fcntl.LOCK_EX)
+                if role == "reviewer":
+                    try:
+                        original_settings_text = settings_path.read_text(encoding="utf-8")
+                        try:
+                            existing_settings = json.loads(original_settings_text)
+                        except json.JSONDecodeError as exc:
+                            raise AgentLoopError(f"settings.json malformed: {exc}") from exc
+                        if not isinstance(existing_settings, dict):
+                            raise AgentLoopError("settings.json root is not a JSON object")
+                    except FileNotFoundError:
+                        original_settings_text = None
+                        existing_settings = {}
+                    try:
+                        injected = {**existing_settings, **_REVIEWER_SETTINGS_INJECTION}
+                        settings_path.write_text(json.dumps(injected, indent=2), encoding="utf-8")
+                        # Inner: GEMINI.md lock
+                        gemini_lock_file = gemini_lock_path.open("a+")
+                        try:
+                            fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
+                            try:
+                                existing_gemini = gemini_md_path.read_text(encoding="utf-8")
+                            except FileNotFoundError:
+                                existing_gemini = None
+                            gemini_md_path.write_text(
+                                single_shot_instruction + (existing_gemini or ""),
+                                encoding="utf-8",
+                            )
+                            try:
+                                result = runner.run_with_log(
+                                    args,
+                                    cwd=config.antigravity_dir,
+                                    log_path=log_path,
+                                    label=f"Antigravity ({model})",
+                                    progress_interval_seconds=config.progress_interval_seconds,
+                                    check=False,
+                                    env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+                                    use_pty=True,
+                                )
+                            finally:
+                                if gemini_md_path.exists():
+                                    current = gemini_md_path.read_text(encoding="utf-8")
+                                    if current.startswith(single_shot_instruction):
+                                        remainder = current[len(single_shot_instruction):]
+                                        if remainder:
+                                            gemini_md_path.write_text(remainder, encoding="utf-8")
+                                        else:
+                                            gemini_md_path.unlink()
+                        finally:
+                            fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
+                            gemini_lock_file.close()
+                    finally:
+                        if original_settings_text is None:
+                            settings_path.unlink(missing_ok=True)
+                        else:
+                            settings_path.write_text(original_settings_text, encoding="utf-8")
+                else:
+                    # Coder path: hold settings lock without modifying settings.json
+                    gemini_lock_file = gemini_lock_path.open("a+")
+                    try:
+                        fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
+                        try:
+                            existing_gemini = gemini_md_path.read_text(encoding="utf-8")
+                        except FileNotFoundError:
+                            existing_gemini = None
+                        gemini_md_path.write_text(
+                            single_shot_instruction + (existing_gemini or ""),
+                            encoding="utf-8",
+                        )
+                        try:
+                            result = runner.run_with_log(
+                                args,
+                                cwd=config.antigravity_dir,
+                                log_path=log_path,
+                                label=f"Antigravity ({model})",
+                                progress_interval_seconds=config.progress_interval_seconds,
+                                check=False,
+                                env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+                                use_pty=True,
+                            )
+                        finally:
+                            if gemini_md_path.exists():
+                                current = gemini_md_path.read_text(encoding="utf-8")
+                                if current.startswith(single_shot_instruction):
+                                    remainder = current[len(single_shot_instruction):]
+                                    if remainder:
+                                        gemini_md_path.write_text(remainder, encoding="utf-8")
+                                    else:
+                                        gemini_md_path.unlink()
+                    finally:
+                        fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
+                        gemini_lock_file.close()
             finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-                lock_file.close()
+                fcntl.flock(settings_lock, fcntl.LOCK_UN)
+                settings_lock.close()
             log(config, f"Antigravity ({model}) finished; log: {log_path}")
 
             if result.returncode != 0:

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -58,6 +58,7 @@ class AgentBackend(Protocol):
         prompt: str,
         session_id: str | None = None,
         run_id: str | None = None,
+        role: str | None = None,
     ) -> AgentResult: ...
 
 

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -107,6 +107,7 @@ class ClaudeBackend:
         prompt: str,
         session_id: str | None = None,
         run_id: str | None = None,
+        role: str | None = None,
     ) -> AgentResult:
         response_path = public_response_path(config, "claude")
         args = [config.claude_cmd, "--print", "--output-format", "json", *config.claude_args]

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -238,6 +238,7 @@ class CodexBackend:
         prompt: str,
         session_id: str | None = None,
         run_id: str | None = None,
+        role: str | None = None,
     ) -> AgentResult:
         log_path = agent_log_path(config, "codex", run_id=run_id)
         response_path = public_response_path(config, "codex")

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -192,6 +192,7 @@ class GeminiBackend:
         prompt: str,
         session_id: str | None = None,
         run_id: str | None = None,
+        role: str | None = None,
     ) -> AgentResult:
         # Gemini CLI only allows file writes inside the trusted workspace (or
         # its own private temp dir, whose path we do not know ahead of time).

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -87,5 +87,6 @@ def run_agent_result(
     prompt: str,
     session_id: str | None = None,
     run_id: str | None = None,
+    role: str | None = None,
 ) -> AgentResult:
-    return get_backend(agent).run(runner, config, prompt, session_id=session_id, run_id=run_id)
+    return get_backend(agent).run(runner, config, prompt, session_id=session_id, run_id=run_id, role=role)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -840,6 +840,7 @@ def _run_validated_agent(
     repair_requires_direct_discussion_ack: bool = False,
     repair_allowed_prior_item_ids: Sequence[str] | None = None,
     ledger_incomplete: bool = False,
+    role: str | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -857,6 +858,7 @@ def _run_validated_agent(
             prompt=prompt,
             session_id=session_id,
             run_id=usage_context.run_id if usage_context is not None else None,
+            role=role,
         )
         last_result = result
         if result.log_path is not None:
@@ -1722,6 +1724,7 @@ def _run_plan_first_loop(
                     repair_expected_kind="plan_review",
                     repair_allowed_prior_item_ids=tuple(item.item_id for item in prior_unresolved_items),
                     ledger_incomplete=round_ledger_incomplete,
+                    role="reviewer",
                 )
                 review_output = review_response.text
                 review_model_used = review_response.model_used
@@ -2676,6 +2679,7 @@ def run_pr_loop(
                         repair_expected_kind="pr_review",
                         repair_allowed_prior_item_ids=tuple(item.item_id for item in prior_unresolved_items),
                         ledger_incomplete=round_ledger_incomplete,
+                        role="reviewer",
                     )
                     review_output = review_response.text
                     review_model_used = review_response.model_used

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -19307,3 +19307,597 @@ def test_base_response_file_instruction_includes_must_write_before_turn_ends(tmp
     from coding_review_agent_loop.agents.base import with_public_response_file_instruction
     composed = with_public_response_file_instruction("BASE PROMPT", tmp_path / "response.md")
     assert "before your turn ends" in composed
+
+
+# ── Tests: issue #400 – toolPermission: "strict" injection for reviewer ────────
+
+
+def test_antigravity_backend_injects_strict_mode_for_reviewer(tmp_path, monkeypatch):
+    """Reviewer run injects toolPermission:strict and expected allow-list while running."""
+    import json as _json
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import (
+        AntigravityBackend,
+        _REVIEWER_SETTINGS_INJECTION,
+    )
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    original = _json.dumps({"existingKey": "existingValue"})
+    settings_file.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    captured_settings: list[dict] = []
+
+    class CapturingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            captured_settings.append(
+                _json.loads(settings_file.read_text(encoding="utf-8"))
+            )
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(
+        CapturingRunner(antigravity_outputs=[("ok", 0)]),
+        config, "Review PR.", role="reviewer",
+    )
+
+    assert len(captured_settings) == 1
+    settings = captured_settings[0]
+    assert settings["toolPermission"] == "strict"
+    assert settings["permissions"] == _REVIEWER_SETTINGS_INJECTION["permissions"]
+    assert settings["existingKey"] == "existingValue"
+
+
+def test_antigravity_backend_restores_original_settings_after_reviewer_run(tmp_path, monkeypatch):
+    """Settings file is verbatim-restored after a successful reviewer run."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    original_text = '{"key": "val", "nested": {"a": 1}}'
+    settings_file.write_text(original_text, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(
+        FakeRunner(antigravity_outputs=[("ok", 0)]),
+        config, "Review.", role="reviewer",
+    )
+
+    assert settings_file.read_text(encoding="utf-8") == original_text
+
+
+def test_antigravity_backend_restores_settings_on_run_exception(tmp_path, monkeypatch):
+    """Settings file is verbatim-restored even when the runner raises."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    original_text = '{"keep": "me"}'
+    settings_file.write_text(original_text, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    class RaisingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            raise RuntimeError("agy crashed")
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    with pytest.raises(RuntimeError, match="agy crashed"):
+        AntigravityBackend().run(RaisingRunner(), config, "Review.", role="reviewer")
+
+    assert settings_file.read_text(encoding="utf-8") == original_text
+
+
+def test_antigravity_backend_restores_settings_on_injection_write_failure(tmp_path, monkeypatch):
+    """If the injection write_text partially truncates then raises, original bytes are restored."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    original_text = '{"preserve": "exactly"}'
+    settings_file.write_text(original_text, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    write_calls = [0]
+    real_write_text = Path.write_text
+
+    def patched_write_text(self, *args, **kwargs):
+        if self == settings_file:
+            write_calls[0] += 1
+            if write_calls[0] == 1:
+                real_write_text(self, "PARTIAL")
+                raise OSError("simulated disk full")
+        real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", patched_write_text)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    with pytest.raises(OSError, match="simulated disk full"):
+        AntigravityBackend().run(
+            FakeRunner(antigravity_outputs=[("ok", 0)]), config, "Review.", role="reviewer",
+        )
+
+    assert settings_file.read_text(encoding="utf-8") == original_text
+
+
+def test_antigravity_backend_does_not_touch_settings_for_non_reviewer(tmp_path, monkeypatch):
+    """Non-reviewer run holds the settings lock but does not read or modify settings.json."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    original_text = '{"untouched": true}'
+    settings_file.write_text(original_text, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    captured_during: list[str] = []
+
+    class CapturingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            captured_during.append(settings_file.read_text(encoding="utf-8"))
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(
+        CapturingRunner(antigravity_outputs=[("ok", 0)]),
+        config, "Implement.", role=None,
+    )
+
+    assert captured_during[0] == original_text
+    assert settings_file.read_text(encoding="utf-8") == original_text
+
+
+def test_antigravity_backend_fails_fast_on_malformed_settings_json(tmp_path, monkeypatch):
+    """AgentLoopError raised before any run if settings.json is not valid JSON."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    from coding_review_agent_loop.errors import AgentLoopError
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("not json at all {{{", encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    with pytest.raises(AgentLoopError, match="settings.json malformed"):
+        AntigravityBackend().run(
+            FakeRunner(antigravity_outputs=[("ok", 0)]), config, "Review.", role="reviewer",
+        )
+
+
+@pytest.mark.parametrize("invalid", ["[]", "null", "42"])
+def test_antigravity_backend_fails_fast_on_non_object_settings_json(
+    tmp_path, monkeypatch, invalid
+):
+    """AgentLoopError raised if settings.json root is not a JSON object."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    from coding_review_agent_loop.errors import AgentLoopError
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(invalid, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    with pytest.raises(AgentLoopError, match="not a JSON object"):
+        AntigravityBackend().run(
+            FakeRunner(antigravity_outputs=[("ok", 0)]), config, "Review.", role="reviewer",
+        )
+
+
+def test_antigravity_backend_strips_dangerously_skip_permissions_for_reviewer(
+    tmp_path, monkeypatch
+):
+    """--dangerously-skip-permissions is removed from args when role=reviewer."""
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    captured_args: list[list[str]] = []
+
+    class CapturingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            captured_args.append(list(args))
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    config = make_config(
+        tmp_path,
+        antigravity_dir=agy_dir,
+        antigravity_args=("--dangerously-skip-permissions",),
+    )
+    AntigravityBackend().run(
+        CapturingRunner(antigravity_outputs=[("ok", 0)]),
+        config, "Review.", role="reviewer",
+    )
+    assert "--dangerously-skip-permissions" not in captured_args[-1]
+
+    # Non-reviewer run keeps the flag
+    captured_args.clear()
+    AntigravityBackend().run(
+        CapturingRunner(antigravity_outputs=[("ok", 0)]),
+        config, "Implement.", role=None,
+    )
+    assert "--dangerously-skip-permissions" in captured_args[-1]
+
+
+def test_antigravity_backend_lock_order_settings_outer_gemini_inner(tmp_path, monkeypatch):
+    """Settings lock (outer) is acquired before GEMINI.md lock (inner);
+    settings are restored before the settings lock is released."""
+    import fcntl as fcntl_mod
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    (agy_dir / ".git").mkdir(parents=True, exist_ok=True)
+    settings_file = tmp_path / "settings.json"
+    original_text = '{"v": 1}'
+    settings_file.write_text(original_text, encoding="utf-8")
+    settings_lock_path = str(settings_file.with_suffix(".json.lock"))
+    gemini_lock_path = str(agy_dir / ".git" / "GEMINI.md.lock")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    real_flock = fcntl_mod.flock
+    operations: list[tuple[str, int]] = []
+    settings_content_at_unlock: list[str | None] = [None]
+
+    def tracking_flock(fd, operation):
+        name = str(getattr(fd, "name", ""))
+        if settings_lock_path in name:
+            label = "settings"
+        elif gemini_lock_path in name:
+            label = "gemini"
+        else:
+            label = "other"
+        if label == "settings" and operation == fcntl_mod.LOCK_UN:
+            settings_content_at_unlock[0] = settings_file.read_text(encoding="utf-8")
+        operations.append((label, operation))
+        real_flock(fd, operation)
+
+    monkeypatch.setattr(fcntl_mod, "flock", tracking_flock)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    AntigravityBackend().run(
+        FakeRunner(antigravity_outputs=[("ok", 0)]),
+        config, "Review.", role="reviewer",
+    )
+
+    relevant = [(label, op) for label, op in operations if label in ("settings", "gemini")]
+    assert relevant == [
+        ("settings", fcntl_mod.LOCK_EX),
+        ("gemini", fcntl_mod.LOCK_EX),
+        ("gemini", fcntl_mod.LOCK_UN),
+        ("settings", fcntl_mod.LOCK_UN),
+    ]
+    assert settings_content_at_unlock[0] == original_text
+
+
+def test_antigravity_settings_lock_serializes_reviewer_vs_reviewer(tmp_path, monkeypatch):
+    """Two concurrent reviewer runs are serialized: runner B starts only after A completes."""
+    import threading
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text('{"k": "v"}', encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    order: list[str] = []
+    a_in_runner = threading.Event()
+    a_release = threading.Event()
+    b_in_runner = threading.Event()
+
+    class RunnerA(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            order.append("a_in_runner")
+            a_in_runner.set()
+            a_release.wait(timeout=10)
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    class RunnerB(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            order.append("b_in_runner")
+            b_in_runner.set()
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    def run_a():
+        AntigravityBackend().run(RunnerA(antigravity_outputs=[("ok", 0)]), config, "PromptA", role="reviewer")
+
+    def run_b():
+        AntigravityBackend().run(RunnerB(antigravity_outputs=[("ok", 0)]), config, "PromptB", role="reviewer")
+
+    ta = threading.Thread(target=run_a, daemon=True)
+    ta.start()
+    a_in_runner.wait(timeout=10)
+
+    tb = threading.Thread(target=run_b, daemon=True)
+    tb.start()
+
+    a_release.set()
+    b_in_runner.wait(timeout=10)
+
+    ta.join(timeout=10)
+    tb.join(timeout=10)
+
+    assert not ta.is_alive(), "Thread A deadlocked"
+    assert not tb.is_alive(), "Thread B deadlocked"
+    assert order == ["a_in_runner", "b_in_runner"]
+    assert settings_file.read_text(encoding="utf-8") == '{"k": "v"}'
+
+
+def test_antigravity_settings_lock_serializes_reviewer_vs_coder_both_orders(
+    tmp_path, monkeypatch
+):
+    """Reviewer-coder and coder-reviewer serialization; LOCK_NB on the contender backend's
+    settings-lock acquisition confirms the holder is actively holding the lock."""
+    import fcntl as fcntl_mod
+    import threading
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    settings_lock_path_str = str(settings_file.with_suffix(".json.lock"))
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    real_flock = fcntl_mod.flock
+    _is_contender: threading.local = threading.local()
+    _probe_done: threading.local = threading.local()
+
+    for holder_role, contender_role in [("reviewer", None), (None, "reviewer")]:
+        settings_file.write_text('{"initial": true}', encoding="utf-8")
+
+        holder_in_runner = threading.Event()
+        release_holder = threading.Event()
+        contender_attempting_lock = threading.Event()
+        contender_probe_done = threading.Event()
+        contender_in_runner = threading.Event()
+        nb_probe_results: list = []
+
+        def instrumented_flock(fd, operation,
+                               _slp=settings_lock_path_str,
+                               _cat=contender_attempting_lock,
+                               _cpd=contender_probe_done,
+                               _nbr=nb_probe_results):
+            if (
+                getattr(_is_contender, "value", False)
+                and _slp in str(getattr(fd, "name", ""))
+                and operation == fcntl_mod.LOCK_EX
+                and not getattr(_probe_done, "done", False)
+            ):
+                _probe_done.done = True
+                _cat.set()
+                try:
+                    real_flock(fd, fcntl_mod.LOCK_EX | fcntl_mod.LOCK_NB)
+                    _nbr.append(None)
+                except BlockingIOError as exc:
+                    _nbr.append(exc)
+                _cpd.set()
+                real_flock(fd, fcntl_mod.LOCK_EX)
+                return
+            real_flock(fd, operation)
+
+        monkeypatch.setattr(fcntl_mod, "flock", instrumented_flock)
+
+        config = make_config(tmp_path, antigravity_dir=agy_dir)
+
+        class HolderRunner(FakeRunner):
+            def run_with_log(self, args, *, cwd, **kwargs):
+                holder_in_runner.set()
+                release_holder.wait(timeout=10)
+                return super().run_with_log(args, cwd=cwd, **kwargs)
+
+        class ContenderRunner(FakeRunner):
+            def run_with_log(self, args, *, cwd, **kwargs):
+                contender_in_runner.set()
+                return super().run_with_log(args, cwd=cwd, **kwargs)
+
+        def run_holder(role=holder_role):
+            AntigravityBackend().run(
+                HolderRunner(antigravity_outputs=[("ok", 0)]),
+                config, "Holder", role=role,
+            )
+
+        def run_contender(role=contender_role):
+            _is_contender.value = True
+            _probe_done.done = False
+            AntigravityBackend().run(
+                ContenderRunner(antigravity_outputs=[("ok", 0)]),
+                config, "Contender", role=role,
+            )
+
+        th = threading.Thread(target=run_holder, daemon=True)
+        th.start()
+        holder_in_runner.wait(timeout=10)
+
+        tc = threading.Thread(target=run_contender, daemon=True)
+        tc.start()
+
+        contender_attempting_lock.wait(timeout=10)
+        contender_probe_done.wait(timeout=10)
+        release_holder.set()
+        contender_in_runner.wait(timeout=10)
+
+        th.join(timeout=10)
+        tc.join(timeout=10)
+
+        assert not th.is_alive(), f"Holder deadlocked (holder_role={holder_role!r})"
+        assert not tc.is_alive(), f"Contender deadlocked (contender_role={contender_role!r})"
+        assert contender_in_runner.is_set()
+        assert len(nb_probe_results) == 1
+        assert isinstance(nb_probe_results[0], BlockingIOError), (
+            f"LOCK_NB probe should have failed with BlockingIOError "
+            f"but got {nb_probe_results[0]!r} "
+            f"(holder_role={holder_role!r}, contender_role={contender_role!r})"
+        )
+
+
+def test_antigravity_settings_lock_restoration_precedes_unlock_on_exception(
+    tmp_path, monkeypatch
+):
+    """Settings are restored before the settings lock is released, even when runner raises.
+
+    Thread A: reviewer run; runner signals `injected_event` (settings injected, lock held),
+    waits for `contention_confirmed_event`, then raises RuntimeError.
+    Thread B: raw-lock contender; LOCK_NB proves A holds the lock, then blocks on LOCK_EX.
+    After A's exception path restores settings and releases the lock, B unblocks and
+    reads the settings file — which must already be restored to the original content.
+    """
+    import fcntl as fcntl_mod
+    import threading
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    settings_lock_path = settings_file.with_suffix(".json.lock")
+    original_text = '{"preserve": "this"}'
+    settings_file.write_text(original_text, encoding="utf-8")
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    injected_event = threading.Event()
+    contention_confirmed_event = threading.Event()
+    thread_a_exc: list[BaseException | None] = [None]
+    thread_b_result: list[str | None] = [None]
+    thread_b_nb_error: list = [None]
+
+    class InjectingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            injected_event.set()
+            contention_confirmed_event.wait(timeout=10)
+            raise RuntimeError("simulated reviewer failure")
+
+    def run_a():
+        try:
+            AntigravityBackend().run(
+                InjectingRunner(),
+                make_config(tmp_path, antigravity_dir=agy_dir),
+                "Review.", role="reviewer",
+            )
+        except RuntimeError as exc:
+            thread_a_exc[0] = exc
+
+    def run_b():
+        lock_f = settings_lock_path.open("a+")
+        try:
+            try:
+                fcntl_mod.flock(lock_f, fcntl_mod.LOCK_EX | fcntl_mod.LOCK_NB)
+                thread_b_nb_error[0] = None
+            except BlockingIOError as exc:
+                thread_b_nb_error[0] = exc
+            contention_confirmed_event.set()
+            fcntl_mod.flock(lock_f, fcntl_mod.LOCK_EX)
+            thread_b_result[0] = settings_file.read_text(encoding="utf-8")
+        finally:
+            fcntl_mod.flock(lock_f, fcntl_mod.LOCK_UN)
+            lock_f.close()
+
+    ta = threading.Thread(target=run_a, daemon=True)
+    ta.start()
+    injected_event.wait(timeout=10)
+
+    tb = threading.Thread(target=run_b, daemon=True)
+    tb.start()
+
+    ta.join(timeout=10)
+    tb.join(timeout=10)
+
+    assert not ta.is_alive(), "Thread A deadlocked"
+    assert not tb.is_alive(), "Thread B deadlocked"
+    assert isinstance(thread_a_exc[0], RuntimeError)
+    assert isinstance(thread_b_nb_error[0], BlockingIOError), (
+        f"LOCK_NB should have raised BlockingIOError; got {thread_b_nb_error[0]!r}"
+    )
+    assert thread_b_result[0] == original_text, (
+        f"Settings must be restored before the lock is released; got {thread_b_result[0]!r}"
+    )
+
+
+def test_reviewer_and_coder_call_sites_pass_correct_role(tmp_path):
+    """_run_validated_agent propagates role= to run_agent_result correctly."""
+    from unittest.mock import patch
+    from coding_review_agent_loop.agents.base import AgentResult
+
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+    captured_roles: list = []
+
+    def mock_run(runner, *, agent, config, prompt, session_id=None, run_id=None, role=None):
+        captured_roles.append(role)
+        return AgentResult(text="ok")
+
+    with patch("coding_review_agent_loop.orchestrator.run_agent_result", mock_run):
+        _run_validated_agent(
+            FakeRunner(),
+            agent="gemini",
+            config=config,
+            prompt="Review the plan.",
+            marker_description="test",
+            validate=lambda text: text,
+            role="reviewer",
+        )
+
+    assert captured_roles == ["reviewer"]
+    captured_roles.clear()
+
+    with patch("coding_review_agent_loop.orchestrator.run_agent_result", mock_run):
+        _run_validated_agent(
+            FakeRunner(),
+            agent="gemini",
+            config=config,
+            prompt="Implement.",
+            marker_description="test",
+            validate=lambda text: text,
+        )
+
+    assert captured_roles == [None]
+
+
+def test_run_agent_result_passes_role_to_backend(tmp_path, monkeypatch):
+    """run_agent_result threads role= through to the backend's run() method."""
+    from coding_review_agent_loop.agents.registry import run_agent_result
+    from coding_review_agent_loop.agents.base import AgentResult
+    from coding_review_agent_loop.agents import registry as reg_mod
+
+    captured: dict = {}
+
+    class TrackingBackend:
+        name = "gemini"
+        display_name = "Gemini"
+        signature = "Google Gemini"
+
+        def workdir(self, config):
+            return tmp_path
+
+        def default_args(self, *, dangerous):
+            return ()
+
+        def run(self, runner, config, prompt, session_id=None, run_id=None, role=None):
+            captured["role"] = role
+            return AgentResult(text="ok")
+
+    monkeypatch.setitem(reg_mod.BACKENDS, "gemini", TrackingBackend())
+    config = make_config(tmp_path, reviewer="gemini")
+    run_agent_result(FakeRunner(), agent="gemini", config=config, prompt="Test", role="reviewer")
+    assert captured["role"] == "reviewer"


### PR DESCRIPTION
## Summary

- Fixes the 5-minute `--print-timeout` hang in Antigravity reviewer runs: `agy`'s default `toolPermission:request-review` blocks on an approval prompt for undeclared tools in non-interactive `--print` mode; injecting `toolPermission:strict` makes undeclared tools fail immediately
- Adds `role: str | None = None` to `AgentBackend.run()` Protocol and all implementations; `role="reviewer"` is passed at the two reviewer call sites (plan-review loop, PR-review loop)
- `AntigravityBackend.run()` acquires a global settings lock (outer) → GEMINI.md lock (inner) for all agy runs; reviewer runs inject `_REVIEWER_SETTINGS_INJECTION` with verbatim save/restore and strip `--dangerously-skip-permissions`; coder runs hold the settings lock without modifying the file
- 16 new tests: correctness (inject/restore, exception path, write-failure restoration, non-reviewer no-touch, malformed JSON, non-object JSON, flag stripping), lock-order proof with `tracking_flock` that captures settings content at `LOCK_UN` time, reviewer-vs-reviewer and reviewer-vs-coder serialization with LOCK_NB contention proofs, exception-path restoration test with raw-lock contender

## Test plan

- [x] `pytest tests/test_agent_loop.py` — 822 passed (16 new tests all green)
- [x] All existing 806 tests continue to pass (no regressions)

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)