### PR TITLE
Consolidate duplicate autouse fixtures into tests/conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_real_repair():
+    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
+
+    Tests that explicitly test repair behaviour patch the orchestrator-level
+    import themselves, which takes precedence over this fixture.  Unit tests
+    for attempt_repair itself patch subprocess.run directly, so they are
+    unaffected here.
+    """
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _agent_commands_available(monkeypatch):
+    """Keep config tests independent of agent CLIs installed on the test host."""
+    import coding_review_agent_loop.config as config_module
+
+    real_which = config_module.shutil.which
+
+    def which(command):
+        resolved = real_which(command)
+        if resolved is not None:
+            return resolved
+        if command in {"claude", "codex", "gemini", "agy"}:
+            return f"/mock/bin/{command}"
+        return None
+
+    monkeypatch.setattr(config_module.shutil, "which", which)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -71,36 +71,6 @@ from agent_loop_helpers import (
     structured_pr_review,
 )
 
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
-
-    Tests that explicitly test repair behaviour patch the orchestrator-level
-    import themselves, which takes precedence over this fixture.  Unit tests
-    for attempt_repair itself patch subprocess.run directly, so they are
-    unaffected here.
-    """
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
-
 
 def test_pre_review_tests_can_be_disabled(tmp_path):
     runner = FakeRunner(

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -1,31 +1,4 @@
-import pytest
-
 from agent_loop_helpers import *  # noqa: F403
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 def test_antigravity_backend_command_and_prefers_response_file(tmp_path):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -28,32 +28,6 @@ from agent_loop_helpers import (
     FakeRunner,
     make_config,
 )
-from unittest.mock import patch
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 def _write_codex_rollout(

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -47,32 +47,6 @@ from agent_loop_helpers import (
     structured_plan_state,
     structured_pr_review,
 )
-from unittest.mock import patch
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 def test_render_canonical_plan_steps_numbers_items():
     assert render_canonical_plan_steps(("Update protocol.py.", "Add tests.")) == (

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
@@ -17,35 +15,6 @@ from coding_review_agent_loop.github import IssueComment
 from coding_review_agent_loop.orchestrator import PostedRoundMetadata, _attach_round_metadata, _plan_subject
 from agent_loop_helpers import FakeRunner, make_config, plan_decomposition_json, structured_plan_review
 
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
-
-    Tests that explicitly test repair behaviour patch the orchestrator-level
-    import themselves, which takes precedence over this fixture.  Unit tests
-    for attempt_repair itself patch subprocess.run directly, so they are
-    unaffected here.
-    """
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 def test_parse_plan_decomposition_accepts_agent_and_human_phases():
     parsed = parse_plan_decomposition(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,31 +1,4 @@
-import pytest
-
 from agent_loop_helpers import *  # noqa: F403
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 def _git(cwd: Path, *args: str) -> None:

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -31,35 +31,6 @@ from agent_loop_helpers import (
     structured_pr_review,
 )
 
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
-
-    Tests that explicitly test repair behaviour patch the orchestrator-level
-    import themselves, which takes precedence over this fixture.  Unit tests
-    for attempt_repair itself patch subprocess.run directly, so they are
-    unaffected here.
-    """
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     runner = FakeRunner(

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -57,35 +57,6 @@ from agent_loop_helpers import (
     structured_pr_review,
 )
 
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
-
-    Tests that explicitly test repair behaviour patch the orchestrator-level
-    import themselves, which takes precedence over this fixture.  Unit tests
-    for attempt_repair itself patch subprocess.run directly, so they are
-    unaffected here.
-    """
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
     runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,7 +2,6 @@ import pytest
 
 from agent_loop_helpers import *  # noqa: F403
 
-
 _EXPECTED_UNRESOLVED_ITEMS_GUIDANCE = """Prior unresolved items are present. Disposition every listed
 item in the JSON `prior_item_dispositions` array — do not add a separate prose section
 or bullet list for prior items outside the JSON object. Valid `disposition` values:
@@ -94,31 +93,6 @@ current round as blocking work, not in a future issue.
 The legacy heading `### Non-blocking follow-ups` is still accepted as future
 follow-ups for compatibility, but prefer `### Future follow-ups`.
 """
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
-
 
 def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
     config = make_config(tmp_path, coder="codex")

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -74,32 +74,7 @@ from agent_loop_helpers import (
     structured_plan_state,
     structured_pr_review,
 )
-from unittest.mock import patch
 
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 def test_parse_agent_state_accepts_html_marker():
     assert parse_agent_state("looks fine\n<!-- AGENT_STATE: approved -->") == "approved"

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,31 +1,4 @@
-import pytest
-
 from agent_loop_helpers import *  # noqa: F403
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 from coding_review_agent_loop.repair import (

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -1,31 +1,4 @@
-import pytest
-
 from agent_loop_helpers import *  # noqa: F403
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 def test_structured_plan_review_preserves_human_requirements_resolution_marker():

--- a/tests/test_task_loop.py
+++ b/tests/test_task_loop.py
@@ -1,39 +1,8 @@
-from unittest.mock import patch
-
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError, run_task_loop
 from agent_loop_helpers import FakeRunner, command_index, make_config, prior_item_dispositions
 
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent attempt_repair from calling the real Gemini CLI in all tests.
-
-    Tests that explicitly test repair behaviour patch the orchestrator-level
-    import themselves, which takes precedence over this fixture.  Unit tests
-    for attempt_repair itself patch subprocess.run directly, so they are
-    unaffected here.
-    """
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 def test_task_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     runner = FakeRunner(

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,31 +1,4 @@
-import pytest
-
 from agent_loop_helpers import *  # noqa: F403
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 def test_codex_usage_summary_records_exact_tokens_from_jsonl_and_public_response(tmp_path):

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -1,31 +1,4 @@
-import pytest
-
 from agent_loop_helpers import *  # noqa: F403
-
-
-@pytest.fixture(autouse=True)
-def _no_real_repair():
-    """Prevent orchestrator repair from invoking a real agent in this module."""
-    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=None):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def _agent_commands_available(monkeypatch):
-    """Keep config tests independent of agent CLIs installed on the test host."""
-    import coding_review_agent_loop.config as config_module
-
-    real_which = config_module.shutil.which
-
-    def which(command):
-        resolved = real_which(command)
-        if resolved is not None:
-            return resolved
-        if command in {"claude", "codex", "gemini", "agy"}:
-            return f"/mock/bin/{command}"
-        return None
-
-    monkeypatch.setattr(config_module.shutil, "which", which)
 
 
 def test_workdir_guard_rejects_outside_home_path(tmp_path):


### PR DESCRIPTION
## Summary

- Creates `tests/conftest.py` with the two identical `autouse` fixtures (`_no_real_repair` and `_agent_commands_available`) that were duplicated across 15 test modules
- Removes the per-module fixture definitions, saving ~380 lines of boilerplate
- Removes now-unused `from unittest.mock import patch` imports from files that only needed it for the fixtures

Fixes #443

## Test plan

- [x] Full test suite: `python3 -m pytest tests/ -q` — 1078 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)