### PR TITLE
Add multi-round discuss deliberation

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,23 +268,38 @@ iteration pass:
 agent-loop pr 456 --repo OWNER/REPO
 ```
 
-Evaluate a GitHub issue without writing any code using discuss mode. All
-configured reviewers read the issue and vote on whether to implement it:
+Evaluate a GitHub issue without writing any code using discuss mode. Reviewers
+first evaluate independently, then debate if their outcomes disagree:
 
 ```bash
 agent-loop discuss 123 --repo OWNER/REPO
 ```
 
 Each reviewer returns a `discuss_review` with one of four outcome votes:
-`implement`, `do-not-implement` (veto), `needs-human`, or `split` (with
-sub-issue proposals). The orchestrator aggregates the votes into a single
-consensus comment posted to the issue. A `do-not-implement` vote from any
-reviewer vetoes the issue regardless of other votes; `split` proposals from
-multiple reviewers are merged. Discuss runs are idempotent: the consensus comment includes an
-`<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker derived from the
-issue title, body, and non-consensus comment bodies. Re-running on an
-unchanged issue posts no second comment; posting a new comment on the issue
-invalidates the cached consensus and triggers a fresh evaluation.
+`implement`, `do-not-implement`, `needs-human`, or `split` (with sub-issue
+proposals). If all reviewers agree in round 1, the consensus comment is marked
+`unanimous`. If they disagree, each debate round sends reviewers the complete
+previous round positions and requires a non-empty `rebuttal` that engages the
+disagreement. Agreement after debate is marked `converged`.
+
+By default, discuss mode runs up to two debate rounds after the initial round.
+Use `--discuss-max-rounds` to change that limit:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --discuss-max-rounds 2
+```
+
+If reviewers still disagree after the configured debate rounds, the comment is
+marked `deadlock`, uses the `needs-human` outcome, and summarizes each final
+position and the core disagreement. `split` proposals are merged in first-seen
+order only when all reviewers in the same round agree on `split`. Discuss runs
+are idempotent: the consensus comment includes an
+`<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker derived from the issue
+title, body, and non-consensus comment bodies. Re-running on an unchanged issue
+posts no second comment; posting a new comment on the issue invalidates the
+cached consensus and triggers a fresh evaluation.
 
 When `--base` is omitted, `pr` mode uses the pull request's base branch.
 `issue` and `task` modes use the repository default branch. If PR metadata does
@@ -573,7 +588,7 @@ The test suite is split across focused modules for faster, targeted runs:
 | `tests/test_backends.py` | Claude, Gemini, and Codex backend output parsing and normalization |
 | `tests/test_protocol.py` | Protocol parsing and validation (parse_review, parse_plan_review, structured payloads) |
 | `tests/test_comment_rendering.py` | Comment rendering (render_canonical_plan_steps, render_public_agent_comment, etc.) |
-| `tests/test_discuss_loop.py` | Discuss mode loop tests (happy path, veto, idempotent resume, split proposals) |
+| `tests/test_discuss_loop.py` | Discuss mode loop tests (happy path, debate/deadlock, idempotent resume, split proposals) |
 | `tests/test_skill_helpers.py` | Skill helper function tests |
 | `tests/test_skill_loop.py` | Skill loop integration tests |
 | `tests/test_transient.py` | Transient error detection tests |

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -299,28 +299,41 @@ agent-loop discuss 123 --repo OWNER/REPO
 
 Discuss mode sends the issue title, body, and comments to all configured
 reviewers and asks each to return a `discuss_review` response with a single
-outcome vote. The four possible votes are:
+outcome vote. Round 1 is independent. If reviewers disagree, each later debate
+round includes the complete prior round positions and requires each reviewer to
+include a non-empty `rebuttal` that engages the disagreement. The four possible
+votes are:
 
 | Vote | Meaning |
 |------|---------|
 | `implement` | Reviewer recommends proceeding with the issue as written. |
-| `do-not-implement` | Reviewer vetoes the issue. Any single veto overrides all other votes. |
+| `do-not-implement` | Reviewer recommends not implementing the issue. |
 | `needs-human` | Reviewer cannot decide without more information from a human. |
 | `split` | Reviewer recommends breaking the issue into smaller sub-issues and may include sub-issue proposals. |
 
-After all reviewers respond, the orchestrator aggregates the votes and posts a
-single consensus comment to the issue. `split` proposals from multiple reviewers
-are merged into one list. Discuss runs are idempotent: the consensus comment
-includes an `<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker derived
-from the issue title, body, and non-consensus comment bodies. A re-run on an
-unchanged issue posts no second comment; posting a new comment on the issue
-invalidates the cached consensus and triggers a fresh evaluation.
+After each round, the orchestrator checks for same-round unanimity. Agreement in
+round 1 is marked `unanimous`; agreement after debate is marked `converged`.
+By default, the orchestrator runs up to two debate rounds after round 1. Set
+`--discuss-max-rounds 0` to post a human-needed deadlock immediately after an
+initial disagreement, or increase the value to allow more debate.
+
+If no consensus is reached after the configured debate rounds, the orchestrator
+posts a `deadlock` comment with the `needs-human` outcome, each final reviewer
+position, and the core disagreement. `split` proposals from multiple reviewers
+are merged in first-seen order only when all reviewers in the same round agree
+on `split`. Discuss runs are idempotent: the consensus comment includes an
+`<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker derived from the issue
+title, body, and non-consensus comment bodies. A re-run on an unchanged issue
+posts no second comment; posting a new comment on the issue invalidates the
+cached consensus and triggers a fresh evaluation.
 
 Discuss mode accepts `--reviewer` the same way as PR mode — repeat the flag to
 require multiple reviewers:
 
 ```bash
-agent-loop discuss 123 --repo OWNER/REPO --reviewer codex --reviewer antigravity
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --discuss-max-rounds 2
 ```
 
 If `--repo` is omitted, the tool runs `gh repo view` from the current working

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -438,6 +438,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run reviewers on an issue and post a consensus outcome comment.",
     )
     discuss.add_argument("issue_number", type=int)
+    discuss.add_argument(
+        "--discuss-max-rounds",
+        type=int,
+        default=2,
+        help="Maximum debate rounds after the initial discuss round (default: 2).",
+    )
     add_common(discuss)
 
     return parser
@@ -506,7 +512,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 max_clarification_rounds=getattr(args, "max_clarification_rounds", 0),
             )
         if args.command == "discuss":
-            return run_discuss_loop(runner, issue_number=args.issue_number, config=config)
+            return run_discuss_loop(
+                runner,
+                issue_number=args.issue_number,
+                config=config,
+                discuss_max_rounds=getattr(args, "discuss_max_rounds", 2),
+            )
         parser.error(f"unknown command: {args.command}")
     except QuotaResetExceededError as exc:
         print(f"agent-loop: {exc}", file=sys.stderr)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -622,19 +622,33 @@ def render_public_agent_comment(
 def render_discuss_consensus_comment(
     *,
     outcome: str,
+    consensus_kind: str = "unanimous",
+    round_number: int = 1,
     reviewer_votes: list[ParsedDiscussReview],
+    round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
     split_proposals: list[str],
     subject: str,
     config: object,
 ) -> str:
+    if consensus_kind not in {"unanimous", "converged", "deadlock"}:
+        raise AgentLoopError("consensus_kind must be `unanimous`, `converged`, or `deadlock`.")
     outcome_heading = {
         "implement": "Consensus: Implement",
         "do-not-implement": "Consensus: Do Not Implement",
         "needs-human": "Consensus: Needs Human Review",
         "split": "Consensus: Split",
     }.get(outcome, f"Consensus: {outcome}")
+    if consensus_kind == "deadlock":
+        outcome_heading = "Consensus: Needs Human Review (Deadlock)"
+    kind_label = {
+        "unanimous": "unanimous",
+        "converged": "converged",
+        "deadlock": "deadlock",
+    }[consensus_kind]
     lines: list[str] = [
         f"## {outcome_heading}",
+        "",
+        f"Consensus kind: `{kind_label}` after round {round_number}.",
         "",
         "| Reviewer | Outcome | Rationale |",
         "| --- | --- | --- |",
@@ -642,12 +656,32 @@ def render_discuss_consensus_comment(
     for vote in reviewer_votes:
         rationale = vote.rationale.replace("|", "\\|").replace("\n", " ")
         lines.append(f"| {vote.reviewer} | {vote.outcome} | {rationale} |")
+    rebuttal_votes = [vote for vote in reviewer_votes if vote.rebuttal]
+    if rebuttal_votes:
+        lines.append("")
+        lines.append("### Final rebuttals")
+        lines.append("")
+        for vote in rebuttal_votes:
+            lines.append(f"- {vote.reviewer}: {vote.rebuttal}")
+    if consensus_kind == "deadlock":
+        lines.append("")
+        lines.append("### Core disagreement")
+        lines.append("")
+        for vote in reviewer_votes:
+            lines.append(f"- {vote.reviewer} held `{vote.outcome}`: {vote.rationale}")
     if outcome == "split" and split_proposals:
         lines.append("")
         lines.append("### Proposed sub-issues")
         lines.append("")
         for proposal in split_proposals:
             lines.append(f"- {proposal}")
+    if round_history:
+        lines.append("")
+        lines.append("### Round history")
+        lines.append("")
+        for index, votes in enumerate(round_history, start=1):
+            rendered_votes = ", ".join(f"{vote.reviewer}: `{vote.outcome}`" for vote in votes)
+            lines.append(f"- Round {index}: {rendered_votes}")
     lines.append("")
     lines.append("-- Orchestrator")
     lines.append(f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3439,26 +3439,27 @@ def _discuss_subject(issue_context: IssueContext) -> str:
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
 
 
-def _aggregate_discuss_votes(
+def _merge_discuss_split_proposals(votes: Sequence[ParsedDiscussReview]) -> list[str]:
+    seen: set[str] = set()
+    merged: list[str] = []
+    for vote in votes:
+        for proposal in vote.split_proposals:
+            if proposal not in seen:
+                seen.add(proposal)
+                merged.append(proposal)
+    return merged
+
+
+def _detect_discuss_consensus(
     votes: list[ParsedDiscussReview],
-) -> tuple[str, list[str]]:
-    outcomes = [v.outcome for v in votes]
-    if any(o == "do-not-implement" for o in outcomes):
-        return "do-not-implement", []
-    if any(o == "needs-human" for o in outcomes):
-        return "needs-human", []
-    if all(o == "implement" for o in outcomes):
-        return "implement", []
-    if all(o == "split" for o in outcomes):
-        seen: set[str] = set()
-        merged: list[str] = []
-        for v in votes:
-            for p in v.split_proposals:
-                if p not in seen:
-                    seen.add(p)
-                    merged.append(p)
-        return "split", merged
-    return "needs-human", []
+) -> tuple[str, list[str]] | None:
+    if not votes:
+        return None
+    outcome = votes[0].outcome
+    if any(vote.outcome != outcome for vote in votes):
+        return None
+    split_proposals = _merge_discuss_split_proposals(votes) if outcome == "split" else []
+    return outcome, split_proposals
 
 
 def _run_discuss_loop(
@@ -3467,8 +3468,11 @@ def _run_discuss_loop(
     issue_number: int,
     config: AgentLoopConfig,
     usage_context: RunUsageContext,
+    discuss_max_rounds: int = 2,
 ) -> int:
     from .config import reviewers as _reviewers
+    if discuss_max_rounds < 0:
+        raise AgentLoopError("--discuss-max-rounds must be zero or greater.")
     issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
     subject = _discuss_subject(issue_context)
     for comment in issue_context.comments or []:
@@ -3478,41 +3482,72 @@ def _run_discuss_loop(
             log(config, f"discuss: found matching consensus comment for issue #{issue_number}; skipping")
             return 0
     memory = prepare_agent_memory(runner, config)
-    reviewer_votes: list[ParsedDiscussReview] = []
-    for reviewer in _reviewers(config):
-        reviewer_name = agent_display_name(reviewer)
-        log(config, f"discuss: invoking {reviewer_name} on issue #{issue_number}")
-        response = _run_validated_agent(
-            runner,
-            agent=reviewer,
-            config=config,
-            prompt=build_discuss_review_prompt(
-                issue_number,
+    round_history: list[list[ParsedDiscussReview]] = []
+    consensus: tuple[str, list[str]] | None = None
+    max_round_number = discuss_max_rounds + 1
+    for round_number in range(1, max_round_number + 1):
+        prior_round_votes = round_history[-1] if round_history else []
+        reviewer_votes: list[ParsedDiscussReview] = []
+        for reviewer in _reviewers(config):
+            reviewer_name = agent_display_name(reviewer)
+            log(
                 config,
-                reviewer=reviewer,
-                memory=memory,
-                issue_context=issue_context,
-            ),
-            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
-            validate=lambda text, r=reviewer_name: validate_structured_discuss_review(text, reviewer=r),
-            usage_context=usage_context,
-            use_repair=True,
-            repair_expected_kind="discuss_review",
-            role="reviewer",
-        )
-        parsed = response.marker_value
-        assert isinstance(parsed, ParsedDiscussReview)
-        reviewer_votes.append(parsed)
-    outcome, split_proposals = _aggregate_discuss_votes(reviewer_votes)
+                f"discuss: invoking {reviewer_name} on issue #{issue_number} "
+                f"(round {round_number})",
+            )
+            response = _run_validated_agent(
+                runner,
+                agent=reviewer,
+                config=config,
+                prompt=build_discuss_review_prompt(
+                    issue_number,
+                    config,
+                    reviewer=reviewer,
+                    memory=memory,
+                    issue_context=issue_context,
+                    round_number=round_number,
+                    prior_round_votes=prior_round_votes,
+                ),
+                marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+                validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
+                    text, reviewer=r, round_number=rn
+                ),
+                usage_context=usage_context,
+                use_repair=True,
+                repair_expected_kind="discuss_review",
+                role="reviewer",
+            )
+            parsed = response.marker_value
+            assert isinstance(parsed, ParsedDiscussReview)
+            reviewer_votes.append(parsed)
+        round_history.append(reviewer_votes)
+        consensus = _detect_discuss_consensus(reviewer_votes)
+        if consensus is not None:
+            break
+    final_votes = round_history[-1]
+    if consensus is None:
+        outcome = "needs-human"
+        split_proposals = []
+        consensus_kind = "deadlock"
+    else:
+        outcome, split_proposals = consensus
+        consensus_kind = "unanimous" if len(round_history) == 1 else "converged"
     body = render_discuss_consensus_comment(
         outcome=outcome,
-        reviewer_votes=reviewer_votes,
+        consensus_kind=consensus_kind,
+        round_number=len(round_history),
+        reviewer_votes=final_votes,
+        round_history=round_history,
         split_proposals=split_proposals,
         subject=subject,
         config=config,
     )
     post_issue_comment(runner, config=config, issue_number=issue_number, body=body)
-    log(config, f"discuss: posted consensus comment for issue #{issue_number} (outcome: {outcome})")
+    log(
+        config,
+        f"discuss: posted consensus comment for issue #{issue_number} "
+        f"(outcome: {outcome}; kind: {consensus_kind})",
+    )
     return 0
 
 
@@ -3521,6 +3556,7 @@ def run_discuss_loop(
     *,
     issue_number: int,
     config: AgentLoopConfig,
+    discuss_max_rounds: int = 2,
     usage_context: RunUsageContext | None = None,
 ) -> int:
     owned_usage_context = usage_context is None
@@ -3535,6 +3571,7 @@ def run_discuss_loop(
             issue_number=issue_number,
             config=config,
             usage_context=usage_context,
+            discuss_max_rounds=discuss_max_rounds,
         )
     finally:
         if owned_usage_context:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -18,6 +18,7 @@ from .memory import AgentMemoryContext, format_agent_memory_context
 from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
+    ParsedDiscussReview,
     UnresolvedReviewItem,
 )
 from .workdirs import agent_workdir
@@ -2154,13 +2155,45 @@ def build_discuss_review_prompt(
     reviewer: AgentName,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    round_number: int = 1,
+    prior_round_votes: Sequence[ParsedDiscussReview] | None = None,
 ) -> str:
     reviewer_signature = agent_signature(reviewer, config)
+    prior_round_votes = tuple(prior_round_votes or ())
+    if round_number <= 1:
+        round_context = (
+            "This is round 1. Evaluate independently; do not assume other reviewers agree."
+        )
+        rebuttal_rule = "- `rebuttal` may be omitted in round 1."
+        rebuttal_example = ""
+    else:
+        prior_lines: list[str] = [
+            f"This is debate round {round_number}. Review the complete prior round below, "
+            "then either keep your position or change it.",
+            "",
+            "Prior round reviewer positions:",
+        ]
+        for vote in prior_round_votes:
+            prior_lines.append(f"- {vote.reviewer}: `{vote.outcome}`")
+            prior_lines.append(f"  Rationale: {vote.rationale}")
+            if vote.rebuttal:
+                prior_lines.append(f"  Rebuttal: {vote.rebuttal}")
+            if vote.split_proposals:
+                prior_lines.append("  Split proposals:")
+                for proposal in vote.split_proposals:
+                    prior_lines.append(f"  - {proposal}")
+        round_context = "\n".join(prior_lines)
+        rebuttal_rule = (
+            "- `rebuttal` is required in debate rounds and must directly engage the prior "
+            "round disagreement."
+        )
+        rebuttal_example = ',\n  "rebuttal": "I considered the scope objection, but the issue is narrow enough because the API boundary is already specified."'
     return f"""Evaluate GitHub issue #{issue_number} in {config.repo} and vote on whether it should be implemented.
 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this evaluation.
 {_issue_context_block(issue_context)}{_memory_block(memory)}
+{round_context}
 
 Vote on one of these outcomes:
 - `implement` — the issue is well-defined and should be implemented as described.
@@ -2175,7 +2208,7 @@ Respond using this mandatory structured JSON format:
   "kind": "discuss_review",
   "outcome": "implement",
   "rationale": "The feature is clearly scoped and fills a documented user need.",
-  "split_proposals": []
+  "split_proposals": []{rebuttal_example}
 }}
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
@@ -2184,6 +2217,7 @@ Rules:
 - `outcome` must be exactly one of: `implement`, `do-not-implement`, `needs-human`, `split`.
 - `rationale` is required and must be non-empty.
 - `split_proposals` is required and must be non-empty when `outcome` is `split`; omit or use `[]` for other outcomes.
+{rebuttal_rule}
 - The footer must always be `<!-- AGENT_PLAN_STATE: approved -->` regardless of your outcome.
 - Do not include prose or code fences before the JSON object.
 - Do not place your signature before the `AGENT_PLAN_STATE` footer.

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -224,6 +224,7 @@ class StructuredDiscussReview:
     outcome: str
     rationale: str
     split_proposals: tuple[str, ...]
+    rebuttal: str | None = None
 
 
 @dataclass(frozen=True)
@@ -232,6 +233,7 @@ class ParsedDiscussReview:
     rationale: str
     split_proposals: tuple[str, ...]
     reviewer: str
+    rebuttal: str | None = None
 
 
 DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-human", "split"})
@@ -1777,7 +1779,7 @@ def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFo
 
 
 def parse_structured_discuss_review(
-    text: str, *, reviewer: str
+    text: str, *, reviewer: str, round_number: int = 1
 ) -> ParsedDiscussReview | None:
     payload = _extract_structured_discuss_review_payload(text)
     if payload is None:
@@ -1790,7 +1792,7 @@ def parse_structured_discuss_review(
         payload,
         context="discuss_review",
         required={"schema_version", "kind", "outcome", "rationale"},
-        optional={"split_proposals"},
+        optional={"split_proposals", "rebuttal"},
     )
     outcome = _expect_non_empty_string(payload["outcome"], context="discuss_review.outcome")
     if outcome not in DISCUSS_OUTCOME_VALUES:
@@ -1807,16 +1809,24 @@ def parse_structured_discuss_review(
         raise AgentLoopError(
             "discuss_review.split_proposals must be non-empty when outcome is `split`."
         )
+    rebuttal = None
+    if "rebuttal" in payload:
+        rebuttal = _expect_non_empty_string(payload["rebuttal"], context="discuss_review.rebuttal")
+    if round_number > 1 and rebuttal is None:
+        raise AgentLoopError("discuss_review.rebuttal is required for debate rounds.")
     return ParsedDiscussReview(
         outcome=outcome,
         rationale=rationale,
         split_proposals=split_proposals,
         reviewer=reviewer,
+        rebuttal=rebuttal,
     )
 
 
-def validate_structured_discuss_review(text: str, *, reviewer: str) -> ParsedDiscussReview:
-    parsed = parse_structured_discuss_review(text, reviewer=reviewer)
+def validate_structured_discuss_review(
+    text: str, *, reviewer: str, round_number: int = 1
+) -> ParsedDiscussReview:
+    parsed = parse_structured_discuss_review(text, reviewer=reviewer, round_number=round_number)
     if parsed is not None:
         return parsed
     raise AgentLoopError("Discuss review did not use the required structured format.")

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -269,7 +269,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
   "kind": "discuss_review",
   "outcome": "implement" | "do-not-implement" | "needs-human" | "split",
   "rationale": "<short rationale>",
-  "split_proposals": ["Sub-issue title 1", "Sub-issue title 2"]
+  "split_proposals": ["Sub-issue title 1", "Sub-issue title 2"],
+  "rebuttal": "<required in debate rounds; omit in initial round>"
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- <Reviewer Name>
@@ -278,6 +279,7 @@ Notes:
 - outcome must be exactly one of the four values above.
 - rationale is required and must be non-empty.
 - split_proposals is required and must be non-empty when outcome is "split"; omit or use [] otherwise.
+- rebuttal is optional in the initial discuss round and required in debate rounds.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format D — Plan Revision:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1193,6 +1193,30 @@ def test_omitted_cli_base_is_preserved_for_runtime_resolution(tmp_path):
     assert config_from_args(args, FakeRunner()).base is None
 
 
+def test_discuss_max_rounds_cli_is_discuss_only():
+    parser = build_parser()
+    args = parser.parse_args([
+        "discuss",
+        "56",
+        "--repo",
+        "OWNER/REPO",
+        "--discuss-max-rounds",
+        "4",
+    ])
+
+    assert args.discuss_max_rounds == 4
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([
+            "pr",
+            "77",
+            "--repo",
+            "OWNER/REPO",
+            "--discuss-max-rounds",
+            "4",
+        ])
+
+
 def test_pre_review_tests_cli_defaults_on_and_can_be_disabled(tmp_path):
     parser = build_parser()
     args = parser.parse_args([
@@ -3622,5 +3646,4 @@ def test_format_invalid_agent_response_error_no_suggestion_empty_response():
         category="empty-response",
     )
     assert "Suggestion:" not in msg
-
 

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -704,12 +704,14 @@ def _discuss_vote(
     rationale: str = "Good scope.",
     proposals: tuple[str, ...] = (),
     reviewer: str = "Gemini",
+    rebuttal: str | None = None,
 ) -> ParsedDiscussReview:
     return ParsedDiscussReview(
         outcome=outcome,
         rationale=rationale,
         split_proposals=proposals,
         reviewer=reviewer,
+        rebuttal=rebuttal,
     )
 
 
@@ -806,4 +808,56 @@ def test_render_discuss_consensus_comment_marker_last_line(tmp_path):
     )
     assert rendered.endswith(f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->")
 
+
+def test_render_discuss_consensus_comment_converged_kind_and_rebuttals(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="implement",
+        consensus_kind="converged",
+        round_number=2,
+        reviewer_votes=[
+            _discuss_vote(
+                "implement",
+                reviewer="Gemini",
+                rebuttal="The scope concern is resolved by the issue body.",
+            )
+        ],
+        round_history=[
+            [_discuss_vote("needs-human", reviewer="Gemini")],
+            [
+                _discuss_vote(
+                    "implement",
+                    reviewer="Gemini",
+                    rebuttal="The scope concern is resolved by the issue body.",
+                )
+            ],
+        ],
+        split_proposals=[],
+        subject="abc123",
+        config=config,
+    )
+    assert "Consensus kind: `converged` after round 2." in rendered
+    assert "### Final rebuttals" in rendered
+    assert "Round 1: Gemini: `needs-human`" in rendered
+
+
+def test_render_discuss_consensus_comment_deadlock_summarizes_disagreement(tmp_path):
+    config = make_config(tmp_path)
+    rendered = render_discuss_consensus_comment(
+        outcome="needs-human",
+        consensus_kind="deadlock",
+        round_number=2,
+        reviewer_votes=[
+            _discuss_vote("implement", rationale="Scoped.", reviewer="Gemini"),
+            _discuss_vote("do-not-implement", rationale="Out of scope.", reviewer="OpenAI Codex"),
+        ],
+        split_proposals=[],
+        subject="abc123",
+        config=config,
+    )
+    assert "## Consensus: Needs Human Review (Deadlock)" in rendered
+    assert "Consensus kind: `deadlock` after round 2." in rendered
+    assert "### Core disagreement" in rendered
+    assert "Gemini held `implement`: Scoped." in rendered
+    assert "OpenAI Codex held `do-not-implement`: Out of scope." in rendered
 

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -6,10 +6,10 @@ import pytest
 
 from coding_review_agent_loop.orchestrator import (
     DISCUSS_CONSENSUS_MARKER_RE,
-    _aggregate_discuss_votes,
     _discuss_subject,
     run_discuss_loop,
 )
+from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import IssueComment, IssueContext
 
 from agent_loop_helpers import FakeRunner, make_config
@@ -20,6 +20,7 @@ def _discuss_review_text(
     outcome: str = "implement",
     rationale: str = "Well-scoped.",
     split_proposals: list[str] | None = None,
+    rebuttal: str | None = None,
     reviewer: str = "OpenAI Codex",
 ) -> str:
     payload: dict = {
@@ -30,6 +31,8 @@ def _discuss_review_text(
     }
     if split_proposals is not None:
         payload["split_proposals"] = split_proposals
+    if rebuttal is not None:
+        payload["rebuttal"] = rebuttal
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
 
 
@@ -53,18 +56,31 @@ def test_discuss_loop_happy_path_two_implement_votes(tmp_path):
     assert "Consensus: Implement" in runner.comments[0]
 
 
-def test_discuss_loop_veto_do_not_implement(tmp_path):
+def test_discuss_loop_debates_then_deadlocks_instead_of_veto(tmp_path):
     runner = FakeRunner(
-        codex_outputs=[_discuss_review_text(outcome="implement")],
-        gemini_outputs=[_discuss_review_text(outcome="do-not-implement", rationale="Out of scope.")],
+        codex_outputs=[
+            _discuss_review_text(outcome="implement"),
+            _discuss_review_text(outcome="implement", rebuttal="The issue is scoped enough."),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="Out of scope."),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Still out of scope.",
+                rebuttal="The scope objection still stands.",
+            ),
+        ],
     )
     config = make_config(tmp_path, reviewer=("codex", "gemini"))
 
-    result = run_discuss_loop(runner, issue_number=56, config=config)
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
 
     assert result == 0
     assert len(runner.comments) == 1
-    assert "Do Not Implement" in runner.comments[0]
+    assert "Consensus: Needs Human Review (Deadlock)" in runner.comments[0]
+    assert "Consensus kind: `deadlock` after round 2." in runner.comments[0]
+    assert "Codex held `implement`" in runner.comments[0]
+    assert "Gemini held `do-not-implement`" in runner.comments[0]
 
 
 def test_discuss_loop_idempotent_when_consensus_comment_exists(tmp_path):
@@ -223,3 +239,93 @@ def test_discuss_loop_split_consensus_includes_proposals(tmp_path):
     assert "Consensus: Split" in posted
     assert "Auth flow" in posted
     assert "Authorization checks" in posted
+
+
+def test_discuss_loop_converges_after_debate(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement"),
+            _discuss_review_text(
+                outcome="needs-human",
+                rationale="The acceptance criteria need a product decision.",
+                rebuttal="I agree the ambiguity blocks a technical verdict.",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="needs-human", rationale="Unclear requirements."),
+            _discuss_review_text(
+                outcome="needs-human",
+                rationale="Unclear requirements remain.",
+                rebuttal="The implement argument depends on unstated requirements.",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    posted = runner.comments[0]
+    assert "Consensus: Needs Human Review" in posted
+    assert "Consensus kind: `converged` after round 2." in posted
+    assert "### Final rebuttals" in posted
+
+
+def test_discuss_loop_zero_debate_rounds_deadlocks_after_initial_disagreement(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[_discuss_review_text(outcome="needs-human", rationale="Needs product input.")],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    posted = runner.comments[0]
+    assert "Consensus kind: `deadlock` after round 1." in posted
+    assert "Codex held `implement`" in posted
+    assert "Gemini held `needs-human`" in posted
+
+
+def test_discuss_loop_passes_prior_round_snapshot_to_debate_prompts(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Still scoped.",
+                rebuttal="The split concern does not apply.",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="split",
+                rationale="Too broad.",
+                split_proposals=["Auth flow"],
+            ),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Can proceed.",
+                rebuttal="I accept the scope argument.",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Codex: `implement`" in prompt
+        assert "Gemini: `split`" in prompt
+        assert "Auth flow" in prompt
+
+
+def test_discuss_loop_rejects_negative_discuss_max_rounds(tmp_path):
+    runner = FakeRunner(codex_outputs=[], gemini_outputs=[])
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    with pytest.raises(AgentLoopError, match="--discuss-max-rounds must be zero or greater"):
+        run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=-1)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -55,7 +55,7 @@ from coding_review_agent_loop.protocol import (
 from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER
 from coding_review_agent_loop.errors import UnknownPriorItemDispositionError
 from coding_review_agent_loop.orchestrator import (
-    _aggregate_discuss_votes,
+    _detect_discuss_consensus,
     _decode_public_response_json_prefix,
     _failure_category,
     _is_transient_public_response,
@@ -2636,6 +2636,7 @@ def _discuss_review(
     outcome: str = "implement",
     rationale: str = "The feature is well-scoped.",
     split_proposals: list[str] | None = None,
+    rebuttal: str | None = None,
     reviewer: str = "Gemini",
     footer: str = "approved",
 ) -> str:
@@ -2647,6 +2648,8 @@ def _discuss_review(
     }
     if split_proposals is not None:
         payload["split_proposals"] = split_proposals
+    if rebuttal is not None:
+        payload["rebuttal"] = rebuttal
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: {footer} -->\n-- {reviewer}"
 
 
@@ -2684,6 +2687,13 @@ def test_parse_structured_discuss_review_accepts_split_with_proposals():
     assert result.split_proposals == ("Sub-issue A", "Sub-issue B")
 
 
+def test_parse_structured_discuss_review_accepts_rebuttal():
+    text = _discuss_review(rebuttal="I considered the opposing concern.")
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.rebuttal == "I considered the opposing concern."
+
+
 def test_parse_structured_discuss_review_rejects_unknown_outcome():
     from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
     text = _discuss_review(outcome="maybe")
@@ -2696,6 +2706,20 @@ def test_parse_structured_discuss_review_rejects_split_with_empty_proposals():
     text = _discuss_review(outcome="split", split_proposals=[])
     with pytest.raises(_AgentLoopError, match="split_proposals must be non-empty"):
         parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_rejects_empty_rebuttal():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    text = _discuss_review(rebuttal=" ")
+    with pytest.raises(_AgentLoopError, match="rebuttal must be a non-empty string"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_validate_structured_discuss_review_requires_rebuttal_after_round_one():
+    from coding_review_agent_loop.errors import AgentLoopError as _AgentLoopError
+    text = _discuss_review()
+    with pytest.raises(_AgentLoopError, match="rebuttal is required for debate rounds"):
+        validate_structured_discuss_review(text, reviewer="Gemini", round_number=2)
 
 
 def test_parse_structured_discuss_review_rejects_blocking_footer():
@@ -2727,7 +2751,7 @@ def test_discuss_outcome_values_contains_all_four():
     assert DISCUSS_OUTCOME_VALUES == {"implement", "do-not-implement", "needs-human", "split"}
 
 
-# --- _aggregate_discuss_votes tests ---
+# --- _detect_discuss_consensus tests ---
 
 
 def _vote(outcome: str, rationale: str = "reason", proposals: tuple[str, ...] = ()) -> ParsedDiscussReview:
@@ -2739,37 +2763,38 @@ def _vote(outcome: str, rationale: str = "reason", proposals: tuple[str, ...] = 
     )
 
 
-def test_aggregate_discuss_votes_unanimous_implement():
+def test_detect_discuss_consensus_unanimous_implement():
     votes = [_vote("implement"), _vote("implement")]
-    outcome, proposals = _aggregate_discuss_votes(votes)
+    consensus = _detect_discuss_consensus(votes)
+    assert consensus is not None
+    outcome, proposals = consensus
     assert outcome == "implement"
     assert proposals == []
 
 
-def test_aggregate_discuss_votes_veto_do_not_implement():
+def test_detect_discuss_consensus_mixed_do_not_implement_is_not_veto():
     votes = [_vote("implement"), _vote("do-not-implement"), _vote("implement")]
-    outcome, proposals = _aggregate_discuss_votes(votes)
-    assert outcome == "do-not-implement"
+    assert _detect_discuss_consensus(votes) is None
 
 
-def test_aggregate_discuss_votes_needs_human_beats_implement():
+def test_detect_discuss_consensus_mixed_needs_human_is_disagreement():
     votes = [_vote("implement"), _vote("needs-human")]
-    outcome, proposals = _aggregate_discuss_votes(votes)
-    assert outcome == "needs-human"
+    assert _detect_discuss_consensus(votes) is None
 
 
-def test_aggregate_discuss_votes_do_not_implement_beats_needs_human():
+def test_detect_discuss_consensus_do_not_implement_requires_unanimity():
     votes = [_vote("needs-human"), _vote("do-not-implement")]
-    outcome, proposals = _aggregate_discuss_votes(votes)
-    assert outcome == "do-not-implement"
+    assert _detect_discuss_consensus(votes) is None
 
 
-def test_aggregate_discuss_votes_all_split_merges_proposals():
+def test_detect_discuss_consensus_all_split_merges_proposals():
     votes = [
         _vote("split", proposals=("Sub A", "Sub B")),
         _vote("split", proposals=("Sub B", "Sub C")),
     ]
-    outcome, proposals = _aggregate_discuss_votes(votes)
+    consensus = _detect_discuss_consensus(votes)
+    assert consensus is not None
+    outcome, proposals = consensus
     assert outcome == "split"
     assert "Sub A" in proposals
     assert "Sub B" in proposals
@@ -2777,8 +2802,6 @@ def test_aggregate_discuss_votes_all_split_merges_proposals():
     assert proposals.index("Sub A") < proposals.index("Sub B") < proposals.index("Sub C")
 
 
-def test_aggregate_discuss_votes_mixed_falls_back_to_needs_human():
+def test_detect_discuss_consensus_mixed_returns_none():
     votes = [_vote("implement"), _vote("split", proposals=("X",))]
-    outcome, proposals = _aggregate_discuss_votes(votes)
-    assert outcome == "needs-human"
-
+    assert _detect_discuss_consensus(votes) is None


### PR DESCRIPTION
## Summary
- add discuss-mode deliberation rounds with --discuss-max-rounds and same-round consensus detection
- require debate-round rebuttals and include prior-round context in reviewer prompts
- render unanimous, converged, and deadlock consensus comments with final disagreement summaries
- update docs and tests for the new discuss behavior

Fixes #465

## Tests
- python3 -m pytest