### PR TITLE
Add optional analyzer-guided debate agenda to discuss mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,26 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-max-rounds 2
 ```
 
+Optionally, pass `--discuss-analyzer <agent>` to add an analyzer agent that
+summarizes each non-final round into a structured debate agenda (consensus
+points, each open disagreement with the debaters' positions and a question for
+the next round, and missing facts). With an analyzer, each debate round's
+prompt contains only that agenda plus the debater's own prior position —
+other debaters' full rationales and rebuttals are omitted — and debaters may
+flag `analyzer_framing: "misframed"` with a `framing_note` when the agenda
+misrepresents them. The analyzer is not authoritative: consensus is still
+detected purely from the votes, the agenda is rendered in the round summary
+for auditing, and the final summary keeps "analyzer-extracted consensus"
+distinct from the debater vote table. If the analyzer fails even after the
+repair pass, the round falls back to the plain mechanical agenda and the run
+continues. Omitting the flag keeps plain direct deliberation unchanged:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --discuss-analyzer claude
+```
+
 If reviewers still disagree after the configured debate rounds, the final
 round-summary comment is marked `deadlock`, uses the `needs-human` outcome, and
 summarizes each final position and the core disagreement. `split` proposals

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -371,6 +371,68 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-max-rounds 2
 ```
 
+### Optional analyzer-guided debate agenda
+
+Pass `--discuss-analyzer <agent>` (`claude`, `codex`, `gemini`, or
+`antigravity`; it may coincide with a `--reviewer`) to add an analyzer agent
+borrowed from the analyzer/debater pattern:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --discuss-analyzer claude
+```
+
+After each non-final round, the analyzer receives the complete multi-round
+vote history (every completed round's outcomes, rationales, rebuttals, and any
+framing corrections, oldest first) plus its own previous agenda, and returns a
+structured `discuss_agenda` response:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "discuss_agenda",
+  "consensus": ["The issue is well-motivated."],
+  "disagreements": [
+    {
+      "topic": "Scope of the change",
+      "positions": {"Codex": "Narrow enough.", "Antigravity": "Too broad; split it."},
+      "question_for_next_round": "Would splitting the API boundary resolve the scope objection?"
+    }
+  ],
+  "missing_facts": ["Whether the API boundary is already specified."]
+}
+```
+
+In analyzer mode, the next debate round's prompt is agenda-focused: it renders
+only the structured agenda plus the target debater's own prior position
+verbatim. Other debaters' full rationales and rebuttals are omitted and reach
+each debater only through the analyzer's summarized `positions`. Each debater
+must concede, defend with evidence, refine its position, or set
+`analyzer_framing: "misframed"` with a `framing_note` correcting the agenda;
+framing corrections are rendered in the debater's public comment.
+
+Guardrails — the analyzer is never authoritative:
+
+- Consensus detection stays vote-only; the analyzer never decides the outcome.
+  An agenda claiming consensus while the votes differ is forwarded, but the
+  votes rule and the divergence stays visible in the summary.
+- The agenda is rendered in the non-final round summary ("Agenda for round
+  N+1 (analyzer: ...)"), so it is auditable on the issue.
+- The final summary adds an "Analyzer-extracted consensus (not
+  debater-confirmed)" section kept distinct from the debater vote table.
+- If the analyzer invocation fails even after the malformed-response repair
+  pass, the orchestrator logs a warning and falls back to the plain mechanical
+  agenda for that round (and full prior positions in the next debate prompt)
+  instead of aborting the run.
+
+The raw agenda rides in the round summary's `AGENT_LOOP_META` metadata, so a
+resumed run restores the structured agenda for the next debate round. Legacy
+summaries without an analyzer payload resume in plain mode. With
+`--discuss-max-rounds 0` there is no non-final round, so the analyzer never
+runs (a note is logged). Omitting `--discuss-analyzer` keeps plain #465-style
+direct deliberation unchanged.
+
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the
 detected `OWNER/REPO`. Pass `--repo` explicitly when running outside the target

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -444,6 +444,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=2,
         help="Maximum debate rounds after the initial discuss round (default: 2).",
     )
+    discuss.add_argument(
+        "--discuss-analyzer",
+        type=normalize_agent_name,
+        choices=("claude", "codex", "gemini", "antigravity"),
+        default=None,
+        help=(
+            "Optional analyzer agent that summarizes each non-final debate round "
+            "into a structured agenda for the next round. May coincide with a "
+            "--reviewer. Omit for plain direct deliberation (default: none)."
+        ),
+    )
     add_common(discuss)
 
     return parser

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -16,6 +16,7 @@ from .protocol import (
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
     PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SIGNATURE_RE,
+    ParsedDiscussAgenda,
     ParsedDiscussReview,
     ParsedPlanReview,
     ParsedReview,
@@ -655,6 +656,14 @@ def _render_public_discuss_review_comment(
     ]
     if parsed.rebuttal:
         sections.append("### Rebuttal\n\n" + parsed.rebuttal.strip())
+    if parsed.analyzer_framing == "misframed":
+        note = (parsed.framing_note or "").strip()
+        sections.append("### Analyzer framing correction\n\n" + note)
+    elif parsed.analyzer_framing == "accurate":
+        framing_line = "**Analyzer framing:** accurate"
+        if parsed.framing_note:
+            framing_line += f" — {parsed.framing_note.strip()}"
+        sections.append(framing_line)
     if parsed.split_proposals:
         proposals = "\n".join(f"- {proposal}" for proposal in parsed.split_proposals)
         sections.append("### Proposed sub-issues\n\n" + proposals)
@@ -664,6 +673,30 @@ def _render_public_discuss_review_comment(
 
 def _render_discuss_agenda_lines(votes: Sequence[ParsedDiscussReview]) -> list[str]:
     return [f"- {vote.reviewer} held `{vote.outcome}`: {vote.rationale}" for vote in votes]
+
+
+def _render_analyzer_agenda_lines(agenda: ParsedDiscussAgenda) -> list[str]:
+    lines: list[str] = []
+    if agenda.consensus:
+        lines.append("Analyzer-extracted consensus so far (not debater-confirmed):")
+        lines.extend(f"- {point}" for point in agenda.consensus)
+    if agenda.disagreements:
+        if lines:
+            lines.append("")
+        lines.append("Open disagreements:")
+        for disagreement in agenda.disagreements:
+            lines.append(f"- **{disagreement.topic}**")
+            for name, position in disagreement.positions:
+                lines.append(f"  - {name}: {position}")
+            lines.append(
+                f"  - Question for next round: {disagreement.question_for_next_round}"
+            )
+    if agenda.missing_facts:
+        if lines:
+            lines.append("")
+        lines.append("Missing facts:")
+        lines.extend(f"- {fact}" for fact in agenda.missing_facts)
+    return lines
 
 
 def render_discuss_round_summary_comment(
@@ -676,13 +709,19 @@ def render_discuss_round_summary_comment(
     consensus_kind: str = "unanimous",
     round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
     split_proposals: Sequence[str] | None = None,
+    analyzer_agenda: ParsedDiscussAgenda | None = None,
+    analyzer_name: str | None = None,
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
     When `is_final` is False this closes out an inconclusive round with an
     agenda for the next round; when True it renders the same consensus/deadlock
     content previously produced by `render_discuss_consensus_comment`, plus the
-    marker that final-only idempotency and legacy detection rely on.
+    marker that final-only idempotency and legacy detection rely on. When an
+    analyzer agenda is supplied, the next-round agenda section shows the
+    analyzer's structured output (attributed and auditable) instead of the
+    mechanical per-vote lines, and final summaries add an analyzer-extracted
+    consensus section kept distinct from the debater vote table.
     """
     split_proposals = list(split_proposals or ())
     if not is_final:
@@ -702,9 +741,17 @@ def render_discuss_round_summary_comment(
             for proposal in split_proposals:
                 lines.append(f"- {proposal}")
         lines.append("")
-        lines.append(f"### Agenda for round {round_number + 1}")
-        lines.append("")
-        lines.extend(_render_discuss_agenda_lines(reviewer_votes))
+        if analyzer_agenda is not None:
+            heading = f"### Agenda for round {round_number + 1}"
+            if analyzer_name:
+                heading += f" (analyzer: {analyzer_name})"
+            lines.append(heading)
+            lines.append("")
+            lines.extend(_render_analyzer_agenda_lines(analyzer_agenda))
+        else:
+            lines.append(f"### Agenda for round {round_number + 1}")
+            lines.append("")
+            lines.extend(_render_discuss_agenda_lines(reviewer_votes))
         lines.append("")
         lines.append("-- Orchestrator")
         return "\n".join(lines)
@@ -750,6 +797,21 @@ def render_discuss_round_summary_comment(
         lines.append("")
         for proposal in split_proposals:
             lines.append(f"- {proposal}")
+    if analyzer_agenda is not None:
+        heading = "### Analyzer-extracted consensus (not debater-confirmed)"
+        if analyzer_name:
+            heading = f"### Analyzer-extracted consensus (analyzer: {analyzer_name}; not debater-confirmed)"
+        lines.append("")
+        lines.append(heading)
+        lines.append("")
+        lines.append(
+            "The debater vote table above is the authoritative consensus. The analyzer's "
+            "last agenda extracted the following; it may misclassify consensus or omit "
+            "minority arguments."
+        )
+        lines.append("")
+        agenda_lines = _render_analyzer_agenda_lines(analyzer_agenda)
+        lines.extend(agenda_lines if agenda_lines else ["(the analyzer extracted no points)"])
     if round_history:
         lines.append("")
         lines.append("### Round history")

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -97,6 +97,9 @@ class AgentLoopConfig:
     repair_backend: str = "antigravity"
     repair_models: tuple[str, ...] = DEFAULT_REPAIR_MODELS
     repair_timeout_seconds: int = 120
+    # Optional analyzer agent for discuss mode (#467). None keeps plain
+    # direct deliberation unchanged. May coincide with a reviewer.
+    discuss_analyzer: AgentName | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -170,10 +173,17 @@ def resolve_base_branch(
     )
 
 
+def required_agents(config: AgentLoopConfig) -> set[AgentName]:
+    required: set[AgentName] = {config.coder, *reviewers(config)}
+    if config.discuss_analyzer is not None:
+        required.add(config.discuss_analyzer)
+    return required
+
+
 def ensure_distinct_workdirs(config: AgentLoopConfig) -> None:
     if config.allow_shared_dir:
         return
-    required: set[AgentName] = {config.coder, *reviewers(config)}
+    required = required_agents(config)
     paths = {
         "claude": (config.claude_dir, "--claude-dir"),
         "codex": (config.codex_dir, "--codex-dir"),
@@ -571,7 +581,7 @@ def sync_checkout_to_pr(
 
 
 def ensure_agent_workdirs(config: AgentLoopConfig, runner: Runner) -> None:
-    required: set[AgentName] = {config.coder, *reviewers(config)}
+    required = required_agents(config)
     paths = {
         "claude": (config.claude_dir, "--claude-dir"),
         "codex": (config.codex_dir, "--codex-dir"),
@@ -619,8 +629,14 @@ def preflight_agent_commands(
         "gemini": (args.gemini_cmd, "--gemini-cmd"),
         "antigravity": (args.antigravity_cmd, "--antigravity-cmd"),
     }
+    discuss_analyzer = getattr(args, "discuss_analyzer", None)
     configured_agents = dict.fromkeys(
-        (args.coder, *configured_reviewers, getattr(args, "repair_backend", "antigravity"))
+        (
+            args.coder,
+            *configured_reviewers,
+            *((discuss_analyzer,) if discuss_analyzer is not None else ()),
+            getattr(args, "repair_backend", "antigravity"),
+        )
     )
     for agent in configured_agents:
         command, override_flag = command_options[agent]
@@ -746,6 +762,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         repair_backend=getattr(args, "repair_backend", "antigravity"),
         repair_models=tuple(getattr(args, "repair_model", None) or DEFAULT_REPAIR_MODELS),
         repair_timeout_seconds=getattr(args, "repair_timeout_seconds", 120),
+        discuss_analyzer=getattr(args, "discuss_analyzer", None),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -54,12 +54,13 @@ from .github import (
     wait_for_ci,
 )
 from .logging import log, new_run_id, run_usage_summary_path
-from .memory import prepare_agent_memory
+from .memory import AgentMemoryContext, prepare_agent_memory
 from .migrations import validate_pr_migration_topology
 from .prompts import (
     CompactPlanTailContext,
     CompactPriorContext,
     CompactPrReviewTailContext,
+    build_discuss_agenda_prompt,
     build_discuss_review_prompt,
     build_followup_prompt,
     build_issue_implementation_prompt,
@@ -77,6 +78,7 @@ from .prompts import (
 )
 from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+    ParsedDiscussAgenda,
     ParsedDiscussReview,
     ParsedPlanReview,
     ParsedReview,
@@ -101,6 +103,7 @@ from .protocol import (
     validate_structured_coder_followup,
     validate_structured_plan_state,
     validate_structured_plan_revision,
+    validate_structured_discuss_agenda,
     validate_structured_discuss_review,
 )
 from .protocol import parse_review
@@ -3572,6 +3575,82 @@ def _detect_discuss_consensus(
     return outcome, split_proposals
 
 
+def _run_discuss_analyzer(
+    runner: Runner,
+    *,
+    issue_number: int,
+    config: AgentLoopConfig,
+    analyzer: AgentName,
+    memory: AgentMemoryContext | None,
+    issue_context: IssueContext,
+    round_number: int,
+    round_history: Sequence[Sequence[ParsedDiscussReview]],
+    prior_agenda: ParsedDiscussAgenda | None,
+    configured_reviewers: Sequence[AgentName],
+    usage_context: RunUsageContext,
+) -> tuple[ParsedDiscussAgenda | None, str | None]:
+    """Run the optional discuss analyzer after a non-final round.
+
+    Returns (parsed_agenda, raw_response). Any analyzer failure that survives
+    the repair pass falls back to (None, None) so the round closes with the
+    mechanical agenda and the next debate round sees the full prior positions;
+    only a quota-reset stop propagates because the whole run must pause.
+    """
+    analyzer_name = agent_display_name(analyzer)
+    log(
+        config,
+        f"discuss: invoking analyzer {analyzer_name} on issue #{issue_number} "
+        f"(after round {round_number})",
+    )
+    try:
+        response = _run_validated_agent(
+            runner,
+            agent=analyzer,
+            config=config,
+            prompt=build_discuss_agenda_prompt(
+                issue_number,
+                config,
+                analyzer=analyzer,
+                memory=memory,
+                issue_context=issue_context,
+                round_number=round_number,
+                round_history=round_history,
+                prior_agenda=prior_agenda,
+            ),
+            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+            validate=validate_structured_discuss_agenda,
+            usage_context=usage_context,
+            use_repair=True,
+            repair_expected_kind="discuss_agenda",
+            role="reviewer",
+        )
+    except QuotaResetExceededError:
+        raise
+    except AgentLoopError as exc:
+        log(
+            config,
+            f"discuss: analyzer {analyzer_name} failed ({exc}); falling back to the "
+            f"mechanical agenda for round {round_number + 1}",
+        )
+        return None, None
+    parsed = response.marker_value
+    assert isinstance(parsed, ParsedDiscussAgenda)
+    known_names = {agent_display_name(reviewer) for reviewer in configured_reviewers}
+    unknown_names = sorted(
+        {name for disagreement in parsed.disagreements for name, _position in disagreement.positions}
+        - known_names
+    )
+    if unknown_names:
+        # Non-authoritative analyzer output is forwarded as-is; debaters and the
+        # public summary can audit and correct it.
+        log(
+            config,
+            f"discuss: analyzer agenda names unknown debater(s): {', '.join(unknown_names)}; "
+            "forwarding as-is",
+        )
+    return parsed, response.text
+
+
 def _run_discuss_loop(
     runner: Runner,
     *,
@@ -3599,10 +3678,35 @@ def _run_discuss_loop(
         log(config, f"discuss: found matching round-summary comment for issue #{issue_number}; skipping")
         return 0
     memory = prepare_agent_memory(runner, config)
+    analyzer = config.discuss_analyzer
+    analyzer_name = agent_display_name(analyzer) if analyzer is not None else None
+    prompt_issue_context = issue_context
+    if analyzer is not None:
+        # Agenda-focused analyzer mode: prior rounds reach debaters only through
+        # the structured agenda (or the analyzer via round_history), so strip
+        # discuss-flow bot comments from the prompt-facing issue context. Plain
+        # mode keeps the full context unchanged.
+        prompt_issue_context = dataclasses_replace(
+            issue_context,
+            comments=tuple(
+                comment
+                for comment in (issue_context.comments or ())
+                if not (comment.body and _is_bot_authored_discuss_comment(comment.body))
+            ),
+        )
+    if analyzer is not None and discuss_max_rounds == 0:
+        log(
+            config,
+            "discuss: --discuss-analyzer is set but --discuss-max-rounds=0 leaves no "
+            "non-final round, so the analyzer will not run.",
+        )
     if resume_state is not None:
         round_history: list[list[ParsedDiscussReview]] = [list(votes) for votes in resume_state.round_history]
         start_round_number = resume_state.next_round_number
         prior_round_agenda: list[str] = list(resume_state.prior_round_agenda)
+        prior_analyzer_agenda: ParsedDiscussAgenda | None = (
+            resume_state.prior_analyzer_agenda if analyzer is not None else None
+        )
         in_progress_votes: dict[str, ParsedDiscussReview] = dict(resume_state.in_progress_votes)
         if round_history or in_progress_votes:
             log(config, f"discuss: resuming issue #{issue_number} at round {start_round_number}")
@@ -3610,6 +3714,7 @@ def _run_discuss_loop(
         round_history = []
         start_round_number = 1
         prior_round_agenda = []
+        prior_analyzer_agenda = None
         in_progress_votes = {}
     max_round_number = discuss_max_rounds + 1
     if start_round_number > max_round_number:
@@ -3638,6 +3743,8 @@ def _run_discuss_loop(
             consensus_kind="deadlock",
             round_history=round_history,
             split_proposals=[],
+            analyzer_agenda=prior_analyzer_agenda,
+            analyzer_name=analyzer_name,
         )
         post_issue_comment(
             runner,
@@ -3693,10 +3800,11 @@ def _run_discuss_loop(
                     config,
                     reviewer=reviewer,
                     memory=memory,
-                    issue_context=issue_context,
+                    issue_context=prompt_issue_context,
                     round_number=round_number,
                     prior_round_votes=prior_round_votes,
                     prior_round_agenda=prior_round_agenda,
+                    analyzer_agenda=prior_analyzer_agenda,
                 ),
                 marker_description="<!-- AGENT_PLAN_STATE: approved -->",
                 validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
@@ -3744,6 +3852,22 @@ def _run_discuss_loop(
         else:
             outcome, round_split_proposals = consensus
             consensus_kind = ("unanimous" if len(round_history) == 1 else "converged") if is_final else None
+        next_analyzer_agenda: ParsedDiscussAgenda | None = None
+        analyzer_response_raw: str | None = None
+        if not is_final and analyzer is not None:
+            next_analyzer_agenda, analyzer_response_raw = _run_discuss_analyzer(
+                runner,
+                issue_number=issue_number,
+                config=config,
+                analyzer=analyzer,
+                memory=memory,
+                issue_context=prompt_issue_context,
+                round_number=round_number,
+                round_history=round_history,
+                prior_agenda=prior_analyzer_agenda,
+                configured_reviewers=configured_reviewers,
+                usage_context=usage_context,
+            )
         summary_body = render_discuss_round_summary_comment(
             round_number=round_number,
             reviewer_votes=reviewer_votes,
@@ -3753,6 +3877,11 @@ def _run_discuss_loop(
             consensus_kind=consensus_kind,
             round_history=round_history if is_final else None,
             split_proposals=round_split_proposals,
+            # Final summaries surface the last non-final round's agenda so
+            # analyzer-extracted consensus stays auditable and distinct from
+            # the debater vote table; non-final summaries show the fresh one.
+            analyzer_agenda=prior_analyzer_agenda if is_final else next_analyzer_agenda,
+            analyzer_name=analyzer_name,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(reviewer_votes))
         post_issue_comment(
@@ -3770,6 +3899,7 @@ def _run_discuss_loop(
                     is_final=is_final,
                     consensus_kind=consensus_kind,
                     agenda=agenda,
+                    analyzer_response=analyzer_response_raw,
                 ),
             ),
         )
@@ -3786,6 +3916,7 @@ def _run_discuss_loop(
             f"continuing to round {round_number + 1}",
         )
         prior_round_agenda = list(agenda)
+        prior_analyzer_agenda = next_analyzer_agenda
     return 0
 
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -18,6 +18,7 @@ from .memory import AgentMemoryContext, format_agent_memory_context
 from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
+    ParsedDiscussAgenda,
     ParsedDiscussReview,
     UnresolvedReviewItem,
 )
@@ -2158,6 +2159,124 @@ the AGENT_STATE footer. Your response must end with, in this exact order:
 """
 
 
+def _render_discuss_agenda_prompt_block(agenda: ParsedDiscussAgenda) -> list[str]:
+    lines: list[str] = []
+    if agenda.consensus:
+        lines.append("Analyzer-extracted consensus so far (not debater-confirmed):")
+        lines.extend(f"- {point}" for point in agenda.consensus)
+        lines.append("")
+    if agenda.disagreements:
+        lines.append("Open disagreements to address this round:")
+        for disagreement in agenda.disagreements:
+            lines.append(f"- Topic: {disagreement.topic}")
+            for name, position in disagreement.positions:
+                lines.append(f"  - {name}: {position}")
+            lines.append(
+                f"  - Question for this round: {disagreement.question_for_next_round}"
+            )
+        lines.append("")
+    if agenda.missing_facts:
+        lines.append("Missing facts or assumptions flagged by the analyzer:")
+        lines.extend(f"- {fact}" for fact in agenda.missing_facts)
+        lines.append("")
+    return lines
+
+
+def build_discuss_agenda_prompt(
+    issue_number: int,
+    config: AgentLoopConfig,
+    *,
+    analyzer: AgentName,
+    memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
+    round_number: int = 1,
+    round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
+    prior_agenda: ParsedDiscussAgenda | None = None,
+) -> str:
+    analyzer_signature = agent_signature(analyzer, config)
+    round_history = tuple(tuple(votes) for votes in (round_history or ()))
+    history_lines: list[str] = []
+    for index, votes in enumerate(round_history, start=1):
+        label = f"Round {index} debater positions"
+        if index == len(round_history):
+            label = f"{label} (latest round)"
+        history_lines.append(f"{label}:")
+        for vote in votes:
+            history_lines.append(f"- {vote.reviewer}: `{vote.outcome}`")
+            history_lines.append(f"  Rationale: {vote.rationale}")
+            if vote.rebuttal:
+                history_lines.append(f"  Rebuttal: {vote.rebuttal}")
+            if vote.analyzer_framing == "misframed" and vote.framing_note:
+                history_lines.append(f"  Framing correction: {vote.framing_note}")
+            if vote.split_proposals:
+                history_lines.append("  Split proposals:")
+                for proposal in vote.split_proposals:
+                    history_lines.append(f"  - {proposal}")
+        history_lines.append("")
+    prior_agenda_block = ""
+    if prior_agenda is not None:
+        prior_agenda_lines = [
+            "Your previous agenda (carry forward points that remain unresolved):",
+            *_render_discuss_agenda_prompt_block(prior_agenda),
+        ]
+        prior_agenda_block = "\n".join(prior_agenda_lines) + "\n"
+    history_block = "\n".join(history_lines)
+    return f"""Summarize debate round {round_number} for GitHub issue #{issue_number} in {config.repo} into a structured agenda for the next round.
+
+You are the analyzer, not a debater. Do not vote on the issue and do not edit
+files, create a branch, commit, push, or open a pull request.
+{_issue_context_block(issue_context)}{_memory_block(memory)}
+Complete debate transcript so far, oldest round first:
+
+{history_block}
+{prior_agenda_block}
+Extract from the transcript:
+- `consensus`: points every debater already agrees on.
+- `disagreements`: each unresolved disagreement, with every named debater's
+  stated position and one specific question the next round must answer.
+- `missing_facts`: facts or assumptions that are missing and block resolution.
+
+Fidelity guardrails:
+- Represent each debater's stated position faithfully; quote or closely
+  paraphrase the transcript, and never invent positions.
+- Preserve minority arguments; do not declare consensus unless every debater's
+  latest position supports it.
+- Distinguish persistent disagreements (repeated across rounds) from points a
+  debater has already conceded or refined.
+- Carry forward unresolved `missing_facts` from your previous agenda.
+
+Respond using this mandatory structured JSON format:
+
+{{
+  "schema_version": 1,
+  "kind": "discuss_agenda",
+  "consensus": ["The issue is well-motivated."],
+  "disagreements": [
+    {{
+      "topic": "Scope of the change",
+      "positions": {{"Codex": "Narrow enough to implement.", "Gemini": "Too broad; split it."}},
+      "question_for_next_round": "Would splitting the API boundary into its own issue resolve the scope objection?"
+    }}
+  ],
+  "missing_facts": ["Whether the API boundary is already specified."]
+}}
+<!-- AGENT_PLAN_STATE: approved -->
+-- {analyzer_signature}
+
+Rules:
+- `consensus`, `disagreements`, and `missing_facts` may be empty arrays.
+- Each disagreement requires non-empty `topic`, `positions`, and `question_for_next_round`.
+- `positions` maps each debater's display name to a short statement of its position.
+- The footer must always be `<!-- AGENT_PLAN_STATE: approved -->`.
+- Do not include prose or code fences before the JSON object.
+- Do not place your signature before the `AGENT_PLAN_STATE` footer.
+- Your response must end with, in this exact order:
+
+<!-- AGENT_PLAN_STATE: approved -->
+-- {analyzer_signature}
+"""
+
+
 def build_discuss_review_prompt(
     issue_number: int,
     config: AgentLoopConfig,
@@ -2168,16 +2287,61 @@ def build_discuss_review_prompt(
     round_number: int = 1,
     prior_round_votes: Sequence[ParsedDiscussReview] | None = None,
     prior_round_agenda: Sequence[str] | None = None,
+    analyzer_agenda: ParsedDiscussAgenda | None = None,
 ) -> str:
     reviewer_signature = agent_signature(reviewer, config)
     prior_round_votes = tuple(prior_round_votes or ())
     prior_round_agenda = tuple(prior_round_agenda or ())
+    analyzer_rules = ""
     if round_number <= 1:
         round_context = (
             "This is round 1. Evaluate independently; do not assume other reviewers agree."
         )
         rebuttal_rule = "- `rebuttal` may be omitted in round 1."
         rebuttal_example = ""
+    elif analyzer_agenda is not None:
+        reviewer_name = agent_display_name(reviewer)
+        own_votes = [vote for vote in prior_round_votes if vote.reviewer == reviewer_name]
+        prior_lines = [
+            f"This is debate round {round_number}. An analyzer agent summarized the prior "
+            "round into the agenda below. The analyzer is not authoritative: it can "
+            "misclassify consensus, omit minority arguments, or misframe your position.",
+            "",
+        ]
+        prior_lines.extend(_render_discuss_agenda_prompt_block(analyzer_agenda))
+        if own_votes:
+            prior_lines.append("Your own prior-round position (verbatim):")
+            for vote in own_votes:
+                prior_lines.append(f"- Outcome: `{vote.outcome}`")
+                prior_lines.append(f"  Rationale: {vote.rationale}")
+                if vote.rebuttal:
+                    prior_lines.append(f"  Rebuttal: {vote.rebuttal}")
+                if vote.split_proposals:
+                    prior_lines.append("  Split proposals:")
+                    for proposal in vote.split_proposals:
+                        prior_lines.append(f"  - {proposal}")
+            prior_lines.append("")
+        prior_lines.append(
+            "For each disagreement that names your position, either concede, defend it "
+            "with evidence, or refine it. If the agenda misrepresents your prior "
+            "position, say so explicitly via `analyzer_framing` and `framing_note`."
+        )
+        round_context = "\n".join(prior_lines)
+        rebuttal_rule = (
+            "- `rebuttal` is required in debate rounds and must directly engage the "
+            "analyzer agenda's disagreements and questions."
+        )
+        rebuttal_example = (
+            ',\n  "rebuttal": "I considered the scope objection, but the issue is narrow'
+            ' enough because the API boundary is already specified.",'
+            '\n  "analyzer_framing": "accurate"'
+        )
+        analyzer_rules = (
+            "\n- `analyzer_framing` must be `accurate` or `misframed`; set `misframed` "
+            "when the analyzer agenda misrepresents your prior position."
+            "\n- `framing_note` is required when `analyzer_framing` is `misframed` and "
+            "must state what the analyzer got wrong."
+        )
     else:
         prior_lines: list[str] = [
             f"This is debate round {round_number}. Review the complete prior round below, "
@@ -2233,7 +2397,7 @@ Rules:
 - `outcome` must be exactly one of: `implement`, `do-not-implement`, `needs-human`, `split`.
 - `rationale` is required and must be non-empty.
 - `split_proposals` is required and must be non-empty when `outcome` is `split`; omit or use `[]` for other outcomes.
-{rebuttal_rule}
+{rebuttal_rule}{analyzer_rules}
 - The footer must always be `<!-- AGENT_PLAN_STATE: approved -->` regardless of your outcome.
 - Do not include prose or code fences before the JSON object.
 - Do not place your signature before the `AGENT_PLAN_STATE` footer.

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -225,6 +225,8 @@ class StructuredDiscussReview:
     rationale: str
     split_proposals: tuple[str, ...]
     rebuttal: str | None = None
+    analyzer_framing: str | None = None
+    framing_note: str | None = None
 
 
 @dataclass(frozen=True)
@@ -234,9 +236,26 @@ class ParsedDiscussReview:
     split_proposals: tuple[str, ...]
     reviewer: str
     rebuttal: str | None = None
+    analyzer_framing: str | None = None
+    framing_note: str | None = None
 
 
 DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-human", "split"})
+DISCUSS_ANALYZER_FRAMING_VALUES = frozenset({"accurate", "misframed"})
+
+
+@dataclass(frozen=True)
+class DiscussAgendaDisagreement:
+    topic: str
+    positions: tuple[tuple[str, str], ...]
+    question_for_next_round: str
+
+
+@dataclass(frozen=True)
+class ParsedDiscussAgenda:
+    consensus: tuple[str, ...]
+    disagreements: tuple[DiscussAgendaDisagreement, ...]
+    missing_facts: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -842,6 +861,31 @@ def _extract_structured_discuss_review_payload(text: str) -> dict[str, object] |
         if footer_state != "approved":
             raise AgentLoopError(
                 f"Structured discuss review footer AGENT_PLAN_STATE must be `approved`; got `{footer_state}`."
+            )
+    return result
+
+
+def _extract_structured_discuss_agenda_payload(text: str) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    result = _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=PLAN_STATE_RE,
+        state_marker_name="AGENT_PLAN_STATE",
+        context_label="Structured discuss agenda",
+    )
+    if result is None:
+        return None
+    footer_match = PLAN_STATE_RE.search(trailing)
+    if footer_match is not None:
+        footer_state = footer_match.group(1).lower()
+        if footer_state != "approved":
+            raise AgentLoopError(
+                f"Structured discuss agenda footer AGENT_PLAN_STATE must be `approved`; got `{footer_state}`."
             )
     return result
 
@@ -1792,7 +1836,7 @@ def parse_structured_discuss_review(
         payload,
         context="discuss_review",
         required={"schema_version", "kind", "outcome", "rationale"},
-        optional={"split_proposals", "rebuttal"},
+        optional={"split_proposals", "rebuttal", "analyzer_framing", "framing_note"},
     )
     outcome = _expect_non_empty_string(payload["outcome"], context="discuss_review.outcome")
     if outcome not in DISCUSS_OUTCOME_VALUES:
@@ -1814,12 +1858,35 @@ def parse_structured_discuss_review(
         rebuttal = _expect_non_empty_string(payload["rebuttal"], context="discuss_review.rebuttal")
     if round_number > 1 and rebuttal is None:
         raise AgentLoopError("discuss_review.rebuttal is required for debate rounds.")
+    analyzer_framing = None
+    if "analyzer_framing" in payload:
+        analyzer_framing = _expect_non_empty_string(
+            payload["analyzer_framing"], context="discuss_review.analyzer_framing"
+        )
+        if analyzer_framing not in DISCUSS_ANALYZER_FRAMING_VALUES:
+            rendered = ", ".join(sorted(DISCUSS_ANALYZER_FRAMING_VALUES))
+            raise AgentLoopError(f"discuss_review.analyzer_framing must be one of: {rendered}")
+    framing_note = None
+    if "framing_note" in payload:
+        framing_note = _expect_non_empty_string(
+            payload["framing_note"], context="discuss_review.framing_note"
+        )
+    if analyzer_framing == "misframed" and framing_note is None:
+        raise AgentLoopError(
+            "discuss_review.framing_note is required when analyzer_framing is `misframed`."
+        )
+    if framing_note is not None and analyzer_framing is None:
+        raise AgentLoopError(
+            "discuss_review.framing_note requires analyzer_framing to be set."
+        )
     return ParsedDiscussReview(
         outcome=outcome,
         rationale=rationale,
         split_proposals=split_proposals,
         reviewer=reviewer,
         rebuttal=rebuttal,
+        analyzer_framing=analyzer_framing,
+        framing_note=framing_note,
     )
 
 
@@ -1830,3 +1897,80 @@ def validate_structured_discuss_review(
     if parsed is not None:
         return parsed
     raise AgentLoopError("Discuss review did not use the required structured format.")
+
+
+def _parse_discuss_agenda_disagreement(
+    value: object, *, context: str
+) -> DiscussAgendaDisagreement:
+    payload = _expect_object(value, context=context)
+    _expect_exact_keys(
+        payload,
+        context=context,
+        required={"topic", "positions", "question_for_next_round"},
+    )
+    positions_payload = _expect_object(payload["positions"], context=f"{context}.positions")
+    if not positions_payload:
+        raise AgentLoopError(f"{context}.positions must not be empty.")
+    positions = tuple(
+        (
+            _expect_non_empty_string(name, context=f"{context}.positions key"),
+            _expect_non_empty_string(position, context=f"{context}.positions[{name!r}]"),
+        )
+        for name, position in positions_payload.items()
+    )
+    return DiscussAgendaDisagreement(
+        topic=_expect_non_empty_string(payload["topic"], context=f"{context}.topic"),
+        positions=positions,
+        question_for_next_round=_expect_non_empty_string(
+            payload["question_for_next_round"],
+            context=f"{context}.question_for_next_round",
+        ),
+    )
+
+
+def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
+    payload = _extract_structured_discuss_agenda_payload(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind != "discuss_agenda":
+        raise AgentLoopError("Structured response kind mismatch: expected `discuss_agenda`.")
+    _expect_exact_keys(
+        payload,
+        context="discuss_agenda",
+        required={"schema_version", "kind", "consensus", "disagreements"},
+        optional={"missing_facts"},
+    )
+    consensus = _expect_string_list(
+        payload["consensus"],
+        context="discuss_agenda.consensus",
+        item_context="discuss_agenda.consensus",
+    )
+    disagreements_value = payload["disagreements"]
+    if not isinstance(disagreements_value, list):
+        raise AgentLoopError("discuss_agenda.disagreements must be a JSON array.")
+    disagreements = tuple(
+        _parse_discuss_agenda_disagreement(
+            item, context=f"discuss_agenda.disagreements at index {index}"
+        )
+        for index, item in enumerate(disagreements_value)
+    )
+    missing_facts = _expect_optional_string_list(
+        payload,
+        "missing_facts",
+        context="discuss_agenda.missing_facts",
+        item_context="discuss_agenda.missing_facts",
+    )
+    return ParsedDiscussAgenda(
+        consensus=consensus,
+        disagreements=disagreements,
+        missing_facts=missing_facts,
+    )
+
+
+def validate_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda:
+    parsed = parse_structured_discuss_agenda(text)
+    if parsed is not None:
+        return parsed
+    raise AgentLoopError("Discuss agenda did not use the required structured format.")

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -85,7 +85,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review"}:
+    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_agenda"}:
         return None
 
     stripped = raw.lstrip()
@@ -100,7 +100,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 
     json_text = stripped[:json_end].rstrip()
     trailing = stripped[json_end:]
-    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review"} else STATE_RE
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review", "discuss_agenda"} else STATE_RE
     state_match = state_re.search(trailing)
     if state_match is None:
         return None
@@ -196,7 +196,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 # Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
-You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, coder follow-up, or discuss review that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
+You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, coder follow-up, discuss review, or discuss agenda that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
 
 {expected_kind_instruction}
 
@@ -280,6 +280,31 @@ Notes:
 - rationale is required and must be non-empty.
 - split_proposals is required and must be non-empty when outcome is "split"; omit or use [] otherwise.
 - rebuttal is optional in the initial discuss round and required in debate rounds.
+- analyzer_framing (optional) must be "accurate" or "misframed"; framing_note is required when analyzer_framing is "misframed".
+- footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
+
+## Valid Format F — Discuss Agenda:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_agenda",
+  "consensus": ["<point every debater already agrees on>"],
+  "disagreements": [
+    {
+      "topic": "<short topic>",
+      "positions": {"<Debater Name>": "<its stated position>"},
+      "question_for_next_round": "<one specific question>"
+    }
+  ],
+  "missing_facts": ["<missing fact or assumption>"]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Analyzer Name>
+
+Notes:
+- consensus, disagreements, and missing_facts may be empty arrays.
+- each disagreement requires non-empty topic, positions, and question_for_next_round.
+- positions maps debater display names to short position statements and must not be empty.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format D — Plan Revision:
@@ -367,6 +392,7 @@ the `### Human requirements` section from Format D.
 - If an expected response kind is provided above, use ONLY that format. Do not infer a different kind from keywords in the malformed response.
 - Use Format C if the original contains "coder_followup" or "addressed_items" or "remaining_items".
 - Use Format D if the original contains "plan_revision" or "plan_steps".
+- Use Format F if the original contains "discuss_agenda" or "question_for_next_round".
 - Use Format B if the original contains AGENT_PLAN_STATE / blocking_plan_issues / same_plan_followups / prior_plan_item_dispositions.
 - Otherwise use Format A.
 
@@ -718,6 +744,51 @@ Notes:
 - Footer state must always be "approved" for discuss_review; never "blocking".
 - split_proposals is only required when outcome is "split"; omit or use [] for other outcomes.
 
+## WORKED EXAMPLE 15 — discuss_agenda with fences and a malformed disagreement:
+
+Original (malformed): discuss_agenda JSON wrapped in ```json fences, with positions
+given as an array of strings instead of a name-to-position object.
+
+```json
+{
+  "schema_version": 1,
+  "kind": "discuss_agenda",
+  "consensus": ["The issue is well-motivated."],
+  "disagreements": [
+    {
+      "topic": "Scope of the change",
+      "positions": ["Codex: narrow enough", "Gemini: too broad, split it"],
+      "question_for_next_round": "Would splitting the API boundary into its own issue resolve the scope objection?"
+    }
+  ],
+  "missing_facts": []
+}
+```
+
+<!-- AGENT_PLAN_STATE: approved -->
+-- Anthropic Claude
+
+CORRECT repair — strip fences, convert positions to an object keyed by debater name:
+{
+  "schema_version": 1,
+  "kind": "discuss_agenda",
+  "consensus": ["The issue is well-motivated."],
+  "disagreements": [
+    {
+      "topic": "Scope of the change",
+      "positions": {"Codex": "Narrow enough.", "Gemini": "Too broad; split it."},
+      "question_for_next_round": "Would splitting the API boundary into its own issue resolve the scope objection?"
+    }
+  ],
+  "missing_facts": []
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Anthropic Claude
+
+Notes:
+- discuss_agenda uses AGENT_PLAN_STATE and the footer state must always be "approved".
+- Preserve every disagreement and every debater position; never invent or drop positions.
+
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,
@@ -733,7 +804,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review"}
+_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_agenda"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
 ]

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -15,9 +15,11 @@ from .errors import AgentLoopError
 from .protocol import (
     HTML_COMMENT_RE,
     SIGNATURE_RE,
+    ParsedDiscussAgenda,
     ParsedDiscussReview,
     ReviewItemDisposition,
     UnresolvedReviewItem,
+    parse_structured_discuss_agenda,
     parse_structured_discuss_review,
 )
 from .unresolved_items import _apply_unresolved_item_dispositions
@@ -44,6 +46,9 @@ class PostedRoundMetadata:
     consensus_kind: str | None = None
     is_final: bool = False
     agenda: tuple[str, ...] = ()
+    # Raw structured discuss-agenda response from the optional analyzer (#467).
+    # None on final summaries, plain-mode rounds, and legacy comments.
+    analyzer_response: str | None = None
 
 
 @dataclass(frozen=True)
@@ -138,6 +143,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "consensus_kind": metadata.consensus_kind,
         "is_final": metadata.is_final,
         "agenda": list(metadata.agenda),
+        "analyzer_response": metadata.analyzer_response,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -179,6 +185,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             consensus_kind=str(payload["consensus_kind"]) if payload.get("consensus_kind") is not None else None,
             is_final=bool(payload.get("is_final", False)),
             agenda=tuple(str(item) for item in payload.get("agenda", [])),
+            analyzer_response=(
+                str(payload["analyzer_response"])
+                if payload.get("analyzer_response") is not None
+                else None
+            ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc
@@ -558,11 +569,22 @@ class ResumedDiscussState:
     round_history: tuple[tuple[ParsedDiscussReview, ...], ...]
     next_round_number: int
     prior_round_agenda: tuple[str, ...] = ()
+    prior_analyzer_agenda: ParsedDiscussAgenda | None = None
     in_progress_votes: dict[str, ParsedDiscussReview] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         if self.in_progress_votes is None:
             object.__setattr__(self, "in_progress_votes", {})
+
+
+def _decode_analyzer_agenda(raw: str | None) -> ParsedDiscussAgenda | None:
+    """Reparse a persisted analyzer agenda; corrupt/legacy payloads resume in plain mode."""
+    if not raw:
+        return None
+    try:
+        return parse_structured_discuss_agenda(raw)
+    except AgentLoopError:
+        return None
 
 
 def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> ParsedDiscussReview:
@@ -594,6 +616,7 @@ def _resume_discuss_round(
 
     round_history: list[tuple[ParsedDiscussReview, ...]] = []
     prior_round_agenda: tuple[str, ...] = ()
+    prior_analyzer_agenda: ParsedDiscussAgenda | None = None
     next_round_number = 1
     in_progress_votes: dict[str, ParsedDiscussReview] = {}
     for round_number in sorted(rounds):
@@ -619,12 +642,14 @@ def _resume_discuss_round(
             )
             round_history.append(votes)
             prior_round_agenda = summary_record.metadata.agenda
+            prior_analyzer_agenda = _decode_analyzer_agenda(summary_record.metadata.analyzer_response)
             if summary_record.metadata.is_final:
                 return ResumedDiscussState(
                     done=True,
                     round_history=tuple(round_history),
                     next_round_number=round_number,
                     prior_round_agenda=prior_round_agenda,
+                    prior_analyzer_agenda=prior_analyzer_agenda,
                 )
             next_round_number = round_number + 1
         else:
@@ -637,5 +662,6 @@ def _resume_discuss_round(
         round_history=tuple(round_history),
         next_round_number=next_round_number,
         prior_round_agenda=prior_round_agenda,
+        prior_analyzer_agenda=prior_analyzer_agenda,
         in_progress_votes=in_progress_votes,
     )

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -942,3 +942,158 @@ def test_render_public_discuss_review_comment_includes_rebuttal_and_split_propos
     assert "### Proposed sub-issues" in rendered
     assert "- Auth flow" in rendered
 
+
+
+# --- analyzer agenda rendering tests (#467) ---
+
+from coding_review_agent_loop.protocol import (
+    DiscussAgendaDisagreement,
+    ParsedDiscussAgenda,
+)
+
+
+def _rendering_agenda(
+    *,
+    consensus: tuple[str, ...] = ("The issue is well-motivated.",),
+    missing_facts: tuple[str, ...] = ("Whether the API boundary is specified.",),
+) -> ParsedDiscussAgenda:
+    return ParsedDiscussAgenda(
+        consensus=consensus,
+        disagreements=(
+            DiscussAgendaDisagreement(
+                topic="Scope of the change",
+                positions=(("Codex", "Narrow enough."), ("Gemini", "Too broad; split it.")),
+                question_for_next_round="Would splitting resolve the scope objection?",
+            ),
+        ),
+        missing_facts=missing_facts,
+    )
+
+
+def test_render_discuss_summary_non_final_uses_analyzer_agenda_with_attribution():
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=[
+            _discuss_vote("implement", rationale="Mechanical rationale.", reviewer="Codex"),
+            _discuss_vote("do-not-implement", rationale="Other rationale.", reviewer="Gemini"),
+        ],
+        analyzer_agenda=_rendering_agenda(),
+        analyzer_name="Anthropic Claude",
+    )
+    assert "### Agenda for round 2 (analyzer: Anthropic Claude)" in rendered
+    assert "Analyzer-extracted consensus so far (not debater-confirmed):" in rendered
+    assert "- The issue is well-motivated." in rendered
+    assert "**Scope of the change**" in rendered
+    assert "Codex: Narrow enough." in rendered
+    assert "Gemini: Too broad; split it." in rendered
+    assert "Question for next round: Would splitting resolve the scope objection?" in rendered
+    assert "Missing facts:" in rendered
+    assert "- Whether the API boundary is specified." in rendered
+    # The mechanical per-vote agenda lines are replaced by the analyzer agenda.
+    assert "- Codex held `implement`: Mechanical rationale." not in rendered
+
+
+def test_render_discuss_summary_non_final_without_agenda_keeps_mechanical_lines():
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=[_discuss_vote("implement", rationale="Mechanical rationale.", reviewer="Codex")],
+    )
+    assert "### Agenda for round 2" in rendered
+    assert "analyzer" not in rendered
+    assert "- Codex held `implement`: Mechanical rationale." in rendered
+
+
+def test_render_discuss_summary_final_distinguishes_analyzer_consensus_from_votes():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="needs-human",
+        consensus_kind="deadlock",
+        subject="abc123",
+        round_number=3,
+        reviewer_votes=[
+            _discuss_vote("implement", reviewer="Codex"),
+            _discuss_vote("do-not-implement", reviewer="Gemini"),
+        ],
+        split_proposals=[],
+        analyzer_agenda=_rendering_agenda(),
+        analyzer_name="Anthropic Claude",
+    )
+    assert (
+        "### Analyzer-extracted consensus (analyzer: Anthropic Claude; not debater-confirmed)"
+        in rendered
+    )
+    assert "The debater vote table above is the authoritative consensus." in rendered
+    assert "| Codex |" in rendered
+    assert "| Gemini |" in rendered
+    # The analyzer section comes after the authoritative vote table.
+    assert rendered.index("| Codex |") < rendered.index("Analyzer-extracted consensus")
+
+
+def test_render_discuss_summary_final_without_agenda_has_no_analyzer_section():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="unanimous",
+        subject="abc123",
+        reviewer_votes=[_discuss_vote("implement", reviewer="Codex")],
+        split_proposals=[],
+    )
+    assert "Analyzer-extracted consensus" not in rendered
+
+
+def test_render_discuss_summary_final_empty_agenda_renders_placeholder():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="needs-human",
+        consensus_kind="deadlock",
+        subject="abc123",
+        reviewer_votes=[_discuss_vote("implement", reviewer="Codex")],
+        split_proposals=[],
+        analyzer_agenda=ParsedDiscussAgenda(consensus=(), disagreements=(), missing_facts=()),
+    )
+    assert "### Analyzer-extracted consensus (not debater-confirmed)" in rendered
+    assert "(the analyzer extracted no points)" in rendered
+
+
+def test_render_public_discuss_comment_renders_misframed_correction():
+    parsed = ParsedDiscussReview(
+        outcome="implement",
+        rationale="Still well-scoped.",
+        split_proposals=(),
+        reviewer="Codex",
+        rebuttal="Engages the agenda.",
+        analyzer_framing="misframed",
+        framing_note="The agenda claims I opposed the feature; I only questioned scope.",
+    )
+    rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=2)
+    assert "### Analyzer framing correction" in rendered
+    assert "The agenda claims I opposed the feature; I only questioned scope." in rendered
+
+
+def test_render_public_discuss_comment_renders_accurate_framing_line():
+    parsed = ParsedDiscussReview(
+        outcome="implement",
+        rationale="Still well-scoped.",
+        split_proposals=(),
+        reviewer="Codex",
+        rebuttal="Engages the agenda.",
+        analyzer_framing="accurate",
+    )
+    rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=2)
+    assert "**Analyzer framing:** accurate" in rendered
+    assert "### Analyzer framing correction" not in rendered
+
+
+def test_render_public_discuss_comment_without_framing_is_unchanged():
+    parsed = ParsedDiscussReview(
+        outcome="implement",
+        rationale="Well-scoped.",
+        split_proposals=(),
+        reviewer="Codex",
+    )
+    rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=1)
+    assert "Analyzer" not in rendered

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -29,6 +29,8 @@ def _discuss_review_text(
     split_proposals: list[str] | None = None,
     rebuttal: str | None = None,
     reviewer: str = "OpenAI Codex",
+    analyzer_framing: str | None = None,
+    framing_note: str | None = None,
 ) -> str:
     payload: dict = {
         "schema_version": 1,
@@ -40,7 +42,36 @@ def _discuss_review_text(
         payload["split_proposals"] = split_proposals
     if rebuttal is not None:
         payload["rebuttal"] = rebuttal
+    if analyzer_framing is not None:
+        payload["analyzer_framing"] = analyzer_framing
+    if framing_note is not None:
+        payload["framing_note"] = framing_note
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+
+
+def _discuss_agenda_text(
+    *,
+    consensus: list[str] | None = None,
+    disagreements: list[dict] | None = None,
+    missing_facts: list[str] | None = None,
+    analyzer: str = "Anthropic Claude",
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_agenda",
+        "consensus": consensus if consensus is not None else ["The issue is well-motivated."],
+        "disagreements": disagreements
+        if disagreements is not None
+        else [
+            {
+                "topic": "Scope of the change",
+                "positions": {"Codex": "Narrow enough.", "Gemini": "Too broad."},
+                "question_for_next_round": "Would splitting resolve the scope objection?",
+            }
+        ],
+        "missing_facts": missing_facts if missing_facts is not None else [],
+    }
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {analyzer}"
 
 
 def _issue_subject(title: str = "Fix issue-mode context", body: str = "Original issue body.") -> str:
@@ -106,6 +137,7 @@ def _seed_summary_comment(
     round_history: list[list[ParsedDiscussReview]] | None = None,
     split_proposals: list[str] | None = None,
     agenda: tuple[str, ...] = (),
+    analyzer_response: str | None = None,
 ) -> dict:
     """Build an issue-comment payload matching what `_run_discuss_loop` posts for a round summary."""
     body = render_discuss_round_summary_comment(
@@ -129,6 +161,7 @@ def _seed_summary_comment(
             is_final=is_final,
             consensus_kind=consensus_kind,
             agenda=agenda,
+            analyzer_response=analyzer_response,
         ),
     )
     return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
@@ -720,3 +753,437 @@ def test_discuss_loop_raises_when_resumed_round_exceeds_max_rounds_with_no_compl
 
     with pytest.raises(AgentLoopError, match="discuss: resumed state expects round"):
         run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+
+# --- analyzer-guided discuss mode tests (#467) ---
+
+
+def _claude_commands(runner):
+    return [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+
+
+def test_discuss_loop_cli_parser_accepts_discuss_analyzer():
+    from coding_review_agent_loop.cli import build_parser
+
+    args = build_parser().parse_args(
+        ["discuss", "56", "--repo", "OWNER/REPO", "--discuss-analyzer", "claude"]
+    )
+    assert args.discuss_analyzer == "claude"
+    plain = build_parser().parse_args(["discuss", "56", "--repo", "OWNER/REPO"])
+    assert plain.discuss_analyzer is None
+
+
+def test_discuss_loop_unanimous_round1_never_invokes_analyzer(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+        claude_outputs=[],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 3
+    assert "Consensus: Implement" in runner.comments[-1]
+    assert not _claude_commands(runner)
+    assert "Analyzer" not in runner.comments[-1]
+
+
+def test_discuss_loop_max_rounds_zero_never_invokes_analyzer(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[_discuss_review_text(outcome="needs-human", rationale="Needs input.")],
+        claude_outputs=[],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    assert not _claude_commands(runner)
+    assert "Consensus kind: `deadlock` after round 1." in runner.comments[-1]
+
+
+def test_discuss_loop_analyzer_agenda_focuses_debate_and_final_summary_distinguishes(tmp_path):
+    agenda_text = _discuss_agenda_text(
+        missing_facts=["Whether the API boundary is specified."],
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Codex round-one rationale."),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Still scoped.",
+                rebuttal="Defending: the boundary is specified.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="do-not-implement", rationale="Gemini round-one rationale."
+            ),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Still out of scope.",
+                rebuttal="The scope objection stands.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        claude_outputs=[agenda_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    # The analyzer ran exactly once, after the non-final round 1, with the
+    # full round history in its prompt.
+    analyzer_commands = [
+        cmd for cmd in _claude_commands(runner) if "Summarize debate round 1" in " ".join(cmd)
+    ]
+    assert len(analyzer_commands) == 1
+    analyzer_prompt = " ".join(analyzer_commands[0])
+    assert "Codex round-one rationale." in analyzer_prompt
+    assert "Gemini round-one rationale." in analyzer_prompt
+    # Round-1 summary shows the attributed analyzer agenda instead of the
+    # mechanical per-vote lines, including missing facts.
+    round1_summary = runner.comments[2]
+    assert "### Agenda for round 2 (analyzer: Claude)" in round1_summary
+    assert "Scope of the change" in round1_summary
+    assert "Missing facts:" in round1_summary
+    assert "Whether the API boundary is specified." in round1_summary
+    assert "- Codex held `implement`: Codex round-one rationale." not in round1_summary
+    # Round-2 debate prompts are agenda-focused: agenda + own prior position
+    # only; the other debater's rationale reaches them only via the analyzer's
+    # summarized positions.
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Scope of the change" in prompt
+        assert "Would splitting resolve the scope objection?" in prompt
+        assert "Whether the API boundary is specified." in prompt
+        assert "The analyzer is not authoritative" in prompt
+        assert "Prior round reviewer positions:" not in prompt
+    codex_prompt = next(
+        p for p in (" ".join(c) for c in debate_commands) if "-- OpenAI Codex" in p
+    )
+    gemini_prompt = next(
+        p for p in (" ".join(c) for c in debate_commands) if "-- Google Gemini" in p
+    )
+    assert "Codex round-one rationale." in codex_prompt
+    assert "Gemini round-one rationale." not in codex_prompt
+    assert "Gemini round-one rationale." in gemini_prompt
+    assert "Codex round-one rationale." not in gemini_prompt
+    # The deadlock final summary keeps analyzer-extracted consensus distinct
+    # from the authoritative debater vote table.
+    final = runner.comments[-1]
+    assert "Consensus kind: `deadlock` after round 2." in final
+    assert (
+        "### Analyzer-extracted consensus (analyzer: Claude; not debater-confirmed)"
+        in final
+    )
+    assert "The debater vote table above is the authoritative consensus." in final
+    assert "The issue is well-motivated." in final
+
+
+def test_discuss_loop_debater_misframing_correction_is_rendered(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Still scoped.",
+                rebuttal="Defending scope.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="Out of scope."),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Still out of scope.",
+                rebuttal="The agenda mischaracterized me.",
+                analyzer_framing="misframed",
+                framing_note="I never proposed splitting; I questioned the motivation.",
+            ),
+        ],
+        claude_outputs=[_discuss_agenda_text()],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    gemini_round2 = next(c for c in runner.comments if "Round 2: Gemini position" in c)
+    assert "### Analyzer framing correction" in gemini_round2
+    assert "I never proposed splitting; I questioned the motivation." in gemini_round2
+    codex_round2 = next(c for c in runner.comments if "Round 2: Codex position" in c)
+    assert "**Analyzer framing:** accurate" in codex_round2
+
+
+def test_discuss_loop_analyzer_failure_falls_back_to_mechanical_agenda(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Codex round-one rationale."),
+            _discuss_review_text(
+                outcome="implement", rationale="Still scoped.", rebuttal="Scope holds."
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="do-not-implement", rationale="Gemini round-one rationale."
+            ),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Still out of scope.",
+                rebuttal="Objection stands.",
+            ),
+        ],
+        # The analyzer emits prose the strict parser rejects, and the repair
+        # backend output is also unusable, so the analyzer fails outright.
+        claude_outputs=["I could not produce a structured agenda, sorry."],
+        antigravity_outputs=[("still not a structured agenda", 0)],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    # The round-1 summary falls back to the mechanical agenda.
+    round1_summary = runner.comments[2]
+    assert "### Agenda for round 2" in round1_summary
+    assert "(analyzer:" not in round1_summary
+    assert "- Codex held `implement`: Codex round-one rationale." in round1_summary
+    # Round-2 debate prompts fall back to the full prior-round transcript.
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Prior round reviewer positions:" in prompt
+        assert "Codex round-one rationale." in prompt
+        assert "Gemini round-one rationale." in prompt
+    # The run still completes with a final summary and no analyzer section.
+    final = runner.comments[-1]
+    assert "Consensus kind: `deadlock` after round 2." in final
+    assert "Analyzer-extracted consensus" not in final
+
+
+def test_discuss_loop_three_rounds_second_analyzer_prompt_includes_full_history(tmp_path):
+    agenda_round1 = _discuss_agenda_text(consensus=["Round-one agenda marker."])
+    agenda_round2 = _discuss_agenda_text(consensus=["Round-two agenda marker."])
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Codex round-one rationale."),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Codex round-two rationale.",
+                rebuttal="Codex round-two rebuttal.",
+                analyzer_framing="accurate",
+            ),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Codex round-three rationale.",
+                rebuttal="Holding position.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="do-not-implement", rationale="Gemini round-one rationale."
+            ),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Gemini round-two rationale.",
+                rebuttal="Gemini round-two rebuttal.",
+                analyzer_framing="accurate",
+            ),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Convinced now.",
+                rebuttal="Conceding the scope point.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        claude_outputs=[agenda_round1, agenda_round2],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=2)
+
+    assert result == 0
+    round2_analyzer_commands = [
+        cmd for cmd in _claude_commands(runner) if "Summarize debate round 2" in " ".join(cmd)
+    ]
+    assert len(round2_analyzer_commands) == 1
+    prompt = " ".join(round2_analyzer_commands[0])
+    # The analyzer sees every completed round, oldest first, plus its own
+    # previous agenda.
+    assert "Round 1 debater positions:" in prompt
+    assert "Round 2 debater positions (latest round):" in prompt
+    assert "Codex round-one rationale." in prompt
+    assert "Gemini round-one rationale." in prompt
+    assert "Codex round-two rebuttal." in prompt
+    assert "Gemini round-two rebuttal." in prompt
+    assert "Your previous agenda" in prompt
+    assert "Round-one agenda marker." in prompt
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Consensus kind: `converged` after round 3." in final
+    assert "Round-two agenda marker." in final
+
+
+def test_discuss_loop_resume_restores_analyzer_agenda_from_summary_metadata(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+    codex_vote_r1 = ParsedDiscussReview(
+        outcome="implement", rationale="Codex round-one rationale.", split_proposals=(), reviewer="Codex"
+    )
+    gemini_vote_r1 = ParsedDiscussReview(
+        outcome="do-not-implement",
+        rationale="Gemini round-one rationale.",
+        split_proposals=(),
+        reviewer="Gemini",
+    )
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Codex round-one rationale.", config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            outcome="do-not-implement", rationale="Gemini round-one rationale.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=(
+                "- Codex held `implement`: Codex round-one rationale.",
+                "- Gemini held `do-not-implement`: Gemini round-one rationale.",
+            ),
+            analyzer_response=_discuss_agenda_text(),
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement", rationale="Agreed now.", rebuttal="Conceding.",
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+        claude_outputs=[],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        # Resumed debate prompts are agenda-focused, not full-transcript.
+        assert "Scope of the change" in prompt
+        assert "Prior round reviewer positions:" not in prompt
+    codex_prompt = next(
+        p for p in (" ".join(c) for c in debate_commands) if "-- OpenAI Codex" in p
+    )
+    assert "Gemini round-one rationale." not in codex_prompt
+    # The restored agenda also feeds the final summary's analyzer section.
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Analyzer-extracted consensus" in final
+
+
+def test_discuss_loop_resume_legacy_summary_metadata_falls_back_to_plain_mode(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+    codex_vote_r1 = ParsedDiscussReview(
+        outcome="implement", rationale="Codex round-one rationale.", split_proposals=(), reviewer="Codex"
+    )
+    gemini_vote_r1 = ParsedDiscussReview(
+        outcome="do-not-implement",
+        rationale="Gemini round-one rationale.",
+        split_proposals=(),
+        reviewer="Gemini",
+    )
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Codex round-one rationale.", config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            outcome="do-not-implement", rationale="Gemini round-one rationale.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=(
+                "- Codex held `implement`: Codex round-one rationale.",
+                "- Gemini held `do-not-implement`: Gemini round-one rationale.",
+            ),
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement", rationale="Agreed now.", rebuttal="Conceding.",
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+        claude_outputs=[],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Prior round reviewer positions:" in prompt
+        assert "Codex round-one rationale." in prompt
+        assert "Gemini round-one rationale." in prompt
+    assert "Analyzer-extracted consensus" not in runner.comments[-1]
+
+
+def test_discuss_loop_agenda_claiming_consensus_is_forwarded_but_votes_rule(tmp_path):
+    # The analyzer wrongly claims full consensus while the votes still differ:
+    # the agenda is forwarded, but vote-only consensus detection rules.
+    agenda_text = _discuss_agenda_text(
+        consensus=["Everyone agrees to implement."], disagreements=[]
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(
+                outcome="implement", rationale="Still scoped.", rebuttal="Holding."
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="Out of scope."),
+            _discuss_review_text(
+                outcome="do-not-implement", rationale="Still out of scope.", rebuttal="Holding."
+            ),
+        ],
+        claude_outputs=[agenda_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    round1_summary = runner.comments[2]
+    assert "Everyone agrees to implement." in round1_summary
+    final = runner.comments[-1]
+    # Votes rule: the run still ends in a deadlock, and the divergence stays
+    # visible next to the vote table.
+    assert "Consensus kind: `deadlock` after round 2." in final
+    assert "Everyone agrees to implement." in final
+    assert "The debater vote table above is the authoritative consensus." in final

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1913,3 +1913,172 @@ def test_reviewer_prompt_includes_documentation_check(tmp_path):
 
     assert phrase in non_compact
     assert phrase in compact
+
+
+# --- discuss agenda / analyzer-mode prompt tests (#467) ---
+
+from coding_review_agent_loop.prompts import (
+    build_discuss_agenda_prompt,
+    build_discuss_review_prompt,
+)
+from coding_review_agent_loop.protocol import (
+    DiscussAgendaDisagreement,
+    ParsedDiscussAgenda,
+    ParsedDiscussReview,
+)
+
+
+def _discuss_prompt_vote(
+    reviewer: str,
+    outcome: str = "implement",
+    rationale: str = "Well-scoped.",
+    rebuttal: str | None = None,
+    split_proposals: tuple[str, ...] = (),
+    analyzer_framing: str | None = None,
+    framing_note: str | None = None,
+) -> ParsedDiscussReview:
+    return ParsedDiscussReview(
+        outcome=outcome,
+        rationale=rationale,
+        split_proposals=split_proposals,
+        reviewer=reviewer,
+        rebuttal=rebuttal,
+        analyzer_framing=analyzer_framing,
+        framing_note=framing_note,
+    )
+
+
+def _sample_agenda() -> ParsedDiscussAgenda:
+    return ParsedDiscussAgenda(
+        consensus=("The issue is well-motivated.",),
+        disagreements=(
+            DiscussAgendaDisagreement(
+                topic="Scope of the change",
+                positions=(("Codex", "Narrow enough."), ("Gemini", "Too broad; split it.")),
+                question_for_next_round="Would splitting resolve the scope objection?",
+            ),
+        ),
+        missing_facts=("Whether the API boundary is specified.",),
+    )
+
+
+def test_build_discuss_agenda_prompt_includes_every_round_of_history(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    round1 = [
+        _discuss_prompt_vote("Codex", rationale="R1 codex rationale."),
+        _discuss_prompt_vote("Gemini", outcome="do-not-implement", rationale="R1 gemini rationale."),
+    ]
+    round2 = [
+        _discuss_prompt_vote("Codex", rationale="R2 codex rationale.", rebuttal="R2 codex rebuttal."),
+        _discuss_prompt_vote(
+            "Gemini",
+            outcome="do-not-implement",
+            rationale="R2 gemini rationale.",
+            rebuttal="R2 gemini rebuttal.",
+            analyzer_framing="misframed",
+            framing_note="The agenda misstated my position.",
+        ),
+    ]
+    prompt = build_discuss_agenda_prompt(
+        56,
+        config,
+        analyzer="claude",
+        round_number=2,
+        round_history=[round1, round2],
+        prior_agenda=_sample_agenda(),
+    )
+    assert "Round 1 debater positions:" in prompt
+    assert "Round 2 debater positions (latest round):" in prompt
+    assert "R1 codex rationale." in prompt
+    assert "R1 gemini rationale." in prompt
+    assert "R2 codex rebuttal." in prompt
+    assert "R2 gemini rebuttal." in prompt
+    assert "Framing correction: The agenda misstated my position." in prompt
+    # Prior agenda is carried into the analyzer prompt.
+    assert "Your previous agenda" in prompt
+    assert "Would splitting resolve the scope objection?" in prompt
+    # Fidelity guardrails.
+    assert "Preserve minority arguments" in prompt
+    assert "never invent positions" in prompt
+    assert "Carry forward unresolved `missing_facts`" in prompt
+    assert '"kind": "discuss_agenda"' in prompt
+
+
+def test_build_discuss_agenda_prompt_without_prior_agenda(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_discuss_agenda_prompt(
+        56,
+        config,
+        analyzer="claude",
+        round_number=1,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+    )
+    assert "Your previous agenda" not in prompt
+    assert "Round 1 debater positions (latest round):" in prompt
+
+
+def test_build_discuss_review_prompt_analyzer_mode_omits_other_debaters_text(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prior_votes = [
+        _discuss_prompt_vote("Codex", rationale="Codex private rationale text."),
+        _discuss_prompt_vote(
+            "Gemini",
+            outcome="do-not-implement",
+            rationale="Gemini private rationale text.",
+            rebuttal="Gemini private rebuttal text.",
+        ),
+    ]
+    prompt = build_discuss_review_prompt(
+        56,
+        config,
+        reviewer="codex",
+        round_number=2,
+        prior_round_votes=prior_votes,
+        prior_round_agenda=("- Gemini held `do-not-implement`: Gemini private rationale text.",),
+        analyzer_agenda=_sample_agenda(),
+    )
+    # The structured agenda is present.
+    assert "Scope of the change" in prompt
+    assert "Too broad; split it." in prompt
+    assert "Would splitting resolve the scope objection?" in prompt
+    assert "Whether the API boundary is specified." in prompt
+    # The target debater's own prior position is present verbatim.
+    assert "Your own prior-round position (verbatim):" in prompt
+    assert "Codex private rationale text." in prompt
+    # Other debaters' full rationale/rebuttal text is omitted; their views reach
+    # the debater only through the analyzer's summarized positions.
+    assert "Gemini private rationale text." not in prompt
+    assert "Gemini private rebuttal text." not in prompt
+    assert "Prior round reviewer positions:" not in prompt
+    # Misframing instructions and rules.
+    assert "analyzer_framing" in prompt
+    assert "misframed" in prompt
+    assert "The analyzer is not authoritative" in prompt
+
+
+def test_build_discuss_review_prompt_plain_mode_unchanged_without_agenda(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prior_votes = [
+        _discuss_prompt_vote("Codex", rationale="Codex rationale."),
+        _discuss_prompt_vote("Gemini", outcome="do-not-implement", rationale="Gemini rationale."),
+    ]
+    kwargs = dict(
+        reviewer="codex",
+        round_number=2,
+        prior_round_votes=prior_votes,
+        prior_round_agenda=("- Gemini held `do-not-implement`: Gemini rationale.",),
+    )
+    plain = build_discuss_review_prompt(56, config, **kwargs)
+    explicit_none = build_discuss_review_prompt(56, config, analyzer_agenda=None, **kwargs)
+    assert plain == explicit_none
+    assert "Prior round reviewer positions:" in plain
+    assert "Gemini rationale." in plain
+    assert "analyzer_framing" not in plain
+    assert "Analyzer" not in plain
+
+
+def test_build_discuss_review_prompt_round1_has_no_analyzer_rules(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_discuss_review_prompt(56, config, reviewer="codex", round_number=1)
+    assert "analyzer_framing" not in prompt
+    assert "This is round 1." in prompt

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -21,7 +21,10 @@ from coding_review_agent_loop.orchestrator import (
 )
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
+    DISCUSS_ANALYZER_FRAMING_VALUES,
     DISCUSS_OUTCOME_VALUES,
+    DiscussAgendaDisagreement,
+    ParsedDiscussAgenda,
     ParsedDiscussReview,
     _expect_string_list,
     _extract_structured_coder_followup_payload,
@@ -36,6 +39,7 @@ from coding_review_agent_loop.protocol import (
     parse_plan_review,
     parse_plan_review_items,
     parse_plan_state,
+    parse_structured_discuss_agenda,
     parse_structured_discuss_review,
     parse_structured_plan_review,
     parse_structured_pr_review,
@@ -47,6 +51,7 @@ from coding_review_agent_loop.protocol import (
     UnresolvedReviewItem,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
+    validate_structured_discuss_agenda,
     validate_structured_discuss_review,
     validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_state,
@@ -2805,3 +2810,194 @@ def test_detect_discuss_consensus_all_split_merges_proposals():
 def test_detect_discuss_consensus_mixed_returns_none():
     votes = [_vote("implement"), _vote("split", proposals=("X",))]
     assert _detect_discuss_consensus(votes) is None
+
+
+# --- discuss_agenda protocol tests ---
+
+
+def _discuss_agenda(
+    *,
+    consensus: list[str] | None = None,
+    disagreements: list[dict] | None = None,
+    missing_facts: list[str] | None = None,
+    kind: str = "discuss_agenda",
+    footer: str = "approved",
+    analyzer: str = "Anthropic Claude",
+    include_missing_facts: bool = True,
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": kind,
+        "consensus": consensus if consensus is not None else ["The issue is well-motivated."],
+        "disagreements": disagreements
+        if disagreements is not None
+        else [
+            {
+                "topic": "Scope of the change",
+                "positions": {"Codex": "Narrow enough.", "Gemini": "Too broad; split it."},
+                "question_for_next_round": "Would splitting resolve the scope objection?",
+            }
+        ],
+    }
+    if include_missing_facts:
+        payload["missing_facts"] = (
+            missing_facts if missing_facts is not None else ["Whether the API boundary is specified."]
+        )
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: {footer} -->\n-- {analyzer}"
+
+
+def test_parse_structured_discuss_agenda_round_trip():
+    result = parse_structured_discuss_agenda(_discuss_agenda())
+    assert result is not None
+    assert result.consensus == ("The issue is well-motivated.",)
+    assert result.missing_facts == ("Whether the API boundary is specified.",)
+    assert result.disagreements == (
+        DiscussAgendaDisagreement(
+            topic="Scope of the change",
+            positions=(("Codex", "Narrow enough."), ("Gemini", "Too broad; split it.")),
+            question_for_next_round="Would splitting resolve the scope objection?",
+        ),
+    )
+
+
+def test_parse_structured_discuss_agenda_accepts_empty_lists():
+    text = _discuss_agenda(consensus=[], disagreements=[], missing_facts=[])
+    result = parse_structured_discuss_agenda(text)
+    assert result == ParsedDiscussAgenda(consensus=(), disagreements=(), missing_facts=())
+
+
+def test_parse_structured_discuss_agenda_missing_facts_is_optional():
+    result = parse_structured_discuss_agenda(_discuss_agenda(include_missing_facts=False))
+    assert result is not None
+    assert result.missing_facts == ()
+
+
+def test_parse_structured_discuss_agenda_rejects_kind_mismatch():
+    with pytest.raises(AgentLoopError, match="kind mismatch"):
+        parse_structured_discuss_agenda(_discuss_agenda(kind="discuss_review"))
+
+
+def test_parse_structured_discuss_agenda_rejects_blocking_footer():
+    with pytest.raises(AgentLoopError, match="must be `approved`"):
+        parse_structured_discuss_agenda(_discuss_agenda(footer="blocking"))
+
+
+def test_parse_structured_discuss_agenda_rejects_empty_topic():
+    disagreements = [
+        {
+            "topic": "",
+            "positions": {"Codex": "Narrow enough."},
+            "question_for_next_round": "Q?",
+        }
+    ]
+    with pytest.raises(AgentLoopError, match="topic"):
+        parse_structured_discuss_agenda(_discuss_agenda(disagreements=disagreements))
+
+
+def test_parse_structured_discuss_agenda_rejects_empty_positions():
+    disagreements = [
+        {"topic": "Scope", "positions": {}, "question_for_next_round": "Q?"}
+    ]
+    with pytest.raises(AgentLoopError, match="positions must not be empty"):
+        parse_structured_discuss_agenda(_discuss_agenda(disagreements=disagreements))
+
+
+def test_parse_structured_discuss_agenda_rejects_missing_question():
+    disagreements = [{"topic": "Scope", "positions": {"Codex": "Fine."}}]
+    with pytest.raises(AgentLoopError):
+        parse_structured_discuss_agenda(_discuss_agenda(disagreements=disagreements))
+
+
+def test_parse_structured_discuss_agenda_accepts_unknown_position_names():
+    # The analyzer is non-authoritative; unknown debater names must not hard-fail.
+    disagreements = [
+        {
+            "topic": "Scope",
+            "positions": {"Some Unknown Agent": "Position."},
+            "question_for_next_round": "Q?",
+        }
+    ]
+    result = parse_structured_discuss_agenda(_discuss_agenda(disagreements=disagreements))
+    assert result is not None
+    assert result.disagreements[0].positions == (("Some Unknown Agent", "Position."),)
+
+
+def test_validate_structured_discuss_agenda_raises_when_no_marker():
+    with pytest.raises(AgentLoopError, match="required structured format"):
+        validate_structured_discuss_agenda("The analyzer wrote free-form prose instead.")
+
+
+def test_validate_structured_discuss_agenda_returns_parsed_agenda():
+    result = validate_structured_discuss_agenda(_discuss_agenda())
+    assert isinstance(result, ParsedDiscussAgenda)
+
+
+# --- discuss_review analyzer-framing field tests ---
+
+
+def _discuss_review_with_framing(
+    *,
+    analyzer_framing: str | None = None,
+    framing_note: str | None = None,
+    rebuttal: str = "Engages the agenda.",
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_review",
+        "outcome": "implement",
+        "rationale": "Well-scoped.",
+        "rebuttal": rebuttal,
+    }
+    if analyzer_framing is not None:
+        payload["analyzer_framing"] = analyzer_framing
+    if framing_note is not None:
+        payload["framing_note"] = framing_note
+    return json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Gemini"
+
+
+def test_parse_structured_discuss_review_defaults_framing_fields_to_none():
+    result = parse_structured_discuss_review(_discuss_review(), reviewer="Gemini")
+    assert result is not None
+    assert result.analyzer_framing is None
+    assert result.framing_note is None
+
+
+def test_parse_structured_discuss_review_accepts_accurate_framing():
+    text = _discuss_review_with_framing(analyzer_framing="accurate")
+    result = parse_structured_discuss_review(text, reviewer="Gemini", round_number=2)
+    assert result is not None
+    assert result.analyzer_framing == "accurate"
+    assert result.framing_note is None
+
+
+def test_parse_structured_discuss_review_accepts_misframed_with_note():
+    text = _discuss_review_with_framing(
+        analyzer_framing="misframed",
+        framing_note="The agenda claims I opposed the feature; I only questioned scope.",
+    )
+    result = parse_structured_discuss_review(text, reviewer="Gemini", round_number=2)
+    assert result is not None
+    assert result.analyzer_framing == "misframed"
+    assert result.framing_note.startswith("The agenda claims")
+
+
+def test_parse_structured_discuss_review_rejects_unknown_framing_value():
+    text = _discuss_review_with_framing(analyzer_framing="wrong")
+    with pytest.raises(AgentLoopError, match="analyzer_framing must be one of"):
+        parse_structured_discuss_review(text, reviewer="Gemini", round_number=2)
+
+
+def test_parse_structured_discuss_review_rejects_misframed_without_note():
+    text = _discuss_review_with_framing(analyzer_framing="misframed")
+    with pytest.raises(AgentLoopError, match="framing_note is required"):
+        parse_structured_discuss_review(text, reviewer="Gemini", round_number=2)
+
+
+def test_parse_structured_discuss_review_rejects_note_without_framing():
+    text = _discuss_review_with_framing(framing_note="Orphan note.")
+    with pytest.raises(AgentLoopError, match="framing_note requires analyzer_framing"):
+        parse_structured_discuss_review(text, reviewer="Gemini", round_number=2)
+
+
+def test_discuss_analyzer_framing_values():
+    assert DISCUSS_ANALYZER_FRAMING_VALUES == {"accurate", "misframed"}

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -3166,3 +3166,46 @@ def test_run_validated_agent_plan_revision_unknown_prior_disposition_fails_when_
     repair_mock.assert_not_called()
     assert "item-15" in str(exc_info.value)
     assert "item-18" in str(exc_info.value)
+
+
+# --- discuss_agenda repair support tests (#467) ---
+
+
+def _agenda_json() -> str:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "discuss_agenda",
+            "consensus": ["The issue is well-motivated."],
+            "disagreements": [
+                {
+                    "topic": "Scope",
+                    "positions": {"Codex": "Narrow enough.", "Gemini": "Too broad."},
+                    "question_for_next_round": "Would splitting resolve the objection?",
+                }
+            ],
+            "missing_facts": [],
+        }
+    )
+
+
+def test_envelope_normalization_discuss_agenda_reversed_footer_and_signature():
+    raw = _agenda_json() + "\n-- Anthropic Claude\n<!-- AGENT_PLAN_STATE: approved -->"
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="discuss_agenda")
+
+    assert normalized is not None
+    from coding_review_agent_loop.protocol import parse_structured_discuss_agenda
+
+    parsed = parse_structured_discuss_agenda(normalized)
+    assert parsed is not None
+    assert parsed.disagreements[0].topic == "Scope"
+
+
+def test_build_repair_prompt_accepts_discuss_agenda_expected_kind():
+    from coding_review_agent_loop.repair import _build_repair_prompt
+
+    prompt = _build_repair_prompt("garbage", expected_kind="discuss_agenda")
+    assert "You MUST repair this response as `discuss_agenda`." in prompt
+    assert "Valid Format F — Discuss Agenda" in prompt
+    assert "question_for_next_round" in prompt


### PR DESCRIPTION
Implements the first scoped stage of #467. Follow-up stages are tracked in #475 and #477. Refs #467

Implements the approved plan for the optional analyzer-guided debate agenda in discuss mode.

## What's new

- **`--discuss-analyzer <agent>`** on the `discuss` subcommand (`claude`/`codex`/`gemini`/`antigravity`; may coincide with a `--reviewer`). Omitting the flag keeps plain #465-style deliberation byte-for-byte unchanged.
- **Structured `discuss_agenda` protocol** (`protocol.py`): `ParsedDiscussAgenda`/`DiscussAgendaDisagreement` with strict parsing/validation — `consensus`/`disagreements`/`missing_facts` may be empty, each disagreement requires non-empty `topic`, `positions`, and `question_for_next_round`, and unknown debater names in `positions` are forwarded with a log instead of hard-failing (the analyzer is non-authoritative). `discuss_review` gains optional `analyzer_framing` (`accurate`|`misframed`) and `framing_note`, defaulting to `None` for backward compatibility.
- **Analyzer prompt** (`build_discuss_agenda_prompt`): receives the complete multi-round vote history (outcomes, rationales, rebuttals, framing corrections, oldest first) plus the previous agenda, with fidelity guardrails (represent positions faithfully, preserve minority arguments, never invent consensus, carry forward unresolved missing facts).
- **Agenda-focused debate prompts**: when an agenda is present, `build_discuss_review_prompt` renders only the structured agenda plus the target debater's own prior position verbatim; other debaters' rationales/rebuttals are omitted (and discuss-flow bot comments are stripped from the prompt-facing issue context so resumed runs can't leak the prior transcript back in). Debaters must concede, defend, refine, or set `analyzer_framing: "misframed"` with a `framing_note`.
- **Orchestrator wiring**: the analyzer runs via `_run_validated_agent` (role `reviewer`, repair kind `discuss_agenda`) after votes are collected on non-final rounds only. Consensus detection stays vote-only. Any analyzer failure that survives repair logs a warning and falls back to the mechanical agenda; only a quota-reset stop propagates.
- **Persistence/resume**: the raw agenda rides in the summary comment's `AGENT_LOOP_META` payload (`analyzer_response`); resume reparses it into `ResumedDiscussState.prior_analyzer_agenda`. Legacy/corrupt payloads resume in plain mode.
- **Rendering**: non-final summaries show the attributed analyzer agenda ("Agenda for round N+1 (analyzer: ...)"); debater comments render framing corrections; final summaries add an "Analyzer-extracted consensus (not debater-confirmed)" section kept distinct from the authoritative vote table.
- **Repair**: `discuss_agenda` added to supported repair kinds and envelope normalization, with a Format F schema and worked example in the repair prompt.
- **Docs**: README and docs/local_agent_loop.md document the flag, guardrails, fallback, and new summary sections.

## Edge cases covered

`--discuss-max-rounds 0` logs a note and never runs the analyzer; round-1 unanimity never invokes it; an agenda claiming consensus while votes differ is forwarded but votes rule; crash-before-summary re-runs the analyzer on resume; legacy summaries resume in plain mode.

## Tests

43 new tests across `tests/test_protocol.py` (agenda round-trip, kind mismatch, field validation, empty lists, framing fields), `tests/test_prompts.py` (full-history analyzer prompt, agenda-focused debate prompt omitting other debaters' text, plain-mode invariance), `tests/test_comment_rendering.py` (attributed agenda, analyzer-vs-vote consensus separation, framing corrections), `tests/test_repair.py` (envelope normalization, repair prompt), and `tests/test_discuss_loop.py` (CLI parsing, unanimity skips analyzer, persistent disagreement with focused prompts and distinguished final summary, misframing rendering, missing-fact escalation, analyzer-failure fallback, three-round full-history analyzer prompt, resume with restored agenda, legacy plain-mode resume, agenda-vs-vote divergence).

Full suite: `python3 -m pytest tests/ -q` → 1224 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude

