### PR TITLE
feat: add coder dispute mechanism for factually incorrect reviewer claims

### DIFF
--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -432,12 +432,25 @@ def _render_public_coder_followup_comment(
     if not remaining_items:
         remaining_items = ["- None."]
 
+    disputed_items: list[str] = []
+    for item_id in parsed_followup.disputed_items:
+        disputed_items.extend(
+            render_item(
+                item_id,
+                note_label="Counter-evidence",
+                note=parsed_followup.dispute_evidence.get(item_id),
+                placeholder="No evidence provided by coder.",
+            )
+        )
+
     sections = [
         "## Coder follow-up",
         parsed_followup.summary.strip(),
         "\n".join(["### Addressed items", *addressed_items]),
         "\n".join(["### Remaining items", *remaining_items]),
     ]
+    if disputed_items:
+        sections.append("\n".join(["### Disputed items", *disputed_items]))
     if parsed_followup.tests_run:
         sections.append(
             "\n".join(["### Tests run", *[f"- {test}" for test in parsed_followup.tests_run]])

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -189,12 +189,15 @@ from .round_state import (
 )
 from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
+    CODER_DISPUTE_NOTE_PREFIX,
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+    _apply_dispute_evidence,
     _apply_unresolved_item_dispositions,
     _collect_prior_compact_summaries,
     _clear_human_requirements_ack_item,
     _format_same_pr_unresolved_items,
     _format_unresolved_items_for_coder,
+    _is_disputed_item,
     _maybe_fill_resolved_dispositions_from_prose,
     _next_unresolved_item,
     _normalize_disposition_section_prose,
@@ -3023,6 +3026,26 @@ def run_pr_loop(
             ]
             must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
 
+            if must_fix_items:
+                prior_item_ids = {item.item_id for item in prior_unresolved_items}
+                disputed_still_blocking = [
+                    item for item in must_fix_items
+                    if item.status == "blocking"
+                    and item.item_id in prior_item_ids
+                    and _is_disputed_item(item)
+                ]
+                if disputed_still_blocking:
+                    item_summaries = "\n".join(
+                        f"- [{item.item_id}] from {item.reviewer}: {item.text[:300]}"
+                        for item in disputed_still_blocking
+                    )
+                    raise AgentLoopError(
+                        f"Reviewer maintained blocking status for "
+                        f"{len(disputed_still_blocking)} disputed item(s) after seeing "
+                        "coder counter-evidence. Human review required to resolve the "
+                        f"disagreement.\n\nDisputed items still blocking:\n{item_summaries}"
+                    )
+
             if not must_fix_items:
                 if human_requirements:
                     missing_acknowledgements = [
@@ -3287,6 +3310,18 @@ def run_pr_loop(
                     assigned_workdir=active_workdir(config),
                 )
                 raw_structured_coder_response = coder_output
+                if coder_response.marker_value.disputed_items:
+                    unresolved_items = _apply_dispute_evidence(
+                        unresolved_items,
+                        disputed_items=coder_response.marker_value.disputed_items,
+                        dispute_evidence=coder_response.marker_value.dispute_evidence,
+                    )
+                    disputed_names = ", ".join(coder_response.marker_value.disputed_items)
+                    log(
+                        config,
+                        f"Round {round_number}: {coder_name} disputed item(s) {disputed_names} "
+                        "with counter-evidence; will surface to human if reviewer still blocks",
+                    )
                 public_comment = render_public_agent_comment(
                     kind="coder_followup",
                     parsed=coder_response.marker_value,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3030,8 +3030,7 @@ def run_pr_loop(
                 prior_item_ids = {item.item_id for item in prior_unresolved_items}
                 disputed_still_blocking = [
                     item for item in must_fix_items
-                    if item.status == "blocking"
-                    and item.item_id in prior_item_ids
+                    if item.item_id in prior_item_ids
                     and _is_disputed_item(item)
                 ]
                 if disputed_still_blocking:
@@ -3040,10 +3039,9 @@ def run_pr_loop(
                         for item in disputed_still_blocking
                     )
                     raise AgentLoopError(
-                        f"Reviewer maintained blocking status for "
-                        f"{len(disputed_still_blocking)} disputed item(s) after seeing "
-                        "coder counter-evidence. Human review required to resolve the "
-                        f"disagreement.\n\nDisputed items still blocking:\n{item_summaries}"
+                        f"Reviewer did not resolve {len(disputed_still_blocking)} disputed item(s) "
+                        "after seeing coder counter-evidence. Human review required to resolve the "
+                        f"disagreement.\n\nDisputed items still unresolved:\n{item_summaries}"
                     )
 
             if not must_fix_items:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -467,8 +467,10 @@ def _structured_coder_followup_guidance(
         '  "summary": "Implemented the requested fix and left one reviewer item for follow-up.",',
         '  "addressed_items": ["item-1"],',
         '  "remaining_items": ["item-2"],',
+        '  "disputed_items": ["item-3"],',
         '  "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},',
         '  "remaining_item_notes": {"item-2": "Deferred because it requires a separate UI change."},',
+        '  "dispute_evidence": {"item-3": "Checked Google pricing page (https://...): $1.50/1M tokens is correct per the official docs."},',
         '  "human_requirements": {',
         f'    "addressed_ids": {example_human_requirement_ids_json},',
         '    "checked_discussion_directly": false',
@@ -476,11 +478,12 @@ def _structured_coder_followup_guidance(
         '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
         "}",
         "",
-        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `addressed_item_notes`, `remaining_item_notes`, and `tests_run` are optional.",
+        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `addressed_item_notes`, `remaining_item_notes`, `disputed_items`, `dispute_evidence`, and `tests_run` are optional.",
         "Your response and public response file must start directly with `{`, contain exactly one top-level JSON object, and must not include stdout filtering markers, prose, headings, or code fences before or between the JSON and footer.",
         "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->`, then only your standalone signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
-        "Use `addressed_items` and `remaining_items` to classify the unresolved reviewer item IDs shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
+        "Use `addressed_items`, `remaining_items`, and `disputed_items` to classify every unresolved reviewer item ID shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
         "Use `addressed_item_notes` to summarize how each addressed item was resolved, and use `remaining_item_notes` to give a visible reason for each intentionally deferred remaining item.",
+        "Use `disputed_items` when a reviewer claim is factually incorrect (wrong pricing, stale diff reading, incorrect behavior assumption) and you have verifiable counter-evidence. Put the item ID in `disputed_items` instead of `addressed_items` or `remaining_items`, and record your evidence in `dispute_evidence`. The reviewer will get one more turn to reconsider with your evidence attached. If the reviewer still blocks after seeing the evidence, the orchestrator will surface the disagreement to a human for resolution.",
     ]
     if human_requirements_context.surfaced_requirement_ids:
         surfaced = ", ".join(f"`{item}`" for item in human_requirements_context.surfaced_requirement_ids)

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Sequence
-from dataclasses import dataclass
+import dataclasses
+from dataclasses import dataclass, field
 
 from .errors import AgentLoopError
 
@@ -193,6 +194,8 @@ class StructuredCoderFollowup:
     addressed_item_notes: dict[str, str]
     remaining_item_notes: dict[str, str]
     tests_run: tuple[str, ...] | None = None
+    disputed_items: tuple[str, ...] = ()
+    dispute_evidence: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -1151,7 +1154,13 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
             "remaining_items",
             "human_requirements",
         },
-        optional={"addressed_item_notes", "remaining_item_notes", "tests_run"},
+        optional={
+            "addressed_item_notes",
+            "remaining_item_notes",
+            "tests_run",
+            "disputed_items",
+            "dispute_evidence",
+        },
     )
     human_requirements_payload = _expect_object(
         payload["human_requirements"],
@@ -1180,6 +1189,10 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
         payload["remaining_items"],
         context="coder_followup.remaining_items",
     )
+    disputed_items = _expect_item_id_list(
+        payload.get("disputed_items", []),
+        context="coder_followup.disputed_items",
+    )
     addressed_item_notes = _expect_item_note_map(
         payload.get("addressed_item_notes", {}),
         context="coder_followup.addressed_item_notes",
@@ -1192,6 +1205,19 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
         allowed_item_ids=set(remaining_items),
         allowed_context="coder_followup.remaining_items",
     )
+    dispute_evidence = _expect_item_note_map(
+        payload.get("dispute_evidence", {}),
+        context="coder_followup.dispute_evidence",
+        allowed_item_ids=set(disputed_items),
+        allowed_context="coder_followup.disputed_items",
+    )
+    all_classified = [*addressed_items, *remaining_items, *disputed_items]
+    duplicates = sorted({item_id for item_id in all_classified if all_classified.count(item_id) > 1})
+    if duplicates:
+        raise AgentLoopError(
+            "Coder follow-up listed unresolved reviewer item IDs more than once: "
+            + ", ".join(duplicates)
+        )
     return StructuredCoderFollowup(
         schema_version=1,
         kind="coder_followup",
@@ -1212,6 +1238,8 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
         addressed_item_notes=addressed_item_notes,
         remaining_item_notes=remaining_item_notes,
         tests_run=tests_run,
+        disputed_items=disputed_items,
+        dispute_evidence=dispute_evidence,
     )
 
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -1211,6 +1211,12 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
         allowed_item_ids=set(disputed_items),
         allowed_context="coder_followup.disputed_items",
     )
+    missing_evidence = sorted(item_id for item_id in disputed_items if not dispute_evidence.get(item_id))
+    if missing_evidence:
+        raise AgentLoopError(
+            "Coder dispute must include non-empty evidence for each disputed item. "
+            "Missing evidence for: " + ", ".join(missing_evidence)
+        )
     all_classified = [*addressed_items, *remaining_items, *disputed_items]
     duplicates = sorted({item_id for item_id in all_classified if all_classified.count(item_id) > 1})
     if duplicates:

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -21,6 +21,7 @@ from .protocol import (
 )
 
 HUMAN_REQUIREMENTS_ACK_ITEM_ID = "item-human-requirements-acknowledgement"
+CODER_DISPUTE_NOTE_PREFIX = "Coder disputes this item"
 ALL_RESOLVED_PROSE_RE = re.compile(
     r"^all (?:prior items|listed items|carried-forward items) are resolved\.?$"
     r"|^all prior unresolved items have been resolved\.?$",
@@ -71,6 +72,45 @@ def _next_unresolved_item(
         source_status=status,
         notes=tuple(notes),
     )
+
+
+def _apply_dispute_evidence(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    *,
+    disputed_items: Sequence[str],
+    dispute_evidence: dict[str, str],
+) -> list[UnresolvedReviewItem]:
+    """Annotate disputed items with coder counter-evidence in their notes field."""
+    if not disputed_items:
+        return list(unresolved_items)
+    disputed_set = set(disputed_items)
+    result: list[UnresolvedReviewItem] = []
+    for item in unresolved_items:
+        if item.item_id not in disputed_set:
+            result.append(item)
+            continue
+        evidence = dispute_evidence.get(item.item_id, "")
+        note = f"{CODER_DISPUTE_NOTE_PREFIX}: {evidence}" if evidence else CODER_DISPUTE_NOTE_PREFIX
+        if note not in item.notes:
+            result.append(
+                UnresolvedReviewItem(
+                    item_id=item.item_id,
+                    reviewer=item.reviewer,
+                    source_round=item.source_round,
+                    text=item.text,
+                    status=item.status,
+                    source_status=item.source_status,
+                    notes=(*item.notes, note),
+                )
+            )
+        else:
+            result.append(item)
+    return result
+
+
+def _is_disputed_item(item: UnresolvedReviewItem) -> bool:
+    """Return True if this item has been disputed by the coder via counter-evidence."""
+    return any(note.startswith(CODER_DISPUTE_NOTE_PREFIX) for note in item.notes)
 
 
 def _same_round_prior_disposition_description(
@@ -227,7 +267,7 @@ def _validate_structured_coder_followup_items(
     expected_ids = [
         item.item_id for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
     ]
-    listed_ids = [*parsed.addressed_items, *parsed.remaining_items]
+    listed_ids = [*parsed.addressed_items, *parsed.remaining_items, *parsed.disputed_items]
     duplicates = sorted({item_id for item_id in listed_ids if listed_ids.count(item_id) > 1})
     if duplicates:
         raise AgentLoopError(
@@ -243,7 +283,8 @@ def _validate_structured_coder_followup_items(
     missing = sorted(set(expected_ids) - set(listed_ids))
     if missing:
         raise AgentLoopError(
-            "Coder follow-up did not classify all unresolved reviewer items into addressed or remaining: "
+            "Coder follow-up did not classify all unresolved reviewer items into "
+            "addressed, remaining, or disputed: "
             + ", ".join(missing)
         )
 

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -853,28 +853,31 @@ def structured_coder_followup(
     human_requirement_ids: list[str] | None = None,
     checked_discussion_directly: bool = False,
     tests_run: list[str] | None = None,
+    disputed_items: list[str] | None = None,
+    dispute_evidence: dict[str, str] | None = None,
     reviewer: str = "Anthropic Claude",
 ) -> str:
-    return (
-        json.dumps(
-            {
-                "schema_version": 1,
-                "kind": "coder_followup",
-                "state": state,
-                "summary": summary,
-                "addressed_items": addressed_items or [],
-                "remaining_items": remaining_items or [],
-                "addressed_item_notes": addressed_item_notes or {},
-                "remaining_item_notes": remaining_item_notes or {},
-                "human_requirements": {
-                    "addressed_ids": human_requirement_ids or [],
-                    "checked_discussion_directly": checked_discussion_directly,
-                },
-                **({"tests_run": tests_run} if tests_run is not None else {}),
-            }
-        )
-        + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
-    )
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "coder_followup",
+        "state": state,
+        "summary": summary,
+        "addressed_items": addressed_items or [],
+        "remaining_items": remaining_items or [],
+        "addressed_item_notes": addressed_item_notes or {},
+        "remaining_item_notes": remaining_item_notes or {},
+        "human_requirements": {
+            "addressed_ids": human_requirement_ids or [],
+            "checked_discussion_directly": checked_discussion_directly,
+        },
+    }
+    if tests_run is not None:
+        payload["tests_run"] = tests_run
+    if disputed_items is not None:
+        payload["disputed_items"] = disputed_items
+    if dispute_evidence is not None:
+        payload["dispute_evidence"] = dispute_evidence
+    return json.dumps(payload) + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
 
 
 def make_config(tmp_path, *, create_dirs=True, **overrides):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -3402,3 +3402,141 @@ def test_pr_initial_coder_post_includes_model(tmp_path):
     stripped = _strip_round_metadata(pr_initial_body)
     assert stripped.endswith("-- Anthropic Claude: gpt-5.5 (medium)")
 
+
+def test_pr_loop_dispute_resolved_when_reviewer_reconsiders(tmp_path):
+    """Coder disputes a blocking item; reviewer sees evidence and approves."""
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_coder_followup(
+                addressed_items=[],
+                remaining_items=[],
+                disputed_items=["item-1"],
+                dispute_evidence={"item-1": "Official docs confirm $1.50/1M tokens is correct."},
+                summary="Disputing item-1: reviewer pricing claim is factually incorrect.",
+            ),
+        ],
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Pricing constant is wrong.",
+                blocking_items=["The gemini-3.5-flash pricing constant is wrong ($0.30 not $1.50)."],
+                prior_item_dispositions=[],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Coder provided valid pricing evidence; approved.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Coder provided valid pricing evidence."},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
+
+    assert run_pr_loop(runner, pr_number=55, config=config) == 0
+
+    followup_comments = [c for c in runner.comments if "## Coder follow-up" in c]
+    assert len(followup_comments) == 1
+    followup_body = _strip_round_metadata(followup_comments[0])
+    assert "### Disputed items" in followup_body
+    assert "item-1" in followup_body
+    assert "Official docs confirm $1.50/1M tokens is correct." in followup_body
+
+
+def test_pr_loop_escalates_to_human_when_reviewer_rejects_dispute(tmp_path):
+    """Coder disputes a blocking item; reviewer still blocks after seeing evidence → escalate."""
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_coder_followup(
+                addressed_items=[],
+                remaining_items=[],
+                disputed_items=["item-1"],
+                dispute_evidence={"item-1": "Official docs confirm $1.50/1M tokens is correct."},
+                summary="Disputing item-1: reviewer pricing claim is factually incorrect.",
+            ),
+        ],
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Pricing constant is wrong.",
+                blocking_items=["The gemini-3.5-flash pricing constant is wrong ($0.30 not $1.50)."],
+                prior_item_dispositions=[],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="blocking",
+                summary="Pricing still incorrect despite coder evidence.",
+                blocking_items=["Pricing is still incorrect."],
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "blocking", "note": "I checked and the pricing is still wrong."},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
+
+    with pytest.raises(
+        AgentLoopError,
+        match="Reviewer maintained blocking status for 1 disputed item",
+    ):
+        run_pr_loop(runner, pr_number=55, config=config)
+
+
+def test_pr_loop_dispute_note_is_visible_to_reviewer_in_next_round(tmp_path):
+    """After coder disputes, the dispute evidence note appears in prior items for reviewer."""
+    from coding_review_agent_loop.unresolved_items import CODER_DISPUTE_NOTE_PREFIX
+
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_coder_followup(
+                addressed_items=[],
+                remaining_items=[],
+                disputed_items=["item-1"],
+                dispute_evidence={"item-1": "Evidence: price is $1.50 not $0.30."},
+                summary="Disputing item-1.",
+            ),
+        ],
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Price is wrong.",
+                blocking_items=["Price is wrong."],
+                prior_item_dispositions=[],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Approved after reviewing coder evidence.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved", "note": "Accepted coder evidence."},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
+    run_pr_loop(runner, pr_number=55, config=config)
+
+    # The prior_items stored in the coder's PR comment should include dispute notes
+    # runner.pr_payload["comments"] retains the raw body with AGENT_LOOP_META intact
+    coder_followup_raw = next(
+        (c["body"] for c in runner.pr_payload["comments"] if "## Coder follow-up" in c["body"]),
+        None,
+    )
+    assert coder_followup_raw is not None, "Expected a coder follow-up comment in PR"
+    meta_match = re.search(
+        r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+        coder_followup_raw,
+    )
+    assert meta_match is not None, "Expected AGENT_LOOP_META in coder followup comment"
+    metadata = _decode_round_metadata(meta_match.group("payload"))
+    assert metadata is not None
+    disputed_item = next(
+        (item for item in metadata.prior_items if item.item_id == "item-1"), None
+    )
+    assert disputed_item is not None
+    assert any(CODER_DISPUTE_NOTE_PREFIX in note for note in disputed_item.notes)
+

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -3480,7 +3480,47 @@ def test_pr_loop_escalates_to_human_when_reviewer_rejects_dispute(tmp_path):
 
     with pytest.raises(
         AgentLoopError,
-        match="Reviewer maintained blocking status for 1 disputed item",
+        match="Reviewer did not resolve 1 disputed item",
+    ):
+        run_pr_loop(runner, pr_number=55, config=config)
+
+
+def test_pr_loop_escalates_when_reviewer_downgrades_disputed_item_to_same_pr(tmp_path):
+    """Coder disputes a blocking item; reviewer downgrades to same-pr instead of resolving → escalate."""
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_coder_followup(
+                addressed_items=[],
+                remaining_items=[],
+                disputed_items=["item-1"],
+                dispute_evidence={"item-1": "Official docs confirm $1.50/1M tokens is correct."},
+                summary="Disputing item-1: reviewer pricing claim is factually incorrect.",
+            ),
+        ],
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Pricing constant is wrong.",
+                blocking_items=["The gemini-3.5-flash pricing constant is wrong ($0.30 not $1.50)."],
+                prior_item_dispositions=[],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="blocking",
+                summary="Ok I'll accept the coder's pricing evidence but still want a same-pr fix.",
+                same_pr_followups=["Please add a comment citing the pricing source."],
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "same-pr", "note": "Downgraded from blocking but still needs attention."},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
+
+    with pytest.raises(
+        AgentLoopError,
+        match="Reviewer did not resolve 1 disputed item",
     ):
         run_pr_loop(runner, pr_number=55, config=config)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2126,6 +2126,112 @@ def test_validate_structured_coder_followup_rejects_trailing_prose_after_footer(
         validate_structured_coder_followup(payload)
 
 
+def test_validate_structured_coder_followup_accepts_disputed_items_with_evidence():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Fixed item-1; disputing item-2 with evidence.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "disputed_items": ["item-2"],
+                "dispute_evidence": {"item-2": "Checked the official docs: $1.50/1M is correct."},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = validate_structured_coder_followup(payload)
+
+    assert parsed is not None
+    assert parsed.addressed_items == ("item-1",)
+    assert parsed.remaining_items == ()
+    assert parsed.disputed_items == ("item-2",)
+    assert parsed.dispute_evidence == {"item-2": "Checked the official docs: $1.50/1M is correct."}
+
+
+def test_validate_structured_coder_followup_accepts_empty_disputed_items():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "No disputes.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "disputed_items": [],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = validate_structured_coder_followup(payload)
+
+    assert parsed is not None
+    assert parsed.disputed_items == ()
+    assert parsed.dispute_evidence == {}
+
+
+def test_validate_structured_coder_followup_rejects_disputed_item_also_in_addressed():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Duplicate classification.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "disputed_items": ["item-1"],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="listed unresolved reviewer item IDs more than once"):
+        validate_structured_coder_followup(payload)
+
+
+def test_validate_structured_coder_followup_rejects_evidence_for_non_disputed_item():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Evidence for wrong item.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "disputed_items": [],
+                "dispute_evidence": {"item-1": "Evidence for an addressed item, not disputed."},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="item-1.*not listed in coder_followup.disputed_items"):
+        validate_structured_coder_followup(payload)
+
+
 @pytest.mark.parametrize(
     ("addressed_ids", "checked_discussion_directly", "surfaced_ids", "requires_direct_discussion_ack", "message"),
     [

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2194,6 +2194,7 @@ def test_validate_structured_coder_followup_rejects_disputed_item_also_in_addres
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
                 "disputed_items": ["item-1"],
+                "dispute_evidence": {"item-1": "Evidence provided but item also in addressed."},
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
@@ -2229,6 +2230,31 @@ def test_validate_structured_coder_followup_rejects_evidence_for_non_disputed_it
     )
 
     with pytest.raises(AgentLoopError, match="item-1.*not listed in coder_followup.disputed_items"):
+        validate_structured_coder_followup(payload)
+
+
+def test_validate_structured_coder_followup_rejects_disputed_item_without_evidence():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Disputing without evidence.",
+                "addressed_items": [],
+                "remaining_items": [],
+                "disputed_items": ["item-1"],
+                "dispute_evidence": {},
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(AgentLoopError, match="Missing evidence for: item-1"):
         validate_structured_coder_followup(payload)
 
 

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -1,4 +1,10 @@
 from agent_loop_helpers import *  # noqa: F403
+from coding_review_agent_loop.protocol import StructuredCoderFollowup
+from coding_review_agent_loop.unresolved_items import (
+    CODER_DISPUTE_NOTE_PREFIX,
+    _apply_dispute_evidence,
+    _is_disputed_item,
+)
 
 
 def test_structured_plan_review_preserves_human_requirements_resolution_marker():
@@ -520,3 +526,180 @@ def test_validate_human_requirements_acknowledgement_accepts_full_truncation_fal
         surfaced_requirement_ids=(),
         requires_direct_discussion_ack=True,
     )
+
+
+def test_validate_coder_followup_response_accepts_disputed_items():
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="The pricing constant is wrong.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Add a regression test.",
+            status="blocking",
+        ),
+    )
+    response = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Disputed item-1 with evidence; fixed item-2.",
+                "addressed_items": ["item-2"],
+                "remaining_items": [],
+                "disputed_items": ["item-1"],
+                "dispute_evidence": {
+                    "item-1": "Checked Google pricing page: $1.50/1M tokens is correct per official docs."
+                },
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    parsed = _validate_coder_followup_response(
+        response,
+        unresolved_items=unresolved_items,
+        human_requirements=(),
+    )
+
+    assert isinstance(parsed, StructuredCoderFollowup)
+    assert parsed.addressed_items == ("item-2",)
+    assert parsed.disputed_items == ("item-1",)
+    assert "item-1" in parsed.dispute_evidence
+
+
+def test_validate_coder_followup_response_rejects_missing_item_when_disputed_not_counted():
+    unresolved_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Fix the bug.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Rename the variable.",
+            status="blocking",
+        ),
+    )
+    response = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "coder_followup",
+                "state": "blocking",
+                "summary": "Only addressed one item.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "disputed_items": [],
+                "human_requirements": {
+                    "addressed_ids": [],
+                    "checked_discussion_directly": False,
+                },
+            }
+        )
+        + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    )
+
+    with pytest.raises(
+        AgentLoopError,
+        match="did not classify all unresolved reviewer items",
+    ):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=unresolved_items,
+            human_requirements=(),
+        )
+
+
+def test_apply_dispute_evidence_adds_note_to_disputed_item():
+    items = [
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="Antigravity",
+            source_round=1,
+            text="Pricing constant is wrong.",
+            status="blocking",
+            notes=(),
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="Antigravity",
+            source_round=1,
+            text="Add a test.",
+            status="blocking",
+            notes=(),
+        ),
+    ]
+
+    result = _apply_dispute_evidence(
+        items,
+        disputed_items=["item-1"],
+        dispute_evidence={"item-1": "Official docs confirm $1.50/1M is correct."},
+    )
+
+    assert len(result) == 2
+    item1 = next(i for i in result if i.item_id == "item-1")
+    item2 = next(i for i in result if i.item_id == "item-2")
+    assert any(CODER_DISPUTE_NOTE_PREFIX in note for note in item1.notes)
+    assert "Official docs confirm $1.50/1M is correct." in item1.notes[0]
+    assert not item2.notes
+
+
+def test_apply_dispute_evidence_is_idempotent():
+    evidence = "Official docs confirm $1.50/1M is correct."
+    items = [
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="Antigravity",
+            source_round=1,
+            text="Pricing constant is wrong.",
+            status="blocking",
+            notes=(f"{CODER_DISPUTE_NOTE_PREFIX}: {evidence}",),
+        ),
+    ]
+
+    result = _apply_dispute_evidence(
+        items,
+        disputed_items=["item-1"],
+        dispute_evidence={"item-1": evidence},
+    )
+
+    assert len(result) == 1
+    assert len(result[0].notes) == 1
+
+
+def test_is_disputed_item_detects_dispute_note():
+    disputed_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="Antigravity",
+        source_round=1,
+        text="Pricing constant is wrong.",
+        status="blocking",
+        notes=(f"{CODER_DISPUTE_NOTE_PREFIX}: some evidence",),
+    )
+    non_disputed_item = UnresolvedReviewItem(
+        item_id="item-2",
+        reviewer="Antigravity",
+        source_round=1,
+        text="Add a test.",
+        status="blocking",
+        notes=("Antigravity: still blocking",),
+    )
+
+    assert _is_disputed_item(disputed_item)
+    assert not _is_disputed_item(non_disputed_item)


### PR DESCRIPTION
## Summary

- Extends `StructuredCoderFollowup` with `disputed_items` and `dispute_evidence` fields so the coder can challenge reviewer blocking claims backed by verifiable counter-evidence (e.g., wrong pricing, stale diff reading, incorrect behavior assumptions)
- Dispute evidence is stored in `UnresolvedReviewItem.notes` using a `CODER_DISPUTE_NOTE_PREFIX` sentinel, preserved through round-state serialization, and surfaced to the reviewer in the next round via the prior-items context
- If the reviewer still blocks after seeing the counter-evidence, the orchestrator raises `AgentLoopError` to escalate to human review rather than looping indefinitely
- Public coder follow-up comments render a `### Disputed items` section with counter-evidence when disputes are present

## Test plan

- [ ] All 1100 tests pass (`python3 -m pytest tests/ -q`)
- [ ] `test_pr_loop_dispute_resolved_when_reviewer_reconsiders` — dispute resolves when reviewer reconsiders
- [ ] `test_pr_loop_escalates_to_human_when_reviewer_rejects_dispute` — escalates when reviewer maintains block
- [ ] `test_pr_loop_dispute_note_is_visible_to_reviewer_in_next_round` — dispute note persists in round metadata
- [ ] Protocol validation tests for `disputed_items` / `dispute_evidence` parsing

Fixes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)