### PR TITLE
Migrate malformed-response repair to Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,25 @@ only the standalone agent signature. The loop renders validated structured
 payloads into normal public GitHub comments, so raw JSON is not posted.
 
 When a structured plan review, plan revision, PR review, or coder follow-up is
-present but malformed, the loop may run one Gemini-backed repair pass. The
-repair pass is format-only: it asks Gemini to re-emit the agent's intent as the
+present but malformed, the loop may run a model-backed repair pass. The default
+backend is Antigravity (`agy`) with the single model `Gemini 3 Flash`. The
+repair pass is format-only: it asks the model to re-emit the agent's intent as the
 required JSON object, footer marker, and signature. The repaired response is
 accepted only if it passes the same strict validation as the original response;
 failed repairs remain local protocol errors and are not posted to GitHub.
+
+Repair runs in a fresh temporary directory with an empty tool allow-list and a
+repair-only `GEMINI.md`; it receives no checkout or repository context. Configure
+it with `--repair-backend antigravity|gemini`, repeat `--repair-model` to define
+an explicit ordered fallback chain, and set `--repair-timeout-seconds`. The
+normal Antigravity coder/reviewer model chain is never inherited. For example:
+
+`--repair-model "Gemini 3 Flash" --repair-model "Gemini 3.1 Pro (High)"`
+
+The legacy `gemini --prompt` path is used only with
+`--repair-backend gemini` and requires non-interactive enterprise/API-key/Vertex
+authentication. Every attempt, including failures and empty output, is recorded
+as estimated usage and consumes the selected provider's quota.
 
 Signed human reviewer comments are approval-critical when they end with a
 standalone `-- Human Reviewer` signature. The loop surfaces those requirements

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -36,7 +36,7 @@ flowchart LR
 
     Orchestrator --> Prompts[Prompt builders<br/>prompts.py]
     Orchestrator --> Protocol[Structured JSON, marker,<br/>and follow-up validation<br/>protocol.py]
-    Orchestrator --> Repair[Malformed structured-response repair<br/>repair.py / Gemini CLI]
+    Orchestrator --> Repair[Malformed structured-response repair<br/>repair.py / Antigravity by default]
     Orchestrator --> RoundState[Round resume metadata<br/>round_state.py / AGENT_LOOP_META]
     Orchestrator --> Registry[Agent registry<br/>agents/registry.py]
     Orchestrator --> GitHubOps[GitHub operations<br/>github.py]
@@ -652,9 +652,13 @@ without the required marker, the loop fails locally with `AgentLoopError` and
 the attempt log path instead of posting that raw output as a review.
 
 For structured plan reviews, plan revisions, PR reviews, and coder follow-ups,
-a present but malformed structured response may get one repair pass before the
-local failure is raised. The repair pass calls the configured Gemini CLI with a
-format-repair prompt and asks it to preserve the agent's intent while emitting
+a present but malformed structured response may get a repair pass before the
+local failure is raised. By default the repair pass calls Antigravity through
+the existing PTY backend with the single model `Gemini 3 Flash`; the normal
+coder/reviewer fallback chain is not inherited. It uses a fresh temporary
+workdir, empty tool permissions, and repair-only instructions forbidding file
+inspection, tests, mutation, background work, and subagents. The format-repair
+prompt asks it to preserve the agent's intent while emitting
 only the required JSON object, matching footer marker, and standalone
 signature. Repaired output is accepted only after it passes the same schema,
 state, footer, follow-up, prior-item, and human-requirement validation as an
@@ -777,6 +781,16 @@ If strict structured-response validation fails, the log may show a repair pass:
 `repair pass recovered malformed response` or `repair pass produced invalid
 output`. A recovered response is still revalidated before posting; a failed
 repair leaves the run in local failure just like any other protocol error.
+
+Use `--repair-backend`, repeatable `--repair-model`, and
+`--repair-timeout-seconds` to configure this path. Multiple models are the only
+repair fallback chain. `--repair-backend gemini` retains the legacy CLI for
+enterprise/API-key/Vertex authentication; personal OAuth may require an
+interactive authorization and is not the default. Normal diagnostics include
+backend, model, return code, a sanitized bounded combined-PTY diagnostic, log
+path, and whether another configured model will run. Usage summaries record
+estimated prompt/output usage plus repair outcome and validation status for
+every attempt, including failed attempts, so repair consumes visible quota.
 
 Long reset or quota responses can exit early with guidance to rerun after the
 reset or switch keys/models. Narrower transient stream, tool-call, network

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -157,9 +157,12 @@ reviewer is marked unavailable, the remaining reviewers still run, and a round i
 never falsely reported `approved`. A malformed-but-content-bearing structured
 review is recovered automatically when possible: safe skill normalization,
 envelope normalization, deterministic unknown-prior-item stripping against the
-complete carried ledger, and then Gemini format repair. The classifier is
-conservative: only known tooling-failure signatures or truly-empty output count
-as unavailable.
+complete carried ledger, and then model format repair. Local-loop repair now
+defaults to isolated Antigravity with `Gemini 3 Flash`; explicit repeatable
+repair models define the only fallback chain. Legacy Gemini CLI repair requires
+`--repair-backend gemini` and suitable non-interactive authentication. The
+classifier is conservative: only known tooling-failure signatures or
+truly-empty output count as unavailable.
 
 The same automatic recovery pipeline covers external-coder `plan_revision`
 responses and `run-pr-fix` `coder_followup` responses. Plan revisions may also

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -23,7 +23,9 @@ emits no token usage (usage falls back to the estimated path).
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
+import tempfile
 from typing import TYPE_CHECKING
 
 from .base import (
@@ -105,6 +107,19 @@ _REVIEWER_SETTINGS_INJECTION = {
         ]
     },
 }
+_REPAIR_SETTINGS_INJECTION = {
+    "toolPermission": "strict",
+    "permissions": {"allow": []},
+}
+
+_REPAIR_GEMINI_MD = """# Agent Loop Format Repair
+
+This is a single-shot formatting-only repair task in an isolated temporary directory.
+Do not inspect files, run shell commands or tests, mutate any repository, start
+background tasks, or invoke subagents. Use only the malformed response and protocol
+examples in the prompt. Return the repaired response immediately.
+
+"""
 
 
 def _antigravity_settings_path() -> Path:
@@ -137,6 +152,7 @@ class AntigravityBackend:
         session_id: str | None = None,
         run_id: str | None = None,
         role: str | None = None,
+        log_path_override: Path | None = None,
     ) -> AgentResult:
         import json, fcntl  # Unix-only (fcntl); imported here so the module loads on Windows
         for i, model in enumerate(config.antigravity_models):
@@ -145,7 +161,7 @@ class AntigravityBackend:
                 with_public_response_file_instruction(prompt, response_path)
             )
             args = [config.antigravity_cmd, "--model", model, *config.antigravity_args]
-            if role == "reviewer":
+            if role in {"reviewer", "repair"}:
                 args = [a for a in args if a != "--dangerously-skip-permissions"]
             # agy resumes by conversation id (not gemini's --resume). agy --print does
             # not surface a conversation id in plain output, so in practice session_id
@@ -154,7 +170,7 @@ class AntigravityBackend:
                 args += ["--conversation", session_id]
             # The prompt is the value of --print (must be last), not a positional.
             args += ["--print", prompt_text]
-            log_path = agent_log_path(config, "antigravity", run_id=run_id)
+            log_path = log_path_override or agent_log_path(config, "antigravity", run_id=run_id)
             log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
             # agy reads GEMINI.md from the workdir as high-priority system context before
             # the model sees the prompt. Injecting a single-shot session rule prevents
@@ -166,8 +182,12 @@ class AntigravityBackend:
             # inject→run→strip sequence across concurrent processes sharing the same
             # default per-repo workdir.
             gemini_md_path = config.antigravity_dir / "GEMINI.md"
-            gemini_lock_path = _git_lock_path(config.antigravity_dir)
-            single_shot_instruction = (
+            gemini_lock_path = (
+                config.antigravity_dir.parent / f".{config.antigravity_dir.name}.GEMINI.md.lock"
+                if role == "repair"
+                else _git_lock_path(config.antigravity_dir)
+            )
+            single_shot_instruction = _REPAIR_GEMINI_MD if role == "repair" else (
                 "# Agent Loop Single-Shot Session\n\n"
                 "You are running in a single-shot, non-interactive `agy --print` session"
                 " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
@@ -193,7 +213,7 @@ class AntigravityBackend:
             settings_lock = settings_lock_path.open("a+")
             try:
                 fcntl.flock(settings_lock, fcntl.LOCK_EX)
-                if role == "reviewer":
+                if role in {"reviewer", "repair"}:
                     try:
                         original_settings_text = settings_path.read_text(encoding="utf-8")
                         try:
@@ -206,7 +226,12 @@ class AntigravityBackend:
                         original_settings_text = None
                         existing_settings = {}
                     try:
-                        injected = {**existing_settings, **_REVIEWER_SETTINGS_INJECTION}
+                        injection = (
+                            _REPAIR_SETTINGS_INJECTION
+                            if role == "repair"
+                            else _REVIEWER_SETTINGS_INJECTION
+                        )
+                        injected = {**existing_settings, **injection}
                         settings_path.write_text(json.dumps(injected, indent=2), encoding="utf-8")
                         # Inner: GEMINI.md lock
                         gemini_lock_file = gemini_lock_path.open("a+")
@@ -230,6 +255,11 @@ class AntigravityBackend:
                                     check=False,
                                     env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
                                     use_pty=True,
+                                    **(
+                                        {"timeout_seconds": config.repair_timeout_seconds}
+                                        if role == "repair"
+                                        else {}
+                                    ),
                                 )
                             finally:
                                 if gemini_md_path.exists():
@@ -322,6 +352,36 @@ class AntigravityBackend:
         
         # This point should not be reached since antigravity_models cannot be empty
         raise RuntimeError("No antigravity models available to run.")
+
+    def run_repair(
+        self,
+        runner: Runner,
+        config: AgentLoopConfig,
+        prompt: str,
+        *,
+        model: str,
+        run_id: str | None = None,
+        log_path: Path | None = None,
+    ) -> AgentResult:
+        """Run one isolated, no-tools Antigravity format-repair attempt."""
+        repair_root = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / "repair"
+        repair_root.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="agy-", dir=repair_root) as temp_dir:
+            workdir = Path(temp_dir)
+            repair_config = replace(
+                config,
+                antigravity_dir=workdir,
+                antigravity_model=None,
+                antigravity_models=(model,),
+            )
+            return self.run(
+                runner,
+                repair_config,
+                prompt,
+                run_id=run_id,
+                role="repair",
+                log_path_override=log_path,
+            )
 
 
 BACKEND = AntigravityBackend()

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -32,7 +32,7 @@ class AgentResult:
     message_text: str | None = None
     session_id: str | None = None
     log_path: Path | None = None
-    returncode: int = 0
+    returncode: int | None = 0
     usage: UsageMetadata | None = None
     raw_usage: object | None = None
     # Human-readable label of the model that actually produced this result (e.g.

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -14,6 +14,7 @@ from .agents.registry import (
     agent_signature,
 )
 from .config import (
+    DEFAULT_REPAIR_MODELS,
     DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES,
     AgentLoopConfig,
     config_from_args,
@@ -118,6 +119,27 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--codex-cmd", default="codex")
         subparser.add_argument("--gemini-cmd", default="gemini")
         subparser.add_argument("--antigravity-cmd", default="agy")
+        subparser.add_argument(
+            "--repair-backend",
+            choices=("antigravity", "gemini"),
+            default="antigravity",
+            help="Malformed-response repair backend (default: antigravity).",
+        )
+        subparser.add_argument(
+            "--repair-model",
+            action="append",
+            default=None,
+            help=(
+                "Repair model to try. Repeat to configure an explicit fallback chain "
+                f"(default: {DEFAULT_REPAIR_MODELS[0]} only)."
+            ),
+        )
+        subparser.add_argument(
+            "--repair-timeout-seconds",
+            type=int,
+            default=120,
+            help="Per-attempt malformed-response repair timeout (default: 120).",
+        )
         agy_model_group = subparser.add_mutually_exclusive_group()
         agy_model_group.add_argument(
             "--antigravity-model",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -37,6 +37,7 @@ DEFAULT_ANTIGRAVITY_MODELS: tuple[str, ...] = (
     "Gemini 3.5 Flash (High)",
     "Gemini 3.1 Pro (High)",
 )
+DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3 Flash",)
 
 
 @dataclass(frozen=True)
@@ -93,6 +94,9 @@ class AgentLoopConfig:
     codex_reasoning_effort: str = ""
     gemini_model: str = ""
     claude_model: str = ""
+    repair_backend: str = "antigravity"
+    repair_models: tuple[str, ...] = DEFAULT_REPAIR_MODELS
+    repair_timeout_seconds: int = 120
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -105,6 +109,12 @@ class AgentLoopConfig:
             object.__setattr__(self, "antigravity_models", DEFAULT_ANTIGRAVITY_MODELS)
         if any(not m.strip() for m in self.antigravity_models):
             raise AgentLoopError("antigravity_models chain cannot be empty or contain blank entries.")
+        if self.repair_backend not in {"antigravity", "gemini"}:
+            raise AgentLoopError("--repair-backend must be either 'antigravity' or 'gemini'.")
+        if not self.repair_models or any(not model.strip() for model in self.repair_models):
+            raise AgentLoopError("--repair-model must contain at least one nonblank model.")
+        if self.repair_timeout_seconds <= 0:
+            raise AgentLoopError("--repair-timeout-seconds must be greater than zero.")
         ensure_no_model_arg_conflicts(self)
         if self.planning_context_mode not in {"full", "compact"}:
             raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")
@@ -609,7 +619,9 @@ def preflight_agent_commands(
         "gemini": (args.gemini_cmd, "--gemini-cmd"),
         "antigravity": (args.antigravity_cmd, "--antigravity-cmd"),
     }
-    configured_agents = dict.fromkeys((args.coder, *configured_reviewers))
+    configured_agents = dict.fromkeys(
+        (args.coder, *configured_reviewers, getattr(args, "repair_backend", "antigravity"))
+    )
     for agent in configured_agents:
         command, override_flag = command_options[agent]
         resolved = shutil.which(command)
@@ -731,6 +743,9 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         codex_reasoning_effort=getattr(args, "codex_reasoning_effort", ""),
         gemini_model=getattr(args, "gemini_model", ""),
         claude_model=getattr(args, "claude_model", ""),
+        repair_backend=getattr(args, "repair_backend", "antigravity"),
+        repair_models=tuple(getattr(args, "repair_model", None) or DEFAULT_REPAIR_MODELS),
+        repair_timeout_seconds=getattr(args, "repair_timeout_seconds", 120),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -99,7 +99,13 @@ from .protocol import (
     validate_structured_plan_revision,
 )
 from .protocol import parse_review
-from .repair import attempt_envelope_normalization, attempt_repair, strip_unknown_prior_item_dispositions
+from .repair import (
+    RepairAttemptResult,
+    attempt_envelope_normalization,
+    attempt_repair,
+    execute_repair,
+    strip_unknown_prior_item_dispositions,
+)
 from .runner import Runner
 from .transient import (
     NON_RETRYABLE_AGENT_OUTPUT_RE,
@@ -824,6 +830,64 @@ def _persist_usage_summary(config: AgentLoopConfig, usage_context: RunUsageConte
     )
 
 
+_ORIGINAL_ATTEMPT_REPAIR = attempt_repair
+
+
+def _run_structured_repair(
+    raw: str,
+    *,
+    runner: Runner,
+    config: AgentLoopConfig,
+    usage_context: RunUsageContext | None,
+    validate: Callable[[str], object],
+    repair_kwargs: dict[str, object],
+) -> tuple[str | None, object | None, list[RepairAttemptResult]]:
+    """Run configured repair, retaining compatibility with patched legacy test hooks."""
+    if attempt_repair is not _ORIGINAL_ATTEMPT_REPAIR:
+        repaired = attempt_repair(raw, config.gemini_cmd, **repair_kwargs)
+        if repaired is None:
+            return None, None, []
+        try:
+            parsed = validate(repaired)
+        except AgentLoopError as exc:
+            return repaired, None, [
+                RepairAttemptResult(
+                    backend="gemini",
+                    model="legacy-test-hook",
+                    prompt="",
+                    output=repaired,
+                    returncode=0,
+                    outcome="invalid_output",
+                    diagnostic=str(exc),
+                    log_path=None,
+                    fallback_planned=False,
+                )
+            ]
+        return repaired, parsed, []
+    return execute_repair(
+        raw,
+        runner=runner,
+        config=config,
+        run_id=usage_context.run_id if usage_context is not None else None,
+        usage_context=usage_context,
+        validate=validate,
+        **repair_kwargs,
+    )
+
+
+def _log_repair_attempts(config: AgentLoopConfig, prefix: str, attempts: Sequence[RepairAttemptResult]) -> None:
+    for attempt in attempts:
+        diagnostic = attempt.diagnostic or "(none)"
+        log(
+            config,
+            f"{prefix}: repair backend={attempt.backend} model={attempt.model} "
+            f"outcome={attempt.outcome} returncode="
+            f"{attempt.returncode if attempt.returncode is not None else 'none'}; "
+            f"diagnostic={diagnostic}; log={attempt.log_path or '(none)'}; "
+            f"fallback_planned={'yes' if attempt.fallback_planned else 'no'}",
+        )
+
+
 def _run_validated_agent(
     runner: Runner,
     *,
@@ -1210,21 +1274,32 @@ def _run_validated_agent(
                         repair_kwargs["same_round_context"] = exc.same_round_description
                     elif repair_allowed_prior_item_ids is not None:
                         repair_kwargs["allowed_prior_item_ids"] = tuple(repair_allowed_prior_item_ids)
-                    repaired = attempt_repair(
+                    original_validation_error = str(exc)
+                    repaired, repaired_marker, repair_attempts = _run_structured_repair(
                         normalized if normalized is not None else text,
-                        config.gemini_cmd,
-                        **repair_kwargs,
+                        runner=runner,
+                        config=config,
+                        usage_context=usage_context,
+                        validate=validate,
+                        repair_kwargs=repair_kwargs,
                     )
+                    _log_repair_attempts(config, agent_name, repair_attempts)
                     if repaired is not None:
-                        try:
-                            marker_value = validate(repaired)
-                        except AgentLoopError as repair_exc:
-                            last_error = str(repair_exc)
+                        if repaired_marker is None:
+                            repair_detail = (
+                                repair_attempts[-1].diagnostic
+                                if repair_attempts
+                                else "repair output failed validation"
+                            )
+                            last_error = (
+                                f"{original_validation_error}; repair failure: {repair_detail}"
+                            )
                             log(
                                 config,
-                                f"{agent_name}: repair pass produced invalid output ({repair_exc})",
+                                f"{agent_name}: repair pass produced invalid output ({repair_detail})",
                             )
                         else:
+                            marker_value = repaired_marker
                             if isinstance(exc, UnknownPriorItemDispositionError):
                                 removed = ", ".join(sorted(exc.unknown_ids))
                                 allowed = ", ".join(sorted(exc.allowed_ids)) or "(none)"
@@ -1244,6 +1319,13 @@ def _run_validated_agent(
                                 usage=usage,
                                 model_used=result.model_used,
                             )
+                    elif repair_attempts:
+                        details = "; ".join(
+                            f"{attempt.backend}/{attempt.model}: {attempt.outcome}"
+                            + (f" ({attempt.diagnostic})" if attempt.diagnostic else "")
+                            for attempt in repair_attempts
+                        )
+                        last_error = f"{original_validation_error}; repair invocation failure: {details}"
             else:
                 if usage_record is not None:
                     usage_record.validation_status = "validated"
@@ -1932,14 +2014,27 @@ def _run_plan_first_loop(
                         f"Planning round {round_number}: {reviewer_name} approved without "
                         "HUMAN_REQUIREMENTS_RESOLVED; attempting repair",
                     )
-                    repaired_text = attempt_repair(
+                    repaired_text, _, repair_attempts = _run_structured_repair(
                         review_output,
-                        config.gemini_cmd,
-                        expected_kind="plan_review",
-                        reviewer_requirement_ids=hr_ids,
-                        allowed_prior_item_ids=tuple(
-                            item.item_id for item in prior_unresolved_items
+                        runner=runner,
+                        config=config,
+                        usage_context=usage_context,
+                        validate=lambda candidate, reviewer_name=reviewer_name: _validate_plan_review_response(
+                            candidate,
+                            reviewer=reviewer_name,
+                            unresolved_items=prior_unresolved_items,
+                            current_round_items=round_new_unresolved_items,
                         ),
+                        repair_kwargs={
+                            "expected_kind": "plan_review",
+                            "reviewer_requirement_ids": hr_ids,
+                            "allowed_prior_item_ids": tuple(
+                                item.item_id for item in prior_unresolved_items
+                            ),
+                        },
+                    )
+                    _log_repair_attempts(
+                        config, f"Planning round {round_number}: {reviewer_name}", repair_attempts
                     )
                     if repaired_text is not None:
                         try:
@@ -2957,14 +3052,27 @@ def run_pr_loop(
                                 f"Round {round_number}: {reviewer_name} approved without "
                                 "HUMAN_REQUIREMENTS_RESOLVED; attempting repair",
                             )
-                            repaired_text = attempt_repair(
+                            repaired_text, _, repair_attempts = _run_structured_repair(
                                 review_output,
-                                config.gemini_cmd,
-                                expected_kind="pr_review",
-                                reviewer_requirement_ids=hr_ids,
-                                allowed_prior_item_ids=tuple(
-                                    item.item_id for item in prior_unresolved_items
+                                runner=runner,
+                                config=config,
+                                usage_context=usage_context,
+                                validate=lambda candidate, reviewer_name=reviewer_name: _validate_review_response(
+                                    candidate,
+                                    reviewer=reviewer_name,
+                                    unresolved_items=prior_unresolved_items,
+                                    current_round_items=round_new_unresolved_items,
                                 ),
+                                repair_kwargs={
+                                    "expected_kind": "pr_review",
+                                    "reviewer_requirement_ids": hr_ids,
+                                    "allowed_prior_item_ids": tuple(
+                                        item.item_id for item in prior_unresolved_items
+                                    ),
+                                },
+                            )
+                            _log_repair_attempts(
+                                config, f"Round {round_number}: {reviewer_name}", repair_attempts
                             )
                             if repaired_text is not None:
                                 try:

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1,9 +1,8 @@
 """LLM repair pass for malformed review/coder-followup outputs.
 
-When an agent produces a review or coder follow-up that fails strict schema
-validation, this module attempts to recover it by calling gemini-3.1-flash-lite
-as a format-repair assistant.  If the repair also fails validation, the caller
-treats the result as blocking per the issue guardrails.
+When an agent produces a structured response that fails strict schema
+validation, this module performs a constrained format-only repair. Antigravity
+is the default backend; legacy Gemini CLI remains available when selected.
 """
 
 from __future__ import annotations
@@ -12,9 +11,17 @@ import json
 import logging
 import re
 import subprocess
+import tempfile
 from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Literal
 
+from .agents.antigravity import AntigravityBackend
 from .agents.gemini import _parse_gemini_payload
+from .logging import agent_log_path
+from .runner import strip_ansi
+from .usage import RunUsageContext, estimate_usage
 from .protocol import (
     HUMAN_REQUIREMENTS_RESOLVED_RE,
     PLAN_STATE_RE,
@@ -23,6 +30,10 @@ from .protocol import (
 )
 
 _logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .config import AgentLoopConfig
+    from .runner import Runner
 
 _SIGNATURE_LINE_RE = re.compile(r"(?m)^--\s+\S[^\n]*")
 
@@ -640,6 +651,219 @@ Output ONLY the repaired response. No explanations.
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
 _SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision"}
+RepairOutcome = Literal[
+    "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
+]
+
+
+@dataclass
+class RepairAttemptResult:
+    backend: Literal["antigravity", "gemini"]
+    model: str
+    prompt: str
+    output: str
+    returncode: int | None
+    outcome: RepairOutcome
+    diagnostic: str
+    log_path: Path | None
+    fallback_planned: bool
+    validation_result: object | None = None
+
+
+_KNOWN_ERROR_RE = re.compile(
+    r"(?i)(fatal|error|exception|authentication|unauthorized|forbidden|quota|rate.?limit|timed?.?out)"
+)
+_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|authorization|password)\b\s*[:=]\s*\S+"
+)
+
+
+def _sanitize_diagnostic(text: str, *, config: AgentLoopConfig | None = None) -> str:
+    clean = strip_ansi(text)
+    clean = _SECRET_RE.sub(r"\1=<redacted>", clean)
+    paths: list[Path] = [Path.home()]
+    repair_root = Path(tempfile.gettempdir()) / "coding-review-agent-loop" / "repair"
+    if config is not None:
+        paths.extend(
+            (config.claude_dir, config.codex_dir, config.gemini_dir, config.antigravity_dir)
+        )
+    for path in paths:
+        rendered = str(path)
+        if rendered and rendered != "/":
+            clean = clean.replace(rendered, "<path>")
+    clean = clean.replace(str(repair_root), "<repair-path>")
+    lines = [line.strip() for line in clean.splitlines() if line.strip()]
+    matching = [line for line in lines if _KNOWN_ERROR_RE.search(line)]
+    selected = matching[-1:] if matching else lines[-20:]
+    encoded = "\n".join(selected).encode("utf-8")[-4096:]
+    return encoded.decode("utf-8", errors="ignore")
+
+
+def _build_repair_prompt(
+    raw: str,
+    *,
+    expected_kind: str | None = None,
+    unresolved_item_ids: Sequence[str] | None = None,
+    surfaced_requirement_ids: Sequence[str] | None = None,
+    reviewer_requirement_ids: Sequence[str] | None = None,
+    allowed_prior_item_ids: Sequence[str] | None = None,
+    unknown_prior_item_ids: Sequence[str] | None = None,
+    same_round_context: str | None = None,
+) -> str:
+    if expected_kind is not None and expected_kind not in _SUPPORTED_EXPECTED_KINDS:
+        raise ValueError(f"Unsupported expected repair kind: {expected_kind}")
+    coder_followup_required_items_instruction = _coder_followup_required_items_instruction(
+        expected_kind, unresolved_item_ids
+    )
+    coder_followup_human_requirements_instruction = _coder_followup_human_requirements_instruction(
+        expected_kind, surfaced_requirement_ids
+    )
+    reviewer_human_requirements_instr = _reviewer_human_requirements_instruction(
+        expected_kind, reviewer_requirement_ids
+    )
+    prior_item_dispositions_instruction = _repair_prior_item_ids_instruction(
+        allowed_prior_item_ids, unknown_prior_item_ids, same_round_context
+    )
+    expected_kind_instruction = (
+        "## Expected response kind:\n"
+        f"You MUST repair this response as `{expected_kind}`. Output no other `kind` value.\n"
+        if expected_kind is not None
+        else "## Expected response kind:\nNo expected response kind was provided; choose from the format-selection rules.\n"
+    )
+    prompt = _REPAIR_PROMPT.replace("{expected_kind_instruction}", expected_kind_instruction, 1)
+    replacements = (
+        ("{coder_followup_required_items_instruction}", coder_followup_required_items_instruction),
+        ("{coder_followup_human_requirements_instruction}", coder_followup_human_requirements_instruction),
+        ("{reviewer_human_requirements_instruction}", reviewer_human_requirements_instr),
+        ("{prior_item_dispositions_instruction}", prior_item_dispositions_instruction),
+        ("{raw_response}", raw),
+    )
+    for placeholder, value in replacements:
+        prompt = prompt.replace(placeholder, value, 1)
+    return prompt
+
+
+def execute_repair(
+    raw: str,
+    *,
+    runner: Runner,
+    config: AgentLoopConfig,
+    run_id: str | None,
+    usage_context: RunUsageContext | None,
+    validate: Callable[[str], object],
+    **prompt_kwargs: object,
+) -> tuple[str | None, object | None, list[RepairAttemptResult]]:
+    """Run the configured repair chain and validate each candidate."""
+    prompt = _build_repair_prompt(raw, **prompt_kwargs)
+    attempts: list[RepairAttemptResult] = []
+    models = config.repair_models
+    for index, model in enumerate(models):
+        fallback_planned = index + 1 < len(models)
+        log_path: Path | None = None
+        output = ""
+        returncode: int | None = None
+        diagnostic = ""
+        outcome: RepairOutcome
+        try:
+            if config.repair_backend == "antigravity":
+                log_path = agent_log_path(config, "antigravity-repair", run_id=run_id)
+                result = AntigravityBackend().run_repair(
+                    runner,
+                    config,
+                    prompt,
+                    model=model,
+                    run_id=run_id,
+                    log_path=log_path,
+                )
+                output = result.text.strip()
+                returncode = result.returncode
+                log_path = result.log_path
+                diagnostic_source = result.raw_output
+            else:
+                log_path = agent_log_path(config, "gemini-repair", run_id=run_id)
+                proc = subprocess.run(
+                    [
+                        config.gemini_cmd,
+                        "--model",
+                        model,
+                        "--skip-trust",
+                        "--prompt",
+                        prompt,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=config.repair_timeout_seconds,
+                )
+                returncode = proc.returncode
+                parsed, _, _, _, _ = _parse_gemini_payload(proc.stdout.strip())
+                output = parsed.strip()
+                diagnostic_source = f"{proc.stdout}\n{proc.stderr}"
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                log_path.write_text(diagnostic_source, encoding="utf-8")
+            if returncode is None:
+                outcome = "timeout"
+            elif returncode != 0:
+                outcome = "nonzero_exit"
+            elif not output:
+                outcome = "empty_output"
+            else:
+                outcome = "succeeded"
+            diagnostic = _sanitize_diagnostic(diagnostic_source, config=config)
+        except subprocess.TimeoutExpired as exc:
+            outcome = "timeout"
+            diagnostic = _sanitize_diagnostic(str(exc), config=config)
+            if log_path is not None:
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                log_path.write_text(diagnostic + "\n", encoding="utf-8")
+        except Exception as exc:
+            outcome = "spawn_error"
+            diagnostic = _sanitize_diagnostic(str(exc), config=config)
+            if log_path is not None:
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                log_path.write_text(diagnostic + "\n", encoding="utf-8")
+
+        attempt = RepairAttemptResult(
+            backend=config.repair_backend,
+            model=model,
+            prompt=prompt,
+            output=output,
+            returncode=returncode,
+            outcome=outcome,
+            diagnostic=diagnostic,
+            log_path=log_path,
+            fallback_planned=fallback_planned,
+        )
+        usage_record = None
+        if usage_context is not None:
+            usage_record = usage_context.add_record(
+                agent=config.repair_backend,
+                session_id=None,
+                returncode=returncode,
+                usage=estimate_usage(prompt, output),
+                role="repair",
+                model=model,
+                outcome=outcome,
+                log_path=str(log_path) if log_path is not None else None,
+                fallback_planned=fallback_planned,
+            )
+        if outcome == "succeeded":
+            try:
+                validation_result = validate(output)
+            except Exception as exc:
+                attempt.outcome = "invalid_output"
+                attempt.diagnostic = _sanitize_diagnostic(str(exc), config=config)
+                if usage_record is not None:
+                    usage_record.outcome = "invalid_output"
+            else:
+                attempt.validation_result = validation_result
+                attempt.fallback_planned = False
+                if usage_record is not None:
+                    usage_record.validation_status = "validated"
+                    usage_record.fallback_planned = False
+                attempts.append(attempt)
+                return output, validation_result, attempts
+        attempts.append(attempt)
+    return None, None, attempts
 
 
 def _coder_followup_required_items_instruction(
@@ -752,53 +976,16 @@ def attempt_repair(
     Returns the repaired text on success, or None when the CLI fails or returns empty output.
     The caller is responsible for re-validating the returned text.
     """
-    if expected_kind is not None and expected_kind not in _SUPPORTED_EXPECTED_KINDS:
-        raise ValueError(f"Unsupported expected repair kind: {expected_kind}")
-    coder_followup_required_items_instruction = _coder_followup_required_items_instruction(
-        expected_kind,
-        unresolved_item_ids,
+    prompt = _build_repair_prompt(
+        raw,
+        expected_kind=expected_kind,
+        unresolved_item_ids=unresolved_item_ids,
+        surfaced_requirement_ids=surfaced_requirement_ids,
+        reviewer_requirement_ids=reviewer_requirement_ids,
+        allowed_prior_item_ids=allowed_prior_item_ids,
+        unknown_prior_item_ids=unknown_prior_item_ids,
+        same_round_context=same_round_context,
     )
-    coder_followup_human_requirements_instruction = _coder_followup_human_requirements_instruction(
-        expected_kind,
-        surfaced_requirement_ids,
-    )
-    reviewer_human_requirements_instr = _reviewer_human_requirements_instruction(
-        expected_kind,
-        reviewer_requirement_ids,
-    )
-    prior_item_dispositions_instruction = _repair_prior_item_ids_instruction(
-        allowed_prior_item_ids,
-        unknown_prior_item_ids,
-        same_round_context,
-    )
-    expected_kind_instruction = (
-        "## Expected response kind:\n"
-        f"You MUST repair this response as `{expected_kind}`. Output no other `kind` value.\n"
-        if expected_kind is not None
-        else "## Expected response kind:\nNo expected response kind was provided; choose from the format-selection rules.\n"
-    )
-    prompt = _REPAIR_PROMPT.replace("{expected_kind_instruction}", expected_kind_instruction, 1)
-    prompt = prompt.replace(
-        "{coder_followup_required_items_instruction}",
-        coder_followup_required_items_instruction,
-        1,
-    )
-    prompt = prompt.replace(
-        "{coder_followup_human_requirements_instruction}",
-        coder_followup_human_requirements_instruction,
-        1,
-    )
-    prompt = prompt.replace(
-        "{reviewer_human_requirements_instruction}",
-        reviewer_human_requirements_instr,
-        1,
-    )
-    prompt = prompt.replace(
-        "{prior_item_dispositions_instruction}",
-        prior_item_dispositions_instruction,
-        1,
-    )
-    prompt = prompt.replace("{raw_response}", raw, 1)
     try:
         result = subprocess.run(
             [gemini_cmd, "--model", _REPAIR_MODEL, "--skip-trust", "--prompt", prompt],

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -22,7 +22,7 @@ class CommandResult:
     cwd: Path
     stdout: str
     stderr: str
-    returncode: int
+    returncode: int | None
 
 
 # Matches ANSI/VT100 control sequences (CSI, OSC, charset selection) that a
@@ -158,6 +158,7 @@ class Runner:
         check: bool = True,
         env: Mapping[str, str] | None = None,
         use_pty: bool = False,
+        timeout_seconds: float | None = None,
     ) -> CommandResult:
         cmd = [str(a) for a in args]
         if self.dry_run:
@@ -175,6 +176,7 @@ class Runner:
                 progress_interval_seconds=progress_interval_seconds,
                 check=check,
                 env=env,
+                timeout_seconds=timeout_seconds,
             )
         started = time.monotonic()
         next_progress = started + progress_interval_seconds
@@ -242,6 +244,7 @@ class Runner:
         progress_interval_seconds: int,
         check: bool,
         env: Mapping[str, str] | None,
+        timeout_seconds: float | None = None,
     ) -> CommandResult:
         """Run a command attached to a pseudo-terminal, logging and capturing output.
 
@@ -249,12 +252,14 @@ class Runner:
         and silently drop their final response when it is not (a pipe / file /
         subprocess), see upstream antigravity-cli issue #76. Allocating a PTY makes
         the agent emit normally; we strip the resulting ANSI control sequences from
-        the captured text before returning it.
+        the captured text before returning it. stdin/stdout/stderr all share the
+        PTY slave, so returned stderr is always empty and stdout is the merged stream.
         """
         import pty
         import select
 
         started = time.monotonic()
+        deadline = started + timeout_seconds if timeout_seconds is not None else None
         next_progress = started + progress_interval_seconds
         header = f"$ {' '.join(cmd)}\n\n"
         chunks: list[bytes] = []
@@ -289,8 +294,30 @@ class Runner:
             master_fd, slave_fd = allocated_fds
             os.close(slave_fd)
             try:
+                timed_out = False
                 while True:
-                    ready, _, _ = select.select([master_fd], [], [], 1.0)
+                    now = time.monotonic()
+                    if deadline is not None and now >= deadline and proc.poll() is None:
+                        timed_out = True
+                        try:
+                            os.killpg(proc.pid, 15)
+                        except ProcessLookupError:
+                            pass
+                        try:
+                            proc.wait(timeout=2)
+                        except subprocess.TimeoutExpired:
+                            try:
+                                os.killpg(proc.pid, 9)
+                            except ProcessLookupError:
+                                pass
+                            proc.wait()
+                    if timed_out:
+                        wait_seconds = 0.1
+                    elif deadline is not None:
+                        wait_seconds = min(1.0, max(0.0, deadline - now))
+                    else:
+                        wait_seconds = 1.0
+                    ready, _, _ = select.select([master_fd], [], [], wait_seconds)
                     if master_fd in ready:
                         try:
                             data = os.read(master_fd, 65536)
@@ -324,7 +351,7 @@ class Runner:
                 raise
             finally:
                 os.close(master_fd)
-            returncode = proc.wait()
+            returncode = None if timed_out else proc.wait()
 
         raw = b"".join(chunks).decode("utf-8", errors="replace")
         output = strip_ansi(raw)

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -84,10 +84,17 @@ class UsageCallRecord:
     call_id: int
     agent: AgentName
     session_id: str | None
-    returncode: int
+    returncode: int | None
     usage: UsageMetadata
     validation_status: Literal["validated", "invalid"] = "invalid"
     raw_backend_usage: object | None = None
+    role: Literal["repair"] | None = None
+    model: str | None = None
+    outcome: Literal[
+        "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
+    ] | None = None
+    log_path: str | None = None
+    fallback_planned: bool | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -100,6 +107,10 @@ class UsageCallRecord:
         }
         if self.raw_backend_usage is not None:
             payload["raw_backend_usage"] = self.raw_backend_usage
+        for key in ("role", "model", "outcome", "log_path", "fallback_planned"):
+            value = getattr(self, key)
+            if value is not None:
+                payload[key] = value
         return payload
 
 
@@ -180,9 +191,16 @@ class RunUsageContext:
         *,
         agent: AgentName,
         session_id: str | None,
-        returncode: int,
+        returncode: int | None,
         usage: UsageMetadata,
         raw_backend_usage: object | None = None,
+        role: Literal["repair"] | None = None,
+        model: str | None = None,
+        outcome: Literal[
+            "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
+        ] | None = None,
+        log_path: str | None = None,
+        fallback_planned: bool | None = None,
     ) -> UsageCallRecord:
         record = UsageCallRecord(
             call_id=self._next_call_id,
@@ -191,6 +209,11 @@ class RunUsageContext:
             returncode=returncode,
             usage=usage,
             raw_backend_usage=raw_backend_usage,
+            role=role,
+            model=model,
+            outcome=outcome,
+            log_path=log_path,
+            fallback_planned=fallback_planned,
         )
         self._next_call_id += 1
         self.records.append(record)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -467,6 +467,7 @@ class FakeRunner(Runner):
         check=True,
         env=None,
         use_pty=False,
+        timeout_seconds=None,
     ):
         cmd, cwd_path = self._record_command(args, cwd)
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -12231,7 +12232,7 @@ def test_config_preflight_checks_only_unique_configured_agents(monkeypatch, tmp_
     config = config_from_args(args, Runner())
 
     assert config.coder == "codex"
-    assert checked == ["codex"]
+    assert checked == ["codex", "agy"]
 
 
 def test_config_preflight_accepts_custom_absolute_command(tmp_path):
@@ -16956,6 +16957,7 @@ from coding_review_agent_loop.repair import (
     _REPAIR_PROMPT,
     attempt_envelope_normalization,
     attempt_repair,
+    execute_repair,
 )
 
 
@@ -17410,6 +17412,199 @@ def test_repair_prompt_substitution_leaves_json_examples_intact():
     assert raw in substituted
     assert "{raw_response}" not in substituted
     assert "schema_version" in substituted
+
+
+def test_execute_repair_defaults_to_isolated_antigravity_and_records_usage(
+    tmp_path, monkeypatch
+):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.usage import RunUsageContext
+
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+    valid = structured_pr_review(state="approved", reviewer="Google Antigravity")
+    captured = {}
+
+    class RepairRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            captured["args"] = list(args)
+            captured["cwd"] = Path(cwd)
+            captured["env"] = kwargs["env"]
+            captured["timeout"] = kwargs["timeout_seconds"]
+            captured["settings"] = json.loads(settings_file.read_text(encoding="utf-8"))
+            captured["gemini_md"] = (Path(cwd) / "GEMINI.md").read_text(encoding="utf-8")
+            assert not (Path(cwd) / ".git").exists()
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    config = make_config(
+        tmp_path,
+        antigravity_args=("--dangerously-skip-permissions",),
+        repair_models=("Gemini 3 Flash",),
+    )
+    usage = RunUsageContext("run-1", tmp_path / "usage.json")
+    repaired, marker, attempts = execute_repair(
+        "malformed",
+        runner=RepairRunner(antigravity_outputs=[(valid, 0)]),
+        config=config,
+        run_id="run-1",
+        usage_context=usage,
+        validate=lambda text: parse_structured_pr_review(
+            text, reviewer="Google Antigravity"
+        ),
+        expected_kind="pr_review",
+    )
+
+    assert repaired == valid
+    assert marker is not None
+    assert attempts[0].model == "Gemini 3 Flash"
+    assert captured["timeout"] == 120
+    assert captured["env"]["AGENT_LOOP_WORKDIR"] == str(captured["cwd"])
+    assert not captured["cwd"].exists()
+    assert "--dangerously-skip-permissions" not in captured["args"]
+    assert captured["settings"]["permissions"]["allow"] == []
+    assert "Do not inspect files" in captured["gemini_md"]
+    assert usage.records[0].role == "repair"
+    assert usage.records[0].outcome == "succeeded"
+    assert usage.records[0].validation_status == "validated"
+
+
+def test_execute_repair_explicit_chain_falls_back_after_failure_and_invalid_output(
+    tmp_path, monkeypatch
+):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.usage import RunUsageContext
+
+    monkeypatch.setattr(
+        agy_mod, "_antigravity_settings_path", lambda: tmp_path / "settings.json"
+    )
+    valid = structured_pr_review(state="approved", reviewer="Google Antigravity")
+    config = make_config(
+        tmp_path,
+        repair_models=("Gemini 3 Flash", "Gemini 3.1 Pro (High)"),
+    )
+    usage = RunUsageContext("run-2", tmp_path / "usage.json")
+    repaired, _, attempts = execute_repair(
+        "malformed",
+        runner=FakeRunner(antigravity_outputs=[("not structured", 0), (valid, 0)]),
+        config=config,
+        run_id="run-2",
+        usage_context=usage,
+        validate=lambda text: (
+            parse_structured_pr_review(text, reviewer="Google Antigravity")
+            or (_ for _ in ()).throw(AgentLoopError("invalid repaired output"))
+        ),
+        expected_kind="pr_review",
+    )
+
+    assert repaired == valid
+    assert [attempt.outcome for attempt in attempts] == ["invalid_output", "succeeded"]
+    assert [record.outcome for record in usage.records] == ["invalid_output", "succeeded"]
+    assert usage.records[0].fallback_planned is True
+    assert usage.records[1].fallback_planned is False
+
+
+@pytest.mark.parametrize(
+    ("output", "returncode", "expected"),
+    [
+        ("fatal auth error", 41, "nonzero_exit"),
+        ("", 0, "empty_output"),
+        (PUBLIC_RESPONSE_MARKER, 0, "empty_output"),
+        ("", None, "timeout"),
+    ],
+)
+def test_execute_repair_records_antigravity_failure_outcomes(
+    tmp_path, monkeypatch, output, returncode, expected
+):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+
+    monkeypatch.setattr(
+        agy_mod, "_antigravity_settings_path", lambda: tmp_path / "settings.json"
+    )
+    repaired, _, attempts = execute_repair(
+        "malformed",
+        runner=FakeRunner(antigravity_outputs=[(output, returncode)]),
+        config=make_config(tmp_path),
+        run_id="run-3",
+        usage_context=None,
+        validate=lambda text: text,
+        expected_kind="pr_review",
+    )
+    assert repaired is None
+    assert attempts[0].outcome == expected
+
+
+def test_execute_repair_records_spawn_error_with_log_path(tmp_path, monkeypatch):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+
+    monkeypatch.setattr(
+        agy_mod, "_antigravity_settings_path", lambda: tmp_path / "settings.json"
+    )
+
+    class SpawnErrorRunner(FakeRunner):
+        def run_with_log(self, *args, **kwargs):
+            raise AgentLoopError("agy executable missing")
+
+    repaired, _, attempts = execute_repair(
+        "malformed",
+        runner=SpawnErrorRunner(),
+        config=make_config(tmp_path),
+        run_id="run-spawn",
+        usage_context=None,
+        validate=lambda text: text,
+        expected_kind="pr_review",
+    )
+    assert repaired is None
+    assert attempts[0].outcome == "spawn_error"
+    assert attempts[0].log_path is not None
+    assert attempts[0].log_path.exists()
+
+
+def test_execute_repair_uses_configured_legacy_gemini_override(tmp_path):
+    valid = structured_pr_review(state="approved", reviewer="Google Gemini")
+    proc = MagicMock(returncode=0, stdout=valid, stderr="")
+    config = make_config(
+        tmp_path,
+        repair_backend="gemini",
+        repair_models=("gemini-enterprise-flash",),
+    )
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=proc) as run:
+        repaired, _, attempts = execute_repair(
+            "malformed",
+            runner=FakeRunner(),
+            config=config,
+            run_id="run-4",
+            usage_context=None,
+            validate=lambda text: parse_structured_pr_review(
+                text, reviewer="Google Gemini"
+            ),
+            expected_kind="pr_review",
+        )
+    assert repaired == valid
+    assert attempts[0].backend == "gemini"
+    assert "gemini-enterprise-flash" in run.call_args.args[0]
+
+
+def test_runner_pty_timeout_is_opt_in_and_retains_combined_log(tmp_path):
+    log_path = tmp_path / "logs" / "timeout.log"
+    result = Runner().run_with_log(
+        [
+            sys.executable,
+            "-c",
+            "import sys,time; print('stderr diagnostic', file=sys.stderr, flush=True); time.sleep(5)",
+        ],
+        cwd=tmp_path,
+        log_path=log_path,
+        label="timeout-test",
+        progress_interval_seconds=30,
+        check=False,
+        use_pty=True,
+        timeout_seconds=0.2,
+    )
+
+    assert result.returncode is None
+    assert result.stderr == ""
+    assert "stderr diagnostic" in result.stdout
+    assert "stderr diagnostic" in log_path.read_text(encoding="utf-8")
 
 
 def test_run_pr_loop_uses_repair_pass_on_format_failure(tmp_path):


### PR DESCRIPTION
## Summary
- make isolated Antigravity repair with Gemini 3 Flash the default
- add repair timeout, sanitized diagnostics, explicit fallback configuration, and repair usage records
- retain explicitly configured legacy Gemini repair and document quota/auth behavior

## Tests
- `python3 -m pytest` (1058 passed)
- `python3 -m compileall -q src`

Fixes #432