### PR TITLE
Factor duplicated followup_guidance blocks into shared helper

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1675,85 +1675,7 @@ merge, use `"blocking"` or `"same-pr"` instead. For any prior item already marke
 """
     else:
         unresolved_items_guidance = ""
-    coder_name = agent_display_name(config.coder)
-    if config.approved_followups == "ignore":
-        followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
-Non-blocking follow-ups sections in approved reviews; this run is configured to
-ignore approved-review follow-up sections. Mark the review blocking instead
-when cleanup should be fixed before merge.
-Trivial style nits in touched code should be omitted unless worth requiring
-before merge; if required, they are current-PR work and the review is blocking,
-not approved with Future follow-ups.
-"""
-    elif config.approved_followups.startswith("fix-and-"):
-        followup_guidance = f"""For small, localized, low-risk cleanup that must still be fixed in this PR
-before merge, return `<!-- AGENT_STATE: blocking -->` and list those items
-under this exact heading:
-
-### Same-PR follow-ups
-
-Use Same-PR follow-ups only for narrow current-PR cleanup in files already
-touched by this PR or directly adjacent code. This includes indentation or
-style cleanup in touched code when it is worth requiring before merge, and
-duplicated helper or prompt wording introduced by this PR. Do not use this
-section for larger redesigns, broad refactors, or independent future work.
-Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
-`blocking_items` for defects, missing requirements, regressions, security
-issues, or consistency gaps that make the PR not merge-ready. Use
-`same_pr_followups` only for small localized cleanup that should be handled in
-this PR but is not itself the reason the PR is blocked.
-Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
-follow-up remains, including a carried-forward prior item that stays
-`still blocking` or `same-pr`, the review is not approved yet.
-
-If the PR is otherwise fully complete for this round but you notice substantial
-work that is better handled separately in a future issue or PR, list at most
-three highest-value items under this exact heading:
-
-### Future follow-ups
-
-Use Future follow-ups only for independent later work that is not necessary for
-this PR to be merge-ready, such as a broader scaling or performance refinement
-for very large histories. Do not put small cleanup in touched or directly
-adjacent code under Future follow-ups; classify it as Same-PR if it should be
-done before merge, otherwise omit it.
-Approved means there are no blocking issues, no Same-PR follow-ups, and no
-carried-forward prior unresolved items left active for this round.
-Same-PR follow-ups will be sent back to {coder_name} and require another review
-round before final approval. Before returning approved, self-check that no
-Future follow-up is trivial or local to the current PR; reclassify it as
-Same-PR or omit it. One-line correctness fixes (e.g. initialising a needed variable)
-belong in `blocking_items`; one-line cleanup (e.g. renaming for clarity, adding an
-annotation) belongs in `same_pr_followups`. Neither belongs in `future_followups`.
-Do not put trivial style nits in either follow-up section.
-If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
-follow-ups; keep all required current-round work in the blocking review so it
-is not missed during revision.
-"""
-    else:
-        followup_guidance = """If you approve but notice substantial work that is better handled separately in
-a future issue or PR, list at most three highest-value items under this exact
-heading:
-
-### Future follow-ups
-
-Use Future follow-ups only for independent later work that is not necessary for
-this PR to be merge-ready, such as a broader scaling or performance refinement
-for very large histories. Do not put small cleanup in touched or directly
-adjacent code under Future follow-ups. Indentation/style cleanup in touched
-code should be omitted unless worth requiring before merge; duplicated helper
-or prompt wording introduced by this PR should make the review blocking if it
-must be fixed now.
-Do not use the Same-PR follow-ups section in this mode; mark the review blocking
-instead when small or local cleanup should be fixed before merge.
-Before returning approved, self-check that no Future follow-up is trivial or
-local to the current PR; reclassify it as blocking current-PR work or omit it.
-One-line or trivially small mechanical fixes — whether a correctness issue (initialising a
-needed variable) or cleanup (renaming for clarity, adding an annotation) — belong in the
-current round as blocking work, not in a future issue.
-The legacy heading `### Non-blocking follow-ups` is still accepted as future
-follow-ups for compatibility, but prefer `### Future follow-ups`.
-"""
+    followup_guidance = _build_followup_guidance(config)
     stable_prefix = _compact_pr_review_stable_prefix(
         config=config,
         workdir_guidance=_coder_workdir_guidance(config, implementation=False, agent=reviewer),
@@ -1808,6 +1730,88 @@ or:
 
 Use blocking only for issues that should prevent merge. Always sign your response:
 -- {reviewer_signature}
+"""
+
+
+def _build_followup_guidance(config: AgentLoopConfig) -> str:
+    coder_name = agent_display_name(config.coder)
+    if config.approved_followups == "ignore":
+        return """Do not include Same-PR follow-ups, Future follow-ups, or legacy
+Non-blocking follow-ups sections in approved reviews; this run is configured to
+ignore approved-review follow-up sections. Mark the review blocking instead
+when cleanup should be fixed before merge.
+Trivial style nits in touched code should be omitted unless worth requiring
+before merge; if required, they are current-PR work and the review is blocking,
+not approved with Future follow-ups.
+"""
+    elif config.approved_followups.startswith("fix-and-"):
+        return f"""For small, localized, low-risk cleanup that must still be fixed in this PR
+before merge, return `<!-- AGENT_STATE: blocking -->` and list those items
+under this exact heading:
+
+### Same-PR follow-ups
+
+Use Same-PR follow-ups only for narrow current-PR cleanup in files already
+touched by this PR or directly adjacent code. This includes indentation or
+style cleanup in touched code when it is worth requiring before merge, and
+duplicated helper or prompt wording introduced by this PR. Do not use this
+section for larger redesigns, broad refactors, or independent future work.
+Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
+`blocking_items` for defects, missing requirements, regressions, security
+issues, or consistency gaps that make the PR not merge-ready. Use
+`same_pr_followups` only for small localized cleanup that should be handled in
+this PR but is not itself the reason the PR is blocked.
+Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
+follow-up remains, including a carried-forward prior item that stays
+`still blocking` or `same-pr`, the review is not approved yet.
+
+If the PR is otherwise fully complete for this round but you notice substantial
+work that is better handled separately in a future issue or PR, list at most
+three highest-value items under this exact heading:
+
+### Future follow-ups
+
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups; classify it as Same-PR if it should be
+done before merge, otherwise omit it.
+Approved means there are no blocking issues, no Same-PR follow-ups, and no
+carried-forward prior unresolved items left active for this round.
+Same-PR follow-ups will be sent back to {coder_name} and require another review
+round before final approval. Before returning approved, self-check that no
+Future follow-up is trivial or local to the current PR; reclassify it as
+Same-PR or omit it. One-line correctness fixes (e.g. initialising a needed variable)
+belong in `blocking_items`; one-line cleanup (e.g. renaming for clarity, adding an
+annotation) belongs in `same_pr_followups`. Neither belongs in `future_followups`.
+Do not put trivial style nits in either follow-up section.
+If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
+follow-ups; keep all required current-round work in the blocking review so it
+is not missed during revision.
+"""
+    else:
+        return """If you approve but notice substantial work that is better handled separately in
+a future issue or PR, list at most three highest-value items under this exact
+heading:
+
+### Future follow-ups
+
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups. Indentation/style cleanup in touched
+code should be omitted unless worth requiring before merge; duplicated helper
+or prompt wording introduced by this PR should make the review blocking if it
+must be fixed now.
+Do not use the Same-PR follow-ups section in this mode; mark the review blocking
+instead when small or local cleanup should be fixed before merge.
+Before returning approved, self-check that no Future follow-up is trivial or
+local to the current PR; reclassify it as blocking current-PR work or omit it.
+One-line or trivially small mechanical fixes — whether a correctness issue (initialising a
+needed variable) or cleanup (renaming for clarity, adding an annotation) — belong in the
+current round as blocking work, not in a future issue.
+The legacy heading `### Non-blocking follow-ups` is still accepted as future
+follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
 
 
@@ -1882,84 +1886,7 @@ merge, use `"blocking"` or `"same-pr"` instead. For any prior item already marke
 """
     else:
         unresolved_items_guidance = ""
-    if config.approved_followups == "ignore":
-        followup_guidance = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
-Non-blocking follow-ups sections in approved reviews; this run is configured to
-ignore approved-review follow-up sections. Mark the review blocking instead
-when cleanup should be fixed before merge.
-Trivial style nits in touched code should be omitted unless worth requiring
-before merge; if required, they are current-PR work and the review is blocking,
-not approved with Future follow-ups.
-"""
-    elif config.approved_followups.startswith("fix-and-"):
-        followup_guidance = f"""For small, localized, low-risk cleanup that must still be fixed in this PR
-before merge, return `<!-- AGENT_STATE: blocking -->` and list those items
-under this exact heading:
-
-### Same-PR follow-ups
-
-Use Same-PR follow-ups only for narrow current-PR cleanup in files already
-touched by this PR or directly adjacent code. This includes indentation or
-style cleanup in touched code when it is worth requiring before merge, and
-duplicated helper or prompt wording introduced by this PR. Do not use this
-section for larger redesigns, broad refactors, or independent future work.
-Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
-`blocking_items` for defects, missing requirements, regressions, security
-issues, or consistency gaps that make the PR not merge-ready. Use
-`same_pr_followups` only for small localized cleanup that should be handled in
-this PR but is not itself the reason the PR is blocked.
-Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
-follow-up remains, including a carried-forward prior item that stays
-`still blocking` or `same-pr`, the review is not approved yet.
-
-If the PR is otherwise fully complete for this round but you notice substantial
-work that is better handled separately in a future issue or PR, list at most
-three highest-value items under this exact heading:
-
-### Future follow-ups
-
-Use Future follow-ups only for independent later work that is not necessary for
-this PR to be merge-ready, such as a broader scaling or performance refinement
-for very large histories. Do not put small cleanup in touched or directly
-adjacent code under Future follow-ups; classify it as Same-PR if it should be
-done before merge, otherwise omit it.
-Approved means there are no blocking issues, no Same-PR follow-ups, and no
-carried-forward prior unresolved items left active for this round.
-Same-PR follow-ups will be sent back to {coder_name} and require another review
-round before final approval. Before returning approved, self-check that no
-Future follow-up is trivial or local to the current PR; reclassify it as
-Same-PR or omit it. One-line correctness fixes (e.g. initialising a needed variable)
-belong in `blocking_items`; one-line cleanup (e.g. renaming for clarity, adding an
-annotation) belongs in `same_pr_followups`. Neither belongs in `future_followups`.
-Do not put trivial style nits in either follow-up section.
-If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
-follow-ups; keep all required current-round work in the blocking review so it
-is not missed during revision.
-"""
-    else:
-        followup_guidance = """If you approve but notice substantial work that is better handled separately in
-a future issue or PR, list at most three highest-value items under this exact
-heading:
-
-### Future follow-ups
-
-Use Future follow-ups only for independent later work that is not necessary for
-this PR to be merge-ready, such as a broader scaling or performance refinement
-for very large histories. Do not put small cleanup in touched or directly
-adjacent code under Future follow-ups. Indentation/style cleanup in touched
-code should be omitted unless worth requiring before merge; duplicated helper
-or prompt wording introduced by this PR should make the review blocking if it
-must be fixed now.
-Do not use the Same-PR follow-ups section in this mode; mark the review blocking
-instead when small or local cleanup should be fixed before merge.
-Before returning approved, self-check that no Future follow-up is trivial or
-local to the current PR; reclassify it as blocking current-PR work or omit it.
-One-line or trivially small mechanical fixes — whether a correctness issue (initialising a
-needed variable) or cleanup (renaming for clarity, adding an annotation) — belong in the
-current round as blocking work, not in a future issue.
-The legacy heading `### Non-blocking follow-ups` is still accepted as future
-follow-ups for compatibility, but prefer `### Future follow-ups`.
-"""
+    followup_guidance = _build_followup_guidance(config)
     return f"""Review pull request #{pr_number} in {config.repo} (round {round_number}).
 
 PR metadata:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -125,6 +125,7 @@ from coding_review_agent_loop.prompts import (
     CompactPriorContext,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
+    _build_followup_guidance,
     build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
@@ -20331,3 +20332,109 @@ def test_run_agent_result_passes_role_to_backend(tmp_path, monkeypatch):
     config = make_config(tmp_path, reviewer="gemini")
     run_agent_result(FakeRunner(), agent="gemini", config=config, prompt="Test", role="reviewer")
     assert captured["role"] == "reviewer"
+
+
+# ---------------------------------------------------------------------------
+# _build_followup_guidance unit and integration tests (#413)
+# ---------------------------------------------------------------------------
+
+_EXPECTED_FOLLOWUP_IGNORE = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
+Non-blocking follow-ups sections in approved reviews; this run is configured to
+ignore approved-review follow-up sections. Mark the review blocking instead
+when cleanup should be fixed before merge.
+Trivial style nits in touched code should be omitted unless worth requiring
+before merge; if required, they are current-PR work and the review is blocking,
+not approved with Future follow-ups.
+"""
+
+_EXPECTED_FOLLOWUP_FIX_AND = """For small, localized, low-risk cleanup that must still be fixed in this PR
+before merge, return `<!-- AGENT_STATE: blocking -->` and list those items
+under this exact heading:
+
+### Same-PR follow-ups
+
+Use Same-PR follow-ups only for narrow current-PR cleanup in files already
+touched by this PR or directly adjacent code. This includes indentation or
+style cleanup in touched code when it is worth requiring before merge, and
+duplicated helper or prompt wording introduced by this PR. Do not use this
+section for larger redesigns, broad refactors, or independent future work.
+Keep `blocking_items` and `same_pr_followups` mutually exclusive. Use
+`blocking_items` for defects, missing requirements, regressions, security
+issues, or consistency gaps that make the PR not merge-ready. Use
+`same_pr_followups` only for small localized cleanup that should be handled in
+this PR but is not itself the reason the PR is blocked.
+Same-PR follow-ups may appear only in blocking reviews. If any Same-PR
+follow-up remains, including a carried-forward prior item that stays
+`still blocking` or `same-pr`, the review is not approved yet.
+
+If the PR is otherwise fully complete for this round but you notice substantial
+work that is better handled separately in a future issue or PR, list at most
+three highest-value items under this exact heading:
+
+### Future follow-ups
+
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups; classify it as Same-PR if it should be
+done before merge, otherwise omit it.
+Approved means there are no blocking issues, no Same-PR follow-ups, and no
+carried-forward prior unresolved items left active for this round.
+Same-PR follow-ups will be sent back to Claude and require another review
+round before final approval. Before returning approved, self-check that no
+Future follow-up is trivial or local to the current PR; reclassify it as
+Same-PR or omit it. One-line correctness fixes (e.g. initialising a needed variable)
+belong in `blocking_items`; one-line cleanup (e.g. renaming for clarity, adding an
+annotation) belongs in `same_pr_followups`. Neither belongs in `future_followups`.
+Do not put trivial style nits in either follow-up section.
+If you return `<!-- AGENT_STATE: blocking -->`, do not use structured Future
+follow-ups; keep all required current-round work in the blocking review so it
+is not missed during revision.
+"""
+
+_EXPECTED_FOLLOWUP_ELSE = """If you approve but notice substantial work that is better handled separately in
+a future issue or PR, list at most three highest-value items under this exact
+heading:
+
+### Future follow-ups
+
+Use Future follow-ups only for independent later work that is not necessary for
+this PR to be merge-ready, such as a broader scaling or performance refinement
+for very large histories. Do not put small cleanup in touched or directly
+adjacent code under Future follow-ups. Indentation/style cleanup in touched
+code should be omitted unless worth requiring before merge; duplicated helper
+or prompt wording introduced by this PR should make the review blocking if it
+must be fixed now.
+Do not use the Same-PR follow-ups section in this mode; mark the review blocking
+instead when small or local cleanup should be fixed before merge.
+Before returning approved, self-check that no Future follow-up is trivial or
+local to the current PR; reclassify it as blocking current-PR work or omit it.
+One-line or trivially small mechanical fixes — whether a correctness issue (initialising a
+needed variable) or cleanup (renaming for clarity, adding an annotation) — belong in the
+current round as blocking work, not in a future issue.
+The legacy heading `### Non-blocking follow-ups` is still accepted as future
+follow-ups for compatibility, but prefer `### Future follow-ups`.
+"""
+
+
+@pytest.mark.parametrize(
+    "approved_followups,expected",
+    [
+        ("ignore", _EXPECTED_FOLLOWUP_IGNORE),
+        ("fix-and-review", _EXPECTED_FOLLOWUP_FIX_AND),
+        ("summarize", _EXPECTED_FOLLOWUP_ELSE),
+    ],
+)
+def test_build_followup_guidance_branches(tmp_path, approved_followups, expected):
+    config = make_config(tmp_path, approved_followups=approved_followups)
+    assert _build_followup_guidance(config) == expected
+
+
+@pytest.mark.parametrize("approved_followups", ["ignore", "fix-and-review", "summarize"])
+def test_build_review_prompt_followup_guidance_parity(tmp_path, approved_followups):
+    config = make_config(tmp_path, approved_followups=approved_followups)
+    g = _build_followup_guidance(config)
+    non_compact = build_review_prompt(77, 1, config, reviewer="codex", compact_context=False)
+    compact = build_review_prompt(77, 1, config, reviewer="codex", compact_context=True)
+    assert g in non_compact
+    assert g in compact


### PR DESCRIPTION
## Summary

- Extracts the three-branch `followup_guidance` construction (`ignore` / `fix-and-*` / else) that was duplicated identically in `build_review_prompt` and `_build_compact_pr_review_prompt` into a single private helper `_build_followup_guidance(config)` in `prompts.py`.
- Replaces both inline blocks with a one-liner `followup_guidance = _build_followup_guidance(config)`.
- Removes the now-unused `coder_name` local assignment from `_build_compact_pr_review_prompt` (it was only used by the followup_guidance block there).

## Tests

Two new parametrised tests added to `tests/test_agent_loop.py`:

- `test_build_followup_guidance_branches` — full-string equality assertions on `_build_followup_guidance(config)` for all three modes (`ignore`, `fix-and-review`, `summarize`), including coder-name interpolation in the `fix-and-*` branch.
- `test_build_review_prompt_followup_guidance_parity` — integration assertion that the helper's complete output appears verbatim in both `compact_context=False` and `compact_context=True` prompt paths.

Full test suite: 842 passed, 0 failed.

Fixes #413

🤖 Generated with [Claude Code](https://claude.ai/claude-code)