### PR TITLE
feat: add discuss mode for reviewer-only issue evaluation

### DIFF
--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -36,6 +36,7 @@ from .github import (
 )
 from .logging import agent_log_path, log
 from .orchestrator import (
+    run_discuss_loop,
     run_issue_loop,
     run_optional_tests,
     run_pr_loop,
@@ -432,6 +433,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_common(task)
 
+    discuss = subparsers.add_parser(
+        "discuss",
+        help="Run reviewers on an issue and post a consensus outcome comment.",
+    )
+    discuss.add_argument("issue_number", type=int)
+    add_common(discuss)
+
     return parser
 
 
@@ -497,6 +505,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 interactive=getattr(args, "interactive", False),
                 max_clarification_rounds=getattr(args, "max_clarification_rounds", 0),
             )
+        if args.command == "discuss":
+            return run_discuss_loop(runner, issue_number=args.issue_number, config=config)
         parser.error(f"unknown command: {args.command}")
     except QuotaResetExceededError as exc:
         print(f"agent-loop: {exc}", file=sys.stderr)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -16,6 +16,7 @@ from .protocol import (
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
     PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SIGNATURE_RE,
+    ParsedDiscussReview,
     ParsedPlanReview,
     ParsedReview,
     ReviewItemDisposition,
@@ -616,3 +617,38 @@ def render_public_agent_comment(
             model_used=model_used,
         )
     raise AgentLoopError(f"Unknown render kind: {kind}")
+
+
+def render_discuss_consensus_comment(
+    *,
+    outcome: str,
+    reviewer_votes: list[ParsedDiscussReview],
+    split_proposals: list[str],
+    subject: str,
+    config: object,
+) -> str:
+    outcome_heading = {
+        "implement": "Consensus: Implement",
+        "do-not-implement": "Consensus: Do Not Implement",
+        "needs-human": "Consensus: Needs Human Review",
+        "split": "Consensus: Split",
+    }.get(outcome, f"Consensus: {outcome}")
+    lines: list[str] = [
+        f"## {outcome_heading}",
+        "",
+        "| Reviewer | Outcome | Rationale |",
+        "| --- | --- | --- |",
+    ]
+    for vote in reviewer_votes:
+        rationale = vote.rationale.replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| {vote.reviewer} | {vote.outcome} | {rationale} |")
+    if outcome == "split" and split_proposals:
+        lines.append("")
+        lines.append("### Proposed sub-issues")
+        lines.append("")
+        for proposal in split_proposals:
+            lines.append(f"- {proposal}")
+    lines.append("")
+    lines.append("-- Orchestrator")
+    lines.append(f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->")
+    return "\n".join(lines)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import re
 import sys
@@ -58,6 +59,7 @@ from .prompts import (
     CompactPlanTailContext,
     CompactPriorContext,
     CompactPrReviewTailContext,
+    build_discuss_review_prompt,
     build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
@@ -74,6 +76,7 @@ from .prompts import (
 )
 from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+    ParsedDiscussReview,
     ParsedPlanReview,
     ParsedReview,
     PUBLIC_RESPONSE_MARKER,
@@ -97,6 +100,7 @@ from .protocol import (
     validate_structured_coder_followup,
     validate_structured_plan_state,
     validate_structured_plan_revision,
+    validate_structured_discuss_review,
 )
 from .protocol import parse_review
 from .repair import (
@@ -140,6 +144,7 @@ from .comment_rendering import (
     _replace_structured_section,
     _review_freeform_summary_text,
     normalize_freeform_signature,
+    render_discuss_consensus_comment,
     render_public_agent_comment,
     render_canonical_plan_revision,
     render_canonical_plan_steps,
@@ -223,7 +228,7 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
     re.I,
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
-    {"plan_review", "pr_review", "coder_followup", "plan_revision"}
+    {"plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review"}
 )
 PLAN_REVISION_FOOTER_RE = re.compile(r"(?m)^<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$")
 STRUCTURED_FENCE_RE = re.compile(
@@ -3371,6 +3376,119 @@ def run_pr_loop(
 
         raise AgentLoopError(
             f"Reached max rounds ({config.max_rounds}) for PR #{pr_number}; human review required."
+        )
+    finally:
+        if owned_usage_context:
+            _persist_usage_summary(config, usage_context)
+
+
+DISCUSS_CONSENSUS_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_DISCUSS_CONSENSUS:\s*([0-9a-f]+)\s*-->",
+    re.I,
+)
+
+
+def _discuss_subject(issue_context: IssueContext) -> str:
+    text = (issue_context.title or "") + "\n\n" + (issue_context.body or "")
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def _aggregate_discuss_votes(
+    votes: list[ParsedDiscussReview],
+) -> tuple[str, list[str]]:
+    outcomes = [v.outcome for v in votes]
+    if any(o == "do-not-implement" for o in outcomes):
+        return "do-not-implement", []
+    if any(o == "needs-human" for o in outcomes):
+        return "needs-human", []
+    if all(o == "implement" for o in outcomes):
+        return "implement", []
+    if all(o == "split" for o in outcomes):
+        seen: set[str] = set()
+        merged: list[str] = []
+        for v in votes:
+            for p in v.split_proposals:
+                if p not in seen:
+                    seen.add(p)
+                    merged.append(p)
+        return "split", merged
+    return "needs-human", []
+
+
+def _run_discuss_loop(
+    runner: Runner,
+    *,
+    issue_number: int,
+    config: AgentLoopConfig,
+    usage_context: RunUsageContext,
+) -> int:
+    from .config import reviewers as _reviewers
+    issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
+    subject = _discuss_subject(issue_context)
+    for comment in issue_context.comments or []:
+        body = comment.body or ""
+        m = DISCUSS_CONSENSUS_MARKER_RE.search(body)
+        if m and m.group(1).lower() == subject:
+            log(config, f"discuss: found matching consensus comment for issue #{issue_number}; skipping")
+            return 0
+    memory = prepare_agent_memory(runner, config)
+    reviewer_votes: list[ParsedDiscussReview] = []
+    for reviewer in _reviewers(config):
+        reviewer_name = agent_display_name(reviewer)
+        log(config, f"discuss: invoking {reviewer_name} on issue #{issue_number}")
+        response = _run_validated_agent(
+            runner,
+            agent=reviewer,
+            config=config,
+            prompt=build_discuss_review_prompt(
+                issue_number,
+                config,
+                reviewer=reviewer,
+                memory=memory,
+                issue_context=issue_context,
+            ),
+            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+            validate=lambda text, r=reviewer_name: validate_structured_discuss_review(text, reviewer=r),
+            usage_context=usage_context,
+            use_repair=True,
+            repair_expected_kind="discuss_review",
+            role="reviewer",
+        )
+        parsed = response.marker_value
+        assert isinstance(parsed, ParsedDiscussReview)
+        reviewer_votes.append(parsed)
+    outcome, split_proposals = _aggregate_discuss_votes(reviewer_votes)
+    body = render_discuss_consensus_comment(
+        outcome=outcome,
+        reviewer_votes=reviewer_votes,
+        split_proposals=split_proposals,
+        subject=subject,
+        config=config,
+    )
+    post_issue_comment(runner, config=config, issue_number=issue_number, body=body)
+    log(config, f"discuss: posted consensus comment for issue #{issue_number} (outcome: {outcome})")
+    return 0
+
+
+def run_discuss_loop(
+    runner: Runner,
+    *,
+    issue_number: int,
+    config: AgentLoopConfig,
+    usage_context: RunUsageContext | None = None,
+) -> int:
+    owned_usage_context = usage_context is None
+    usage_context = usage_context or _new_usage_context(config)
+    try:
+        config = resolve_base_branch(config, runner)
+        ensure_agent_workdirs(config, runner)
+        log(config, f"discuss: validating issue #{issue_number}")
+        validate_open_issue(runner, config=config, issue_number=issue_number)
+        return _run_discuss_loop(
+            runner,
+            issue_number=issue_number,
+            config=config,
+            usage_context=usage_context,
         )
     finally:
         if owned_usage_context:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3390,6 +3390,13 @@ DISCUSS_CONSENSUS_MARKER_RE = re.compile(
 
 def _discuss_subject(issue_context: IssueContext) -> str:
     text = (issue_context.title or "") + "\n\n" + (issue_context.body or "")
+    non_consensus_bodies = [
+        c.body
+        for c in issue_context.comments
+        if c.body and not DISCUSS_CONSENSUS_MARKER_RE.search(c.body)
+    ]
+    if non_consensus_bodies:
+        text += "\n\n" + "\n\n".join(non_consensus_bodies)
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
 
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2130,3 +2130,50 @@ the AGENT_STATE footer. Your response must end with, in this exact order:
 <!-- AGENT_STATE: blocking -->
 -- {coder_signature}
 """
+
+
+def build_discuss_review_prompt(
+    issue_number: int,
+    config: AgentLoopConfig,
+    *,
+    reviewer: AgentName,
+    memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
+) -> str:
+    reviewer_signature = agent_signature(reviewer, config)
+    return f"""Evaluate GitHub issue #{issue_number} in {config.repo} and vote on whether it should be implemented.
+
+Use this local checkout only to inspect context. Do not edit files, create a
+branch, commit, push, or open a pull request during this evaluation.
+{_issue_context_block(issue_context)}{_memory_block(memory)}
+
+Vote on one of these outcomes:
+- `implement` — the issue is well-defined and should be implemented as described.
+- `do-not-implement` — the issue should not be implemented (duplicate, out of scope, won't fix, etc.).
+- `needs-human` — the issue needs human clarification or decision before a technical verdict can be given.
+- `split` — the issue is too broad and should be split into smaller focused sub-issues.
+
+Respond using this mandatory structured JSON format:
+
+{{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "implement",
+  "rationale": "The feature is clearly scoped and fills a documented user need.",
+  "split_proposals": []
+}}
+<!-- AGENT_PLAN_STATE: approved -->
+-- {reviewer_signature}
+
+Rules:
+- `outcome` must be exactly one of: `implement`, `do-not-implement`, `needs-human`, `split`.
+- `rationale` is required and must be non-empty.
+- `split_proposals` is required and must be non-empty when `outcome` is `split`; omit or use `[]` for other outcomes.
+- The footer must always be `<!-- AGENT_PLAN_STATE: approved -->` regardless of your outcome.
+- Do not include prose or code fences before the JSON object.
+- Do not place your signature before the `AGENT_PLAN_STATE` footer.
+- Your response must end with, in this exact order:
+
+<!-- AGENT_PLAN_STATE: approved -->
+-- {reviewer_signature}
+"""

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -218,6 +218,26 @@ class StructuredPlanState:
 
 
 @dataclass(frozen=True)
+class StructuredDiscussReview:
+    schema_version: int
+    kind: str
+    outcome: str
+    rationale: str
+    split_proposals: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ParsedDiscussReview:
+    outcome: str
+    rationale: str
+    split_proposals: tuple[str, ...]
+    reviewer: str
+
+
+DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-human", "split"})
+
+
+@dataclass(frozen=True)
 class ParsedHumanRequirementsAcknowledgement:
     marker_present: bool
     section_present: bool
@@ -797,6 +817,31 @@ def _extract_structured_plan_state_payload(text: str) -> dict[str, object] | Non
         state_marker_name="AGENT_PLAN_STATE",
         context_label="Structured plan state",
     )
+
+
+def _extract_structured_discuss_review_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    result = _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=PLAN_STATE_RE,
+        state_marker_name="AGENT_PLAN_STATE",
+        context_label="Structured discuss review",
+    )
+    if result is None:
+        return None
+    footer_match = PLAN_STATE_RE.search(trailing)
+    if footer_match is not None:
+        footer_state = footer_match.group(1).lower()
+        if footer_state != "approved":
+            raise AgentLoopError(
+                f"Structured discuss review footer AGENT_PLAN_STATE must be `approved`; got `{footer_state}`."
+            )
+    return result
 
 
 def _extract_structured_coder_followup_payload(text: str) -> dict[str, object] | None:
@@ -1729,3 +1774,49 @@ def parse_plan_review(text: str, *, reviewer: str) -> ParsedPlanReview:
 def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFollowup]:
     """Extract legacy non-blocking follow-ups as future follow-ups."""
     return list(parse_approved_followups(text, reviewer=reviewer).future)
+
+
+def parse_structured_discuss_review(
+    text: str, *, reviewer: str
+) -> ParsedDiscussReview | None:
+    payload = _extract_structured_discuss_review_payload(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "discuss_review":
+        raise AgentLoopError("Structured response kind mismatch: expected `discuss_review`.")
+    _expect_exact_keys(
+        payload,
+        context="discuss_review",
+        required={"schema_version", "kind", "outcome", "rationale"},
+        optional={"split_proposals"},
+    )
+    outcome = _expect_non_empty_string(payload["outcome"], context="discuss_review.outcome")
+    if outcome not in DISCUSS_OUTCOME_VALUES:
+        rendered = ", ".join(sorted(DISCUSS_OUTCOME_VALUES))
+        raise AgentLoopError(f"discuss_review.outcome must be one of: {rendered}")
+    rationale = _expect_non_empty_string(payload["rationale"], context="discuss_review.rationale")
+    split_proposals = _expect_optional_string_list(
+        payload,
+        "split_proposals",
+        context="discuss_review.split_proposals",
+        item_context="discuss_review.split_proposals",
+    )
+    if outcome == "split" and not split_proposals:
+        raise AgentLoopError(
+            "discuss_review.split_proposals must be non-empty when outcome is `split`."
+        )
+    return ParsedDiscussReview(
+        outcome=outcome,
+        rationale=rationale,
+        split_proposals=split_proposals,
+        reviewer=reviewer,
+    )
+
+
+def validate_structured_discuss_review(text: str, *, reviewer: str) -> ParsedDiscussReview:
+    parsed = parse_structured_discuss_review(text, reviewer=reviewer)
+    if parsed is not None:
+        return parsed
+    raise AgentLoopError("Discuss review did not use the required structured format.")

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -85,7 +85,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup"}:
+    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review"}:
         return None
 
     stripped = raw.lstrip()
@@ -100,7 +100,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 
     json_text = stripped[:json_end].rstrip()
     trailing = stripped[json_end:]
-    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision"} else STATE_RE
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review"} else STATE_RE
     state_match = state_re.search(trailing)
     if state_match is None:
         return None
@@ -196,7 +196,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 # Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
-You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, or coder follow-up that failed strict schema validation. Extract its intent and reformat it into one of these four valid formats.
+You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, coder follow-up, or discuss review that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
 
 {expected_kind_instruction}
 
@@ -261,6 +261,24 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
 }
 <!-- AGENT_STATE: approved -->
 -- <Coder Name>
+
+## Valid Format E — Discuss Review:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "implement" | "do-not-implement" | "needs-human" | "split",
+  "rationale": "<short rationale>",
+  "split_proposals": ["Sub-issue title 1", "Sub-issue title 2"]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Reviewer Name>
+
+Notes:
+- outcome must be exactly one of the four values above.
+- rationale is required and must be non-empty.
+- split_proposals is required and must be non-empty when outcome is "split"; omit or use [] otherwise.
+- footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format D — Plan Revision:
 
@@ -652,6 +670,52 @@ item-1 is removed because it was a same-round finding, not an eligible carried p
 The future_followups entry is moved to blocking_plan_issues because it concerns current-plan correctness.
 Only genuinely independent later work should remain in future_followups on an approved review.
 
+## WORKED EXAMPLE 13 — discuss_review with outcome and rationale:
+
+Original (malformed): discuss_review JSON wrapped in ```json fences.
+
+```json
+{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "implement",
+  "rationale": "The feature is well-scoped and fills a clear user need."
+}
+```
+
+<!-- AGENT_PLAN_STATE: approved -->
+-- Gemini
+
+CORRECT repair — strip fences, output bare JSON + AGENT_PLAN_STATE footer + signature:
+{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "implement",
+  "rationale": "The feature is well-scoped and fills a clear user need."
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Gemini
+
+## WORKED EXAMPLE 14 — discuss_review with outcome split and split_proposals:
+
+Original (malformed): discuss_review without split_proposals despite split outcome.
+
+CORRECT repair — add split_proposals derived from rationale; footer must be AGENT_PLAN_STATE: approved:
+{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "split",
+  "rationale": "Issue is too broad; should be split into authentication and authorization sub-issues.",
+  "split_proposals": ["Implement authentication flow", "Implement authorization checks"]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Reviewer
+
+Notes:
+- discuss_review uses AGENT_PLAN_STATE (not AGENT_STATE).
+- Footer state must always be "approved" for discuss_review; never "blocking".
+- split_proposals is only required when outcome is "split"; omit or use [] for other outcomes.
+
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,
@@ -667,7 +731,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision"}
+_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
 ]

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -13,7 +13,9 @@ from coding_review_agent_loop.comment_rendering import (
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
     normalize_freeform_signature,
+    render_discuss_consensus_comment,
 )
+from coding_review_agent_loop.protocol import ParsedDiscussReview
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     ITEM_SUMMARY_LIMIT,
@@ -692,5 +694,116 @@ def test_render_public_review_comment_preserves_unknown_disposition_values():
         "Keep the parser and renderer aligned when new dispositions are added. "
         "-> deferred: tracked for a later parser update"
     ) in rendered
+
+
+# --- render_discuss_consensus_comment tests ---
+
+
+def _discuss_vote(
+    outcome: str = "implement",
+    rationale: str = "Good scope.",
+    proposals: tuple[str, ...] = (),
+    reviewer: str = "Gemini",
+) -> ParsedDiscussReview:
+    return ParsedDiscussReview(
+        outcome=outcome,
+        rationale=rationale,
+        split_proposals=proposals,
+        reviewer=reviewer,
+    )
+
+
+def test_render_discuss_consensus_comment_implement_heading(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="implement",
+        reviewer_votes=[_discuss_vote("implement")],
+        split_proposals=[],
+        subject="abc123",
+        config=config,
+    )
+    assert "## Consensus: Implement" in rendered
+
+
+def test_render_discuss_consensus_comment_do_not_implement_heading(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="do-not-implement",
+        reviewer_votes=[_discuss_vote("do-not-implement", rationale="Out of scope.")],
+        split_proposals=[],
+        subject="deadbeef",
+        config=config,
+    )
+    assert "## Consensus: Do Not Implement" in rendered
+
+
+def test_render_discuss_consensus_comment_needs_human_heading(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="needs-human",
+        reviewer_votes=[_discuss_vote("needs-human", rationale="Unclear requirements.")],
+        split_proposals=[],
+        subject="cafe1234",
+        config=config,
+    )
+    assert "## Consensus: Needs Human Review" in rendered
+
+
+def test_render_discuss_consensus_comment_split_heading_and_proposals(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="split",
+        reviewer_votes=[_discuss_vote("split", proposals=("Sub A", "Sub B"))],
+        split_proposals=["Sub A", "Sub B"],
+        subject="f00dbeef",
+        config=config,
+    )
+    assert "## Consensus: Split" in rendered
+    assert "### Proposed sub-issues" in rendered
+    assert "- Sub A" in rendered
+    assert "- Sub B" in rendered
+
+
+def test_render_discuss_consensus_comment_reviewer_table_row(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="implement",
+        reviewer_votes=[
+            _discuss_vote("implement", rationale="Well-scoped.", reviewer="Gemini"),
+            _discuss_vote("implement", rationale="Clear value.", reviewer="OpenAI Codex"),
+        ],
+        split_proposals=[],
+        subject="abc123",
+        config=config,
+    )
+    assert "| Gemini |" in rendered
+    assert "| OpenAI Codex |" in rendered
+    assert "Well-scoped." in rendered
+    assert "Clear value." in rendered
+
+
+def test_render_discuss_consensus_comment_orchestrator_footer(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="implement",
+        reviewer_votes=[_discuss_vote()],
+        split_proposals=[],
+        subject="abc123",
+        config=config,
+    )
+    assert "-- Orchestrator" in rendered
+
+
+def test_render_discuss_consensus_comment_marker_last_line(tmp_path):
+    config = make_config(tmp_path)
+    subject = "deadbeef1234"
+    rendered = render_discuss_consensus_comment(
+        outcome="implement",
+        reviewer_votes=[_discuss_vote()],
+        split_proposals=[],
+        subject=subject,
+        config=config,
+    )
+    assert rendered.endswith(f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->")
 
 

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -1,0 +1,172 @@
+"""Integration tests for the discuss-mode orchestration loop."""
+import hashlib
+import json
+
+import pytest
+
+from coding_review_agent_loop.orchestrator import (
+    DISCUSS_CONSENSUS_MARKER_RE,
+    _aggregate_discuss_votes,
+    _discuss_subject,
+    run_discuss_loop,
+)
+from coding_review_agent_loop.github import IssueContext
+
+from agent_loop_helpers import FakeRunner, make_config
+
+
+def _discuss_review_text(
+    *,
+    outcome: str = "implement",
+    rationale: str = "Well-scoped.",
+    split_proposals: list[str] | None = None,
+    reviewer: str = "OpenAI Codex",
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_review",
+        "outcome": outcome,
+        "rationale": rationale,
+    }
+    if split_proposals is not None:
+        payload["split_proposals"] = split_proposals
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+
+
+def _issue_subject(title: str = "Fix issue-mode context", body: str = "Original issue body.") -> str:
+    text = title + "\n\n" + body
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def test_discuss_loop_happy_path_two_implement_votes(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 1
+    assert "Consensus: Implement" in runner.comments[0]
+
+
+def test_discuss_loop_veto_do_not_implement(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[_discuss_review_text(outcome="do-not-implement", rationale="Out of scope.")],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 1
+    assert "Do Not Implement" in runner.comments[0]
+
+
+def test_discuss_loop_idempotent_when_consensus_comment_exists(tmp_path):
+    subject = _issue_subject()
+    existing_body = f"## Consensus: Implement\n-- Orchestrator\n<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->"
+    runner = FakeRunner(
+        issue_comments=[{"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": existing_body}],
+        codex_outputs=[],
+        gemini_outputs=[],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 0
+
+
+def test_discuss_loop_reruns_when_subject_hash_differs(tmp_path):
+    old_body = "## Consensus: Implement\n-- Orchestrator\n<!-- AGENT_DISCUSS_CONSENSUS: oldhashabc123 -->"
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        issue_comments=[{"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": old_body}],
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 1
+    assert "Consensus: Implement" in runner.comments[0]
+
+
+def test_discuss_loop_consensus_comment_contains_subject_hash(tmp_path):
+    subject = _issue_subject()
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    run_discuss_loop(runner, issue_number=56, config=config)
+
+    posted = runner.comments[0]
+    m = DISCUSS_CONSENSUS_MARKER_RE.search(posted)
+    assert m is not None, "AGENT_DISCUSS_CONSENSUS marker not found in posted comment"
+    assert m.group(1) == subject
+
+
+def test_discuss_subject_changes_when_body_changes():
+    ctx_a = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="My issue",
+        body="Original body",
+        url=None,
+        comments=(),
+    )
+    ctx_b = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="My issue",
+        body="Updated body",
+        url=None,
+        comments=(),
+    )
+    assert _discuss_subject(ctx_a) != _discuss_subject(ctx_b)
+
+
+def test_discuss_subject_handles_none_fields():
+    ctx = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title=None,
+        body=None,
+        url=None,
+        comments=(),
+    )
+    subject = _discuss_subject(ctx)
+    expected = hashlib.sha256("".encode("utf-8")).hexdigest()
+    assert subject == expected
+
+
+def test_discuss_loop_split_consensus_includes_proposals(tmp_path):
+    split_text = _discuss_review_text(
+        outcome="split",
+        rationale="Too broad.",
+        split_proposals=["Auth flow", "Authorization checks"],
+    )
+    runner = FakeRunner(
+        codex_outputs=[split_text],
+        gemini_outputs=[split_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    posted = runner.comments[0]
+    assert "Consensus: Split" in posted
+    assert "Auth flow" in posted
+    assert "Authorization checks" in posted

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -10,7 +10,7 @@ from coding_review_agent_loop.orchestrator import (
     _discuss_subject,
     run_discuss_loop,
 )
-from coding_review_agent_loop.github import IssueContext
+from coding_review_agent_loop.github import IssueComment, IssueContext
 
 from agent_loop_helpers import FakeRunner, make_config
 
@@ -149,6 +149,59 @@ def test_discuss_subject_handles_none_fields():
     subject = _discuss_subject(ctx)
     expected = hashlib.sha256("".encode("utf-8")).hexdigest()
     assert subject == expected
+
+
+def test_discuss_subject_changes_when_human_comment_added():
+    ctx_no_comment = IssueContext(
+        number=1, repo="OWNER/REPO", title="My issue", body="Body", url=None, comments=()
+    )
+    ctx_with_comment = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="My issue",
+        body="Body",
+        url=None,
+        comments=(IssueComment(author="user", created_at=None, body="Clarifying comment"),),
+    )
+    assert _discuss_subject(ctx_no_comment) != _discuss_subject(ctx_with_comment)
+
+
+def test_discuss_subject_excludes_consensus_comment_from_hash():
+    ctx_base = IssueContext(
+        number=1, repo="OWNER/REPO", title="My issue", body="Body", url=None, comments=()
+    )
+    subject = _discuss_subject(ctx_base)
+    consensus_body = f"## Consensus: Implement\n-- Orchestrator\n<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->"
+    ctx_with_consensus = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="My issue",
+        body="Body",
+        url=None,
+        comments=(IssueComment(author="bot", created_at=None, body=consensus_body),),
+    )
+    assert _discuss_subject(ctx_with_consensus) == subject
+
+
+def test_discuss_loop_reruns_when_human_comment_added(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    old_subject = _issue_subject()
+    old_consensus_body = f"## Consensus: Implement\n-- Orchestrator\n<!-- AGENT_DISCUSS_CONSENSUS: {old_subject} -->"
+    new_comment = "Actually please also consider the auth flow."
+    runner = FakeRunner(
+        issue_comments=[
+            {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:01Z", "body": old_consensus_body},
+            {"author": {"login": "human"}, "createdAt": "2026-01-01T00:01:00Z", "body": new_comment},
+        ],
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 1
 
 
 def test_discuss_loop_split_consensus_includes_proposals(tmp_path):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -21,6 +21,8 @@ from coding_review_agent_loop.orchestrator import (
 )
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
+    DISCUSS_OUTCOME_VALUES,
+    ParsedDiscussReview,
     _expect_string_list,
     _extract_structured_coder_followup_payload,
     _extract_structured_plan_review_payload,
@@ -34,6 +36,7 @@ from coding_review_agent_loop.protocol import (
     parse_plan_review,
     parse_plan_review_items,
     parse_plan_state,
+    parse_structured_discuss_review,
     parse_structured_plan_review,
     parse_structured_pr_review,
     parse_review,
@@ -44,6 +47,7 @@ from coding_review_agent_loop.protocol import (
     UnresolvedReviewItem,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
+    validate_structured_discuss_review,
     validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_state,
     validate_structured_plan_revision,
@@ -51,6 +55,7 @@ from coding_review_agent_loop.protocol import (
 from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER
 from coding_review_agent_loop.errors import UnknownPriorItemDispositionError
 from coding_review_agent_loop.orchestrator import (
+    _aggregate_discuss_votes,
     _decode_public_response_json_prefix,
     _failure_category,
     _is_transient_public_response,
@@ -2621,4 +2626,159 @@ def test_extract_structured_plan_revision_payload_rejects_bad_footer_ordering():
 def test_expect_string_list_enforces_min_length():
     with pytest.raises(AgentLoopError, match="must contain at least 1 item"):
         _expect_string_list([], context="plan_revision.plan_steps", item_context="plan_revision.plan_steps", min_length=1)
+
+
+# --- discuss_review protocol tests ---
+
+
+def _discuss_review(
+    *,
+    outcome: str = "implement",
+    rationale: str = "The feature is well-scoped.",
+    split_proposals: list[str] | None = None,
+    reviewer: str = "Gemini",
+    footer: str = "approved",
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_review",
+        "outcome": outcome,
+        "rationale": rationale,
+    }
+    if split_proposals is not None:
+        payload["split_proposals"] = split_proposals
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: {footer} -->\n-- {reviewer}"
+
+
+def test_parse_structured_discuss_review_accepts_implement():
+    text = _discuss_review(outcome="implement")
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.outcome == "implement"
+    assert result.reviewer == "Gemini"
+
+
+def test_parse_structured_discuss_review_accepts_do_not_implement():
+    text = _discuss_review(outcome="do-not-implement", rationale="Out of scope.")
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.outcome == "do-not-implement"
+
+
+def test_parse_structured_discuss_review_accepts_needs_human():
+    text = _discuss_review(outcome="needs-human", rationale="Needs clarification.")
+    result = parse_structured_discuss_review(text, reviewer="OpenAI Codex")
+    assert result is not None
+    assert result.outcome == "needs-human"
+
+
+def test_parse_structured_discuss_review_accepts_split_with_proposals():
+    text = _discuss_review(
+        outcome="split",
+        rationale="Too broad.",
+        split_proposals=["Sub-issue A", "Sub-issue B"],
+    )
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.outcome == "split"
+    assert result.split_proposals == ("Sub-issue A", "Sub-issue B")
+
+
+def test_parse_structured_discuss_review_rejects_unknown_outcome():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    text = _discuss_review(outcome="maybe")
+    with pytest.raises(_AgentLoopError, match="outcome must be one of"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_rejects_split_with_empty_proposals():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    text = _discuss_review(outcome="split", split_proposals=[])
+    with pytest.raises(_AgentLoopError, match="split_proposals must be non-empty"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_rejects_blocking_footer():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    text = _discuss_review(footer="blocking")
+    with pytest.raises(_AgentLoopError, match="approved"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_rejects_wrong_kind():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    payload = json.dumps({
+        "schema_version": 1,
+        "kind": "plan_review",
+        "outcome": "implement",
+        "rationale": "Looks good.",
+    }) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Gemini"
+    with pytest.raises(_AgentLoopError, match="kind mismatch"):
+        parse_structured_discuss_review(payload, reviewer="Gemini")
+
+
+def test_validate_structured_discuss_review_raises_when_no_marker():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    with pytest.raises(_AgentLoopError, match="structured format"):
+        validate_structured_discuss_review("No structured content here.", reviewer="Gemini")
+
+
+def test_discuss_outcome_values_contains_all_four():
+    assert DISCUSS_OUTCOME_VALUES == {"implement", "do-not-implement", "needs-human", "split"}
+
+
+# --- _aggregate_discuss_votes tests ---
+
+
+def _vote(outcome: str, rationale: str = "reason", proposals: tuple[str, ...] = ()) -> ParsedDiscussReview:
+    return ParsedDiscussReview(
+        outcome=outcome,
+        rationale=rationale,
+        split_proposals=proposals,
+        reviewer="Test",
+    )
+
+
+def test_aggregate_discuss_votes_unanimous_implement():
+    votes = [_vote("implement"), _vote("implement")]
+    outcome, proposals = _aggregate_discuss_votes(votes)
+    assert outcome == "implement"
+    assert proposals == []
+
+
+def test_aggregate_discuss_votes_veto_do_not_implement():
+    votes = [_vote("implement"), _vote("do-not-implement"), _vote("implement")]
+    outcome, proposals = _aggregate_discuss_votes(votes)
+    assert outcome == "do-not-implement"
+
+
+def test_aggregate_discuss_votes_needs_human_beats_implement():
+    votes = [_vote("implement"), _vote("needs-human")]
+    outcome, proposals = _aggregate_discuss_votes(votes)
+    assert outcome == "needs-human"
+
+
+def test_aggregate_discuss_votes_do_not_implement_beats_needs_human():
+    votes = [_vote("needs-human"), _vote("do-not-implement")]
+    outcome, proposals = _aggregate_discuss_votes(votes)
+    assert outcome == "do-not-implement"
+
+
+def test_aggregate_discuss_votes_all_split_merges_proposals():
+    votes = [
+        _vote("split", proposals=("Sub A", "Sub B")),
+        _vote("split", proposals=("Sub B", "Sub C")),
+    ]
+    outcome, proposals = _aggregate_discuss_votes(votes)
+    assert outcome == "split"
+    assert "Sub A" in proposals
+    assert "Sub B" in proposals
+    assert "Sub C" in proposals
+    assert proposals.index("Sub A") < proposals.index("Sub B") < proposals.index("Sub C")
+
+
+def test_aggregate_discuss_votes_mixed_falls_back_to_needs_human():
+    votes = [_vote("implement"), _vote("split", proposals=("X",))]
+    outcome, proposals = _aggregate_discuss_votes(votes)
+    assert outcome == "needs-human"
 


### PR DESCRIPTION
## Summary

- Adds a `discuss` subcommand (`agent-loop discuss <issue_number>`) that runs all configured reviewers on a GitHub issue and aggregates their votes into a consensus outcome comment.
- Four outcome values: `implement`, `do-not-implement` (veto), `needs-human`, `split` (with merged sub-issue proposals).
- Idempotency via `<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker — re-runs skip issues already decided for the current title+body.
- Repair support (`discuss_review` added to `_SUPPORTED_EXPECTED_KINDS`, `attempt_envelope_normalization`, and `_REPAIR_PROMPT` worked examples).

## Test plan

- [ ] `tests/test_protocol.py` — unit tests for `parse_structured_discuss_review`, `validate_structured_discuss_review`, `_aggregate_discuss_votes`, outcome validation, `DISCUSS_OUTCOME_VALUES`
- [ ] `tests/test_comment_rendering.py` — `render_discuss_consensus_comment` heading, table rows, split proposals, Orchestrator footer, marker as final line
- [ ] `tests/test_discuss_loop.py` (new) — happy path (two implement votes → consensus posted), veto path (do-not-implement), idempotent resume (existing matching hash → no invocations), different-hash rerun, `_discuss_subject` with None fields, split proposals in posted comment
- [ ] Full suite: `python3 -m pytest tests/ -q` → 1133 passed

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)