### PR TITLE
Stop pending GitHub checks from wasting a coder follow-up round

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -557,6 +557,8 @@ agent-loop pr 123 \
 
 When enabled, the tool waits for the configured GitHub check-run to pass before merging. Local `--test-command` is an additional local gate, not a replacement for CI. By default, `--test-command` also runs after coder-created or coder-updated changes before reviewer rounds, so reviewers are less likely to spend rounds on code that already fails the configured local test command. Use `--no-pre-review-tests` to keep `--test-command` as a post-approval gate only.
 
+Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. With `--auto-merge`, the loop instead keeps waiting for the configured check-run to resolve before merging, as before.
+
 ## Agent Permission Flags
 
 By default, this standalone package does not pass permission-bypass flags to either agent. This is safer for open-source use, but some CLIs may prompt or fail in non-interactive mode unless you provide suitable flags.

--- a/src/coding_review_agent_loop/checks.py
+++ b/src/coding_review_agent_loop/checks.py
@@ -59,6 +59,26 @@ def _pr_check_blocking_review(pr_number: int, state: str, details: list[str]) ->
     return "\n".join(lines)
 
 
+def _pending_ci_stop_message(pr_number: int, state: str, details: list[str]) -> str:
+    headline = {
+        "pending": f"Reviewers approved PR #{pr_number}, but GitHub checks are still pending.",
+        "unavailable": (
+            f"Reviewers approved PR #{pr_number}, but GitHub check status is unavailable."
+        ),
+    }[state]
+    lines = [
+        headline,
+        "",
+        "This is an external wait, not actionable coder feedback, so no new follow-up "
+        "round was started. Rerun once GitHub checks complete (or check status can be "
+        "confirmed) to finish approval.",
+        "",
+    ]
+    lines.extend(f"- {detail}" for detail in details)
+    lines.extend(["", "-- coding-review-agent-loop"])
+    return "\n".join(lines)
+
+
 def _pr_check_details(pr_checks: PullRequestChecks) -> list[str]:
     details: list[str] = []
     if pr_checks.required_checks:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -9,7 +9,7 @@ import re
 import sys
 import zoneinfo
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dataclasses_replace
 
 from .agents.base import AgentName, AgentResult
 from .agents.registry import agent_display_name, run_agent_result
@@ -39,6 +39,7 @@ from .decomposition import (
 from .errors import AgentLoopError, QuotaResetExceededError, UnknownPriorItemDispositionError
 from .github import (
     IssueContext,
+    PullRequestChecks,
     PullRequestReviewContext,
     get_issue_context,
     get_pr_checks,
@@ -125,6 +126,7 @@ from .workdir_guard import (
 )
 from .checks import (
     _format_pr_checks_comment,
+    _pending_ci_stop_message,
     _pr_check_blocking_review,
     _pr_check_details,
     run_optional_tests,
@@ -1507,6 +1509,54 @@ def _validate_plan_revision_response(
             )
         return parsed
     raise AgentLoopError("Plan revision did not use the required structured format.")
+
+
+_PENDING_CI_TEXT_KEYWORDS = (
+    "pending",
+    "in progress",
+    "in_progress",
+    "queued",
+    "still running",
+    "not yet report",
+    "unavailable",
+    "check status",
+    "github check",
+    "ci check",
+)
+
+
+def _is_pending_ci_only_review(parsed_review: ParsedReview, pr_checks: PullRequestChecks) -> bool:
+    """Detect a blocking review whose only content restates pending/unavailable
+    GitHub check status rather than an actionable code-level finding.
+
+    This is a defense-in-depth backstop: the reviewer prompt already instructs
+    reviewers not to use pending/unavailable checks as the sole reason to
+    block, but a reviewer may still do so. Any other content (a distinct
+    blocking item, or a Same-PR follow-up) causes this to return False so
+    mixed responses still route back to the coder normally.
+    """
+    if pr_checks.state not in {"pending", "unavailable"}:
+        return False
+    if parsed_review.followups.same_pr:
+        return False
+    if any(item.disposition in {"blocking", "same-pr"} for item in parsed_review.dispositions):
+        return False
+    candidate_texts = [
+        item.text for item in parsed_review.blocking_items if item.text and item.text.strip()
+    ]
+    if not candidate_texts and parsed_review.summary and parsed_review.summary.strip():
+        candidate_texts = [parsed_review.summary]
+    if not candidate_texts:
+        return False
+    check_names = {check.name.lower() for check in pr_checks.pending}
+    check_names.update(name.lower() for name in pr_checks.missing_required)
+    for text in candidate_texts:
+        lowered = text.lower()
+        mentions_check_name = any(name in lowered for name in check_names)
+        mentions_ci_keyword = any(keyword in lowered for keyword in _PENDING_CI_TEXT_KEYWORDS)
+        if not (mentions_check_name or mentions_ci_keyword):
+            return False
+    return True
 
 
 def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
@@ -2897,6 +2947,20 @@ def run_pr_loop(
                     review_state = parsed_review.state
                     reviewer_new_unresolved_items = []
 
+                if (
+                    resumed_record is None
+                    and review_state == "blocking"
+                    and _is_pending_ci_only_review(parsed_review, pr_checks)
+                ):
+                    log(
+                        config,
+                        f"Round {round_number}: {reviewer_name} blocking review only restates "
+                        f"GitHub check status ({pr_checks.state}); treating as approved instead "
+                        "of starting a new coder follow-up round",
+                    )
+                    parsed_review = dataclasses_replace(parsed_review, state="approved", blocking_items=())
+                    review_state = parsed_review.state
+
                 for disposition in parsed_review.dispositions:
                     _record_prior_item_disposition(
                         prior_dispositions,
@@ -3227,15 +3291,52 @@ def run_pr_loop(
                     must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
                 if not must_fix_items:
                     if pr_checks.state in {"pending", "unavailable"}:
-                        _publish_approved_followups(
+                        details = _pr_check_details(pr_checks)
+                        if not config.auto_merge:
+                            # Pending/unavailable checks are an external wait, not
+                            # actionable coder feedback: stop cleanly instead of
+                            # erroring or spending another coder/reviewer round.
+                            _publish_approved_followups(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                head_sha=pr_metadata.head_sha,
+                                pr_comments=pr_comments,
+                                followups=future_followups,
+                            )
+                            post_pr_comment(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                body=_format_pr_checks_comment(pr_number, pr_checks.state, details),
+                            )
+                            post_pr_comment(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                body=_pending_ci_stop_message(pr_number, pr_checks.state, details),
+                            )
+                            log(
+                                config,
+                                f"Round {round_number}: reviewers approved PR #{pr_number}; "
+                                f"GitHub checks are {pr_checks.state}; stopping without a "
+                                "coder follow-up round",
+                            )
+                            print(
+                                f"PR #{pr_number} approved by "
+                                f"{format_agent_list(configured_reviewers)}; GitHub checks are "
+                                f"{pr_checks.state}. Rerun after CI completes."
+                            )
+                            return 0
+                        # --auto-merge: post the informational comment, then fall
+                        # through to wait for CI before merging, as today.
+                        post_pr_comment(
                             runner,
                             config=config,
                             pr_number=pr_number,
-                            head_sha=pr_metadata.head_sha,
-                            pr_comments=pr_comments,
-                            followups=future_followups,
+                            body=_format_pr_checks_comment(pr_number, pr_checks.state, details),
                         )
-                    if pr_checks.state in {"failing", "pending", "unavailable"}:
+                    elif pr_checks.state == "failing":
                         details = _pr_check_details(pr_checks)
                         post_pr_comment(
                             runner,
@@ -3243,29 +3344,23 @@ def run_pr_loop(
                             pr_number=pr_number,
                             body=_format_pr_checks_comment(pr_number, pr_checks.state, details),
                         )
-                        if pr_checks.state == "failing":
-                            log(
-                                config,
-                                f"Round {round_number}: GitHub PR checks blocked approval ({pr_checks.state})",
+                        log(
+                            config,
+                            f"Round {round_number}: GitHub PR checks blocked approval ({pr_checks.state})",
+                        )
+                        unresolved_items.append(
+                            _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer="GitHub PR checks",
+                                source_round=round_number,
+                                text=_pr_check_blocking_review(pr_number, pr_checks.state, details),
+                                status="blocking",
                             )
-                            unresolved_items.append(
-                                _next_unresolved_item(
-                                    item_number=next_unresolved_item_number,
-                                    reviewer="GitHub PR checks",
-                                    source_round=round_number,
-                                    text=_pr_check_blocking_review(pr_number, pr_checks.state, details),
-                                    status="blocking",
-                                )
-                            )
-                            next_unresolved_item_number += 1
-                            must_fix_items = [
-                                item for item in unresolved_items if item.status in {"blocking", "same-pr"}
-                            ]
-                        else:
-                            raise AgentLoopError(
-                                f"GitHub PR checks for PR #{pr_number} are {pr_checks.state}; "
-                                "wait for CI or investigate GitHub API access before treating the PR as approved."
-                            )
+                        )
+                        next_unresolved_item_number += 1
+                        must_fix_items = [
+                            item for item in unresolved_items if item.status in {"blocking", "same-pr"}
+                        ]
                 if not must_fix_items:
                     _publish_approved_followups(
                         runner,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1665,7 +1665,12 @@ Treat the GitHub PR checks block in the volatile tail as authoritative for curre
 Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
-Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
+Do not defer your review to wait for CI checks to finish. Review the PR now.
+Failing GitHub checks may justify a blocking review and a `blocking_items` entry.
+Pending or unavailable GitHub checks are an external wait state: mention them
+only in `summary`, never in `blocking_items`, and never as the sole reason to
+return `state: "blocking"` — only failing checks or real code-level findings
+justify a blocking review.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
@@ -1983,7 +1988,12 @@ Treat the GitHub PR checks block above as authoritative for current CI state.
 Do not say or imply that tests passed globally unless the GitHub PR checks
 state is `passing` or `no_checks`. If only a local subset passed while GitHub
 checks are `failing`, `pending`, or `unavailable`, say that explicitly.
-Do not defer your review to wait for CI checks to finish. Review the PR now and report any pending or failing check status in your findings.
+Do not defer your review to wait for CI checks to finish. Review the PR now.
+Failing GitHub checks may justify a blocking review and a `blocking_items` entry.
+Pending or unavailable GitHub checks are an external wait state: mention them
+only in `summary`, never in `blocking_items`, and never as the sole reason to
+return `state: "blocking"` — only failing checks or real code-level findings
+justify a blocking review.
 When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -747,7 +747,108 @@ def test_pr_loop_routes_failing_github_checks_through_coder_followup(tmp_path, m
     assert "Failing checks: tests/test_security.py (failure)" in followup_prompt
     assert "Do not claim global test success unless GitHub PR checks are green." in followup_prompt
 
-def test_pr_loop_blocks_final_approval_when_github_checks_pending(tmp_path):
+def test_pr_loop_failing_github_checks_block_approval_even_with_auto_merge(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload={
+            "check_runs": [{"name": "test", "status": "completed", "conclusion": "failure"}]
+        },
+    )
+    config = make_config(tmp_path, auto_merge=True, max_rounds=1)
+
+    with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert any(
+        comment.startswith("GitHub PR checks are failing for PR #77.") for comment in runner.comments
+    )
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+
+def test_pr_loop_downgrades_pending_ci_only_blocking_review_without_auto_merge(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Model-default consistency gaps are fixed.",
+                blocking_items=["GitHub check `test` is still pending/in_progress."],
+            )
+        ],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    review_comment = runner.comments[0]
+    assert review_comment.startswith("**Review verdict:** Approved")
+    assert "### Blocking issues" not in review_comment
+    stop_comment = runner.comments[-1]
+    assert stop_comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+
+def test_pr_loop_downgrades_pending_ci_only_blocking_review_with_auto_merge(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Model-default consistency gaps are fixed.",
+                blocking_items=["GitHub check `test` is still pending/in_progress."],
+            )
+        ],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, auto_merge=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+    review_comment = runner.comments[0]
+    assert review_comment.startswith("**Review verdict:** Approved")
+
+def test_pr_loop_keeps_blocking_review_when_mixed_with_real_finding(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Missing null check in models.py causing a crash on empty input.",
+                blocking_items=[
+                    "Missing null check in models.py causing a crash on empty input.",
+                    "GitHub check `test` is still pending/in_progress.",
+                ],
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Codex final approval.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Added the missing null check.",
+                addressed_items=["item-1"],
+                remaining_items=[],
+            ),
+        ],
+        pr_check_runs_payload={"check_runs": []},
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    review_comment = next(comment for comment in runner.comments if "Missing null check" in comment)
+    assert review_comment.startswith("**Review verdict:** Blocking")
+    followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "Missing null check in models.py" in followup_prompt
+
+def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(tmp_path):
     runner = FakeRunner(
         codex_outputs=["Looks good locally.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
         pr_check_runs_payload={"check_runs": []},
@@ -756,15 +857,18 @@ def test_pr_loop_blocks_final_approval_when_github_checks_pending(tmp_path):
     )
     config = make_config(tmp_path)
 
-    with pytest.raises(AgentLoopError, match="GitHub PR checks for PR #77 are pending"):
-        run_pr_loop(runner, pr_number=77, config=config)
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert any(
         comment.startswith("GitHub PR checks are still pending for PR #77.")
         for comment in runner.comments
     )
+    stop_comment = runner.comments[-1]
+    assert stop_comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+    assert "external wait" in stop_comment
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
-def test_pr_loop_summarizes_approved_followups_before_pending_check_exit(tmp_path):
+def test_pr_loop_summarizes_approved_followups_before_pending_check_stop(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
             "Looks good locally.\n\n### Future follow-ups\n- Add cleanup docs.\n"
@@ -776,14 +880,14 @@ def test_pr_loop_summarizes_approved_followups_before_pending_check_exit(tmp_pat
     )
     config = make_config(tmp_path, approved_followups="summarize")
 
-    with pytest.raises(AgentLoopError, match="GitHub PR checks for PR #77 are pending"):
-        run_pr_loop(runner, pr_number=77, config=config)
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    assert len(runner.comments) == 3
+    assert len(runner.comments) == 4
     assert runner.comments[1].startswith("Approved-review future follow-ups for PR #77:")
     assert "- Add cleanup docs. (Codex)" in runner.comments[1]
     assert "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=summarize -->" in runner.comments[1]
     assert runner.comments[2].startswith("GitHub PR checks are still pending for PR #77.")
+    assert runner.comments[3].startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
 
 def test_pr_loop_summary_marker_has_single_blank_line_before_footer_marker(tmp_path):
     runner = FakeRunner(
@@ -803,7 +907,7 @@ def test_pr_loop_summary_marker_has_single_blank_line_before_footer_marker(tmp_p
         "-- coding-review-agent-loop"
     ) in summary
 
-def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_exit(tmp_path):
+def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_stop(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
             "Looks good locally.\n\n### Future follow-ups\n- Add cleanup docs.\n"
@@ -819,15 +923,17 @@ def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_exit(
     )
     config = make_config(tmp_path, approved_followups="issue")
 
-    with pytest.raises(AgentLoopError, match="GitHub PR checks for PR #77 are unavailable"):
-        run_pr_loop(runner, pr_number=77, config=config)
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert len(runner.issues) == 1
     assert runner.issues[0]["title"] == "Follow up future review note: Add cleanup docs."
-    assert len(runner.comments) == 3
+    assert len(runner.comments) == 4
     assert runner.comments[1].startswith("Created approved-review future follow-up issues for PR #77:")
     assert "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=issue -->" in runner.comments[1]
     assert runner.comments[2].startswith("GitHub PR check status is unavailable for PR #77.")
+    assert runner.comments[3].startswith(
+        "Reviewers approved PR #77, but GitHub check status is unavailable."
+    )
 
 def test_pr_loop_skips_duplicate_approved_followup_issue_creation_when_marker_exists(tmp_path):
     runner = FakeRunner(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1344,6 +1344,23 @@ def test_review_prompt_includes_failing_github_check_status(tmp_path):
     assert "- Failing checks: tests/test_security.py (failure)" in prompt
 
 @pytest.mark.parametrize("compact_context", [False, True])
+def test_review_prompt_distinguishes_failing_from_pending_check_blocking_policy(
+    tmp_path, compact_context
+):
+    config = make_config(tmp_path)
+    prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact_context)
+    assert "Do not defer your review to wait for CI" in prompt
+    assert (
+        "Failing GitHub checks may justify a blocking review and a `blocking_items` entry."
+        in prompt
+    )
+    assert (
+        "Pending or unavailable GitHub checks are an external wait state: mention them"
+        in prompt
+    )
+    assert 'never as the sole reason to\nreturn `state: "blocking"`' in prompt
+
+@pytest.mark.parametrize("compact_context", [False, True])
 def test_review_prompt_allows_read_only_local_inspection_but_prohibits_execution(
     tmp_path, compact_context
 ):


### PR DESCRIPTION
## Summary

Fixes #466. Pending GitHub checks are now treated as an external wait state rather than actionable coder feedback:

- Reviewer prompts (compact + full paths) now explicitly say only failing checks or real code-level findings justify a blocking review; pending/unavailable checks belong only in `summary`.
- Added a deterministic backstop, `_is_pending_ci_only_review`, that downgrades a reviewer's `blocking` response to `approved` when its entire content just restates pending/unavailable check status (matching the actual check names/state fetched by the orchestrator). Any real blocking item or Same-PR follow-up mixed in with CI commentary prevents the downgrade, so genuine findings still route back to the coder.
- Restructured the final post-approval CI gate: failing checks still create a blocking item and route to the coder. Pending/unavailable checks now stop the loop with a clear "reviewers approved, but GitHub checks are pending; rerun after CI completes" message when `auto_merge=False`, instead of raising a hard error. With `--auto-merge`, the loop now actually reaches the existing `wait_for_ci`/`merge_pr` path instead of erroring out before it (that path was previously unreachable whenever checks started out pending).
- Updated `docs/local_agent_loop.md`'s Auto-Merge section to describe this behavior.

## Test plan

- [x] `python -m pytest tests/ -q` — full suite passes (1181 passed)
- New/updated tests in `tests/test_orchestrator_pr.py`:
  - Failing checks still block even with `--auto-merge`
  - Reviewer-level pending-CI-only blocking is downgraded and does not route to the coder, without `--auto-merge`
  - Same, with `--auto-merge` (loop proceeds to wait-for-CI/merge)
  - Mixed-signal regression: a blocking review combining a real finding with pending-CI commentary is NOT downgraded and still routes to the coder
  - Updated the three existing tests that previously expected a hard `AgentLoopError` for pending/unavailable checks to instead expect a graceful `return 0` with the new stop message
- Updated `tests/test_prompts.py` to assert the new failing-vs-pending blocking policy text appears in both compact and full reviewer prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)