### PR TITLE
fix: sync reviewer workdir to PR branch after cleaning

### DIFF
--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -165,6 +165,18 @@ def main() -> None:
              "When provided, workdir is validated and re-cloned automatically.",
     )
     parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="PR number. When provided with --flow pr, syncs the workdir to the PR head "
+             "instead of leaving it on the base branch after cleaning.",
+    )
+    parser.add_argument(
+        "--pr-head-sha",
+        default=None,
+        help="Expected PR head SHA for verification (optional). Used with --pr.",
+    )
+    parser.add_argument(
         "--max-retries",
         type=int,
         default=2,
@@ -247,7 +259,9 @@ def main() -> None:
         AgentLoopConfig,
         AgentName,
         ensure_temp_checkout,
+        sync_checkout_to_pr,
     )
+    from coding_review_agent_loop.github import PullRequestMetadata
     from coding_review_agent_loop.transient import is_transient_agent_output
     from coding_review_agent_loop.usage import estimate_usage
 
@@ -317,6 +331,26 @@ def main() -> None:
     # deterministically and re-cloning per attempt would be wasteful.
     if args.repo:
         ensure_temp_checkout(workdir, agent=agent_name, config=config, runner=runner)
+        if args.flow == "pr" and args.pr is not None:
+            # After ensure_temp_checkout leaves the workdir on the base branch,
+            # sync to the PR head so the reviewer sees the PR branch, not main.
+            sync_checkout_to_pr(
+                config,
+                runner,
+                path=workdir,
+                label=f"Default {agent_name} workdir",
+                default_owned=True,
+                pr_number=args.pr,
+                pr_metadata=PullRequestMetadata(
+                    number=args.pr,
+                    repo=args.repo,
+                    title=None,
+                    head_branch=None,
+                    base_branch=None,
+                    head_sha=args.pr_head_sha,
+                    url=None,
+                ),
+            )
     if agent_name == "codex":
         backend = CodexBackend()
     elif agent_name == "antigravity":

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -1326,6 +1326,8 @@ def _run_reviewer(
         "--flow", flow,
         "--usage-output", str(usage_file),
         "--response-evidence-output", str(evidence_file),
+        *(["--pr", str(issue), "--pr-head-sha", round_subject] if flow == "pr" and round_subject else
+          ["--pr", str(issue)] if flow == "pr" else []),
         *(["--cmd", gemini_cmd] if agent == "gemini" else []),
         *external_args,
         *(["--dry-run"] if dry_run else []),

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1407,6 +1407,116 @@ class TestRunExternalRetries:
 
 
 # ---------------------------------------------------------------------------
+# helpers/run_external.py  PR workdir sync (#449)
+# ---------------------------------------------------------------------------
+
+class TestRunExternalPRWorkdirSync:
+    """run_external syncs workdir to the PR head (not base) when --flow pr --pr N is given."""
+
+    def _invoke_pr(self, monkeypatch, tmp_path, *, pr=42, head_sha="abc123", repo="owner/repo"):
+        """Call run_external.main() in PR flow with mocked checkout functions and a trivial backend."""
+        import helpers.run_external as rex
+        import coding_review_agent_loop.config as cfg_mod
+        from coding_review_agent_loop.agents.base import AgentResult
+
+        ensure_calls: list[dict] = []
+        sync_calls: list[dict] = []
+
+        def fake_ensure_temp_checkout(path, *, agent, config, runner):
+            ensure_calls.append({"path": path, "agent": agent})
+
+        def fake_sync_checkout_to_pr(config, runner, *, path, label, default_owned, pr_number, pr_metadata):
+            sync_calls.append({
+                "path": path,
+                "pr_number": pr_number,
+                "head_sha": pr_metadata.head_sha,
+                "default_owned": default_owned,
+            })
+
+        monkeypatch.setattr(cfg_mod, "ensure_temp_checkout", fake_ensure_temp_checkout)
+        monkeypatch.setattr(cfg_mod, "sync_checkout_to_pr", fake_sync_checkout_to_pr)
+
+        class FakeBackend:
+            def run(self, runner, config, prompt):
+                return AgentResult(text="review body", returncode=0)
+
+        monkeypatch.setattr("coding_review_agent_loop.agents.codex.CodexBackend", FakeBackend)
+
+        prompt = tmp_path / "prompt.md"
+        output = tmp_path / "output.md"
+        prompt.write_text("Review this PR.", encoding="utf-8")
+
+        argv = [
+            "run_external", "--agent", "codex",
+            "--prompt-file", str(prompt),
+            "--output", str(output),
+            "--workdir", str(tmp_path),
+            "--flow", "pr",
+            "--repo", repo,
+            "--pr", str(pr),
+        ]
+        if head_sha:
+            argv += ["--pr-head-sha", head_sha]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        rex.main()
+
+        return ensure_calls, sync_calls, output
+
+    def test_pr_flow_calls_sync_checkout_to_pr(self, monkeypatch, tmp_path) -> None:
+        """sync_checkout_to_pr is called after ensure_temp_checkout for PR flow."""
+        ensure_calls, sync_calls, output = self._invoke_pr(monkeypatch, tmp_path)
+
+        assert len(ensure_calls) == 1, "ensure_temp_checkout must be called once"
+        assert len(sync_calls) == 1, "sync_checkout_to_pr must be called once to reach the PR branch"
+
+    def test_pr_flow_passes_pr_number(self, monkeypatch, tmp_path) -> None:
+        _ensure, sync_calls, _ = self._invoke_pr(monkeypatch, tmp_path, pr=99)
+        assert sync_calls[0]["pr_number"] == 99
+
+    def test_pr_flow_passes_head_sha(self, monkeypatch, tmp_path) -> None:
+        _ensure, sync_calls, _ = self._invoke_pr(monkeypatch, tmp_path, head_sha="deadbeef")
+        assert sync_calls[0]["head_sha"] == "deadbeef"
+
+    def test_pr_flow_no_head_sha_still_syncs(self, monkeypatch, tmp_path) -> None:
+        """--pr-head-sha is optional; sync still runs when omitted."""
+        _ensure, sync_calls, _ = self._invoke_pr(monkeypatch, tmp_path, head_sha=None)
+        assert len(sync_calls) == 1
+        assert sync_calls[0]["head_sha"] is None
+
+    def test_plan_flow_does_not_call_sync_checkout_to_pr(self, monkeypatch, tmp_path) -> None:
+        """For plan flow (not PR), sync_checkout_to_pr must not be called."""
+        import helpers.run_external as rex
+        import coding_review_agent_loop.config as cfg_mod
+        from coding_review_agent_loop.agents.base import AgentResult
+
+        sync_calls: list = []
+        monkeypatch.setattr(cfg_mod, "ensure_temp_checkout", lambda *a, **k: None)
+        monkeypatch.setattr(cfg_mod, "sync_checkout_to_pr", lambda *a, **k: sync_calls.append(True))
+
+        class FakeBackend:
+            def run(self, runner, config, prompt):
+                return AgentResult(text="ok", returncode=0)
+
+        monkeypatch.setattr("coding_review_agent_loop.agents.codex.CodexBackend", FakeBackend)
+
+        prompt = tmp_path / "prompt.md"
+        output = tmp_path / "output.md"
+        prompt.write_text("Review this plan.", encoding="utf-8")
+
+        monkeypatch.setattr(sys, "argv", [
+            "run_external", "--agent", "codex",
+            "--prompt-file", str(prompt),
+            "--output", str(output),
+            "--workdir", str(tmp_path),
+            "--flow", "plan",
+            "--repo", "owner/repo",
+        ])
+        rex.main()
+        assert sync_calls == [], "sync_checkout_to_pr must not be called for plan flow"
+
+
+# ---------------------------------------------------------------------------
 # helpers/prompt_builders.py  checkout path embedding (#297)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `run-pr-round --workdir-codex PATH` with a dirty workdir called `ensure_temp_checkout` which cleaned the workdir but then left it on the base branch (main). Codex then reviewed the stale tree and produced false-positive blocking reviews.
- Added `--pr` and `--pr-head-sha` arguments to `helpers/run_external.py`. When `--flow pr --pr N` is provided, `sync_checkout_to_pr` is called after `ensure_temp_checkout` to detach HEAD at the PR head ref.
- Updated `_run_reviewer` in `helpers/skill_runner.py` to pass `--pr <pr_number>` (and `--pr-head-sha <head_sha>` when available) to `run_external` for PR-flow reviewer turns.
- Added `TestRunExternalPRWorkdirSync` with 5 tests covering: PR flow triggers sync, correct PR number, correct head SHA, optional SHA (graceful), and plan flow does not trigger sync.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 1088 passed
- [x] New `TestRunExternalPRWorkdirSync` tests verify the fix end-to-end via monkeypatched checkout functions

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)