### PR TITLE
Clean up compact summaries and response-evidence docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -390,8 +390,10 @@ safe deterministic normalization, envelope normalization, known-ledger
 disposition cleanup, context-specific acknowledgement reconstruction, then a
 Gemini format-repair pass. Pass `--gemini-cmd PATH` to the round/fix command to
 select the Gemini executable used both for Gemini agent turns and repair. The
-agent's original output is saved before recovery. If every recovery stage fails,
-fix the preserved repair-dir `raw.md` with
+skill runner requests the recovery evidence sidecar from `run_external` with
+`--response-evidence-output PATH`, alongside the existing `--usage-output PATH`
+sidecar. The agent's original output is saved before recovery. If every recovery
+stage fails, fix the preserved repair-dir `raw.md` with
 `retry-validate --repair-dir <dir>` (or inspect the PR-fix debug directory), then
 re-run the parent command.
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -164,7 +164,9 @@ as unavailable.
 The same automatic recovery pipeline covers external-coder `plan_revision`
 responses and `run-pr-fix` `coder_followup` responses. Plan revisions may also
 recover one unique, independently valid signed-human-requirements
-acknowledgement from the external agent's captured response evidence. Use
+acknowledgement from the external agent's captured response evidence.
+`skill_runner` requests that sidecar from `run_external` with
+`--response-evidence-output PATH`, alongside `--usage-output PATH`. Use
 `--gemini-cmd PATH` to configure both Gemini agent invocations and the final
 repair pass. The original response is saved before recovery; `retry-validate`
 repair directories and PR-fix debug directories remain the final fallback for

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1907,7 +1907,6 @@ def _run_plan_first_loop(
             _collect_prior_compact_summaries(
                 prior_unresolved_items,
                 unresolved_items,
-                (),
                 prior_dispositions,
             )
         )
@@ -2920,7 +2919,6 @@ def run_pr_loop(
                     _collect_prior_compact_summaries(
                         prior_unresolved_items,
                         unresolved_items,
-                        future_from_prior_items,
                         prior_dispositions,
                     )
                 )

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -347,12 +347,10 @@ def _apply_unresolved_item_dispositions(
 def _collect_prior_compact_summaries(
     prior_items: Sequence[UnresolvedReviewItem],
     remaining_items: Sequence[UnresolvedReviewItem],
-    future_from_prior: Sequence[UnresolvedReviewItem],
     dispositions_by_item: dict[str, list[ReviewItemDisposition]],
 ) -> tuple[str, ...]:
     """Render append-only summaries for prior items that just left the active ledger."""
     remaining_ids = {item.item_id for item in remaining_items}
-    future_ids = {item.item_id for item in future_from_prior}
     summaries: list[str] = []
     for item in sorted(prior_items, key=lambda prior: prior.item_id):
         if item.item_id in remaining_ids:
@@ -360,7 +358,12 @@ def _collect_prior_compact_summaries(
         dispositions = dispositions_by_item.get(item.item_id, [])
         if not dispositions:
             continue
-        label = "future follow-up" if item.item_id in future_ids else "resolved"
+        outcomes = {disposition.disposition for disposition in dispositions}
+        label = (
+            "future follow-up"
+            if "future" in outcomes and not {"blocking", "same-pr", "same-plan"} & outcomes
+            else "resolved"
+        )
         lines = [
             f"[{item.item_id}] {label}: {item.reviewer} {item.source_status or item.status} item from round {item.source_round}",
             "Original item text:",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -101,6 +101,7 @@ from coding_review_agent_loop.orchestrator import (
     ValidatedAgentResponse,
     _apply_unresolved_item_dispositions,
     _attach_round_metadata,
+    _collect_prior_compact_summaries,
     _decode_round_metadata,
     _encode_round_metadata,
     _format_unresolved_item_label,
@@ -6140,6 +6141,41 @@ def test_apply_unresolved_item_dispositions_appends_disposition_notes_to_text():
         "Update from Anthropic Claude: include API error path too"
     )
     assert updated_items[0].notes == ("Anthropic Claude: include API error path too",)
+
+
+@pytest.mark.parametrize(
+    ("disposition", "expected_label"),
+    [("future", "future follow-up"), ("resolved", "resolved")],
+)
+def test_collect_prior_compact_summaries_infers_departed_item_label(
+    disposition, expected_label
+):
+    prior_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Preserve the original item detail.",
+        status="blocking",
+    )
+    dispositions_by_item = {
+        "item-1": [
+            ReviewItemDisposition(
+                item_id="item-1",
+                reviewer="Anthropic Claude",
+                disposition=disposition,
+                note="Reconciled in the current round.",
+            )
+        ]
+    }
+
+    summaries = _collect_prior_compact_summaries(
+        (prior_item,),
+        (),
+        dispositions_by_item,
+    )
+
+    assert summaries[0].startswith(f"[item-1] {expected_label}:")
+    assert "Anthropic Claude: " + disposition in summaries[0]
 
 
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])


### PR DESCRIPTION
## Summary

- remove the redundant `future_from_prior` argument from compact prior-summary collection and infer future labels from reconciled dispositions
- preserve compact PR summary behavior while simplifying the planning-flow call site
- document the `--response-evidence-output` sidecar argument used by `skill_runner` alongside `--usage-output`
- add regression coverage for inferred future/resolved compact-summary labels

Closes #419.
Closes #364.

## Tests

- `python3 -m pytest tests/test_agent_loop.py -k 'collect_prior_compact_summaries or compact_review_mode_uses_fresh_sessions or issue_loop_plan_first_files_surviving_future_from_mixed_outcome_round'` — 4 passed
- `python3 -m pytest` — 1046 passed
