### PR TITLE
Reviewer: suggest one-line fixes as same-plan follow-ups, not future issues

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -627,7 +627,11 @@ Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
 follow-ups are small current-plan refinements that must be incorporated before
 implementation starts; they may appear only in blocking plan reviews. Future
 follow-ups are independent later work that remains valid after the current
-plan is approved; they are allowed only in approved plan reviews. A concern or
+plan is approved; they are allowed only in approved plan reviews. Before adding a
+`future_followups` entry, ask whether the finding is a one-line or trivially small
+mechanical change — initialising a variable, renaming for clarity, adding a missing
+annotation. If so, put it in `same_plan_followups` instead; a separate PR just for a
+one-liner adds overhead without value. A concern or
 paraphrase belongs in exactly one current-round list: `blocking_plan_issues`,
 `same_plan_followups`, or `future_followups`. Do not duplicate or reclassify
 the same concern across Same-plan and Future follow-up lists.
@@ -950,7 +954,11 @@ Blocking plan issues and Same-plan follow-ups both prevent approval. Same-plan
 follow-ups are small current-plan refinements that must be incorporated before
 implementation starts; they may appear only in blocking plan reviews. Future
 follow-ups are independent later work that remains valid after the current
-plan is approved; they are allowed only in approved plan reviews. A concern or
+plan is approved; they are allowed only in approved plan reviews. Before adding a
+`future_followups` entry, ask whether the finding is a one-line or trivially small
+mechanical change — initialising a variable, renaming for clarity, adding a missing
+annotation. If so, put it in `same_plan_followups` instead; a separate PR just for a
+one-liner adds overhead without value. A concern or
 paraphrase belongs in exactly one current-round list: `blocking_plan_issues`,
 `same_plan_followups`, or `future_followups`. Do not duplicate or reclassify
 the same concern across Same-plan and Future follow-up lists.
@@ -1714,7 +1722,10 @@ carried-forward prior unresolved items left active for this round.
 Same-PR follow-ups will be sent back to {coder_name} and require another review
 round before final approval. Before returning approved, self-check that no
 Future follow-up is trivial or local to the current PR; reclassify it as
-Same-PR or omit it. Do not put trivial style nits in either follow-up section.
+Same-PR or omit it. One-line correctness fixes (e.g. initialising a needed variable)
+belong in `blocking_items`; one-line cleanup (e.g. renaming for clarity, adding an
+annotation) belongs in `same_pr_followups`. Neither belongs in `future_followups`.
+Do not put trivial style nits in either follow-up section.
 If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
 follow-ups; keep all required current-round work in the blocking review so it
 is not missed during revision.
@@ -1737,6 +1748,9 @@ Do not use the Same-PR follow-ups section in this mode; mark the review blocking
 instead when small or local cleanup should be fixed before merge.
 Before returning approved, self-check that no Future follow-up is trivial or
 local to the current PR; reclassify it as blocking current-PR work or omit it.
+One-line or trivially small mechanical fixes — whether a correctness issue (initialising a
+needed variable) or cleanup (renaming for clarity, adding an annotation) — belong in the
+current round as blocking work, not in a future issue.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
@@ -1914,7 +1928,10 @@ carried-forward prior unresolved items left active for this round.
 Same-PR follow-ups will be sent back to {coder_name} and require another review
 round before final approval. Before returning approved, self-check that no
 Future follow-up is trivial or local to the current PR; reclassify it as
-Same-PR or omit it. Do not put trivial style nits in either follow-up section.
+Same-PR or omit it. One-line correctness fixes (e.g. initialising a needed variable)
+belong in `blocking_items`; one-line cleanup (e.g. renaming for clarity, adding an
+annotation) belongs in `same_pr_followups`. Neither belongs in `future_followups`.
+Do not put trivial style nits in either follow-up section.
 If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
 follow-ups; keep all required current-round work in the blocking review so it
 is not missed during revision.
@@ -1937,6 +1954,9 @@ Do not use the Same-PR follow-ups section in this mode; mark the review blocking
 instead when small or local cleanup should be fixed before merge.
 Before returning approved, self-check that no Future follow-up is trivial or
 local to the current PR; reclassify it as blocking current-PR work or omit it.
+One-line or trivially small mechanical fixes — whether a correctness issue (initialising a
+needed variable) or cleanup (renaming for clarity, adding an annotation) — belong in the
+current round as blocking work, not in a future issue.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9570,6 +9570,40 @@ def test_review_prompt_allows_same_pr_followups_for_fix_modes(tmp_path):
     ) in prompt
 
 
+def test_plan_review_prompt_directs_one_liner_to_same_plan(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex",))
+    for compact in (False, True):
+        prompt = build_plan_review_prompt(
+            56, 1, "Plan.", config, reviewer="codex", compact_context=compact
+        )
+        # Proves the guidance names future_followups as the excluded destination
+        assert "Before adding a\n`future_followups` entry" in prompt
+        # Proves the destination is same_plan_followups (not future)
+        assert "same_plan_followups` instead" in prompt
+        # Proves the classification-threshold text is present
+        assert "trivially small\nmechanical change" in prompt
+
+
+def test_review_prompt_one_liner_preserves_blocking_vs_same_pr_in_fix_and_mode(tmp_path):
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    for compact in (False, True):
+        prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact)
+        # Proves defect one-liners stay in blocking_items, cleanup goes to same_pr_followups
+        assert "blocking_items`; one-line cleanup" in prompt
+        # Proves explicit exclusion from future_followups
+        assert "Neither belongs in `future_followups`" in prompt
+
+
+def test_review_prompt_one_liner_excluded_from_future_in_standard_mode(tmp_path):
+    config = make_config(tmp_path, approved_followups="summarize")
+    for compact in (False, True):
+        prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact)
+        # Proves exclusion from future follow-up issues
+        assert "not in a future issue" in prompt
+        # Proves the classification-threshold text is present
+        assert "trivially small mechanical fixes" in prompt
+
+
 def test_same_pr_followup_prompt_no_longer_claims_pr_was_approved(tmp_path):
     config = make_config(tmp_path)
 


### PR DESCRIPTION
## Summary

- Add guidance to plan-review prompts (compact and non-compact) directing reviewers to use `same_plan_followups` for one-line or trivially small mechanical changes rather than `future_followups`, avoiding unnecessary PR-cycle overhead for one-liners.
- Add guidance to PR-review prompts (fix-and-* mode) clarifying that one-line correctness fixes belong in `blocking_items` and one-line cleanup belongs in `same_pr_followups` — neither in `future_followups`.
- Add guidance to PR-review prompts (standard mode) that one-line or trivially small mechanical fixes belong in the current review round as blocking work, not as a future issue.
- Add three targeted tests asserting the semantic direction and explicit `future_followups` exclusion for both compact and non-compact paths.

## Test plan

- [ ] `python3 -m pytest tests/test_agent_loop.py::test_plan_review_prompt_directs_one_liner_to_same_plan` — verifies plan-review guidance in both compact/non-compact paths
- [ ] `python3 -m pytest tests/test_agent_loop.py::test_review_prompt_one_liner_preserves_blocking_vs_same_pr_in_fix_and_mode` — verifies fix-and-* PR-review guidance
- [ ] `python3 -m pytest tests/test_agent_loop.py::test_review_prompt_one_liner_excluded_from_future_in_standard_mode` — verifies standard PR-review guidance
- [ ] `python3 -m pytest tests/test_agent_loop.py -q` — full suite (836 passed)

Fixes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)