### PR TITLE
Preserve future plan follow-ups across mixed rounds

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -141,7 +141,6 @@ from .followups import (
     APPROVED_FOLLOWUP_MARKER_RE,
     GroupedApprovedFollowup,
     MAX_APPROVED_FOLLOWUP_ISSUES,
-    PlanApprovedFollowupSource,
     _append_approved_followups_marker,
     _approved_followup_from_unresolved_item,
     _approved_followups_marker,
@@ -1627,7 +1626,6 @@ def _run_plan_first_loop(
     reviewer_session_ids: dict[AgentName, str | None] = {}
     unresolved_items: list[UnresolvedReviewItem] = []
     compact_prior_summaries: list[str] = []
-    approved_future_followup_sources: list[PlanApprovedFollowupSource] = []
     next_unresolved_item_number = 1
     resume_state = _resume_plan_round(issue_context.comments, configured_reviewers=configured_reviewers)
     if resume_state is None:
@@ -1724,7 +1722,6 @@ def _run_plan_first_loop(
             and round_number >= 2
             and round_ledger_incomplete
         ) else ""
-        round_approved_future_followup_sources: list[PlanApprovedFollowupSource] = []
         blocking_reviews: list[tuple[str, str]] = []
         approved_review_outputs: list[tuple[str, str]] = []
         all_approved = True
@@ -1860,9 +1857,6 @@ def _run_plan_first_loop(
                     round_new_unresolved_items.append(tracked_item)
                     reviewer_new_unresolved_items.append(tracked_item)
                     next_unresolved_item_number += 1
-                    round_approved_future_followup_sources.append(
-                        _plan_followup_source_from_unresolved_item(tracked_item)
-                    )
                 post_issue_comment(
                     runner,
                     config=config,
@@ -1896,31 +1890,23 @@ def _run_plan_first_loop(
                 )
             else:
                 round_new_unresolved_items.extend(reviewer_new_unresolved_items)
-                round_approved_future_followup_sources.extend(
-                    _plan_followup_source_from_unresolved_item(item)
-                    for item in reviewer_new_unresolved_items
-                    if item.status == "future"
-                )
 
-        unresolved_items, future_from_prior_items = _apply_unresolved_item_dispositions(
+        unresolved_items, _ = _apply_unresolved_item_dispositions(
             prior_unresolved_items,
             prior_dispositions,
             same_status="same-plan",
-            retain_future=False,
+            retain_future=True,
         )
         compact_prior_summaries.extend(
             _collect_prior_compact_summaries(
                 prior_unresolved_items,
                 unresolved_items,
-                future_from_prior_items,
+                (),
                 prior_dispositions,
             )
         )
         unresolved_items = [*unresolved_items, *round_new_unresolved_items]
         must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-plan"}]
-        approved_future_followup_sources.extend(
-            _plan_followup_source_from_unresolved_item(item) for item in future_from_prior_items
-        )
         if all_approved and not must_fix_items and issue_context.human_requirements:
             missing_acknowledgements = [
                 reviewer_name
@@ -2042,10 +2028,12 @@ def _run_plan_first_loop(
                     ]
                     all_approved = False
 
-        if all_approved:
-            approved_future_followup_sources.extend(round_approved_future_followup_sources)
-
         if all_approved and not must_fix_items:
+            approved_future_followup_sources = [
+                _plan_followup_source_from_unresolved_item(item)
+                for item in unresolved_items
+                if item.status == "future"
+            ]
             plan_hash = approved_plan_hash(current_plan)
             plan_subject = _plan_subject(current_plan)
             mode = config.plan_execution_mode
@@ -2299,14 +2287,13 @@ def _run_plan_first_loop(
                     agent=coder_name,
                     round_number=round_number + 1,
                     subject=_plan_subject(current_plan),
-                    prior_items=tuple(must_fix_items),
+                    prior_items=tuple(unresolved_items),
                     canonical_plan=canonical_plan,
                     raw_structured_coder_response=raw_structured_coder_response,
                     compact_prior_summaries=tuple(compact_prior_summaries),
                 ),
             ),
         )
-        unresolved_items = list(must_fix_items)
         resumed_round = None
 
     raise AgentLoopError(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -14858,6 +14858,229 @@ def test_issue_loop_plan_first_files_approved_future_followups_before_implementa
     assert issue_create_index < second_claude_index
 
 
+def test_issue_loop_plan_first_files_surviving_future_from_mixed_outcome_round(tmp_path):
+    future_text = "Factor the shared follow-up guidance into a reusable helper."
+    runner = FakeRunner(
+        claude_outputs=[
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(
+                summary="Address the blocking test gap.",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-2", "disposition": "resolved", "note": "Added the test."}
+                ],
+                plan_steps=["Make the change.", "Add the missing regression test."],
+            ),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="approved",
+                future_followups=[future_text],
+            ),
+            structured_plan_review(
+                state="approved",
+                prior_plan_item_dispositions=[
+                    {
+                        "item_id": "item-1",
+                        "disposition": "future",
+                        "note": "Keep this as confirmed post-plan cleanup.",
+                    },
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+            ),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        gemini_outputs=[
+            structured_plan_review(
+                state="blocking",
+                blocking_plan_issues=["Add a regression test for the plan-review ledger."],
+                reviewer="Google Gemini",
+            ),
+            structured_plan_review(
+                state="approved",
+                future_followups=[future_text],
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "future"},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="Google Gemini",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="LGTM.",
+                reviewer="Google Gemini",
+            ),
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/99"],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        approved_followups="issue",
+        max_rounds=2,
+    )
+
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
+
+    coder_revision_prompt = next(
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and '"kind": "plan_revision"' in cmd[-1]
+    )
+    assert "item-2" in coder_revision_prompt
+    assert "item-1" not in coder_revision_prompt
+    assert future_text not in coder_revision_prompt
+
+    round_two_reviewer_prompts = [
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if "Planning round: 2" in cmd[-1] and "Role: reviewer" in cmd[-1]
+    ]
+    assert len(round_two_reviewer_prompts) == 2
+    assert all("item-1" in prompt for prompt in round_two_reviewer_prompts)
+
+    assert len(runner.issues) == 1
+    issue_body = runner.issues[0]["body"]
+    assert "Planning round(s): 1, 2" in issue_body
+    assert "Reviewers: Codex, Gemini" in issue_body
+    assert "Original plan item ID(s): item-1, item-3" in issue_body
+    assert "Keep this as confirmed post-plan cleanup." in issue_body
+    assert any(
+        "Reconciliation: 1 filed, 1 deduplicated, 0 skipped by cap." in comment
+        for comment in runner.comments
+    )
+
+    issue_create_index = command_index(runner.commands, ["gh", "issue", "create"])
+    round_two_review_indexes = [
+        index
+        for index, (cmd, _cwd) in enumerate(runner.commands)
+        if "Planning round: 2" in cmd[-1] and "Role: reviewer" in cmd[-1]
+    ]
+    assert issue_create_index > max(round_two_review_indexes)
+
+
+@pytest.mark.parametrize("later_disposition", ["resolved", "same-plan", "blocking"])
+def test_issue_loop_plan_first_does_not_file_future_item_after_later_lifecycle_change(
+    tmp_path, later_disposition
+):
+    future_text = "Extract the shared plan-review formatting helper."
+    promoted = later_disposition in {"same-plan", "blocking"}
+    promotion_state = "blocking" if promoted else "approved"
+    final_plan_dispositions = [
+        {"item_id": "item-1", "disposition": later_disposition},
+        {"item_id": "item-2", "disposition": "resolved"},
+    ]
+    claude_outputs = [
+        "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+        structured_plan_revision(
+            summary="Address the original blocker.",
+            prior_plan_item_dispositions=[{"item_id": "item-2", "disposition": "resolved"}],
+        ),
+    ]
+    if promoted:
+        claude_outputs.append(
+            structured_plan_revision(
+                summary="Address the promoted future item.",
+                prior_plan_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"}
+                ],
+            )
+        )
+    claude_outputs.append(
+        "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n"
+        "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    )
+
+    def reviewer_outputs(reviewer):
+        outputs = [
+            structured_plan_review(
+                state="approved",
+                future_followups=[future_text],
+                reviewer=reviewer,
+            ),
+            structured_plan_review(
+                state=promotion_state,
+                prior_plan_item_dispositions=final_plan_dispositions,
+                reviewer=reviewer,
+            ),
+        ]
+        if promoted:
+            outputs.append(
+                structured_plan_review(
+                    state="approved",
+                    prior_plan_item_dispositions=[
+                        {"item_id": "item-1", "disposition": "resolved"}
+                    ],
+                    reviewer=reviewer,
+                )
+            )
+        outputs.append(structured_pr_review(state="approved", reviewer=reviewer))
+        return outputs
+
+    runner = FakeRunner(
+        claude_outputs=claude_outputs,
+        codex_outputs=reviewer_outputs("OpenAI Codex"),
+        gemini_outputs=[
+            structured_plan_review(
+                state="blocking",
+                blocking_plan_issues=["Add the initial ledger regression."],
+                reviewer="Google Gemini",
+            ),
+            *reviewer_outputs("Google Gemini")[1:],
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        approved_followups="issue",
+        max_rounds=3,
+    )
+
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
+
+    assert runner.issues == []
+    assert not any(future_text in comment for comment in runner.comments[-2:])
+    if promoted:
+        coder_revision_prompts = [
+            cmd[-1]
+            for cmd, _cwd in runner.commands
+            if cmd[:1] == ["claude"] and '"kind": "plan_revision"' in cmd[-1]
+        ]
+        assert len(coder_revision_prompts) == 2
+        assert "item-1" in coder_revision_prompts[1]
+        assert future_text in coder_revision_prompts[1]
+        final_round_review_indexes = [
+            index
+            for index, (cmd, _cwd) in enumerate(runner.commands)
+            if "Planning round: 3" in cmd[-1] and "Role: reviewer" in cmd[-1]
+        ]
+        implementation_index = next(
+            index
+            for index, (cmd, _cwd) in enumerate(runner.commands)
+            if cmd[:1] == ["claude"] and "Implement the approved plan" in cmd[-1]
+        )
+        assert implementation_index > max(final_round_review_indexes)
+
+
 def test_issue_loop_plan_first_ignore_mode_keeps_pr_prior_ledger_clean(tmp_path):
     runner = FakeRunner(
         claude_outputs=[


### PR DESCRIPTION
## Summary
- keep future plan-review items in the reconciled unresolved-item ledger across rounds
- derive publishable future follow-ups only from items still marked future at final approval
- cover mixed-outcome, deduplication, resolution, and promotion lifecycles

## Tests
- `python3 -m pytest tests/test_agent_loop.py -k 'plan_first or apply_unresolved_item_dispositions'`
- `python3 -m pytest`

Fixes #414