### PR TITLE
feat: remind coder and reviewer to check docs for user-facing changes

### DIFF
--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -86,6 +86,21 @@ def _coder_test_reporting_guidance() -> str:
     )
 
 
+def _coder_documentation_guidance() -> str:
+    return (
+        "If your implementation adds or changes a user-facing subcommand, flag, "
+        "or mode, update README.md and any relevant docs/ files as part of this PR.\n"
+    )
+
+
+def _reviewer_documentation_check() -> str:
+    return (
+        "If this PR adds or changes a user-facing subcommand, flag, or mode, "
+        "verify that README.md and any relevant docs/ files are updated. "
+        "Flag missing or stale documentation as a blocking item.\n"
+    )
+
+
 def _review_command_policy(
     config: AgentLoopConfig, pr_metadata: PullRequestMetadata
 ) -> str:
@@ -840,7 +855,7 @@ Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1404,7 +1419,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1449,7 +1464,7 @@ Use this local checkout as your workspace. Decide between two paths:
     {config.base}. Do not wait for {reviewer_name}; this local orchestrator
     will run {reviewer_name} after you create the PR.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 
 (b) If the task is genuinely ambiguous or missing information that would change
     the implementation, do NOT write code. Instead, ask focused clarifying
@@ -1496,7 +1511,7 @@ Clarification so far:
 Now proceed. Strongly prefer to implement the task and open a PR. Only ask
 again if a critical detail is still missing.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 
 Do not place your signature before the AGENT_STATE or AGENT_CLARIFY marker.
 Your response must end with, in this exact order:
@@ -1653,7 +1668,7 @@ Do not defer your review to wait for CI checks to finish. Review the PR now and 
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
-"""
+{_reviewer_documentation_check()}"""
     non_future_items = [item for item in unresolved_items if item.status != "future"]
     return "\n".join(
         part.rstrip()
@@ -1971,7 +1986,7 @@ Do not defer your review to wait for CI checks to finish. Review the PR now and 
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
-{human_requirements_guidance}
+{_reviewer_documentation_check()}{human_requirements_guidance}
 Only items listed under `Prior unresolved review items from earlier rounds`
 are eligible for dispositions in this round. If same-round findings from
 other reviewers appear elsewhere in the PR discussion, treat them as
@@ -2062,7 +2077,7 @@ needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}
@@ -2110,7 +2125,7 @@ current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead. The PR
 remains blocked pending another review round after this cleanup.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1867,3 +1867,32 @@ def test_compact_plan_review_stable_prefix_is_byte_identical_with_phased_guard(t
     assert first_prefix.encode() == second_prefix.encode()
     assert "Phased-delivery guard" in first_prefix
     assert "implement-by-phase" in first_prefix
+
+
+def test_coder_prompt_includes_documentation_reminder(tmp_path):
+    from coding_review_agent_loop.prompts import build_task_clarification_prompt
+
+    config = make_config(tmp_path)
+    prompts = [
+        build_issue_prompt(1, config),
+        build_issue_implementation_prompt(1, "1. Fix it.", config),
+        build_task_prompt("Fix the bug.", config),
+        build_task_clarification_prompt("Fix the bug.", [("What?", "This.")], config),
+        build_followup_prompt(77, 1, "Needs tests.", config),
+        build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+    ]
+    for prompt in prompts:
+        assert "README.md" in prompt
+        assert "docs/" in prompt
+        assert "user-facing subcommand" in prompt
+
+
+def test_reviewer_prompt_includes_documentation_check(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex",))
+    phrase = "Flag missing or stale documentation as a blocking item"
+
+    non_compact = build_review_prompt(77, 1, config, reviewer="codex")
+    compact = build_review_prompt(77, 1, config, reviewer="codex", compact_context=True)
+
+    assert phrase in non_compact
+    assert phrase in compact


### PR DESCRIPTION
## Summary

- Add `_coder_documentation_guidance()` helper that reminds coders to update `README.md` and `docs/` when a PR adds or changes a user-facing subcommand, flag, or mode.
- Add `_reviewer_documentation_check()` helper that instructs reviewers to flag missing or stale documentation as a blocking item.
- Inject the coder reminder into all six coder-facing prompt builders (`build_issue_prompt`, `build_issue_implementation_prompt`, `build_task_prompt`, `build_task_clarification_prompt`, `build_followup_prompt`, `build_same_pr_followup_prompt`).
- Inject the reviewer check into both the compact (`_compact_pr_review_stable_prefix`) and non-compact (`build_review_prompt`) reviewer prompt paths.

## Test plan

- `test_coder_prompt_includes_documentation_reminder`: verifies all six coder-facing builders include `README.md`, `docs/`, and `user-facing subcommand`.
- `test_reviewer_prompt_includes_documentation_check`: verifies the phrase `Flag missing or stale documentation as a blocking item` appears in both `compact_context=False` and `compact_context=True` reviewer prompts.
- Full suite: 1138 tests pass.

Fixes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)