### PR TITLE
Discuss mode: post per-round debater and summary comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,10 @@ each posted comment carries round metadata the orchestrator uses to
 reconstruct completed rounds (including a partially-completed round) on the
 next run. Re-running after a final summary posts no second transcript; posting
 a new human comment on the issue invalidates the cached result and triggers a
-fresh evaluation from round 1.
+fresh evaluation from round 1. If a resumed run's next round would exceed a
+`--discuss-max-rounds` value that was lowered since the prior run, the
+orchestrator immediately posts a final `deadlock` summary from the last
+completed round instead of silently exiting without a result.
 
 When `--base` is omitted, `pr` mode uses the pull request's base branch.
 `issue` and `task` modes use the repository default branch. If PR metadata does

--- a/README.md
+++ b/README.md
@@ -277,10 +277,25 @@ agent-loop discuss 123 --repo OWNER/REPO
 
 Each reviewer returns a `discuss_review` with one of four outcome votes:
 `implement`, `do-not-implement`, `needs-human`, or `split` (with sub-issue
-proposals). If all reviewers agree in round 1, the consensus comment is marked
-`unanimous`. If they disagree, each debate round sends reviewers the complete
-previous round positions and requires a non-empty `rebuttal` that engages the
-disagreement. Agreement after debate is marked `converged`.
+proposals). Discuss mode posts a readable transcript to the issue instead of a
+single aggregate comment: each round, every reviewer posts its own vote and
+rationale as a separate issue comment, and once all reviewers for the round
+have posted, the orchestrator posts a round-summary comment. If all reviewers
+agree in round 1, that round's summary is the final result and is marked
+`unanimous`. If they disagree, the summary lists the disagreement and the
+agenda for the next round, and each debate round sends reviewers the complete
+previous round positions plus that agenda and requires a non-empty `rebuttal`
+that engages the disagreement. Agreement after debate is marked `converged`. A
+transcript looks like:
+
+```text
+Round 1: Codex position
+Round 1: Antigravity position
+Round 1: Orchestrator summary (agenda for round 2)
+Round 2: Codex rebuttal
+Round 2: Antigravity rebuttal
+Round 2: Orchestrator final consensus/deadlock
+```
 
 By default, discuss mode runs up to two debate rounds after the initial round.
 Use `--discuss-max-rounds` to change that limit:
@@ -291,15 +306,20 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-max-rounds 2
 ```
 
-If reviewers still disagree after the configured debate rounds, the comment is
-marked `deadlock`, uses the `needs-human` outcome, and summarizes each final
-position and the core disagreement. `split` proposals are merged in first-seen
-order only when all reviewers in the same round agree on `split`. Discuss runs
-are idempotent: the consensus comment includes an
-`<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker derived from the issue
-title, body, and non-consensus comment bodies. Re-running on an unchanged issue
-posts no second comment; posting a new comment on the issue invalidates the
-cached consensus and triggers a fresh evaluation.
+If reviewers still disagree after the configured debate rounds, the final
+round-summary comment is marked `deadlock`, uses the `needs-human` outcome, and
+summarizes each final position and the core disagreement. `split` proposals
+are merged in first-seen order only when all reviewers in the same round agree
+on `split`. Only the final round-summary comment is marked as the result; the
+per-reviewer and interim round-summary comments remain separately identifiable
+in the issue timeline. Discuss runs are idempotent and resumable: the final
+summary comment includes an `<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->`
+marker derived from the issue title, body, and non-round comment bodies, and
+each posted comment carries round metadata the orchestrator uses to
+reconstruct completed rounds (including a partially-completed round) on the
+next run. Re-running after a final summary posts no second transcript; posting
+a new human comment on the issue invalidates the cached result and triggers a
+fresh evaluation from round 1.
 
 When `--base` is omitted, `pr` mode uses the pull request's base branch.
 `issue` and `task` modes use the repository default branch. If PR metadata does
@@ -588,7 +608,7 @@ The test suite is split across focused modules for faster, targeted runs:
 | `tests/test_backends.py` | Claude, Gemini, and Codex backend output parsing and normalization |
 | `tests/test_protocol.py` | Protocol parsing and validation (parse_review, parse_plan_review, structured payloads) |
 | `tests/test_comment_rendering.py` | Comment rendering (render_canonical_plan_steps, render_public_agent_comment, etc.) |
-| `tests/test_discuss_loop.py` | Discuss mode loop tests (happy path, debate/deadlock, idempotent resume, split proposals) |
+| `tests/test_discuss_loop.py` | Discuss mode loop tests (per-round comments, debate/deadlock, idempotent and mid-round/multi-round resume, split proposals) |
 | `tests/test_skill_helpers.py` | Skill helper function tests |
 | `tests/test_skill_loop.py` | Skill loop integration tests |
 | `tests/test_transient.py` | Transient error detection tests |

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -299,10 +299,35 @@ agent-loop discuss 123 --repo OWNER/REPO
 
 Discuss mode sends the issue title, body, and comments to all configured
 reviewers and asks each to return a `discuss_review` response with a single
-outcome vote. Round 1 is independent. If reviewers disagree, each later debate
-round includes the complete prior round positions and requires each reviewer to
-include a non-empty `rebuttal` that engages the disagreement. The four possible
-votes are:
+outcome vote. Instead of collapsing a round into one orchestrator comment,
+discuss mode posts a transcript to the issue, similar to how PR review mode
+posts a comment per reviewer per round:
+
+1. Each configured reviewer ("debater") posts its own issue comment with its
+   structured vote and rationale, tagged with round metadata.
+2. Once every reviewer has posted for the round, the orchestrator posts a
+   separate round-summary comment identifying consensus or disagreement.
+3. If the round is not the final one, the summary comment also lists the
+   agenda for the next round (each reviewer's held position). Unresolved
+   disagreement carries this agenda plus the prior round's comments into the
+   next round's prompts, and requires each reviewer to include a non-empty
+   `rebuttal` that engages the disagreement.
+4. The final consensus/deadlock result is always its own round-summary
+   comment, separate from the per-reviewer comments and from any interim
+   round summaries.
+
+A two-round debate transcript looks like:
+
+```text
+Round 1: Codex position
+Round 1: Antigravity position
+Round 1: Orchestrator summary (agenda for round 2)
+Round 2: Codex rebuttal
+Round 2: Antigravity rebuttal
+Round 2: Orchestrator final consensus/deadlock
+```
+
+The four possible votes are:
 
 | Vote | Meaning |
 |------|---------|
@@ -317,15 +342,20 @@ By default, the orchestrator runs up to two debate rounds after round 1. Set
 `--discuss-max-rounds 0` to post a human-needed deadlock immediately after an
 initial disagreement, or increase the value to allow more debate.
 
-If no consensus is reached after the configured debate rounds, the orchestrator
-posts a `deadlock` comment with the `needs-human` outcome, each final reviewer
-position, and the core disagreement. `split` proposals from multiple reviewers
-are merged in first-seen order only when all reviewers in the same round agree
-on `split`. Discuss runs are idempotent: the consensus comment includes an
+If no consensus is reached after the configured debate rounds, the final
+round-summary comment is a `deadlock` comment with the `needs-human` outcome,
+each final reviewer position, and the core disagreement. `split` proposals
+from multiple reviewers are merged in first-seen order only when all reviewers
+in the same round agree on `split`. Discuss runs are idempotent and resumable:
+the final round-summary comment includes an
 `<!-- AGENT_DISCUSS_CONSENSUS: <subject-hash> -->` marker derived from the issue
-title, body, and non-consensus comment bodies. A re-run on an unchanged issue
-posts no second comment; posting a new comment on the issue invalidates the
-cached consensus and triggers a fresh evaluation.
+title, body, and non-round comment bodies, and every posted comment carries an
+`<!-- AGENT_LOOP_META: ... -->` marker the orchestrator decodes to reconstruct
+completed rounds — including a round that only partially posted before a
+crash — from the public comment thread on the next run, without relying on one
+aggregate comment. A re-run on an unchanged issue with a final result posts no
+second transcript; posting a new human comment on the issue invalidates the
+cached result and triggers a fresh evaluation from round 1.
 
 Discuss mode accepts `--reviewer` the same way as PR mode — repeat the flag to
 require multiple reviewers:

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -355,7 +355,12 @@ completed rounds — including a round that only partially posted before a
 crash — from the public comment thread on the next run, without relying on one
 aggregate comment. A re-run on an unchanged issue with a final result posts no
 second transcript; posting a new human comment on the issue invalidates the
-cached result and triggers a fresh evaluation from round 1.
+cached result and triggers a fresh evaluation from round 1. If a resumed run's
+next round would exceed a `--discuss-max-rounds` value that was lowered since
+the prior run, the orchestrator immediately posts a final `deadlock` summary
+from the last completed round instead of silently exiting without a result;
+if no completed round exists to finalize from, it raises instead of exiting
+silently.
 
 Discuss mode accepts `--reviewer` the same way as PR mode — repeat the flag to
 require multiple reviewers:

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -547,6 +547,7 @@ def render_public_agent_comment(
         | StructuredCoderFollowup
         | StructuredPlanRevision
         | StructuredPlanState
+        | ParsedDiscussReview
     ),
     agent: str,
     config: AgentLoopConfig | None = None,
@@ -555,6 +556,7 @@ def render_public_agent_comment(
     dispositions: Sequence[ReviewItemDisposition] = (),
     raw_text: str = "",
     human_requirements_resolved_flag: bool = False,
+    round_number: int = 1,
 ) -> str:
     """Render a parsed agent response and stamp the agent/model signature.
 
@@ -616,22 +618,101 @@ def render_public_agent_comment(
             config=config,
             model_used=model_used,
         )
+    if kind == "discuss_review":
+        if not isinstance(parsed, ParsedDiscussReview):
+            raise AgentLoopError("render_public_agent_comment expected ParsedDiscussReview.")
+        return _render_public_discuss_review_comment(
+            parsed,
+            reviewer=agent,
+            round_number=round_number,
+            config=config,
+            model_used=model_used,
+        )
     raise AgentLoopError(f"Unknown render kind: {kind}")
 
 
-def render_discuss_consensus_comment(
+_DISCUSS_OUTCOME_LABELS = {
+    "implement": "Implement",
+    "do-not-implement": "Do Not Implement",
+    "needs-human": "Needs Human Review",
+    "split": "Split",
+}
+
+
+def _render_public_discuss_review_comment(
+    parsed: ParsedDiscussReview,
     *,
-    outcome: str,
-    consensus_kind: str = "unanimous",
+    reviewer: str,
     round_number: int = 1,
-    reviewer_votes: list[ParsedDiscussReview],
-    round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
-    split_proposals: list[str],
-    subject: str,
-    config: object,
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
 ) -> str:
+    outcome_label = _DISCUSS_OUTCOME_LABELS.get(parsed.outcome, parsed.outcome)
+    sections: list[str] = [
+        f"## Round {round_number}: {reviewer} position",
+        f"**Vote:** {outcome_label} (`{parsed.outcome}`)",
+        parsed.rationale.strip(),
+    ]
+    if parsed.rebuttal:
+        sections.append("### Rebuttal\n\n" + parsed.rebuttal.strip())
+    if parsed.split_proposals:
+        proposals = "\n".join(f"- {proposal}" for proposal in parsed.split_proposals)
+        sections.append("### Proposed sub-issues\n\n" + proposals)
+    sections.append(f"-- {_comment_signature(reviewer, config, model_used)}")
+    return "\n\n".join(section for section in sections if section)
+
+
+def _render_discuss_agenda_lines(votes: Sequence[ParsedDiscussReview]) -> list[str]:
+    return [f"- {vote.reviewer} held `{vote.outcome}`: {vote.rationale}" for vote in votes]
+
+
+def render_discuss_round_summary_comment(
+    *,
+    is_final: bool,
+    subject: str,
+    round_number: int = 1,
+    reviewer_votes: Sequence[ParsedDiscussReview],
+    outcome: str | None = None,
+    consensus_kind: str = "unanimous",
+    round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
+    split_proposals: Sequence[str] | None = None,
+) -> str:
+    """Render the orchestrator/analyzer round-summary comment.
+
+    When `is_final` is False this closes out an inconclusive round with an
+    agenda for the next round; when True it renders the same consensus/deadlock
+    content previously produced by `render_discuss_consensus_comment`, plus the
+    marker that final-only idempotency and legacy detection rely on.
+    """
+    split_proposals = list(split_proposals or ())
+    if not is_final:
+        lines: list[str] = [
+            f"## Round {round_number} summary: Consensus Pending",
+            "",
+            "| Reviewer | Outcome | Rationale |",
+            "| --- | --- | --- |",
+        ]
+        for vote in reviewer_votes:
+            rationale = vote.rationale.replace("|", "\\|").replace("\n", " ")
+            lines.append(f"| {vote.reviewer} | {vote.outcome} | {rationale} |")
+        if split_proposals:
+            lines.append("")
+            lines.append("### Proposed sub-issues raised this round")
+            lines.append("")
+            for proposal in split_proposals:
+                lines.append(f"- {proposal}")
+        lines.append("")
+        lines.append(f"### Agenda for round {round_number + 1}")
+        lines.append("")
+        lines.extend(_render_discuss_agenda_lines(reviewer_votes))
+        lines.append("")
+        lines.append("-- Orchestrator")
+        return "\n".join(lines)
+
     if consensus_kind not in {"unanimous", "converged", "deadlock"}:
         raise AgentLoopError("consensus_kind must be `unanimous`, `converged`, or `deadlock`.")
+    if outcome is None:
+        raise AgentLoopError("outcome is required when is_final=True.")
     outcome_heading = {
         "implement": "Consensus: Implement",
         "do-not-implement": "Consensus: Do Not Implement",
@@ -640,15 +721,10 @@ def render_discuss_consensus_comment(
     }.get(outcome, f"Consensus: {outcome}")
     if consensus_kind == "deadlock":
         outcome_heading = "Consensus: Needs Human Review (Deadlock)"
-    kind_label = {
-        "unanimous": "unanimous",
-        "converged": "converged",
-        "deadlock": "deadlock",
-    }[consensus_kind]
-    lines: list[str] = [
+    lines = [
         f"## {outcome_heading}",
         "",
-        f"Consensus kind: `{kind_label}` after round {round_number}.",
+        f"Consensus kind: `{consensus_kind}` after round {round_number}.",
         "",
         "| Reviewer | Outcome | Rationale |",
         "| --- | --- | --- |",
@@ -667,8 +743,7 @@ def render_discuss_consensus_comment(
         lines.append("")
         lines.append("### Core disagreement")
         lines.append("")
-        for vote in reviewer_votes:
-            lines.append(f"- {vote.reviewer} held `{vote.outcome}`: {vote.rationale}")
+        lines.extend(_render_discuss_agenda_lines(reviewer_votes))
     if outcome == "split" and split_proposals:
         lines.append("")
         lines.append("### Proposed sub-issues")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3517,6 +3517,57 @@ def _run_discuss_loop(
         prior_round_agenda = []
         in_progress_votes = {}
     max_round_number = discuss_max_rounds + 1
+    if start_round_number > max_round_number:
+        if not round_history:
+            raise AgentLoopError(
+                "discuss: resumed state expects round "
+                f"{start_round_number} but --discuss-max-rounds={discuss_max_rounds} allows only "
+                f"{max_round_number} round(s), and no completed round was found to finalize from. "
+                "Rerun with a --discuss-max-rounds at least as large as the rounds already posted "
+                "on the issue, or repair the discuss transcript."
+            )
+        log(
+            config,
+            f"discuss: resumed round {start_round_number} exceeds --discuss-max-rounds="
+            f"{discuss_max_rounds} (allows {max_round_number} round(s)); finalizing from the last "
+            "completed round instead of starting a new one.",
+        )
+        final_round_number = len(round_history)
+        final_votes = round_history[-1]
+        summary_body = render_discuss_round_summary_comment(
+            round_number=final_round_number,
+            reviewer_votes=final_votes,
+            is_final=True,
+            subject=subject,
+            outcome="needs-human",
+            consensus_kind="deadlock",
+            round_history=round_history,
+            split_proposals=[],
+        )
+        post_issue_comment(
+            runner,
+            config=config,
+            issue_number=issue_number,
+            body=_attach_round_metadata(
+                summary_body,
+                PostedRoundMetadata(
+                    flow="discuss",
+                    role="summary",
+                    agent="Orchestrator",
+                    round_number=final_round_number,
+                    subject=subject,
+                    is_final=True,
+                    consensus_kind="deadlock",
+                    agenda=(),
+                ),
+            ),
+        )
+        log(
+            config,
+            f"discuss: posted final summary comment for issue #{issue_number} "
+            "(outcome: needs-human; kind: deadlock)",
+        )
+        return 0
     for round_number in range(start_round_number, max_round_number + 1):
         prior_round_votes = round_history[-1] if round_history else []
         reviewer_votes: list[ParsedDiscussReview] = []

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -144,10 +144,11 @@ from .comment_rendering import (
     _replace_structured_section,
     _review_freeform_summary_text,
     normalize_freeform_signature,
-    render_discuss_consensus_comment,
+    render_discuss_round_summary_comment,
     render_public_agent_comment,
     render_canonical_plan_revision,
     render_canonical_plan_steps,
+    _render_discuss_agenda_lines,
 )
 from .followups import (
     APPROVED_FOLLOWUP_MARKER_RE,
@@ -185,6 +186,7 @@ from .round_state import (
     _max_unresolved_item_number_from_records,
     _plan_subject,
     _prior_item_ledger_signature,
+    _resume_discuss_round,
     _resume_plan_round,
     _resume_pr_round,
     _select_current_round_records,
@@ -3427,15 +3429,28 @@ DISCUSS_CONSENSUS_MARKER_RE = re.compile(
 )
 
 
+def _is_bot_authored_discuss_comment(body: str) -> bool:
+    if DISCUSS_CONSENSUS_MARKER_RE.search(body):
+        return True
+    match = ROUND_RESUME_MARKER_RE.search(body)
+    if match is None:
+        return False
+    try:
+        metadata = _decode_round_metadata(match.group("payload"))
+    except AgentLoopError:
+        return False
+    return metadata.flow == "discuss"
+
+
 def _discuss_subject(issue_context: IssueContext) -> str:
     text = (issue_context.title or "") + "\n\n" + (issue_context.body or "")
-    non_consensus_bodies = [
+    non_bot_bodies = [
         c.body
         for c in issue_context.comments
-        if c.body and not DISCUSS_CONSENSUS_MARKER_RE.search(c.body)
+        if c.body and not _is_bot_authored_discuss_comment(c.body)
     ]
-    if non_consensus_bodies:
-        text += "\n\n" + "\n\n".join(non_consensus_bodies)
+    if non_bot_bodies:
+        text += "\n\n" + "\n\n".join(non_bot_bodies)
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
 
 
@@ -3481,15 +3496,43 @@ def _run_discuss_loop(
         if m and m.group(1).lower() == subject:
             log(config, f"discuss: found matching consensus comment for issue #{issue_number}; skipping")
             return 0
+    configured_reviewers = list(_reviewers(config))
+    resume_state = _resume_discuss_round(
+        issue_context.comments, subject=subject, configured_reviewers=configured_reviewers
+    )
+    if resume_state is not None and resume_state.done:
+        log(config, f"discuss: found matching round-summary comment for issue #{issue_number}; skipping")
+        return 0
     memory = prepare_agent_memory(runner, config)
-    round_history: list[list[ParsedDiscussReview]] = []
-    consensus: tuple[str, list[str]] | None = None
+    if resume_state is not None:
+        round_history: list[list[ParsedDiscussReview]] = [list(votes) for votes in resume_state.round_history]
+        start_round_number = resume_state.next_round_number
+        prior_round_agenda: list[str] = list(resume_state.prior_round_agenda)
+        in_progress_votes: dict[str, ParsedDiscussReview] = dict(resume_state.in_progress_votes)
+        if round_history or in_progress_votes:
+            log(config, f"discuss: resuming issue #{issue_number} at round {start_round_number}")
+    else:
+        round_history = []
+        start_round_number = 1
+        prior_round_agenda = []
+        in_progress_votes = {}
     max_round_number = discuss_max_rounds + 1
-    for round_number in range(1, max_round_number + 1):
+    for round_number in range(start_round_number, max_round_number + 1):
         prior_round_votes = round_history[-1] if round_history else []
         reviewer_votes: list[ParsedDiscussReview] = []
-        for reviewer in _reviewers(config):
+        for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
+            resumed_vote = (
+                in_progress_votes.get(reviewer_name) if round_number == start_round_number else None
+            )
+            if resumed_vote is not None:
+                log(
+                    config,
+                    f"discuss: resuming {reviewer_name}'s posted round {round_number} position "
+                    f"on issue #{issue_number}",
+                )
+                reviewer_votes.append(resumed_vote)
+                continue
             log(
                 config,
                 f"discuss: invoking {reviewer_name} on issue #{issue_number} "
@@ -3507,6 +3550,7 @@ def _run_discuss_loop(
                     issue_context=issue_context,
                     round_number=round_number,
                     prior_round_votes=prior_round_votes,
+                    prior_round_agenda=prior_round_agenda,
                 ),
                 marker_description="<!-- AGENT_PLAN_STATE: approved -->",
                 validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
@@ -3519,35 +3563,83 @@ def _run_discuss_loop(
             )
             parsed = response.marker_value
             assert isinstance(parsed, ParsedDiscussReview)
+            post_issue_comment(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                body=_attach_round_metadata(
+                    render_public_agent_comment(
+                        kind="discuss_review",
+                        parsed=parsed,
+                        agent=reviewer_name,
+                        config=config,
+                        model_used=response.model_used,
+                        round_number=round_number,
+                    ),
+                    PostedRoundMetadata(
+                        flow="discuss",
+                        role="debater",
+                        agent=reviewer_name,
+                        round_number=round_number,
+                        subject=subject,
+                        raw_structured_coder_response=response.text,
+                        model_used=response.model_used,
+                    ),
+                ),
+            )
             reviewer_votes.append(parsed)
         round_history.append(reviewer_votes)
         consensus = _detect_discuss_consensus(reviewer_votes)
-        if consensus is not None:
-            break
-    final_votes = round_history[-1]
-    if consensus is None:
-        outcome = "needs-human"
-        split_proposals = []
-        consensus_kind = "deadlock"
-    else:
-        outcome, split_proposals = consensus
-        consensus_kind = "unanimous" if len(round_history) == 1 else "converged"
-    body = render_discuss_consensus_comment(
-        outcome=outcome,
-        consensus_kind=consensus_kind,
-        round_number=len(round_history),
-        reviewer_votes=final_votes,
-        round_history=round_history,
-        split_proposals=split_proposals,
-        subject=subject,
-        config=config,
-    )
-    post_issue_comment(runner, config=config, issue_number=issue_number, body=body)
-    log(
-        config,
-        f"discuss: posted consensus comment for issue #{issue_number} "
-        f"(outcome: {outcome}; kind: {consensus_kind})",
-    )
+        is_final = consensus is not None or round_number == max_round_number
+        if consensus is None:
+            outcome = "needs-human"
+            round_split_proposals: list[str] = _merge_discuss_split_proposals(reviewer_votes)
+            consensus_kind = "deadlock" if is_final else None
+        else:
+            outcome, round_split_proposals = consensus
+            consensus_kind = ("unanimous" if len(round_history) == 1 else "converged") if is_final else None
+        summary_body = render_discuss_round_summary_comment(
+            round_number=round_number,
+            reviewer_votes=reviewer_votes,
+            is_final=is_final,
+            subject=subject,
+            outcome=outcome if is_final else None,
+            consensus_kind=consensus_kind,
+            round_history=round_history if is_final else None,
+            split_proposals=round_split_proposals,
+        )
+        agenda = () if is_final else tuple(_render_discuss_agenda_lines(reviewer_votes))
+        post_issue_comment(
+            runner,
+            config=config,
+            issue_number=issue_number,
+            body=_attach_round_metadata(
+                summary_body,
+                PostedRoundMetadata(
+                    flow="discuss",
+                    role="summary",
+                    agent="Orchestrator",
+                    round_number=round_number,
+                    subject=subject,
+                    is_final=is_final,
+                    consensus_kind=consensus_kind,
+                    agenda=agenda,
+                ),
+            ),
+        )
+        if is_final:
+            log(
+                config,
+                f"discuss: posted final summary comment for issue #{issue_number} "
+                f"(outcome: {outcome}; kind: {consensus_kind})",
+            )
+            return 0
+        log(
+            config,
+            f"discuss: posted round {round_number} summary comment for issue #{issue_number}; "
+            f"continuing to round {round_number + 1}",
+        )
+        prior_round_agenda = list(agenda)
     return 0
 
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2157,9 +2157,11 @@ def build_discuss_review_prompt(
     issue_context: IssueContext | None = None,
     round_number: int = 1,
     prior_round_votes: Sequence[ParsedDiscussReview] | None = None,
+    prior_round_agenda: Sequence[str] | None = None,
 ) -> str:
     reviewer_signature = agent_signature(reviewer, config)
     prior_round_votes = tuple(prior_round_votes or ())
+    prior_round_agenda = tuple(prior_round_agenda or ())
     if round_number <= 1:
         round_context = (
             "This is round 1. Evaluate independently; do not assume other reviewers agree."
@@ -2182,6 +2184,10 @@ def build_discuss_review_prompt(
                 prior_lines.append("  Split proposals:")
                 for proposal in vote.split_proposals:
                     prior_lines.append(f"  - {proposal}")
+        if prior_round_agenda:
+            prior_lines.append("")
+            prior_lines.append("Orchestrator's round summary and agenda for this round:")
+            prior_lines.extend(prior_round_agenda)
         round_context = "\n".join(prior_lines)
         rebuttal_rule = (
             "- `rebuttal` is required in debate rounds and must directly engage the prior "

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -15,8 +15,10 @@ from .errors import AgentLoopError
 from .protocol import (
     HTML_COMMENT_RE,
     SIGNATURE_RE,
+    ParsedDiscussReview,
     ReviewItemDisposition,
     UnresolvedReviewItem,
+    parse_structured_discuss_review,
 )
 from .unresolved_items import _apply_unresolved_item_dispositions
 
@@ -39,6 +41,9 @@ class PostedRoundMetadata:
     compact_prior_summaries: tuple[str, ...] = ()
     usage: dict | None = None
     model_used: str | None = None
+    consensus_kind: str | None = None
+    is_final: bool = False
+    agenda: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -130,6 +135,9 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "compact_prior_summaries": list(metadata.compact_prior_summaries),
         "usage": metadata.usage,
         "model_used": metadata.model_used,
+        "consensus_kind": metadata.consensus_kind,
+        "is_final": metadata.is_final,
+        "agenda": list(metadata.agenda),
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -168,6 +176,9 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             ),
             usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else None,
             model_used=str(payload["model_used"]) if payload.get("model_used") is not None else None,
+            consensus_kind=str(payload["consensus_kind"]) if payload.get("consensus_kind") is not None else None,
+            is_final=bool(payload.get("is_final", False)),
+            agenda=tuple(str(item) for item in payload.get("agenda", [])),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc
@@ -538,4 +549,93 @@ def _resume_plan_round(
             ledger_may_be_incomplete=ledger_may_be_incomplete,
             compact_prior_summaries=latest_coder_record.metadata.compact_prior_summaries,
         ),
+    )
+
+
+@dataclass(frozen=True)
+class ResumedDiscussState:
+    done: bool
+    round_history: tuple[tuple[ParsedDiscussReview, ...], ...]
+    next_round_number: int
+    prior_round_agenda: tuple[str, ...] = ()
+    in_progress_votes: dict[str, ParsedDiscussReview] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.in_progress_votes is None:
+            object.__setattr__(self, "in_progress_votes", {})
+
+
+def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> ParsedDiscussReview:
+    text = record.metadata.raw_structured_coder_response or record.body
+    vote = parse_structured_discuss_review(text, reviewer=record.metadata.agent, round_number=round_number)
+    if vote is None:
+        raise AgentLoopError(
+            f"Could not decode discuss_review metadata for {record.metadata.agent} "
+            f"(round {round_number}); the posted comment's structured payload is missing "
+            "or invalid."
+        )
+    return vote
+
+
+def _resume_discuss_round(
+    comments: Sequence[object],
+    *,
+    subject: str,
+    configured_reviewers: Sequence[AgentName],
+) -> ResumedDiscussState | None:
+    records = _extract_round_metadata_records(comments, flow="discuss")
+    subject_records = [record for record in records if record.metadata.subject == subject]
+    if not subject_records:
+        return None
+    configured_reviewer_names = [agent_display_name(agent) for agent in configured_reviewers]
+    rounds: dict[int, list[PostedRoundRecord]] = {}
+    for record in subject_records:
+        rounds.setdefault(record.metadata.round_number, []).append(record)
+
+    round_history: list[tuple[ParsedDiscussReview, ...]] = []
+    prior_round_agenda: tuple[str, ...] = ()
+    next_round_number = 1
+    in_progress_votes: dict[str, ParsedDiscussReview] = {}
+    for round_number in sorted(rounds):
+        round_records = rounds[round_number]
+        summary_record = next(
+            (record for record in round_records if record.metadata.role == "summary"), None
+        )
+        debater_records: dict[str, PostedRoundRecord] = {}
+        for record in round_records:
+            if record.metadata.role == "debater":
+                debater_records[record.metadata.agent] = record
+        if summary_record is not None:
+            missing = [name for name in configured_reviewer_names if name not in debater_records]
+            if missing:
+                raise AgentLoopError(
+                    "Discuss round metadata is inconsistent: round "
+                    f"{round_number} has a summary comment but is missing debater "
+                    f"comments for: {', '.join(missing)}."
+                )
+            votes = tuple(
+                _decode_discuss_vote(debater_records[name], round_number=round_number)
+                for name in configured_reviewer_names
+            )
+            round_history.append(votes)
+            prior_round_agenda = summary_record.metadata.agenda
+            if summary_record.metadata.is_final:
+                return ResumedDiscussState(
+                    done=True,
+                    round_history=tuple(round_history),
+                    next_round_number=round_number,
+                    prior_round_agenda=prior_round_agenda,
+                )
+            next_round_number = round_number + 1
+        else:
+            next_round_number = round_number
+            for name, record in debater_records.items():
+                in_progress_votes[name] = _decode_discuss_vote(record, round_number=round_number)
+            break
+    return ResumedDiscussState(
+        done=False,
+        round_history=tuple(round_history),
+        next_round_number=next_round_number,
+        prior_round_agenda=prior_round_agenda,
+        in_progress_votes=in_progress_votes,
     )

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -9,11 +9,12 @@ import pytest
 
 from coding_review_agent_loop.comment_rendering import (
     _render_public_coder_followup_comment,
+    _render_public_discuss_review_comment,
     _render_public_plan_review_comment,
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
     normalize_freeform_signature,
-    render_discuss_consensus_comment,
+    render_discuss_round_summary_comment,
 )
 from coding_review_agent_loop.protocol import ParsedDiscussReview
 from coding_review_agent_loop.orchestrator import (
@@ -40,7 +41,6 @@ from coding_review_agent_loop.protocol import (
 
 from agent_loop_helpers import (
     blocking_issues,
-    make_config,
     prior_item_dispositions,
     prior_plan_item_dispositions,
     structured_coder_followup,
@@ -696,7 +696,7 @@ def test_render_public_review_comment_preserves_unknown_disposition_values():
     ) in rendered
 
 
-# --- render_discuss_consensus_comment tests ---
+# --- render_discuss_round_summary_comment tests ---
 
 
 def _discuss_vote(
@@ -715,50 +715,46 @@ def _discuss_vote(
     )
 
 
-def test_render_discuss_consensus_comment_implement_heading(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_implement_heading():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="implement",
         reviewer_votes=[_discuss_vote("implement")],
         split_proposals=[],
         subject="abc123",
-        config=config,
     )
     assert "## Consensus: Implement" in rendered
 
 
-def test_render_discuss_consensus_comment_do_not_implement_heading(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_do_not_implement_heading():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="do-not-implement",
         reviewer_votes=[_discuss_vote("do-not-implement", rationale="Out of scope.")],
         split_proposals=[],
         subject="deadbeef",
-        config=config,
     )
     assert "## Consensus: Do Not Implement" in rendered
 
 
-def test_render_discuss_consensus_comment_needs_human_heading(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_needs_human_heading():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="needs-human",
         reviewer_votes=[_discuss_vote("needs-human", rationale="Unclear requirements.")],
         split_proposals=[],
         subject="cafe1234",
-        config=config,
     )
     assert "## Consensus: Needs Human Review" in rendered
 
 
-def test_render_discuss_consensus_comment_split_heading_and_proposals(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_split_heading_and_proposals():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="split",
         reviewer_votes=[_discuss_vote("split", proposals=("Sub A", "Sub B"))],
         split_proposals=["Sub A", "Sub B"],
         subject="f00dbeef",
-        config=config,
     )
     assert "## Consensus: Split" in rendered
     assert "### Proposed sub-issues" in rendered
@@ -766,9 +762,9 @@ def test_render_discuss_consensus_comment_split_heading_and_proposals(tmp_path):
     assert "- Sub B" in rendered
 
 
-def test_render_discuss_consensus_comment_reviewer_table_row(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_reviewer_table_row():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="implement",
         reviewer_votes=[
             _discuss_vote("implement", rationale="Well-scoped.", reviewer="Gemini"),
@@ -776,7 +772,6 @@ def test_render_discuss_consensus_comment_reviewer_table_row(tmp_path):
         ],
         split_proposals=[],
         subject="abc123",
-        config=config,
     )
     assert "| Gemini |" in rendered
     assert "| OpenAI Codex |" in rendered
@@ -784,34 +779,32 @@ def test_render_discuss_consensus_comment_reviewer_table_row(tmp_path):
     assert "Clear value." in rendered
 
 
-def test_render_discuss_consensus_comment_orchestrator_footer(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_orchestrator_footer():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="implement",
         reviewer_votes=[_discuss_vote()],
         split_proposals=[],
         subject="abc123",
-        config=config,
     )
     assert "-- Orchestrator" in rendered
 
 
-def test_render_discuss_consensus_comment_marker_last_line(tmp_path):
-    config = make_config(tmp_path)
+def test_render_discuss_round_summary_comment_final_marker_last_line():
     subject = "deadbeef1234"
-    rendered = render_discuss_consensus_comment(
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="implement",
         reviewer_votes=[_discuss_vote()],
         split_proposals=[],
         subject=subject,
-        config=config,
     )
     assert rendered.endswith(f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->")
 
 
-def test_render_discuss_consensus_comment_converged_kind_and_rebuttals(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_converged_kind_and_rebuttals():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="implement",
         consensus_kind="converged",
         round_number=2,
@@ -834,16 +827,15 @@ def test_render_discuss_consensus_comment_converged_kind_and_rebuttals(tmp_path)
         ],
         split_proposals=[],
         subject="abc123",
-        config=config,
     )
     assert "Consensus kind: `converged` after round 2." in rendered
     assert "### Final rebuttals" in rendered
     assert "Round 1: Gemini: `needs-human`" in rendered
 
 
-def test_render_discuss_consensus_comment_deadlock_summarizes_disagreement(tmp_path):
-    config = make_config(tmp_path)
-    rendered = render_discuss_consensus_comment(
+def test_render_discuss_round_summary_comment_final_deadlock_summarizes_disagreement():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
         outcome="needs-human",
         consensus_kind="deadlock",
         round_number=2,
@@ -853,11 +845,100 @@ def test_render_discuss_consensus_comment_deadlock_summarizes_disagreement(tmp_p
         ],
         split_proposals=[],
         subject="abc123",
-        config=config,
     )
     assert "## Consensus: Needs Human Review (Deadlock)" in rendered
     assert "Consensus kind: `deadlock` after round 2." in rendered
     assert "### Core disagreement" in rendered
     assert "Gemini held `implement`: Scoped." in rendered
     assert "OpenAI Codex held `do-not-implement`: Out of scope." in rendered
+
+
+def test_render_discuss_round_summary_comment_interim_round_has_agenda_and_no_marker():
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        round_number=1,
+        reviewer_votes=[
+            _discuss_vote("implement", rationale="Scoped.", reviewer="Gemini"),
+            _discuss_vote("do-not-implement", rationale="Out of scope.", reviewer="OpenAI Codex"),
+        ],
+        split_proposals=[],
+        subject="abc123",
+    )
+    assert "## Round 1 summary: Consensus Pending" in rendered
+    assert "### Agenda for round 2" in rendered
+    assert "Gemini held `implement`: Scoped." in rendered
+    assert "OpenAI Codex held `do-not-implement`: Out of scope." in rendered
+    assert "-- Orchestrator" in rendered
+    assert "AGENT_DISCUSS_CONSENSUS" not in rendered
+    assert "Consensus:" not in rendered
+
+
+def test_render_discuss_round_summary_comment_interim_round_lists_split_proposals():
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        round_number=1,
+        reviewer_votes=[_discuss_vote("split", proposals=("Sub A",), reviewer="Gemini")],
+        split_proposals=["Sub A"],
+        subject="abc123",
+    )
+    assert "### Proposed sub-issues raised this round" in rendered
+    assert "- Sub A" in rendered
+
+
+def test_render_discuss_round_summary_comment_final_includes_full_resumed_history():
+    """A resumed final summary must list every prior round, not just the last one."""
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="converged",
+        round_number=3,
+        reviewer_votes=[
+            _discuss_vote("implement", reviewer="Gemini"),
+            _discuss_vote("implement", reviewer="OpenAI Codex"),
+        ],
+        round_history=[
+            [
+                _discuss_vote("do-not-implement", reviewer="Gemini"),
+                _discuss_vote("implement", reviewer="OpenAI Codex"),
+            ],
+            [
+                _discuss_vote("do-not-implement", reviewer="Gemini"),
+                _discuss_vote("implement", reviewer="OpenAI Codex"),
+            ],
+            [
+                _discuss_vote("implement", reviewer="Gemini"),
+                _discuss_vote("implement", reviewer="OpenAI Codex"),
+            ],
+        ],
+        split_proposals=[],
+        subject="abc123",
+    )
+    assert "Round 1: Gemini: `do-not-implement`, OpenAI Codex: `implement`" in rendered
+    assert "Round 2: Gemini: `do-not-implement`, OpenAI Codex: `implement`" in rendered
+    assert "Round 3: Gemini: `implement`, OpenAI Codex: `implement`" in rendered
+
+
+def test_render_public_discuss_review_comment_includes_vote_and_signature():
+    vote = _discuss_vote("implement", rationale="Well-scoped.", reviewer="Codex")
+    rendered = _render_public_discuss_review_comment(vote, reviewer="Codex", round_number=1)
+    assert "## Round 1: Codex position" in rendered
+    assert "**Vote:** Implement (`implement`)" in rendered
+    assert "Well-scoped." in rendered
+    assert rendered.strip().endswith("Codex")
+
+
+def test_render_public_discuss_review_comment_includes_rebuttal_and_split_proposals():
+    vote = _discuss_vote(
+        "split",
+        rationale="Too broad.",
+        proposals=("Auth flow",),
+        reviewer="Codex",
+        rebuttal="I still think it should be split.",
+    )
+    rendered = _render_public_discuss_review_comment(vote, reviewer="Codex", round_number=2)
+    assert "## Round 2: Codex position" in rendered
+    assert "### Rebuttal" in rendered
+    assert "I still think it should be split." in rendered
+    assert "### Proposed sub-issues" in rendered
+    assert "- Auth flow" in rendered
 

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -661,3 +661,62 @@ def test_discuss_loop_idempotent_when_final_summary_metadata_exists(tmp_path):
     assert len(runner.comments) == 0
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
     assert not any(cmd[:1] == ["gemini"] for cmd, _cwd in runner.commands)
+
+
+def test_discuss_loop_finalizes_from_last_completed_round_when_resumed_round_exceeds_lowered_max_rounds(tmp_path):
+    """Regression test: resuming a non-final round with a since-lowered
+    --discuss-max-rounds must post a final deadlock summary instead of silently
+    returning 0 with no final summary (review blocking-1 on PR #471)."""
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    gemini_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="Out of scope.", split_proposals=(), reviewer="Gemini")
+    seeded = [
+        _seed_debater_comment(reviewer="Codex", round_number=1, subject=subject, outcome="implement", rationale="Scoped.", config=config),
+        _seed_debater_comment(reviewer="Gemini", round_number=1, subject=subject, outcome="do-not-implement", rationale="Out of scope.", config=config),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=("- Codex held `implement`: Scoped.", "- Gemini held `do-not-implement`: Out of scope."),
+        ),
+    ]
+    # discuss_max_rounds was previously left at the default (>=1 debate round), but this
+    # run uses 0, so the resumed round 2 is no longer allowed.
+    runner = FakeRunner(issue_comments=seeded, codex_outputs=[], gemini_outputs=[])
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    # No debaters should be re-invoked for a round that is no longer allowed.
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:1] == ["gemini"] for cmd, _cwd in runner.commands)
+    assert len(runner.comments) == 1
+    final = runner.comments[-1]
+    assert "Consensus: Needs Human Review (Deadlock)" in final
+    assert "Consensus kind: `deadlock` after round 1." in final
+    assert "Codex held `implement`: Scoped." in final
+    assert "Gemini held `do-not-implement`: Out of scope." in final
+    m = DISCUSS_CONSENSUS_MARKER_RE.search(final)
+    assert m is not None
+    assert m.group(1) == subject
+
+
+def test_discuss_loop_raises_when_resumed_round_exceeds_max_rounds_with_no_completed_round(tmp_path):
+    """Defensive guard: if resume ever reports a start round beyond the configured
+    limit with no completed round history to finalize from (e.g. corrupted/partial
+    metadata with no round-1 records at all), fail loudly instead of silently
+    returning 0 with no final summary."""
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=2, subject=subject, outcome="implement",
+            rationale="Scoped.", rebuttal="Still scoped.", config=config,
+        ),
+    ]
+    runner = FakeRunner(issue_comments=seeded, codex_outputs=[], gemini_outputs=[])
+
+    with pytest.raises(AgentLoopError, match="discuss: resumed state expects round"):
+        run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -6,11 +6,18 @@ import pytest
 
 from coding_review_agent_loop.orchestrator import (
     DISCUSS_CONSENSUS_MARKER_RE,
+    PostedRoundMetadata,
+    ROUND_RESUME_MARKER_RE,
+    _attach_round_metadata,
+    _decode_round_metadata,
     _discuss_subject,
+    render_public_agent_comment,
     run_discuss_loop,
 )
+from coding_review_agent_loop.comment_rendering import render_discuss_round_summary_comment
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import IssueComment, IssueContext
+from coding_review_agent_loop.protocol import ParsedDiscussReview
 
 from agent_loop_helpers import FakeRunner, make_config
 
@@ -41,6 +48,92 @@ def _issue_subject(title: str = "Fix issue-mode context", body: str = "Original 
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
 
 
+def _seed_debater_comment(
+    *,
+    reviewer: str,
+    round_number: int,
+    subject: str,
+    outcome: str = "implement",
+    rationale: str = "Well-scoped.",
+    split_proposals: list[str] | None = None,
+    rebuttal: str | None = None,
+    config=None,
+) -> dict:
+    """Build an issue-comment payload matching what `_run_discuss_loop` posts for a debater."""
+    vote = ParsedDiscussReview(
+        outcome=outcome,
+        rationale=rationale,
+        split_proposals=tuple(split_proposals or ()),
+        reviewer=reviewer,
+        rebuttal=rebuttal,
+    )
+    raw_text = _discuss_review_text(
+        outcome=outcome,
+        rationale=rationale,
+        split_proposals=split_proposals,
+        rebuttal=rebuttal,
+        reviewer=reviewer,
+    )
+    body = render_public_agent_comment(
+        kind="discuss_review",
+        parsed=vote,
+        agent=reviewer,
+        config=config,
+        round_number=round_number,
+    )
+    body = _attach_round_metadata(
+        body,
+        PostedRoundMetadata(
+            flow="discuss",
+            role="debater",
+            agent=reviewer,
+            round_number=round_number,
+            subject=subject,
+            raw_structured_coder_response=raw_text,
+        ),
+    )
+    return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
+
+
+def _seed_summary_comment(
+    *,
+    round_number: int,
+    reviewer_votes: list[ParsedDiscussReview],
+    is_final: bool,
+    subject: str,
+    outcome: str | None = None,
+    consensus_kind: str | None = None,
+    round_history: list[list[ParsedDiscussReview]] | None = None,
+    split_proposals: list[str] | None = None,
+    agenda: tuple[str, ...] = (),
+) -> dict:
+    """Build an issue-comment payload matching what `_run_discuss_loop` posts for a round summary."""
+    body = render_discuss_round_summary_comment(
+        round_number=round_number,
+        reviewer_votes=reviewer_votes,
+        is_final=is_final,
+        subject=subject,
+        outcome=outcome,
+        consensus_kind=consensus_kind,
+        round_history=round_history,
+        split_proposals=split_proposals,
+    )
+    body = _attach_round_metadata(
+        body,
+        PostedRoundMetadata(
+            flow="discuss",
+            role="summary",
+            agent="Orchestrator",
+            round_number=round_number,
+            subject=subject,
+            is_final=is_final,
+            consensus_kind=consensus_kind,
+            agenda=agenda,
+        ),
+    )
+    return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
+
+
 def test_discuss_loop_happy_path_two_implement_votes(tmp_path):
     implement_text = _discuss_review_text(outcome="implement")
     runner = FakeRunner(
@@ -52,8 +145,10 @@ def test_discuss_loop_happy_path_two_implement_votes(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config)
 
     assert result == 0
-    assert len(runner.comments) == 1
-    assert "Consensus: Implement" in runner.comments[0]
+    assert len(runner.comments) == 3
+    assert "Round 1: Codex position" in runner.comments[0]
+    assert "Round 1: Gemini position" in runner.comments[1]
+    assert "Consensus: Implement" in runner.comments[2]
 
 
 def test_discuss_loop_debates_then_deadlocks_instead_of_veto(tmp_path):
@@ -76,11 +171,12 @@ def test_discuss_loop_debates_then_deadlocks_instead_of_veto(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
 
     assert result == 0
-    assert len(runner.comments) == 1
-    assert "Consensus: Needs Human Review (Deadlock)" in runner.comments[0]
-    assert "Consensus kind: `deadlock` after round 2." in runner.comments[0]
-    assert "Codex held `implement`" in runner.comments[0]
-    assert "Gemini held `do-not-implement`" in runner.comments[0]
+    assert len(runner.comments) == 6
+    final = runner.comments[-1]
+    assert "Consensus: Needs Human Review (Deadlock)" in final
+    assert "Consensus kind: `deadlock` after round 2." in final
+    assert "Codex held `implement`" in final
+    assert "Gemini held `do-not-implement`" in final
 
 
 def test_discuss_loop_idempotent_when_consensus_comment_exists(tmp_path):
@@ -112,8 +208,8 @@ def test_discuss_loop_reruns_when_subject_hash_differs(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config)
 
     assert result == 0
-    assert len(runner.comments) == 1
-    assert "Consensus: Implement" in runner.comments[0]
+    assert len(runner.comments) == 3
+    assert "Consensus: Implement" in runner.comments[-1]
 
 
 def test_discuss_loop_consensus_comment_contains_subject_hash(tmp_path):
@@ -127,7 +223,7 @@ def test_discuss_loop_consensus_comment_contains_subject_hash(tmp_path):
 
     run_discuss_loop(runner, issue_number=56, config=config)
 
-    posted = runner.comments[0]
+    posted = runner.comments[-1]
     m = DISCUSS_CONSENSUS_MARKER_RE.search(posted)
     assert m is not None, "AGENT_DISCUSS_CONSENSUS marker not found in posted comment"
     assert m.group(1) == subject
@@ -199,6 +295,33 @@ def test_discuss_subject_excludes_consensus_comment_from_hash():
     assert _discuss_subject(ctx_with_consensus) == subject
 
 
+def test_discuss_subject_excludes_debater_and_summary_comments_from_hash():
+    ctx_base = IssueContext(
+        number=1, repo="OWNER/REPO", title="My issue", body="Body", url=None, comments=()
+    )
+    subject = _discuss_subject(ctx_base)
+    debater_comment = _seed_debater_comment(reviewer="OpenAI Codex", round_number=1, subject=subject)
+    summary_comment = _seed_summary_comment(
+        round_number=1,
+        reviewer_votes=[ParsedDiscussReview(outcome="implement", rationale="x", split_proposals=(), reviewer="OpenAI Codex")],
+        is_final=False,
+        subject=subject,
+        agenda=("- OpenAI Codex held `implement`: x",),
+    )
+    ctx_with_rounds = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="My issue",
+        body="Body",
+        url=None,
+        comments=(
+            IssueComment(author="bot", created_at=None, body=debater_comment["body"]),
+            IssueComment(author="bot", created_at=None, body=summary_comment["body"]),
+        ),
+    )
+    assert _discuss_subject(ctx_with_rounds) == subject
+
+
 def test_discuss_loop_reruns_when_human_comment_added(tmp_path):
     implement_text = _discuss_review_text(outcome="implement")
     old_subject = _issue_subject()
@@ -217,7 +340,7 @@ def test_discuss_loop_reruns_when_human_comment_added(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config)
 
     assert result == 0
-    assert len(runner.comments) == 1
+    assert len(runner.comments) == 3
 
 
 def test_discuss_loop_split_consensus_includes_proposals(tmp_path):
@@ -235,7 +358,7 @@ def test_discuss_loop_split_consensus_includes_proposals(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config)
 
     assert result == 0
-    posted = runner.comments[0]
+    posted = runner.comments[-1]
     assert "Consensus: Split" in posted
     assert "Auth flow" in posted
     assert "Authorization checks" in posted
@@ -265,7 +388,7 @@ def test_discuss_loop_converges_after_debate(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
 
     assert result == 0
-    posted = runner.comments[0]
+    posted = runner.comments[-1]
     assert "Consensus: Needs Human Review" in posted
     assert "Consensus kind: `converged` after round 2." in posted
     assert "### Final rebuttals" in posted
@@ -281,7 +404,8 @@ def test_discuss_loop_zero_debate_rounds_deadlocks_after_initial_disagreement(tm
     result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
 
     assert result == 0
-    posted = runner.comments[0]
+    assert len(runner.comments) == 3
+    posted = runner.comments[-1]
     assert "Consensus kind: `deadlock` after round 1." in posted
     assert "Codex held `implement`" in posted
     assert "Gemini held `needs-human`" in posted
@@ -323,9 +447,217 @@ def test_discuss_loop_passes_prior_round_snapshot_to_debate_prompts(tmp_path):
         assert "Auth flow" in prompt
 
 
+def test_discuss_loop_round2_prompt_includes_round1_agenda(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Still scoped.",
+                rebuttal="The split concern does not apply.",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="Out of scope entirely."),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Still out of scope.",
+                rebuttal="The scope objection still stands.",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Orchestrator's round summary and agenda for this round" in prompt
+        assert "Out of scope entirely." in prompt
+
+
 def test_discuss_loop_rejects_negative_discuss_max_rounds(tmp_path):
     runner = FakeRunner(codex_outputs=[], gemini_outputs=[])
     config = make_config(tmp_path, reviewer=("codex", "gemini"))
 
     with pytest.raises(AgentLoopError, match="--discuss-max-rounds must be zero or greater"):
         run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=-1)
+
+
+def test_discuss_loop_resumes_missing_debater_mid_round(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    seeded = _seed_debater_comment(
+        reviewer="Codex",
+        round_number=1,
+        subject=subject,
+        outcome="implement",
+        rationale="Scoped.",
+        config=config,
+    )
+    implement_text = _discuss_review_text(outcome="implement", rationale="Agreed.", reviewer="Gemini")
+    runner = FakeRunner(
+        issue_comments=[seeded],
+        codex_outputs=[],
+        gemini_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    # Only Gemini should have been invoked; Codex's posted round-1 vote is reused.
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert len(runner.comments) == 2  # Gemini debater comment + final summary
+    assert "Round 1: Gemini position" in runner.comments[0]
+    assert "Consensus: Implement" in runner.comments[-1]
+
+
+def test_discuss_loop_resumes_after_closed_non_final_round(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    gemini_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="Out of scope.", split_proposals=(), reviewer="Gemini")
+    agenda = (
+        "- Codex held `implement`: Scoped.",
+        "- Gemini held `do-not-implement`: Out of scope.",
+    )
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Scoped.", config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            outcome="do-not-implement", rationale="Out of scope.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            split_proposals=[],
+            agenda=agenda,
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement", rationale="Still scoped.", rebuttal="The split concern does not apply.",
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    # Round 1 agents must not be re-invoked; only round 2's two debaters run.
+    assert len(runner.comments) == 3  # 2 round-2 debater comments + final summary
+    assert "Round 2: Codex position" in runner.comments[0]
+    assert "Round 2: Gemini position" in runner.comments[1]
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "### Round history" in final
+    assert "Round 1: Codex: `implement`, Gemini: `do-not-implement`" in final
+    assert "Round 2: Codex: `implement`, Gemini: `implement`" in final
+    round2_commands = [
+        cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)
+    ]
+    assert len(round2_commands) == 2
+    for command in round2_commands:
+        prompt = " ".join(command)
+        assert "Out of scope." in prompt
+
+
+def test_discuss_loop_resume_reconstructs_full_round_history_across_multiple_closed_rounds(tmp_path):
+    """Regression test for review blocking-1: the final summary after a resume must
+    include every prior closed round, not just the round immediately before it."""
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="R1 scoped.", split_proposals=(), reviewer="Codex")
+    gemini_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="R1 out of scope.", split_proposals=(), reviewer="Gemini")
+    codex_vote_r2 = ParsedDiscussReview(
+        outcome="implement", rationale="R2 scoped.", split_proposals=(), reviewer="Codex",
+        rebuttal="Still scoped.",
+    )
+    gemini_vote_r2 = ParsedDiscussReview(
+        outcome="do-not-implement", rationale="R2 still out of scope.", split_proposals=(), reviewer="Gemini",
+        rebuttal="Scope objection remains.",
+    )
+    seeded = [
+        _seed_debater_comment(reviewer="Codex", round_number=1, subject=subject, outcome="implement", rationale="R1 scoped.", config=config),
+        _seed_debater_comment(reviewer="Gemini", round_number=1, subject=subject, outcome="do-not-implement", rationale="R1 out of scope.", config=config),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=("- Codex held `implement`: R1 scoped.", "- Gemini held `do-not-implement`: R1 out of scope."),
+        ),
+        _seed_debater_comment(
+            reviewer="Codex", round_number=2, subject=subject, outcome="implement",
+            rationale="R2 scoped.", rebuttal="Still scoped.", config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=2, subject=subject, outcome="do-not-implement",
+            rationale="R2 still out of scope.", rebuttal="Scope objection remains.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=2,
+            reviewer_votes=[codex_vote_r2, gemini_vote_r2],
+            is_final=False,
+            subject=subject,
+            agenda=("- Codex held `implement`: R2 scoped.", "- Gemini held `do-not-implement`: R2 still out of scope."),
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement", rationale="R3 agreed.", rebuttal="Convinced by the narrowed scope.",
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=2)
+
+    assert result == 0
+    assert len(runner.comments) == 3  # 2 round-3 debater comments + final summary
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Consensus kind: `converged` after round 3." in final
+    assert "### Round history" in final
+    assert "Round 1: Codex: `implement`, Gemini: `do-not-implement`" in final
+    assert "Round 2: Codex: `implement`, Gemini: `do-not-implement`" in final
+    assert "Round 3: Codex: `implement`, Gemini: `implement`" in final
+
+
+def test_discuss_loop_idempotent_when_final_summary_metadata_exists(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    codex_vote = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    gemini_vote = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Gemini")
+    seeded = [
+        _seed_debater_comment(reviewer="Codex", round_number=1, subject=subject, outcome="implement", rationale="Scoped.", config=config),
+        _seed_debater_comment(reviewer="Gemini", round_number=1, subject=subject, outcome="implement", rationale="Scoped.", config=config),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote, gemini_vote],
+            is_final=True,
+            subject=subject,
+            outcome="implement",
+            consensus_kind="unanimous",
+            round_history=[[codex_vote, gemini_vote]],
+            split_proposals=[],
+        ),
+    ]
+    runner = FakeRunner(issue_comments=seeded, codex_outputs=[], gemini_outputs=[])
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 0
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:1] == ["gemini"] for cmd, _cwd in runner.commands)


### PR DESCRIPTION
## Summary
- Discuss mode now posts each configured reviewer's structured vote as its own issue comment per round (tagged with round metadata), instead of only surfacing votes as rows in one final orchestrator table.
- After all debaters have posted for a round, the orchestrator posts a separate round-summary comment: interim rounds get a "Consensus Pending" summary with an agenda for the next round; the final round gets the consensus/deadlock summary (still carrying the `AGENT_DISCUSS_CONSENSUS` marker for idempotency).
- Resume logic reconstructs the full ordered round history (including a round that only partially posted before a crash) from the public `AGENT_LOOP_META` comment metadata already used by the plan/PR review loops, rather than relying on one aggregate comment.
- Next-round prompts now include the prior round's orchestrator agenda in addition to the raw prior votes.
- Legacy issues that finished under the old single-comment scheme are still recognized as complete (backward-compatible idempotency).

## Test plan
- [x] `python -m pytest tests/` (1173 passed) — includes reworked `tests/test_discuss_loop.py` (unanimous one-round, multi-round debate/deadlock/converged transcripts, mid-round resume, resume-after-closed-round, multi-round resume-history regression test, legacy and new-format idempotency) and new `tests/test_comment_rendering.py` cases for the per-debater and interim/final round-summary renderers.
- [ ] Manual smoke test against a real GitHub issue (not run in this environment).

Fixes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)