### PR TITLE
Fix auth regex, reversed-signature normalization, base-branch GEMINI.md, lock cleanup, and double-validation

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -187,26 +187,35 @@ class AntigravityBackend:
                 if role == "repair"
                 else _git_lock_path(config.antigravity_dir)
             )
-            single_shot_instruction = _REPAIR_GEMINI_MD if role == "repair" else (
-                "# Agent Loop Single-Shot Session\n\n"
-                "You are running in a single-shot, non-interactive `agy --print` session"
-                " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
-                "**Do NOT spawn background execution tasks or subagents under any"
-                " circumstances.**\n\n"
-                "**For code review tasks: DO NOT run tests, builds, compilation,"
-                " mutation, commits, background work, or unrelated discovery commands.**"
-                " You may use only the strict allow-listed read-only commands to inspect"
-                " the assigned checkout and local PR diff. Prefer `git diff"
-                " <base>...HEAD`, `git show`, `git status`, `git log`, `rg`, `sed`, and"
-                " direct file reads over web search. Do not fetch, checkout, reset, clean,"
-                " or write files. Tests are CI's responsibility; your job is to read code"
-                " and identify issues. If you find yourself about to run `pytest`, `npm"
-                " test`, `go test`, or any build command, stop and write your review from"
-                " code inspection alone.\n\n"
-                "For non-review tasks that require shell commands, run them synchronously"
-                " in this same turn before writing your response.\n\n"
-                "---\n\n"
-            )
+            if role == "repair":
+                single_shot_instruction = _REPAIR_GEMINI_MD
+            else:
+                resolved_base = (config.base or "").strip()
+                diff_cmd = (
+                    f"`git diff {resolved_base}...HEAD`"
+                    if resolved_base
+                    else "`git diff <base>...HEAD` (replace `<base>` with the resolved base branch)"
+                )
+                single_shot_instruction = (
+                    "# Agent Loop Single-Shot Session\n\n"
+                    "You are running in a single-shot, non-interactive `agy --print` session"
+                    " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
+                    "**Do NOT spawn background execution tasks or subagents under any"
+                    " circumstances.**\n\n"
+                    "**For code review tasks: DO NOT run tests, builds, compilation,"
+                    " mutation, commits, background work, or unrelated discovery commands.**"
+                    f" You may use only the strict allow-listed read-only commands to inspect"
+                    " the assigned checkout and local PR diff. Prefer "
+                    f"{diff_cmd}, `git show`, `git status`, `git log`, `rg`, `sed`, and"
+                    " direct file reads over web search. Do not fetch, checkout, reset, clean,"
+                    " or write files. Tests are CI's responsibility; your job is to read code"
+                    " and identify issues. If you find yourself about to run `pytest`, `npm"
+                    " test`, `go test`, or any build command, stop and write your review from"
+                    " code inspection alone.\n\n"
+                    "For non-review tasks that require shell commands, run them synchronously"
+                    " in this same turn before writing your response.\n\n"
+                    "---\n\n"
+                )
             settings_path = _antigravity_settings_path()
             settings_lock_path = settings_path.with_suffix(".json.lock")
             settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -273,6 +282,8 @@ class AntigravityBackend:
                         finally:
                             fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
                             gemini_lock_file.close()
+                            if role == "repair":
+                                gemini_lock_path.unlink(missing_ok=True)
                     finally:
                         if original_settings_text is None:
                             settings_path.unlink(missing_ok=True)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2014,7 +2014,7 @@ def _run_plan_first_loop(
                         f"Planning round {round_number}: {reviewer_name} approved without "
                         "HUMAN_REQUIREMENTS_RESOLVED; attempting repair",
                     )
-                    repaired_text, _, repair_attempts = _run_structured_repair(
+                    repaired_text, repaired_validated, repair_attempts = _run_structured_repair(
                         review_output,
                         runner=runner,
                         config=config,
@@ -2036,61 +2036,53 @@ def _run_plan_first_loop(
                     _log_repair_attempts(
                         config, f"Planning round {round_number}: {reviewer_name}", repair_attempts
                     )
-                    if repaired_text is not None:
-                        try:
-                            repaired_parsed = _validate_plan_review_response(
-                                repaired_text,
-                                reviewer=reviewer_name,
-                                unresolved_items=prior_unresolved_items,
-                                current_round_items=round_new_unresolved_items,
+                    if repaired_validated is not None:
+                        repaired_parsed = repaired_validated
+                        if (
+                            repaired_parsed.state == "approved"
+                            and human_requirements_resolved(repaired_text)
+                        ):
+                            log(
+                                config,
+                                f"Planning round {round_number}: repair recovered "
+                                f"HUMAN_REQUIREMENTS_RESOLVED for {reviewer_name}",
                             )
-                            if (
-                                repaired_parsed.state == "approved"
-                                and human_requirements_resolved(repaired_text)
-                            ):
-                                log(
-                                    config,
-                                    f"Planning round {round_number}: repair recovered "
-                                    f"HUMAN_REQUIREMENTS_RESOLVED for {reviewer_name}",
+                            continue
+                        if repaired_parsed.state == "blocking":
+                            log(
+                                config,
+                                f"Planning round {round_number}: repair returned blocking for "
+                                f"{reviewer_name}; treating as reviewer blocking",
+                            )
+                            blocking_reviews.append((reviewer_name, repaired_text))
+                            for item in repaired_parsed.items.blocking:
+                                new_item = _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer=item.reviewer,
+                                    source_round=round_number,
+                                    text=item.text,
+                                    status="blocking",
                                 )
-                                continue
-                            if repaired_parsed.state == "blocking":
-                                log(
-                                    config,
-                                    f"Planning round {round_number}: repair returned blocking for "
-                                    f"{reviewer_name}; treating as reviewer blocking",
+                                round_new_unresolved_items.append(new_item)
+                                unresolved_items = [*unresolved_items, new_item]
+                                next_unresolved_item_number += 1
+                            for item in repaired_parsed.items.same_plan:
+                                new_item = _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer=item.reviewer,
+                                    source_round=round_number,
+                                    text=item.text,
+                                    status="same-plan",
                                 )
-                                blocking_reviews.append((reviewer_name, repaired_text))
-                                for item in repaired_parsed.items.blocking:
-                                    new_item = _next_unresolved_item(
-                                        item_number=next_unresolved_item_number,
-                                        reviewer=item.reviewer,
-                                        source_round=round_number,
-                                        text=item.text,
-                                        status="blocking",
-                                    )
-                                    round_new_unresolved_items.append(new_item)
-                                    unresolved_items = [*unresolved_items, new_item]
-                                    next_unresolved_item_number += 1
-                                for item in repaired_parsed.items.same_plan:
-                                    new_item = _next_unresolved_item(
-                                        item_number=next_unresolved_item_number,
-                                        reviewer=item.reviewer,
-                                        source_round=round_number,
-                                        text=item.text,
-                                        status="same-plan",
-                                    )
-                                    round_new_unresolved_items.append(new_item)
-                                    unresolved_items = [*unresolved_items, new_item]
-                                    next_unresolved_item_number += 1
-                                all_approved = False
-                                must_fix_items = [
-                                    item for item in unresolved_items
-                                    if item.status in {"blocking", "same-plan"}
-                                ]
-                                continue
-                        except AgentLoopError:
-                            pass
+                                round_new_unresolved_items.append(new_item)
+                                unresolved_items = [*unresolved_items, new_item]
+                                next_unresolved_item_number += 1
+                            all_approved = False
+                            must_fix_items = [
+                                item for item in unresolved_items
+                                if item.status in {"blocking", "same-plan"}
+                            ]
+                            continue
                     still_missing.append(reviewer_name)
                 if still_missing:
                     log(
@@ -3052,7 +3044,7 @@ def run_pr_loop(
                                 f"Round {round_number}: {reviewer_name} approved without "
                                 "HUMAN_REQUIREMENTS_RESOLVED; attempting repair",
                             )
-                            repaired_text, _, repair_attempts = _run_structured_repair(
+                            repaired_text, repaired_validated, repair_attempts = _run_structured_repair(
                                 review_output,
                                 runner=runner,
                                 config=config,
@@ -3074,60 +3066,52 @@ def run_pr_loop(
                             _log_repair_attempts(
                                 config, f"Round {round_number}: {reviewer_name}", repair_attempts
                             )
-                            if repaired_text is not None:
-                                try:
-                                    repaired_parsed = _validate_review_response(
-                                        repaired_text,
-                                        reviewer=reviewer_name,
-                                        unresolved_items=prior_unresolved_items,
-                                        current_round_items=round_new_unresolved_items,
+                            if repaired_validated is not None:
+                                repaired_parsed = repaired_validated
+                                if (
+                                    repaired_parsed.state == "approved"
+                                    and human_requirements_resolved(repaired_text)
+                                ):
+                                    log(
+                                        config,
+                                        f"Round {round_number}: repair recovered "
+                                        f"HUMAN_REQUIREMENTS_RESOLVED for {reviewer_name}",
                                     )
-                                    if (
-                                        repaired_parsed.state == "approved"
-                                        and human_requirements_resolved(repaired_text)
-                                    ):
-                                        log(
-                                            config,
-                                            f"Round {round_number}: repair recovered "
-                                            f"HUMAN_REQUIREMENTS_RESOLVED for {reviewer_name}",
+                                    continue
+                                if repaired_parsed.state == "blocking":
+                                    log(
+                                        config,
+                                        f"Round {round_number}: repair returned blocking for "
+                                        f"{reviewer_name}; treating as reviewer blocking",
+                                    )
+                                    for item in repaired_parsed.blocking_items:
+                                        new_item = _next_unresolved_item(
+                                            item_number=next_unresolved_item_number,
+                                            reviewer=item.reviewer,
+                                            source_round=round_number,
+                                            text=item.text,
+                                            status="blocking",
                                         )
-                                        continue
-                                    if repaired_parsed.state == "blocking":
-                                        log(
-                                            config,
-                                            f"Round {round_number}: repair returned blocking for "
-                                            f"{reviewer_name}; treating as reviewer blocking",
+                                        round_new_unresolved_items.append(new_item)
+                                        unresolved_items.append(new_item)
+                                        next_unresolved_item_number += 1
+                                    for item in repaired_parsed.followups.same_pr:
+                                        new_item = _next_unresolved_item(
+                                            item_number=next_unresolved_item_number,
+                                            reviewer=item.reviewer,
+                                            source_round=round_number,
+                                            text=item.text,
+                                            status="same-pr",
                                         )
-                                        for item in repaired_parsed.blocking_items:
-                                            new_item = _next_unresolved_item(
-                                                item_number=next_unresolved_item_number,
-                                                reviewer=item.reviewer,
-                                                source_round=round_number,
-                                                text=item.text,
-                                                status="blocking",
-                                            )
-                                            round_new_unresolved_items.append(new_item)
-                                            unresolved_items.append(new_item)
-                                            next_unresolved_item_number += 1
-                                        for item in repaired_parsed.followups.same_pr:
-                                            new_item = _next_unresolved_item(
-                                                item_number=next_unresolved_item_number,
-                                                reviewer=item.reviewer,
-                                                source_round=round_number,
-                                                text=item.text,
-                                                status="same-pr",
-                                            )
-                                            round_new_unresolved_items.append(new_item)
-                                            unresolved_items.append(new_item)
-                                            next_unresolved_item_number += 1
-                                        all_approved = False
-                                        must_fix_items = [
-                                            item for item in unresolved_items
-                                            if item.status in {"blocking", "same-pr"}
-                                        ]
-                                        continue
-                                except AgentLoopError:
-                                    pass
+                                        round_new_unresolved_items.append(new_item)
+                                        unresolved_items.append(new_item)
+                                        next_unresolved_item_number += 1
+                                    all_approved = False
+                                    must_fix_items = [
+                                        item for item in unresolved_items
+                                        if item.status in {"blocking", "same-pr"}
+                                    ]
+                                    continue
                             still_missing.append(reviewer_name)
                         if still_missing:
                             log(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -831,16 +831,11 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_memory_block(memory)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
-you create the PR. In your final response, include the PR number using exactly
-this marker:
+you create the PR. Use blocking here to hand the PR to {reviewer_name} for review. Do not place
+your signature before the AGENT_STATE marker. Your response must end with, in this exact order:
 
 <!-- AGENT_PR: <number> -->
-
-Also include exactly one state marker:
-
 <!-- AGENT_STATE: blocking -->
-
-Use blocking here to hand the PR to {reviewer_name} for review. Sign the response as:
 -- {coder_signature}
 """
 
@@ -877,18 +872,18 @@ areas to change, edge cases, and test strategy.
 {_memory_block(memory)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run
-{reviewer_name} to review the plan. End your final response with exactly one
-planning marker:
+{reviewer_name} to review the plan. Use blocking to hand the plan to {reviewer_name}
+for review. If the issue is materially ambiguous before a useful plan can be written,
+ask focused clarifying questions and use <!-- AGENT_CLARIFY --> instead. Do not place
+your signature before the AGENT_PLAN_STATE or AGENT_CLARIFY marker. Your response
+must end with, in this exact order:
 
 <!-- AGENT_PLAN_STATE: blocking -->
+-- {coder_signature}
 
-Use blocking here to hand the plan to {reviewer_name} for review. If the issue
-is materially ambiguous before a useful plan can be written, ask focused
-clarifying questions and end with exactly this marker:
+or, if clarifying:
 
 <!-- AGENT_CLARIFY -->
-
-Sign the response as:
 -- {coder_signature}
 """
 
@@ -1289,12 +1284,11 @@ the `AGENT_PLAN_STATE` footer immediately after the JSON. Make the footer state
 match the JSON state, and include only your standalone signature after the
 footer.
 
-This is planning round {round_number}. End your final response with exactly one
-planning marker:
+This is planning round {round_number}. Use blocking to hand the revised plan back to
+{reviewer_name}. Do not place your signature before the AGENT_PLAN_STATE footer. Your
+response must end with, in this exact order:
 
 <!-- AGENT_PLAN_STATE: blocking -->
-
-Use blocking to hand the revised plan back to {reviewer_name}. Sign the response as:
 -- {coder_signature}
 """
 
@@ -1405,16 +1399,12 @@ Approved implementation plan:
 {approved_plan}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run
-{reviewer_name} after you create the PR. In your final response, include the PR
-number using exactly this marker:
+{reviewer_name} after you create the PR. Use blocking here to hand the PR to
+{reviewer_name} for review. Do not place your signature before the AGENT_STATE
+marker. Your response must end with, in this exact order:
 
 <!-- AGENT_PR: <number> -->
-
-Also include exactly one state marker:
-
 <!-- AGENT_STATE: blocking -->
-
-Use blocking here to hand the PR to {reviewer_name} for review. Sign the response as:
 -- {coder_signature}
 """
 
@@ -1438,22 +1428,26 @@ Use this local checkout as your workspace. Decide between two paths:
 (a) If the task is clear enough to implement, create a branch, implement the
     change, run relevant tests, commit, push, and open a pull request against
     {config.base}. Do not wait for {reviewer_name}; this local orchestrator
-    will run {reviewer_name} after you create the PR. End your final response
-    with both markers:
+    will run {reviewer_name} after you create the PR.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 
-    <!-- AGENT_PR: <number> -->
-    <!-- AGENT_STATE: blocking -->
-
 (b) If the task is genuinely ambiguous or missing information that would change
     the implementation, do NOT write code. Instead, ask focused clarifying
-    questions and end your final response with exactly this marker:
-
-    <!-- AGENT_CLARIFY -->
+    questions.
 
 Prefer (a) when reasonable assumptions can be documented in the PR description;
-choose (b) only for material ambiguity. Sign your response as:
+choose (b) only for material ambiguity. Do not place your signature before the
+AGENT_STATE or AGENT_CLARIFY marker. Your response must end with, in this exact
+order — for (a):
+
+<!-- AGENT_PR: <number> -->
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+or for (b):
+
+<!-- AGENT_CLARIFY -->
 -- {coder_signature}
 """
 
@@ -1481,17 +1475,20 @@ Clarification so far:
 {qa_blocks}
 
 Now proceed. Strongly prefer to implement the task and open a PR. Only ask
-again if a critical detail is still missing. Use the same response markers as
-before:
+again if a critical detail is still missing.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}
 
-- For implementation: include both <!-- AGENT_PR: <number> --> and
-  <!-- AGENT_STATE: blocking --> at the end of your final response.
-- For another clarification round: end your final response with exactly
-  <!-- AGENT_CLARIFY -->.
+Do not place your signature before the AGENT_STATE or AGENT_CLARIFY marker.
+Your response must end with, in this exact order:
 
-Sign your response as:
+For implementation:
+<!-- AGENT_PR: <number> -->
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For another clarification round:
+<!-- AGENT_CLARIFY -->
 -- {coder_signature}
 """
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1008,21 +1008,20 @@ plan review.
 Use blocking only when the current plan still has blocking plan issues or
 same-plan follow-ups. All configured reviewers ({reviewer_group}) must approve
 in the same planning round before implementation can proceed.
-
-End your final response with exactly one planning marker:
+Use approved only if there are no blocking plan issues, no Same-plan
+follow-ups, and no carried-forward plan items left active for this planning
+round. Structured responses must start with one top-level JSON object, place
+the `AGENT_PLAN_STATE` footer immediately after that payload, then your
+standalone signature on the final line. Do not include prose or code fences
+before the JSON object. Do not place your signature before the
+AGENT_PLAN_STATE footer. Your response must end with, in this exact order:
 
 <!-- AGENT_PLAN_STATE: approved -->
+-- {reviewer_signature}
 
 or:
 
 <!-- AGENT_PLAN_STATE: blocking -->
-
-Use approved only if there are no blocking plan issues, no Same-plan
-follow-ups, and no carried-forward plan items left active for this planning
-round. Structured responses must start with one top-level JSON object, place
-the `AGENT_PLAN_STATE` footer immediately after that payload, and end with only
-your standalone signature. Do not include prose or code fences before the JSON
-object. Always sign your response:
 -- {reviewer_signature}
 """
 
@@ -1104,18 +1103,17 @@ Current implementation plan from {coder_name}:
 {plan}
 
 All configured reviewers ({reviewer_group}) must approve in the same planning
-round before implementation can proceed. End your final response with exactly
-one planning marker:
+round before implementation can proceed. Use approved only if there are no
+blocking plan issues, no Same-plan follow-ups, and no carried-forward plan
+items left active for this planning round. Do not place your signature before
+the AGENT_PLAN_STATE footer. Your response must end with, in this exact order:
 
 <!-- AGENT_PLAN_STATE: approved -->
+-- {reviewer_signature}
 
 or:
 
 <!-- AGENT_PLAN_STATE: blocking -->
-
-Use approved only if there are no blocking plan issues, no Same-plan
-follow-ups, and no carried-forward plan items left active for this planning
-round. Always sign your response:
 -- {reviewer_signature}
 """
 
@@ -1363,11 +1361,11 @@ Blocking plan review payload:
 
 {review}
 
-End your final response with exactly one planning marker:
+Use blocking to hand the revised plan back to {reviewer_name}. Do not place
+your signature before the AGENT_PLAN_STATE footer. Your response must end with,
+in this exact order:
 
 <!-- AGENT_PLAN_STATE: blocking -->
-
-Use blocking to hand the revised plan back to {reviewer_name}. Sign the response as:
 -- {coder_signature}
 """
 
@@ -1743,15 +1741,16 @@ available, or produce a blocking review explaining the limitation.
 Reviewer: {reviewer_name}
 Action for this call: {action}
 
-End your final response with exactly one marker:
+Use blocking only for issues that should prevent merge. Do not place your
+signature before the AGENT_STATE footer. Your response must end with, in this
+exact order:
 
 <!-- AGENT_STATE: approved -->
+-- {reviewer_signature}
 
 or:
 
 <!-- AGENT_STATE: blocking -->
-
-Use blocking only for issues that should prevent merge. Always sign your response:
 -- {reviewer_signature}
 """
 
@@ -2010,19 +2009,17 @@ After the JSON object, include only:
 
 Do not include any extra prose, headings, bullets, or fenced blocks before or
 after that structured response. The footer AGENT_STATE must match the JSON
-`state`.
-
-End your final response with exactly one marker:
+`state`. Do not place your signature before the AGENT_STATE footer.
+Use approved only if there are no blocking issues, no Same-PR follow-ups, and
+no carried-forward unresolved items left active for this round. Your response
+must end with, in this exact order:
 
 <!-- AGENT_STATE: approved -->
+-- {reviewer_signature}
 
 or:
 
 <!-- AGENT_STATE: blocking -->
-
-Use approved only if there are no blocking issues, no Same-PR follow-ups, and
-no carried-forward unresolved items left active for this round. Always sign
-your response:
 -- {reviewer_signature}
 """
 
@@ -2061,13 +2058,12 @@ Do not create a new PR.
 {_structured_coder_followup_guidance(
     reviewer_name=reviewer_name,
     human_requirements_context=human_requirements_context,
-)}This is round {round_number}. End your final response with exactly one marker:
+)}This is round {round_number}. Use blocking to hand the updated PR back to {reviewer_name}.
+If you cannot safely address the review, explain why and still use the blocking
+marker so a human can intervene. Do not place your signature before the
+AGENT_STATE footer. Your response must end with, in this exact order:
 
 <!-- AGENT_STATE: blocking -->
-
-Use blocking to hand the updated PR back to {reviewer_name}. If you cannot safely address
-the review, explain why and still use the blocking marker so a human can
-intervene. Sign the response as:
 -- {coder_signature}
 """
 
@@ -2110,12 +2106,11 @@ Same-PR follow-ups:
 {_structured_coder_followup_guidance(
     reviewer_name=reviewer_name,
     human_requirements_context=human_requirements_context,
-)}This is round {round_number}. End your final response with exactly one marker:
+)}This is round {round_number}. Use blocking to hand the updated PR back to {reviewer_name}.
+If you cannot safely address the follow-ups, explain why and still use the
+blocking marker so a human can intervene. Do not place your signature before
+the AGENT_STATE footer. Your response must end with, in this exact order:
 
 <!-- AGENT_STATE: blocking -->
-
-Use blocking to hand the updated PR back to {reviewer_name}. If you cannot safely address
-the follow-ups, explain why and still use the blocking marker so a human can
-intervene. Sign the response as:
 -- {coder_signature}
 """

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -106,6 +106,25 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
         return None
 
     before_footer = trailing[: state_match.start()]
+    after_footer_raw = trailing[state_match.end() :]
+    footer = trailing[state_match.start() : state_match.end()].strip()
+
+    # Normalize reversed-order envelope: JSON + signature + footer → JSON + footer + signature.
+    # Applies when before_footer is exactly one signature line and nothing follows the footer.
+    if not after_footer_raw.strip():
+        before_stripped = before_footer.strip()
+        sig_candidate = _SIGNATURE_LINE_RE.search(before_stripped)
+        if sig_candidate is not None and before_stripped == before_stripped[sig_candidate.start() : sig_candidate.end()].strip():
+            footer_state = state_match.group(1).lower()
+            payload_state = payload.get("state")
+            state_ok = not (
+                isinstance(payload_state, str)
+                and payload_state.strip()
+                and payload_state.strip() != footer_state
+            )
+            if state_ok:
+                return f"{json_text}\n{footer}\n{before_stripped}"
+
     preserved_before = ""
     if expected_kind in {"pr_review", "plan_review"}:
         before_lstripped = before_footer.lstrip()
@@ -126,9 +145,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
     elif before_footer.strip():
         return None
 
-    footer = trailing[state_match.start() : state_match.end()].strip()
-    after_footer = trailing[state_match.end() :]
-    after_footer_lstripped = after_footer.lstrip()
+    after_footer_lstripped = after_footer_raw.lstrip()
     preserved_after = ""
     if expected_kind == "pr_review":
         marker_match = HUMAN_REQUIREMENTS_RESOLVED_RE.match(after_footer_lstripped)

--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -22,7 +22,7 @@ TRANSIENT_AGENT_OUTPUT_RE = re.compile(
     re.I,
 )
 NON_RETRYABLE_AGENT_OUTPUT_RE = re.compile(
-    r"auth(?:entication|orization)?|unauthorized|forbidden|invalid api key|"
+    r"\bauth(?:entication|orization)?\b|unauthorized|forbidden|invalid api key|"
     r"credit|billing|dirty (?:checkout|workdir|working tree)",
     re.I,
 )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -6180,6 +6180,39 @@ def test_collect_prior_compact_summaries_infers_departed_item_label(
     assert "Anthropic Claude: " + disposition in summaries[0]
 
 
+def test_collect_prior_compact_summaries_future_blocked_by_blocking_outcome_infers_resolved():
+    """An item with both 'future' and 'blocking' outcomes is labelled 'resolved' (blocking wins)."""
+    prior_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Original blocking item.",
+        status="blocking",
+    )
+    dispositions_by_item = {
+        "item-1": [
+            ReviewItemDisposition(
+                item_id="item-1",
+                reviewer="Reviewer A",
+                disposition="future",
+            ),
+            ReviewItemDisposition(
+                item_id="item-1",
+                reviewer="Reviewer B",
+                disposition="blocking",
+            ),
+        ]
+    }
+
+    summaries = _collect_prior_compact_summaries(
+        (prior_item,),
+        (),
+        dispositions_by_item,
+    )
+
+    assert summaries[0].startswith("[item-1] resolved:")
+
+
 @pytest.mark.parametrize("terminator", ["<!-- AGENT_STATE: approved -->", "-- OpenAI Codex"])
 def test_parse_non_blocking_followups_stops_at_final_markers(terminator):
     review = f"""
@@ -7076,6 +7109,50 @@ def test_source_line_references_with_5xx_numbers_are_not_transient(text):
 def test_explicit_server_error_phrases_remain_transient(text):
     assert _is_transient_agent_output(text)
     assert _failure_category(text) == "transient"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The authoritative PR diff shows no regressions.",
+        "Authoritative source confirms the change.",
+        "The author of this commit fixed the bug.",
+        "This is an authoritative reference.",
+    ],
+)
+def test_auth_prefix_words_are_not_non_retryable(text):
+    """Words starting with 'auth' that are not auth-failure keywords must not match."""
+    from coding_review_agent_loop.transient import NON_RETRYABLE_AGENT_OUTPUT_RE
+
+    assert not NON_RETRYABLE_AGENT_OUTPUT_RE.search(text), (
+        f"NON_RETRYABLE_AGENT_OUTPUT_RE unexpectedly matched: {text!r}"
+    )
+    assert _is_transient_agent_output(text) is False or True  # no crash; classification is unrelated
+    assert _failure_category(text) != "non-retryable"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "authentication failed",
+        "Authorization error",
+        "auth failed",
+        "unauthorized",
+        "forbidden",
+        "Invalid API Key",
+        "billing issue",
+        "credit limit exceeded",
+        "dirty checkout",
+    ],
+)
+def test_genuine_auth_and_billing_terms_remain_non_retryable(text):
+    """Real auth/billing/dirty-checkout diagnostics must still be non-retryable."""
+    from coding_review_agent_loop.transient import NON_RETRYABLE_AGENT_OUTPUT_RE
+
+    assert NON_RETRYABLE_AGENT_OUTPUT_RE.search(text), (
+        f"NON_RETRYABLE_AGENT_OUTPUT_RE did not match: {text!r}"
+    )
+    assert _failure_category(text) == "non-retryable"
 
 
 def test_plan_review_does_not_post_diagnostics_without_plan_state(tmp_path):
@@ -17103,6 +17180,115 @@ def test_envelope_normalization_plan_review_drops_after_footer_hr_marker():
         "item-1": "resolved",
         "item-2": "future",
     }
+
+
+@pytest.mark.parametrize(
+    "expected_kind",
+    ["pr_review", "plan_review", "coder_followup", "plan_revision"],
+)
+def test_envelope_normalization_recovers_reversed_signature_before_footer(expected_kind):
+    """Signature placed before the AGENT_STATE footer is reordered deterministically."""
+    if expected_kind == "pr_review":
+        json_obj = {
+            "schema_version": 1,
+            "kind": "pr_review",
+            "state": "blocking",
+            "summary": "Found issues.",
+            "blocking_items": ["Fix the bug"],
+            "same_pr_followups": [],
+            "future_followups": [],
+            "prior_item_dispositions": [],
+        }
+        footer = "<!-- AGENT_STATE: blocking -->"
+        signature = "-- OpenAI Codex"
+    elif expected_kind == "plan_review":
+        json_obj = {
+            "schema_version": 1,
+            "kind": "plan_review",
+            "state": "blocking",
+            "summary": "Plan needs work.",
+            "blocking_plan_issues": ["Missing tests"],
+            "same_plan_followups": [],
+            "future_followups": [],
+            "prior_plan_item_dispositions": [],
+        }
+        footer = "<!-- AGENT_PLAN_STATE: blocking -->"
+        signature = "-- OpenAI Codex"
+    elif expected_kind == "coder_followup":
+        json_obj = {
+            "schema_version": 1,
+            "kind": "coder_followup",
+            "state": "approved",
+            "summary": "All done.",
+            "addressed_items": [],
+            "remaining_items": [],
+            "addressed_item_notes": {},
+            "remaining_item_notes": {},
+            "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+        }
+        footer = "<!-- AGENT_STATE: approved -->"
+        signature = "-- Anthropic Claude"
+    else:  # plan_revision
+        json_obj = {
+            "schema_version": 1,
+            "kind": "plan_revision",
+            "state": "blocking",
+            "summary": "Revised.",
+            "prior_plan_item_dispositions": [],
+            "plan_steps": ["Do the thing."],
+        }
+        footer = "<!-- AGENT_PLAN_STATE: blocking -->"
+        signature = "-- Anthropic Claude"
+
+    # Reversed: signature comes before footer
+    raw = f"{json.dumps(json_obj)}\n{signature}\n{footer}"
+    normalized = attempt_envelope_normalization(raw, expected_kind=expected_kind)
+
+    assert normalized is not None, f"Expected normalization to succeed for {expected_kind}"
+    # Canonical order: JSON → footer → signature
+    assert normalized.endswith(f"\n{footer}\n{signature}"), (
+        f"Expected footer before signature; got:\n{normalized}"
+    )
+    assert normalized.index(footer) < normalized.index(signature)
+
+
+def test_envelope_normalization_reversed_signature_state_mismatch_returns_none():
+    """Reversed-signature recovery must not proceed when state mismatches."""
+    json_obj = {
+        "schema_version": 1,
+        "kind": "pr_review",
+        "state": "approved",  # JSON says approved
+        "summary": "All good.",
+        "blocking_items": [],
+        "same_pr_followups": [],
+        "future_followups": [],
+        "prior_item_dispositions": [],
+    }
+    # Footer says blocking — mismatch
+    raw = f"{json.dumps(json_obj)}\n-- OpenAI Codex\n<!-- AGENT_STATE: blocking -->"
+
+    assert attempt_envelope_normalization(raw, expected_kind="pr_review") is None
+
+
+def test_envelope_normalization_reversed_signature_with_extra_prose_returns_none():
+    """Reversed-signature recovery must not fire when extra prose precedes the footer."""
+    json_obj = {
+        "schema_version": 1,
+        "kind": "pr_review",
+        "state": "blocking",
+        "summary": "Issues found.",
+        "blocking_items": ["Fix it"],
+        "same_pr_followups": [],
+        "future_followups": [],
+        "prior_item_dispositions": [],
+    }
+    # Extra prose between JSON and signature — not a clean reversed envelope
+    raw = (
+        f"{json.dumps(json_obj)}\nExtra prose here.\n"
+        "-- OpenAI Codex\n<!-- AGENT_STATE: blocking -->"
+    )
+
+    assert attempt_envelope_normalization(raw, expected_kind="pr_review") is None
 
 
 def test_envelope_normalization_returns_none_when_no_footer():


### PR DESCRIPTION
## Summary

Addresses issues #425, #428, #430, #431, #434, #435 in one PR.

- **#428**: Bound `NON_RETRYABLE_AGENT_OUTPUT_RE` with `\b` word boundaries around `auth` so words like `authoritative`, `author` are not classified as authentication failures. Adds tests for both the false-positive cases and the genuine auth/billing terms.

- **#431**: Extend `attempt_envelope_normalization` to deterministically recover the reversed signature/footer ordering (`JSON → signature → footer` → `JSON → footer → signature`). Applies when `before_footer` is exactly one signature line and nothing follows the footer, with state-match validation. Adds tests for all four structured kinds, state-mismatch rejection, and extra-prose rejection.

- **#430**: Replace the static `<base>` placeholder in Antigravity's GEMINI.md single-shot instruction with the resolved `config.base` branch (when available). Falls back to a descriptive placeholder when the base is unknown.

- **#434**: Unlink the orphaned `gemini_lock_path` after releasing the lock in the `role == "repair"` path. Each repair run uses a unique tempdir suffix, so the lock files accumulated; they are now removed after use.

- **#435**: Thread the validated result returned by `execute_repair` (second element of the tuple) through to the callers in `_run_plan_first_loop` and `run_pr_loop`, eliminating the redundant `_validate_plan_review_response` / `_validate_review_response` re-call and the surrounding `try/except AgentLoopError`. The guard is now `if repaired_validated is not None:` which subsumes both `repaired_text is not None` and the validation-exception path.

- **#425**: Add `test_collect_prior_compact_summaries_future_blocked_by_blocking_outcome_infers_resolved` confirming that an item dispositioned with both `future` and `blocking` outcomes is labelled `resolved` (blocking wins over future in the guard set).

## Test plan

- All 900 existing tests continue to pass (`python3 -m pytest tests/test_agent_loop.py -q`).
- New tests: 13 for auth regex (#428), 6 for reversed-signature envelope normalization (#431), 1 for future+blocking label inference (#425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)