### PR TITLE
Add discuss research policy (--discuss-research none|required|auto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,42 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-analyzer claude
 ```
 
+Discuss mode also takes a research policy via `--discuss-research
+none|required|auto` (default: `none`) for questions that depend on current
+external facts:
+
+- `none`: debaters use only repo/issue context; prompts explicitly forbid
+  online research, so plain discuss mode and analyzer mode stay usable without
+  network-dependent behavior. Best for internal design questions.
+- `required`: every debater must do online research before answering, cite a
+  source for each external fact, and keep sourced facts separate from its own
+  judgment. Responses must carry a `research` object whose `status` is
+  `sourced`, `unavailable`, or `inconclusive` (never `not-needed`), with
+  `sourced_facts` entries of `{fact, source}` pairs when `sourced`. Use this to
+  force research instead of relying on automatic detection.
+- `auto`: debaters (and the analyzer, if configured) decide whether research is
+  needed using conservative triggers — current vendor/product behavior,
+  pricing, quotas, model availability, laws/policies, dependency behavior, or
+  market/tool comparisons — and set `status` to `not-needed` when no trigger
+  applies.
+
+With `--discuss-analyzer` and a non-`none` research policy, the analyzer also
+emits `research_required` and `research_questions` in its agenda; the
+orchestrator forwards those questions to the next round's debaters as a shared
+research brief so parallel turns do not duplicate work. Debater comments show
+each reviewer's research status and cited sourced facts, and the final summary
+includes a Research section that keeps debater-cited facts distinct from agent
+judgment and states explicitly when research was deemed unnecessary, was not
+reported, or came back unavailable or inconclusive — instead of presenting
+stale assumptions as fact:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --discuss-analyzer claude \
+  --discuss-research auto
+```
+
 If reviewers still disagree after the configured debate rounds, the final
 round-summary comment is marked `deadlock`, uses the `needs-human` outcome, and
 summarizes each final position and the core disagreement. `split` proposals

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -433,6 +433,65 @@ summaries without an analyzer payload resume in plain mode. With
 runs (a note is logged). Omitting `--discuss-analyzer` keeps plain #465-style
 direct deliberation unchanged.
 
+### Discuss research policy
+
+`--discuss-research none|required|auto` (default: `none`) controls whether
+debaters may use current external facts:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --discuss-analyzer claude \
+  --discuss-research auto
+```
+
+- `none`: prompts explicitly forbid online research; plain discuss mode and
+  analyzer mode remain usable without network-dependent behavior. Best for
+  internal design questions.
+- `required`: every debater must research before answering. The structured
+  `discuss_review` must include a `research` object; its `status` must be
+  `sourced`, `unavailable`, or `inconclusive` (`not-needed` is rejected), and a
+  `sourced` status requires non-empty `sourced_facts` of `{"fact", "source"}`
+  pairs. Validation enforces this (with the malformed-response repair pass as
+  fallback), so the user can force research instead of relying on automatic
+  detection.
+- `auto`: debaters self-decide using conservative triggers — current
+  vendor/product behavior, pricing, quotas, model availability, laws/policies,
+  dependency behavior, or market/tool comparisons — and report
+  `status: "not-needed"` when no trigger applies.
+
+With an analyzer and a non-`none` policy, the analyzer's `discuss_agenda` may
+add a shared research brief:
+
+```json
+{
+  "research_required": true,
+  "research_questions": ["Is Gemini CLI still available for enterprise users?"]
+}
+```
+
+The orchestrator forwards those questions to the next round's debater prompts
+("Shared research brief") so parallel or repeated debater turns do not
+duplicate work, and carries unresolved questions forward between rounds. In
+`auto` mode the analyzer is told to set `research_required: true` only when a
+conservative trigger applies, so it can decide research is unnecessary.
+
+Rendering keeps sourced facts distinct from judgment:
+
+- Each debater comment shows a `Research:` status line and a "Sourced facts"
+  list (`fact — source`).
+- The final summary adds a "Research" section with the policy, each debater's
+  research status, and all cited sourced facts. Gap cases are explicit: it
+  states when all debaters deemed research unnecessary, when a debater
+  reported research `unavailable`/`inconclusive`, and when a debater reported
+  no research status — in each case telling the reader to treat the related
+  claims as judgment, not sourced fact.
+- The research policy in effect also rides in each posted comment's
+  `AGENT_LOOP_META` metadata. Resume decoding of already-posted votes is
+  lenient, so rerunning a transcript that was started under a different
+  research policy never fails on old comments; enforcement applies only to
+  newly invoked debaters.
+
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the
 detected `OWNER/REPO`. Pass `--repo` explicitly when running outside the target

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -455,6 +455,19 @@ def build_parser() -> argparse.ArgumentParser:
             "--reviewer. Omit for plain direct deliberation (default: none)."
         ),
     )
+    discuss.add_argument(
+        "--discuss-research",
+        choices=("none", "required", "auto"),
+        default="none",
+        help=(
+            "Research policy for debaters (default: none). 'none' forbids online "
+            "research; 'required' makes every debater research and cite sources; "
+            "'auto' lets debaters (and the analyzer, if configured) decide using "
+            "conservative triggers such as current vendor behavior, pricing, "
+            "quotas, model availability, policies/laws, dependency behavior, or "
+            "tool comparisons."
+        ),
+    )
     add_common(discuss)
 
     return parser

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -639,6 +639,13 @@ _DISCUSS_OUTCOME_LABELS = {
     "split": "Split",
 }
 
+_DISCUSS_RESEARCH_STATUS_LABELS = {
+    "sourced": "done, sourced facts cited below",
+    "not-needed": "not needed (no external-fact trigger applies)",
+    "unavailable": "unavailable — related claims are judgment, not sourced fact",
+    "inconclusive": "inconclusive — related claims are judgment, not sourced fact",
+}
+
 
 def _render_public_discuss_review_comment(
     parsed: ParsedDiscussReview,
@@ -667,6 +674,14 @@ def _render_public_discuss_review_comment(
     if parsed.split_proposals:
         proposals = "\n".join(f"- {proposal}" for proposal in parsed.split_proposals)
         sections.append("### Proposed sub-issues\n\n" + proposals)
+    if parsed.research_status is not None:
+        label = _DISCUSS_RESEARCH_STATUS_LABELS.get(parsed.research_status, parsed.research_status)
+        sections.append(f"**Research:** {label} (`{parsed.research_status}`)")
+    if parsed.sourced_facts:
+        facts = "\n".join(
+            f"- {fact.fact} — source: {fact.source}" for fact in parsed.sourced_facts
+        )
+        sections.append("### Sourced facts\n\n" + facts)
     sections.append(f"-- {_comment_signature(reviewer, config, model_used)}")
     return "\n\n".join(section for section in sections if section)
 
@@ -696,6 +711,80 @@ def _render_analyzer_agenda_lines(agenda: ParsedDiscussAgenda) -> list[str]:
             lines.append("")
         lines.append("Missing facts:")
         lines.extend(f"- {fact}" for fact in agenda.missing_facts)
+    if agenda.research_required and agenda.research_questions:
+        if lines:
+            lines.append("")
+        lines.append("Research brief for the next round (answer with cited sources):")
+        lines.extend(f"- {question}" for question in agenda.research_questions)
+    return lines
+
+
+def _render_discuss_research_section(
+    *,
+    research_mode: str,
+    reviewer_votes: Sequence[ParsedDiscussReview],
+    round_history: Sequence[Sequence[ParsedDiscussReview]] | None,
+) -> list[str]:
+    """Render the final-summary research section (#477).
+
+    Keeps debater-cited external facts distinct from agent judgment, and makes
+    missing, unavailable, or inconclusive research explicit instead of letting
+    stale assumptions read as fact.
+    """
+    lines = ["### Research", "", f"Research policy: `{research_mode}`."]
+    if research_mode == "none":
+        lines.append("")
+        lines.append("Online research was disabled; all positions are agent judgment.")
+        return lines
+    lines.append("")
+    for vote in reviewer_votes:
+        if vote.research_status is None:
+            lines.append(f"- {vote.reviewer}: no research status reported")
+        else:
+            label = _DISCUSS_RESEARCH_STATUS_LABELS.get(
+                vote.research_status, vote.research_status
+            )
+            lines.append(f"- {vote.reviewer}: {label} (`{vote.research_status}`)")
+    fact_rounds = round_history if round_history else [reviewer_votes]
+    sourced: list[str] = []
+    seen: set[tuple[str, str, str]] = set()
+    for votes in fact_rounds:
+        for vote in votes:
+            for fact in vote.sourced_facts:
+                key = (vote.reviewer, fact.fact, fact.source)
+                if key not in seen:
+                    seen.add(key)
+                    sourced.append(f"- {vote.reviewer}: {fact.fact} — source: {fact.source}")
+    if sourced:
+        lines.append("")
+        lines.append(
+            "Sourced facts cited by debaters (everything else above is agent judgment):"
+        )
+        lines.extend(sourced)
+    statuses = [vote.research_status for vote in reviewer_votes]
+    if statuses and all(status == "not-needed" for status in statuses):
+        lines.append("")
+        lines.append(
+            "All debaters determined external research was unnecessary for this question."
+        )
+    gap_reviewers = [
+        vote.reviewer
+        for vote in reviewer_votes
+        if vote.research_status in {"unavailable", "inconclusive"}
+    ]
+    if gap_reviewers:
+        lines.append("")
+        lines.append(
+            f"Research was unavailable or inconclusive for {', '.join(gap_reviewers)}; "
+            "treat their related claims as judgment, not sourced fact."
+        )
+    unreported = [vote.reviewer for vote in reviewer_votes if vote.research_status is None]
+    if unreported:
+        lines.append("")
+        lines.append(
+            f"No research status was reported by {', '.join(unreported)}; treat their "
+            "claims as judgment, not sourced fact."
+        )
     return lines
 
 
@@ -711,6 +800,7 @@ def render_discuss_round_summary_comment(
     split_proposals: Sequence[str] | None = None,
     analyzer_agenda: ParsedDiscussAgenda | None = None,
     analyzer_name: str | None = None,
+    research_mode: str | None = None,
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -812,6 +902,15 @@ def render_discuss_round_summary_comment(
         lines.append("")
         agenda_lines = _render_analyzer_agenda_lines(analyzer_agenda)
         lines.extend(agenda_lines if agenda_lines else ["(the analyzer extracted no points)"])
+    if research_mode is not None:
+        lines.append("")
+        lines.extend(
+            _render_discuss_research_section(
+                research_mode=research_mode,
+                reviewer_votes=reviewer_votes,
+                round_history=round_history,
+            )
+        )
     if round_history:
         lines.append("")
         lines.append("### Round history")

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -39,6 +39,10 @@ DEFAULT_ANTIGRAVITY_MODELS: tuple[str, ...] = (
 )
 DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3 Flash",)
 
+# Discuss-mode research policy values (#477). The CLI flag choices, the config
+# validation, and the prompt builders all derive from this set.
+DISCUSS_RESEARCH_MODES: frozenset[str] = frozenset({"none", "required", "auto"})
+
 
 @dataclass(frozen=True)
 class AgentLoopConfig:
@@ -100,6 +104,10 @@ class AgentLoopConfig:
     # Optional analyzer agent for discuss mode (#467). None keeps plain
     # direct deliberation unchanged. May coincide with a reviewer.
     discuss_analyzer: AgentName | None = None
+    # Discuss-mode research policy (#477): "none" forbids online research,
+    # "required" enforces sourced external facts from every debater, "auto"
+    # lets debaters/analyzer decide using conservative triggers.
+    discuss_research: str = "none"
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -123,6 +131,9 @@ class AgentLoopConfig:
             raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")
         if self.pr_review_context_mode not in {"full", "compact"}:
             raise AgentLoopError("--pr-review-context-mode must be either 'full' or 'compact'.")
+        if self.discuss_research not in DISCUSS_RESEARCH_MODES:
+            rendered = ", ".join(f"'{mode}'" for mode in sorted(DISCUSS_RESEARCH_MODES))
+            raise AgentLoopError(f"--discuss-research must be one of: {rendered}.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -763,6 +774,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         repair_models=tuple(getattr(args, "repair_model", None) or DEFAULT_REPAIR_MODELS),
         repair_timeout_seconds=getattr(args, "repair_timeout_seconds", 120),
         discuss_analyzer=getattr(args, "discuss_analyzer", None),
+        discuss_research=getattr(args, "discuss_research", "none") or "none",
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3616,6 +3616,7 @@ def _run_discuss_analyzer(
                 round_number=round_number,
                 round_history=round_history,
                 prior_agenda=prior_agenda,
+                research_mode=config.discuss_research,
             ),
             marker_description="<!-- AGENT_PLAN_STATE: approved -->",
             validate=validate_structured_discuss_agenda,
@@ -3745,6 +3746,7 @@ def _run_discuss_loop(
             split_proposals=[],
             analyzer_agenda=prior_analyzer_agenda,
             analyzer_name=analyzer_name,
+            research_mode=config.discuss_research,
         )
         post_issue_comment(
             runner,
@@ -3761,6 +3763,7 @@ def _run_discuss_loop(
                     is_final=True,
                     consensus_kind="deadlock",
                     agenda=(),
+                    research_mode=config.discuss_research,
                 ),
             ),
         )
@@ -3805,10 +3808,11 @@ def _run_discuss_loop(
                     prior_round_votes=prior_round_votes,
                     prior_round_agenda=prior_round_agenda,
                     analyzer_agenda=prior_analyzer_agenda,
+                    research_mode=config.discuss_research,
                 ),
                 marker_description="<!-- AGENT_PLAN_STATE: approved -->",
                 validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
-                    text, reviewer=r, round_number=rn
+                    text, reviewer=r, round_number=rn, research_mode=config.discuss_research
                 ),
                 usage_context=usage_context,
                 use_repair=True,
@@ -3838,6 +3842,7 @@ def _run_discuss_loop(
                         subject=subject,
                         raw_structured_coder_response=response.text,
                         model_used=response.model_used,
+                        research_mode=config.discuss_research,
                     ),
                 ),
             )
@@ -3882,6 +3887,7 @@ def _run_discuss_loop(
             # the debater vote table; non-final summaries show the fresh one.
             analyzer_agenda=prior_analyzer_agenda if is_final else next_analyzer_agenda,
             analyzer_name=analyzer_name,
+            research_mode=config.discuss_research,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(reviewer_votes))
         post_issue_comment(
@@ -3900,6 +3906,7 @@ def _run_discuss_loop(
                     consensus_kind=consensus_kind,
                     agenda=agenda,
                     analyzer_response=analyzer_response_raw,
+                    research_mode=config.discuss_research,
                 ),
             ),
         )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2179,7 +2179,50 @@ def _render_discuss_agenda_prompt_block(agenda: ParsedDiscussAgenda) -> list[str
         lines.append("Missing facts or assumptions flagged by the analyzer:")
         lines.extend(f"- {fact}" for fact in agenda.missing_facts)
         lines.append("")
+    if agenda.research_required and agenda.research_questions:
+        lines.append(
+            "Shared research brief — answer these with cited sources before "
+            "restating positions, so parallel debater turns do not duplicate work:"
+        )
+        lines.extend(f"- {question}" for question in agenda.research_questions)
+        lines.append("")
     return lines
+
+
+# Conservative triggers for `auto` research mode (#477). Shared verbatim between
+# the debater and analyzer prompts and documented in README/docs so the policy
+# cannot drift.
+DISCUSS_RESEARCH_AUTO_TRIGGERS = (
+    "current vendor/product behavior, pricing, quotas, model availability, "
+    "laws/policies, dependency behavior, or market/tool comparisons"
+)
+
+
+def _discuss_research_policy_block(research_mode: str) -> str:
+    if research_mode == "required":
+        return (
+            "Research policy: `required`. Before answering, do online research on the\n"
+            "external facts this question depends on. Cite a source (URL or equivalent\n"
+            "reference) for every external fact via `research.sourced_facts`, and keep\n"
+            "sourced facts separate from your own judgment. If research is unavailable\n"
+            "or inconclusive, say so via `research.status` instead of presenting stale\n"
+            "assumptions as fact."
+        )
+    if research_mode == "auto":
+        return (
+            "Research policy: `auto`. Do online research only if the question materially\n"
+            f"depends on current external facts — conservative triggers: {DISCUSS_RESEARCH_AUTO_TRIGGERS}.\n"
+            "If no trigger applies, set `research.status` to `not-needed` and use only\n"
+            "repo/issue context. If you do research, cite a source (URL or equivalent\n"
+            "reference) for every external fact via `research.sourced_facts`, and keep\n"
+            "sourced facts separate from your own judgment. If research is unavailable\n"
+            "or inconclusive, say so via `research.status` instead of presenting stale\n"
+            "assumptions as fact."
+        )
+    return (
+        "Research policy: `none`. Use only the repository and issue context; do not\n"
+        "perform online research."
+    )
 
 
 def build_discuss_agenda_prompt(
@@ -2192,6 +2235,7 @@ def build_discuss_agenda_prompt(
     round_number: int = 1,
     round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
     prior_agenda: ParsedDiscussAgenda | None = None,
+    research_mode: str = "none",
 ) -> str:
     analyzer_signature = agent_signature(analyzer, config)
     round_history = tuple(tuple(votes) for votes in (round_history or ()))
@@ -2221,6 +2265,39 @@ def build_discuss_agenda_prompt(
         ]
         prior_agenda_block = "\n".join(prior_agenda_lines) + "\n"
     history_block = "\n".join(history_lines)
+    research_extract = ""
+    research_guardrail = ""
+    research_example = ""
+    research_rules = ""
+    if research_mode in {"required", "auto"}:
+        research_extract = (
+            "\n- `research_required` / `research_questions`: whether the next round "
+            "depends on current external facts, and the specific questions debaters "
+            "should research (a shared brief so parallel turns do not duplicate work)."
+        )
+        if research_mode == "auto":
+            research_guardrail = (
+                "\n- The research policy is `auto`: set `research_required` to true "
+                "only when resolution depends on current external facts — "
+                f"conservative triggers: {DISCUSS_RESEARCH_AUTO_TRIGGERS}. Prefer "
+                "false when repo/issue context suffices. Carry forward unresolved "
+                "research questions from your previous agenda."
+            )
+        else:
+            research_guardrail = (
+                "\n- The research policy is `required`: debaters must research "
+                "regardless, so use `research_questions` to focus that research on "
+                "the unresolved external facts. Carry forward unresolved research "
+                "questions from your previous agenda."
+            )
+        research_example = (
+            ',\n  "research_required": true,\n'
+            '  "research_questions": ["Is Gemini CLI still available for enterprise users?"]'
+        )
+        research_rules = (
+            "\n- `research_questions` must be non-empty when `research_required` is "
+            "true, and empty or omitted when it is false."
+        )
     return f"""Summarize debate round {round_number} for GitHub issue #{issue_number} in {config.repo} into a structured agenda for the next round.
 
 You are the analyzer, not a debater. Do not vote on the issue and do not edit
@@ -2234,7 +2311,7 @@ Extract from the transcript:
 - `consensus`: points every debater already agrees on.
 - `disagreements`: each unresolved disagreement, with every named debater's
   stated position and one specific question the next round must answer.
-- `missing_facts`: facts or assumptions that are missing and block resolution.
+- `missing_facts`: facts or assumptions that are missing and block resolution.{research_extract}
 
 Fidelity guardrails:
 - Represent each debater's stated position faithfully; quote or closely
@@ -2243,7 +2320,7 @@ Fidelity guardrails:
   latest position supports it.
 - Distinguish persistent disagreements (repeated across rounds) from points a
   debater has already conceded or refined.
-- Carry forward unresolved `missing_facts` from your previous agenda.
+- Carry forward unresolved `missing_facts` from your previous agenda.{research_guardrail}
 
 Respond using this mandatory structured JSON format:
 
@@ -2258,7 +2335,7 @@ Respond using this mandatory structured JSON format:
       "question_for_next_round": "Would splitting the API boundary into its own issue resolve the scope objection?"
     }}
   ],
-  "missing_facts": ["Whether the API boundary is already specified."]
+  "missing_facts": ["Whether the API boundary is already specified."]{research_example}
 }}
 <!-- AGENT_PLAN_STATE: approved -->
 -- {analyzer_signature}
@@ -2266,7 +2343,7 @@ Respond using this mandatory structured JSON format:
 Rules:
 - `consensus`, `disagreements`, and `missing_facts` may be empty arrays.
 - Each disagreement requires non-empty `topic`, `positions`, and `question_for_next_round`.
-- `positions` maps each debater's display name to a short statement of its position.
+- `positions` maps each debater's display name to a short statement of its position.{research_rules}
 - The footer must always be `<!-- AGENT_PLAN_STATE: approved -->`.
 - Do not include prose or code fences before the JSON object.
 - Do not place your signature before the `AGENT_PLAN_STATE` footer.
@@ -2288,6 +2365,7 @@ def build_discuss_review_prompt(
     prior_round_votes: Sequence[ParsedDiscussReview] | None = None,
     prior_round_agenda: Sequence[str] | None = None,
     analyzer_agenda: ParsedDiscussAgenda | None = None,
+    research_mode: str = "none",
 ) -> str:
     reviewer_signature = agent_signature(reviewer, config)
     prior_round_votes = tuple(prior_round_votes or ())
@@ -2368,12 +2446,42 @@ def build_discuss_review_prompt(
             "round disagreement."
         )
         rebuttal_example = ',\n  "rebuttal": "I considered the scope objection, but the issue is narrow enough because the API boundary is already specified."'
+    research_example = ""
+    research_rules = ""
+    if research_mode in {"required", "auto"}:
+        example_status = "sourced" if research_mode == "required" else "not-needed"
+        example_facts = (
+            '[\n      {"fact": "Gemini CLI remains available for enterprise users as of'
+            ' this week.", "source": "https://example.com/gemini-cli-notice"}\n    ]'
+            if example_status == "sourced"
+            else "[]"
+        )
+        research_example = (
+            ',\n  "research": {\n'
+            f'    "status": "{example_status}",\n'
+            f'    "sourced_facts": {example_facts}\n'
+            "  }"
+        )
+        research_rules = (
+            "\n- The `research` object is required. `research.status` must be one of: "
+            "`sourced`, `not-needed`, `unavailable`, `inconclusive`."
+            "\n- `research.sourced_facts` must be non-empty when `research.status` is "
+            "`sourced`; each entry needs a non-empty `fact` and `source`. Omit or use "
+            "`[]` for other statuses."
+        )
+        if research_mode == "required":
+            research_rules += (
+                "\n- The research policy is `required`, so `research.status` must not "
+                "be `not-needed`."
+            )
     return f"""Evaluate GitHub issue #{issue_number} in {config.repo} and vote on whether it should be implemented.
 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this evaluation.
 {_issue_context_block(issue_context)}{_memory_block(memory)}
 {round_context}
+
+{_discuss_research_policy_block(research_mode)}
 
 Vote on one of these outcomes:
 - `implement` — the issue is well-defined and should be implemented as described.
@@ -2388,7 +2496,7 @@ Respond using this mandatory structured JSON format:
   "kind": "discuss_review",
   "outcome": "implement",
   "rationale": "The feature is clearly scoped and fills a documented user need.",
-  "split_proposals": []{rebuttal_example}
+  "split_proposals": []{rebuttal_example}{research_example}
 }}
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
@@ -2397,7 +2505,7 @@ Rules:
 - `outcome` must be exactly one of: `implement`, `do-not-implement`, `needs-human`, `split`.
 - `rationale` is required and must be non-empty.
 - `split_proposals` is required and must be non-empty when `outcome` is `split`; omit or use `[]` for other outcomes.
-{rebuttal_rule}{analyzer_rules}
+{rebuttal_rule}{analyzer_rules}{research_rules}
 - The footer must always be `<!-- AGENT_PLAN_STATE: approved -->` regardless of your outcome.
 - Do not include prose or code fences before the JSON object.
 - Do not place your signature before the `AGENT_PLAN_STATE` footer.

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -230,6 +230,12 @@ class StructuredDiscussReview:
 
 
 @dataclass(frozen=True)
+class DiscussSourcedFact:
+    fact: str
+    source: str
+
+
+@dataclass(frozen=True)
 class ParsedDiscussReview:
     outcome: str
     rationale: str
@@ -238,10 +244,15 @@ class ParsedDiscussReview:
     rebuttal: str | None = None
     analyzer_framing: str | None = None
     framing_note: str | None = None
+    # Research policy fields (#477). None means the response carried no
+    # `research` object (legacy transcripts and `none`-mode responses).
+    research_status: str | None = None
+    sourced_facts: tuple[DiscussSourcedFact, ...] = ()
 
 
 DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-human", "split"})
 DISCUSS_ANALYZER_FRAMING_VALUES = frozenset({"accurate", "misframed"})
+DISCUSS_RESEARCH_STATUS_VALUES = frozenset({"sourced", "not-needed", "unavailable", "inconclusive"})
 
 
 @dataclass(frozen=True)
@@ -256,6 +267,11 @@ class ParsedDiscussAgenda:
     consensus: tuple[str, ...]
     disagreements: tuple[DiscussAgendaDisagreement, ...]
     missing_facts: tuple[str, ...]
+    # Shared research brief (#477). Emitted by the analyzer when a research
+    # policy is active; forwarded to the next round's debaters so parallel
+    # turns do not duplicate work.
+    research_required: bool = False
+    research_questions: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1822,8 +1838,47 @@ def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFo
     return list(parse_approved_followups(text, reviewer=reviewer).future)
 
 
+def _parse_discuss_research(value: object) -> tuple[str, tuple[DiscussSourcedFact, ...]]:
+    payload = _expect_object(value, context="discuss_review.research")
+    _expect_exact_keys(
+        payload,
+        context="discuss_review.research",
+        required={"status"},
+        optional={"sourced_facts"},
+    )
+    status = _expect_non_empty_string(payload["status"], context="discuss_review.research.status")
+    if status not in DISCUSS_RESEARCH_STATUS_VALUES:
+        rendered = ", ".join(sorted(DISCUSS_RESEARCH_STATUS_VALUES))
+        raise AgentLoopError(f"discuss_review.research.status must be one of: {rendered}")
+    facts_value = payload.get("sourced_facts", [])
+    if not isinstance(facts_value, list):
+        raise AgentLoopError("discuss_review.research.sourced_facts must be a JSON array.")
+    sourced_facts: list[DiscussSourcedFact] = []
+    for index, item in enumerate(facts_value):
+        context = f"discuss_review.research.sourced_facts at index {index}"
+        fact_payload = _expect_object(item, context=context)
+        _expect_exact_keys(fact_payload, context=context, required={"fact", "source"})
+        sourced_facts.append(
+            DiscussSourcedFact(
+                fact=_expect_non_empty_string(fact_payload["fact"], context=f"{context}.fact"),
+                source=_expect_non_empty_string(
+                    fact_payload["source"], context=f"{context}.source"
+                ),
+            )
+        )
+    if status == "sourced" and not sourced_facts:
+        raise AgentLoopError(
+            "discuss_review.research.sourced_facts must be non-empty when status is `sourced`."
+        )
+    if status != "sourced" and sourced_facts:
+        raise AgentLoopError(
+            "discuss_review.research.sourced_facts requires status `sourced`."
+        )
+    return status, tuple(sourced_facts)
+
+
 def parse_structured_discuss_review(
-    text: str, *, reviewer: str, round_number: int = 1
+    text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
 ) -> ParsedDiscussReview | None:
     payload = _extract_structured_discuss_review_payload(text)
     if payload is None:
@@ -1836,7 +1891,7 @@ def parse_structured_discuss_review(
         payload,
         context="discuss_review",
         required={"schema_version", "kind", "outcome", "rationale"},
-        optional={"split_proposals", "rebuttal", "analyzer_framing", "framing_note"},
+        optional={"split_proposals", "rebuttal", "analyzer_framing", "framing_note", "research"},
     )
     outcome = _expect_non_empty_string(payload["outcome"], context="discuss_review.outcome")
     if outcome not in DISCUSS_OUTCOME_VALUES:
@@ -1879,6 +1934,21 @@ def parse_structured_discuss_review(
         raise AgentLoopError(
             "discuss_review.framing_note requires analyzer_framing to be set."
         )
+    research_status: str | None = None
+    sourced_facts: tuple[DiscussSourcedFact, ...] = ()
+    if "research" in payload:
+        research_status, sourced_facts = _parse_discuss_research(payload["research"])
+    if research_mode == "required":
+        if research_status is None:
+            raise AgentLoopError(
+                "discuss_review.research is required when the research policy is `required`."
+            )
+        if research_status == "not-needed":
+            raise AgentLoopError(
+                "discuss_review.research.status must not be `not-needed` when the "
+                "research policy is `required`; use `sourced`, `unavailable`, or "
+                "`inconclusive`."
+            )
     return ParsedDiscussReview(
         outcome=outcome,
         rationale=rationale,
@@ -1887,13 +1957,17 @@ def parse_structured_discuss_review(
         rebuttal=rebuttal,
         analyzer_framing=analyzer_framing,
         framing_note=framing_note,
+        research_status=research_status,
+        sourced_facts=sourced_facts,
     )
 
 
 def validate_structured_discuss_review(
-    text: str, *, reviewer: str, round_number: int = 1
+    text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
 ) -> ParsedDiscussReview:
-    parsed = parse_structured_discuss_review(text, reviewer=reviewer, round_number=round_number)
+    parsed = parse_structured_discuss_review(
+        text, reviewer=reviewer, round_number=round_number, research_mode=research_mode
+    )
     if parsed is not None:
         return parsed
     raise AgentLoopError("Discuss review did not use the required structured format.")
@@ -1940,7 +2014,7 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         payload,
         context="discuss_agenda",
         required={"schema_version", "kind", "consensus", "disagreements"},
-        optional={"missing_facts"},
+        optional={"missing_facts", "research_required", "research_questions"},
     )
     consensus = _expect_string_list(
         payload["consensus"],
@@ -1962,10 +2036,32 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         context="discuss_agenda.missing_facts",
         item_context="discuss_agenda.missing_facts",
     )
+    research_required = False
+    if "research_required" in payload:
+        research_required = _expect_bool(
+            payload["research_required"], context="discuss_agenda.research_required"
+        )
+    research_questions = _expect_optional_string_list(
+        payload,
+        "research_questions",
+        context="discuss_agenda.research_questions",
+        item_context="discuss_agenda.research_questions",
+    )
+    if research_required and not research_questions:
+        raise AgentLoopError(
+            "discuss_agenda.research_questions must be non-empty when "
+            "research_required is true."
+        )
+    if research_questions and not research_required:
+        raise AgentLoopError(
+            "discuss_agenda.research_questions requires research_required to be true."
+        )
     return ParsedDiscussAgenda(
         consensus=consensus,
         disagreements=disagreements,
         missing_facts=missing_facts,
+        research_required=research_required,
+        research_questions=research_questions,
     )
 
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -270,7 +270,11 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
   "outcome": "implement" | "do-not-implement" | "needs-human" | "split",
   "rationale": "<short rationale>",
   "split_proposals": ["Sub-issue title 1", "Sub-issue title 2"],
-  "rebuttal": "<required in debate rounds; omit in initial round>"
+  "rebuttal": "<required in debate rounds; omit in initial round>",
+  "research": {
+    "status": "sourced" | "not-needed" | "unavailable" | "inconclusive",
+    "sourced_facts": [{"fact": "<external fact>", "source": "<URL or reference>"}]
+  }
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- <Reviewer Name>
@@ -281,6 +285,8 @@ Notes:
 - split_proposals is required and must be non-empty when outcome is "split"; omit or use [] otherwise.
 - rebuttal is optional in the initial discuss round and required in debate rounds.
 - analyzer_framing (optional) must be "accurate" or "misframed"; framing_note is required when analyzer_framing is "misframed".
+- research (optional): keep it only when the original reported research; never invent statuses, facts, or sources, and never drop ones the original stated.
+- research.sourced_facts must be non-empty when research.status is "sourced" (each entry needs non-empty fact and source) and empty or omitted for other statuses.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format F — Discuss Agenda:
@@ -296,7 +302,9 @@ Notes:
       "question_for_next_round": "<one specific question>"
     }
   ],
-  "missing_facts": ["<missing fact or assumption>"]
+  "missing_facts": ["<missing fact or assumption>"],
+  "research_required": false,
+  "research_questions": []
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- <Analyzer Name>
@@ -305,6 +313,8 @@ Notes:
 - consensus, disagreements, and missing_facts may be empty arrays.
 - each disagreement requires non-empty topic, positions, and question_for_next_round.
 - positions maps debater display names to short position statements and must not be empty.
+- research_required/research_questions (optional): keep them only when present in the original; never invent research questions or drop ones the original stated.
+- research_questions must be non-empty when research_required is true, and empty or omitted when it is false or absent.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format D — Plan Revision:
@@ -788,6 +798,48 @@ CORRECT repair — strip fences, convert positions to an object keyed by debater
 Notes:
 - discuss_agenda uses AGENT_PLAN_STATE and the footer state must always be "approved".
 - Preserve every disagreement and every debater position; never invent or drop positions.
+
+## WORKED EXAMPLE 16 — discuss_review with a research object:
+
+Original (malformed): discuss_review JSON wrapped in ```json fences, with sourced research.
+
+```json
+{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "implement",
+  "rationale": "The migration is still supported, so the issue is actionable.",
+  "research": {
+    "status": "sourced",
+    "sourced_facts": [
+      {"fact": "Gemini CLI remains available for enterprise users.", "source": "https://example.com/gemini-cli-notice"}
+    ]
+  }
+}
+```
+
+<!-- AGENT_PLAN_STATE: approved -->
+-- Codex
+
+CORRECT repair — strip fences and keep the research object exactly as stated:
+{
+  "schema_version": 1,
+  "kind": "discuss_review",
+  "outcome": "implement",
+  "rationale": "The migration is still supported, so the issue is actionable.",
+  "research": {
+    "status": "sourced",
+    "sourced_facts": [
+      {"fact": "Gemini CLI remains available for enterprise users.", "source": "https://example.com/gemini-cli-notice"}
+    ]
+  }
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Codex
+
+Notes:
+- Preserve research.status, every sourced fact, and every source verbatim; never invent or drop them.
+- If the original reported no research, do not add a research object.
 
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -49,6 +49,9 @@ class PostedRoundMetadata:
     # Raw structured discuss-agenda response from the optional analyzer (#467).
     # None on final summaries, plain-mode rounds, and legacy comments.
     analyzer_response: str | None = None
+    # Discuss research policy in effect when the comment was posted (#477).
+    # None on non-discuss flows and legacy comments.
+    research_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -144,6 +147,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "is_final": metadata.is_final,
         "agenda": list(metadata.agenda),
         "analyzer_response": metadata.analyzer_response,
+        "research_mode": metadata.research_mode,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -188,6 +192,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             analyzer_response=(
                 str(payload["analyzer_response"])
                 if payload.get("analyzer_response") is not None
+                else None
+            ),
+            research_mode=(
+                str(payload["research_mode"])
+                if payload.get("research_mode") is not None
                 else None
             ),
         )

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -1097,3 +1097,213 @@ def test_render_public_discuss_comment_without_framing_is_unchanged():
     )
     rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=1)
     assert "Analyzer" not in rendered
+
+
+# --- discuss research policy rendering tests (#477) ---
+
+from coding_review_agent_loop.protocol import DiscussSourcedFact
+
+
+def _discuss_research_vote(
+    *,
+    reviewer: str,
+    outcome: str = "implement",
+    research_status: str | None = None,
+    sourced_facts: tuple[DiscussSourcedFact, ...] = (),
+) -> ParsedDiscussReview:
+    return ParsedDiscussReview(
+        outcome=outcome,
+        rationale="Good scope.",
+        split_proposals=(),
+        reviewer=reviewer,
+        research_status=research_status,
+        sourced_facts=sourced_facts,
+    )
+
+
+def test_render_public_discuss_comment_renders_sourced_facts():
+    parsed = _discuss_research_vote(
+        reviewer="Codex",
+        research_status="sourced",
+        sourced_facts=(
+            DiscussSourcedFact(
+                fact="Gemini CLI remains available for enterprise users.",
+                source="https://example.com/gemini-cli-notice",
+            ),
+        ),
+    )
+    rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=1)
+    assert "**Research:** done, sourced facts cited below (`sourced`)" in rendered
+    assert "### Sourced facts" in rendered
+    assert (
+        "- Gemini CLI remains available for enterprise users. — source: "
+        "https://example.com/gemini-cli-notice" in rendered
+    )
+
+
+def test_render_public_discuss_comment_renders_unavailable_status_without_facts():
+    parsed = _discuss_research_vote(reviewer="Codex", research_status="unavailable")
+    rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=1)
+    assert "**Research:**" in rendered
+    assert "`unavailable`" in rendered
+    assert "### Sourced facts" not in rendered
+
+
+def test_render_public_discuss_comment_without_research_is_unchanged():
+    parsed = _discuss_research_vote(reviewer="Codex")
+    rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=1)
+    assert "Research" not in rendered
+    assert "Sourced facts" not in rendered
+
+
+def test_render_discuss_summary_final_default_has_no_research_section():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="unanimous",
+        subject="abc123",
+        reviewer_votes=[_discuss_vote("implement", reviewer="Codex")],
+        split_proposals=[],
+    )
+    assert "### Research" not in rendered
+
+
+def test_render_discuss_summary_final_research_none_notes_disabled():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="unanimous",
+        subject="abc123",
+        reviewer_votes=[_discuss_vote("implement", reviewer="Codex")],
+        split_proposals=[],
+        research_mode="none",
+    )
+    assert "### Research" in rendered
+    assert "Research policy: `none`." in rendered
+    assert "Online research was disabled; all positions are agent judgment." in rendered
+
+
+def test_render_discuss_summary_final_research_distinguishes_facts_from_judgment():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="unanimous",
+        subject="abc123",
+        reviewer_votes=[
+            _discuss_research_vote(
+                reviewer="Codex",
+                research_status="sourced",
+                sourced_facts=(
+                    DiscussSourcedFact(
+                        fact="Gemini CLI remains available.",
+                        source="https://example.com/notice",
+                    ),
+                ),
+            ),
+            _discuss_research_vote(reviewer="Gemini", research_status="unavailable"),
+        ],
+        split_proposals=[],
+        research_mode="required",
+    )
+    assert "### Research" in rendered
+    assert "Research policy: `required`." in rendered
+    assert "- Codex: done, sourced facts cited below (`sourced`)" in rendered
+    assert "- Gemini: unavailable — related claims are judgment, not sourced fact (`unavailable`)" in rendered
+    assert (
+        "Sourced facts cited by debaters (everything else above is agent judgment):"
+        in rendered
+    )
+    assert "- Codex: Gemini CLI remains available. — source: https://example.com/notice" in rendered
+    assert (
+        "Research was unavailable or inconclusive for Gemini; treat their related "
+        "claims as judgment, not sourced fact." in rendered
+    )
+
+
+def test_render_discuss_summary_final_research_auto_all_not_needed_is_explicit():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="unanimous",
+        subject="abc123",
+        reviewer_votes=[
+            _discuss_research_vote(reviewer="Codex", research_status="not-needed"),
+            _discuss_research_vote(reviewer="Gemini", research_status="not-needed"),
+        ],
+        split_proposals=[],
+        research_mode="auto",
+    )
+    assert "Research policy: `auto`." in rendered
+    assert (
+        "All debaters determined external research was unnecessary for this question."
+        in rendered
+    )
+
+
+def test_render_discuss_summary_final_research_unreported_status_is_explicit():
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="unanimous",
+        subject="abc123",
+        reviewer_votes=[
+            _discuss_research_vote(reviewer="Codex", research_status="not-needed"),
+            _discuss_research_vote(reviewer="Gemini"),
+        ],
+        split_proposals=[],
+        research_mode="auto",
+    )
+    assert "- Gemini: no research status reported" in rendered
+    assert (
+        "No research status was reported by Gemini; treat their claims as judgment, "
+        "not sourced fact." in rendered
+    )
+    assert "All debaters determined external research was unnecessary" not in rendered
+
+
+def test_render_discuss_summary_final_research_aggregates_facts_across_rounds():
+    round1_codex = _discuss_research_vote(
+        reviewer="Codex",
+        research_status="sourced",
+        sourced_facts=(
+            DiscussSourcedFact(fact="Round-one fact.", source="https://example.com/r1"),
+        ),
+    )
+    round2_codex = _discuss_research_vote(reviewer="Codex", research_status="not-needed")
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        outcome="implement",
+        consensus_kind="converged",
+        subject="abc123",
+        round_number=2,
+        reviewer_votes=[round2_codex],
+        round_history=[[round1_codex], [round2_codex]],
+        split_proposals=[],
+        research_mode="required",
+    )
+    # Facts cited in earlier rounds stay visible in the final summary.
+    assert "- Codex: Round-one fact. — source: https://example.com/r1" in rendered
+
+
+def test_render_discuss_summary_non_final_agenda_includes_research_brief():
+    agenda = ParsedDiscussAgenda(
+        consensus=(),
+        disagreements=(),
+        missing_facts=(),
+        research_required=True,
+        research_questions=("Is Gemini CLI still available for enterprise users?",),
+    )
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=[
+            _discuss_vote("implement", reviewer="Codex"),
+            _discuss_vote("do-not-implement", reviewer="Gemini"),
+        ],
+        analyzer_agenda=agenda,
+        analyzer_name="Anthropic Claude",
+        research_mode="auto",
+    )
+    assert "Research brief for the next round (answer with cited sources):" in rendered
+    assert "- Is Gemini CLI still available for enterprise users?" in rendered

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -31,6 +31,7 @@ def _discuss_review_text(
     reviewer: str = "OpenAI Codex",
     analyzer_framing: str | None = None,
     framing_note: str | None = None,
+    research: dict | None = None,
 ) -> str:
     payload: dict = {
         "schema_version": 1,
@@ -46,6 +47,8 @@ def _discuss_review_text(
         payload["analyzer_framing"] = analyzer_framing
     if framing_note is not None:
         payload["framing_note"] = framing_note
+    if research is not None:
+        payload["research"] = research
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
 
 
@@ -55,6 +58,8 @@ def _discuss_agenda_text(
     disagreements: list[dict] | None = None,
     missing_facts: list[str] | None = None,
     analyzer: str = "Anthropic Claude",
+    research_required: bool | None = None,
+    research_questions: list[str] | None = None,
 ) -> str:
     payload: dict = {
         "schema_version": 1,
@@ -71,6 +76,10 @@ def _discuss_agenda_text(
         ],
         "missing_facts": missing_facts if missing_facts is not None else [],
     }
+    if research_required is not None:
+        payload["research_required"] = research_required
+    if research_questions is not None:
+        payload["research_questions"] = research_questions
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {analyzer}"
 
 
@@ -1187,3 +1196,319 @@ def test_discuss_loop_agenda_claiming_consensus_is_forwarded_but_votes_rule(tmp_
     assert "Consensus kind: `deadlock` after round 2." in final
     assert "Everyone agrees to implement." in final
     assert "The debater vote table above is the authoritative consensus." in final
+
+
+# --- discuss research policy tests (#477) ---
+
+
+_SOURCED_RESEARCH = {
+    "status": "sourced",
+    "sourced_facts": [
+        {
+            "fact": "Gemini CLI remains available for enterprise users.",
+            "source": "https://example.com/gemini-cli-notice",
+        }
+    ],
+}
+
+
+def test_discuss_loop_cli_parser_accepts_discuss_research():
+    from coding_review_agent_loop.cli import build_parser
+
+    args = build_parser().parse_args(
+        ["discuss", "56", "--repo", "OWNER/REPO", "--discuss-research", "auto"]
+    )
+    assert args.discuss_research == "auto"
+    plain = build_parser().parse_args(["discuss", "56", "--repo", "OWNER/REPO"])
+    assert plain.discuss_research == "none"
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(
+            ["discuss", "56", "--repo", "OWNER/REPO", "--discuss-research", "always"]
+        )
+
+
+def test_discuss_loop_config_rejects_unknown_research_mode(tmp_path):
+    with pytest.raises(AgentLoopError, match="--discuss-research must be one of"):
+        make_config(tmp_path, reviewer=("codex", "gemini"), discuss_research="always")
+
+
+def test_discuss_loop_none_mode_prompts_forbid_research(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    review_commands = [
+        cmd for cmd, _cwd in runner.commands if "vote on whether" in " ".join(cmd)
+    ]
+    assert len(review_commands) == 2
+    for command in review_commands:
+        prompt = " ".join(command)
+        assert "Research policy: `none`" in prompt
+        assert "sourced_facts" not in prompt
+    final = runner.comments[-1]
+    assert "Research policy: `none`." in final
+    assert "Online research was disabled; all positions are agent judgment." in final
+
+
+def test_discuss_loop_required_research_renders_sourced_facts(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement", research=_SOURCED_RESEARCH)
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_research="required")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    review_commands = [
+        cmd for cmd, _cwd in runner.commands if "vote on whether" in " ".join(cmd)
+    ]
+    assert len(review_commands) == 2
+    for command in review_commands:
+        prompt = " ".join(command)
+        assert "Research policy: `required`" in prompt
+        assert "must not be `not-needed`" in prompt
+    debater_comment = runner.comments[0]
+    assert "### Sourced facts" in debater_comment
+    assert "https://example.com/gemini-cli-notice" in debater_comment
+    final = runner.comments[-1]
+    assert "### Research" in final
+    assert "Research policy: `required`." in final
+    assert "Sourced facts cited by debaters" in final
+    assert "Gemini CLI remains available for enterprise users." in final
+
+
+def test_discuss_loop_required_research_missing_research_repaired(tmp_path):
+    # The debater omits the research object; the repair pass restores it, so
+    # `required` mode is enforced by validation with repair as fallback.
+    from unittest.mock import patch
+
+    repaired = _discuss_review_text(outcome="implement", research=_SOURCED_RESEARCH)
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[repaired],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_research="required")
+
+    with patch(
+        "coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired
+    ):
+        result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert "### Sourced facts" in runner.comments[0]
+
+
+def test_discuss_loop_required_research_fails_when_repair_cannot_restore(tmp_path):
+    # conftest neuters the repair pass, so the missing research object survives
+    # repair and the debater invocation fails instead of being silently accepted.
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_research="required")
+
+    with pytest.raises(AgentLoopError, match="research is required"):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+
+def test_discuss_loop_auto_mode_analyzer_brief_propagates_to_next_round(tmp_path):
+    agenda_text = _discuss_agenda_text(
+        research_required=True,
+        research_questions=["Is Gemini CLI still available for enterprise users?"],
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(
+                outcome="implement", rationale="Scoped.", research={"status": "not-needed"}
+            ),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Still scoped.",
+                rebuttal="Holding.",
+                analyzer_framing="accurate",
+                research=_SOURCED_RESEARCH,
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Out of scope.",
+                research={"status": "not-needed"},
+            ),
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Still out of scope.",
+                rebuttal="Holding.",
+                analyzer_framing="accurate",
+                research={"status": "unavailable"},
+            ),
+        ],
+        claude_outputs=[agenda_text],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        discuss_analyzer="claude",
+        discuss_research="auto",
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    # The analyzer was asked for a research brief.
+    analyzer_prompt = " ".join(
+        next(cmd for cmd in _claude_commands(runner) if "Summarize debate round 1" in " ".join(cmd))
+    )
+    assert "research_required" in analyzer_prompt
+    # The brief propagates into round-2 debate prompts as shared context.
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Shared research brief" in prompt
+        assert "Is Gemini CLI still available for enterprise users?" in prompt
+    # The round-1 summary shows the research brief for auditability.
+    round1_summary = runner.comments[2]
+    assert "Research brief for the next round (answer with cited sources):" in round1_summary
+    # The final deadlock summary distinguishes sourced facts from judgment and
+    # is explicit about unavailable research.
+    final = runner.comments[-1]
+    assert "Research policy: `auto`." in final
+    assert "Gemini CLI remains available for enterprise users." in final
+    assert "Research was unavailable or inconclusive for Gemini" in final
+
+
+def test_discuss_loop_auto_mode_analyzer_can_decide_no_research(tmp_path):
+    agenda_text = _discuss_agenda_text(research_required=False, research_questions=[])
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(
+                outcome="implement", rationale="Scoped.", research={"status": "not-needed"}
+            ),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Still scoped.",
+                rebuttal="Holding.",
+                analyzer_framing="accurate",
+                research={"status": "not-needed"},
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="do-not-implement",
+                rationale="Out of scope.",
+                research={"status": "not-needed"},
+            ),
+            _discuss_review_text(
+                outcome="implement",
+                rationale="Convinced.",
+                rebuttal="Conceding.",
+                analyzer_framing="accurate",
+                research={"status": "not-needed"},
+            ),
+        ],
+        claude_outputs=[agenda_text],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        discuss_analyzer="claude",
+        discuss_research="auto",
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        assert "Shared research brief" not in " ".join(command)
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Research policy: `auto`." in final
+    assert (
+        "All debaters determined external research was unnecessary for this question."
+        in final
+    )
+
+
+def test_discuss_loop_research_mode_recorded_in_round_metadata(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement", research=_SOURCED_RESEARCH)
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_research="required")
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    # runner.comments strips AGENT_LOOP_META; the raw posted bodies keep it.
+    assert len(runner.issue_comments) == 3
+    for comment in runner.issue_comments:
+        match = ROUND_RESUME_MARKER_RE.search(comment["body"])
+        assert match is not None
+        metadata = _decode_round_metadata(match.group("payload"))
+        assert metadata.research_mode == "required"
+
+
+def test_discuss_loop_resume_is_lenient_about_prior_votes_without_research(tmp_path):
+    # A transcript started without a research policy resumes cleanly under
+    # `required`: enforcement applies only to newly invoked debaters.
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_research="required")
+    codex_vote_r1 = ParsedDiscussReview(
+        outcome="implement", rationale="Codex round-one rationale.", split_proposals=(), reviewer="Codex"
+    )
+    gemini_vote_r1 = ParsedDiscussReview(
+        outcome="do-not-implement",
+        rationale="Gemini round-one rationale.",
+        split_proposals=(),
+        reviewer="Gemini",
+    )
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Codex round-one rationale.", config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            outcome="do-not-implement", rationale="Gemini round-one rationale.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=(
+                "- Codex held `implement`: Codex round-one rationale.",
+                "- Gemini held `do-not-implement`: Gemini round-one rationale.",
+            ),
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement",
+        rationale="Agreed now.",
+        rebuttal="Conceding.",
+        research=_SOURCED_RESEARCH,
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Research policy: `required`." in final

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2082,3 +2082,127 @@ def test_build_discuss_review_prompt_round1_has_no_analyzer_rules(tmp_path):
     prompt = build_discuss_review_prompt(56, config, reviewer="codex", round_number=1)
     assert "analyzer_framing" not in prompt
     assert "This is round 1." in prompt
+
+
+# --- discuss research policy prompt tests (#477) ---
+
+
+def test_build_discuss_review_prompt_research_none_forbids_research(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    default = build_discuss_review_prompt(56, config, reviewer="codex", round_number=1)
+    explicit = build_discuss_review_prompt(
+        56, config, reviewer="codex", round_number=1, research_mode="none"
+    )
+    assert default == explicit
+    assert "Research policy: `none`" in default
+    assert "do not\nperform online research" in default
+    assert '"research"' not in default
+    assert "sourced_facts" not in default
+
+
+def test_build_discuss_review_prompt_research_required_enforces_sources(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_discuss_review_prompt(
+        56, config, reviewer="codex", round_number=1, research_mode="required"
+    )
+    assert "Research policy: `required`" in prompt
+    assert "Cite a source" in prompt
+    assert '"research"' in prompt
+    assert '"status": "sourced"' in prompt
+    assert "sourced_facts" in prompt
+    assert "must not be `not-needed`" in prompt
+    assert "instead of presenting stale\nassumptions as fact" in prompt
+
+
+def test_build_discuss_review_prompt_research_auto_documents_triggers(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_discuss_review_prompt(
+        56, config, reviewer="codex", round_number=1, research_mode="auto"
+    )
+    assert "Research policy: `auto`" in prompt
+    assert "conservative triggers" in prompt
+    assert "pricing, quotas, model availability" in prompt
+    assert "`not-needed`" in prompt
+    assert '"status": "not-needed"' in prompt
+    assert "must not be `not-needed`" not in prompt
+
+
+def test_build_discuss_review_prompt_renders_shared_research_brief(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    agenda = ParsedDiscussAgenda(
+        consensus=(),
+        disagreements=(
+            DiscussAgendaDisagreement(
+                topic="Scope of the change",
+                positions=(("Codex", "Narrow enough."),),
+                question_for_next_round="Would splitting resolve it?",
+            ),
+        ),
+        missing_facts=(),
+        research_required=True,
+        research_questions=("Is Gemini CLI still available for enterprise users?",),
+    )
+    prompt = build_discuss_review_prompt(
+        56,
+        config,
+        reviewer="codex",
+        round_number=2,
+        prior_round_votes=[_discuss_prompt_vote("Codex")],
+        analyzer_agenda=agenda,
+        research_mode="auto",
+    )
+    assert "Shared research brief" in prompt
+    assert "Is Gemini CLI still available for enterprise users?" in prompt
+    assert "do not duplicate work" in prompt
+
+
+def test_build_discuss_agenda_prompt_research_auto_requests_brief(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_discuss_agenda_prompt(
+        56,
+        config,
+        analyzer="claude",
+        round_number=1,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+        research_mode="auto",
+    )
+    assert "`research_required` / `research_questions`" in prompt
+    assert "conservative\ntriggers" in prompt or "conservative triggers" in prompt
+    assert '"research_required": true' in prompt
+    assert "must be non-empty when `research_required` is" in prompt
+
+
+def test_build_discuss_agenda_prompt_research_none_omits_research_fields(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    default = build_discuss_agenda_prompt(
+        56,
+        config,
+        analyzer="claude",
+        round_number=1,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+    )
+    explicit = build_discuss_agenda_prompt(
+        56,
+        config,
+        analyzer="claude",
+        round_number=1,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+        research_mode="none",
+    )
+    assert default == explicit
+    assert "research_required" not in default
+    assert "research_questions" not in default
+
+
+def test_build_discuss_agenda_prompt_research_required_focuses_questions(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    prompt = build_discuss_agenda_prompt(
+        56,
+        config,
+        analyzer="claude",
+        round_number=1,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+        research_mode="required",
+    )
+    assert "debaters must research" in prompt
+    assert "`research_required` / `research_questions`" in prompt

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -23,7 +23,9 @@ from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
     DISCUSS_ANALYZER_FRAMING_VALUES,
     DISCUSS_OUTCOME_VALUES,
+    DISCUSS_RESEARCH_STATUS_VALUES,
     DiscussAgendaDisagreement,
+    DiscussSourcedFact,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
     _expect_string_list,
@@ -2658,6 +2660,19 @@ def _discuss_review(
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: {footer} -->\n-- {reviewer}"
 
 
+def _discuss_review_with_research(*, research: dict, rebuttal: str | None = None) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_review",
+        "outcome": "implement",
+        "rationale": "The feature is well-scoped.",
+        "research": research,
+    }
+    if rebuttal is not None:
+        payload["rebuttal"] = rebuttal
+    return json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Gemini"
+
+
 def test_parse_structured_discuss_review_accepts_implement():
     text = _discuss_review(outcome="implement")
     result = parse_structured_discuss_review(text, reviewer="Gemini")
@@ -3001,3 +3016,195 @@ def test_parse_structured_discuss_review_rejects_note_without_framing():
 
 def test_discuss_analyzer_framing_values():
     assert DISCUSS_ANALYZER_FRAMING_VALUES == {"accurate", "misframed"}
+
+
+# --- discuss_review research policy tests (#477) ---
+
+
+def test_discuss_research_status_values():
+    assert DISCUSS_RESEARCH_STATUS_VALUES == {
+        "sourced",
+        "not-needed",
+        "unavailable",
+        "inconclusive",
+    }
+
+
+def test_parse_structured_discuss_review_defaults_research_fields():
+    result = parse_structured_discuss_review(_discuss_review(), reviewer="Gemini")
+    assert result is not None
+    assert result.research_status is None
+    assert result.sourced_facts == ()
+
+
+def test_parse_structured_discuss_review_research_sourced_round_trip():
+    text = _discuss_review_with_research(
+        research={
+            "status": "sourced",
+            "sourced_facts": [
+                {
+                    "fact": "Gemini CLI remains available for enterprise users.",
+                    "source": "https://example.com/gemini-cli-notice",
+                }
+            ],
+        }
+    )
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.research_status == "sourced"
+    assert result.sourced_facts == (
+        DiscussSourcedFact(
+            fact="Gemini CLI remains available for enterprise users.",
+            source="https://example.com/gemini-cli-notice",
+        ),
+    )
+
+
+def test_parse_structured_discuss_review_research_accepts_not_needed_without_facts():
+    text = _discuss_review_with_research(research={"status": "not-needed"})
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.research_status == "not-needed"
+    assert result.sourced_facts == ()
+
+
+def test_parse_structured_discuss_review_research_rejects_unknown_status():
+    text = _discuss_review_with_research(research={"status": "done"})
+    with pytest.raises(AgentLoopError, match="research.status must be one of"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_research_rejects_sourced_without_facts():
+    text = _discuss_review_with_research(research={"status": "sourced", "sourced_facts": []})
+    with pytest.raises(AgentLoopError, match="sourced_facts must be non-empty"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_research_rejects_fact_without_source():
+    text = _discuss_review_with_research(
+        research={"status": "sourced", "sourced_facts": [{"fact": "A fact."}]}
+    )
+    with pytest.raises(AgentLoopError, match="missing required field"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_research_rejects_empty_source():
+    text = _discuss_review_with_research(
+        research={"status": "sourced", "sourced_facts": [{"fact": "A fact.", "source": ""}]}
+    )
+    with pytest.raises(AgentLoopError, match="source"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_parse_structured_discuss_review_research_rejects_facts_without_sourced_status():
+    text = _discuss_review_with_research(
+        research={
+            "status": "unavailable",
+            "sourced_facts": [{"fact": "A fact.", "source": "https://example.com"}],
+        }
+    )
+    with pytest.raises(AgentLoopError, match="requires status `sourced`"):
+        parse_structured_discuss_review(text, reviewer="Gemini")
+
+
+def test_validate_structured_discuss_review_required_mode_rejects_missing_research():
+    with pytest.raises(AgentLoopError, match="research is required"):
+        validate_structured_discuss_review(
+            _discuss_review(), reviewer="Gemini", research_mode="required"
+        )
+
+
+def test_validate_structured_discuss_review_required_mode_rejects_not_needed():
+    text = _discuss_review_with_research(research={"status": "not-needed"})
+    with pytest.raises(AgentLoopError, match="must not be `not-needed`"):
+        validate_structured_discuss_review(text, reviewer="Gemini", research_mode="required")
+
+
+def test_validate_structured_discuss_review_required_mode_accepts_unavailable():
+    text = _discuss_review_with_research(research={"status": "unavailable"})
+    result = validate_structured_discuss_review(
+        text, reviewer="Gemini", research_mode="required"
+    )
+    assert result.research_status == "unavailable"
+
+
+def test_validate_structured_discuss_review_lenient_without_research_mode():
+    # Resume decoding and repair use the lenient default so transcripts started
+    # under a different research policy never fail on already-posted votes.
+    result = validate_structured_discuss_review(_discuss_review(), reviewer="Gemini")
+    assert result.research_status is None
+
+
+def test_validate_structured_discuss_review_auto_mode_accepts_missing_research():
+    result = validate_structured_discuss_review(
+        _discuss_review(), reviewer="Gemini", research_mode="auto"
+    )
+    assert result.research_status is None
+
+
+# --- discuss_agenda research brief tests (#477) ---
+
+
+def _discuss_agenda_with_research(
+    *, research_required: bool | None, research_questions: list[str] | None
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_agenda",
+        "consensus": [],
+        "disagreements": [],
+        "missing_facts": [],
+    }
+    if research_required is not None:
+        payload["research_required"] = research_required
+    if research_questions is not None:
+        payload["research_questions"] = research_questions
+    return json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+
+
+def test_parse_structured_discuss_agenda_defaults_research_fields():
+    result = parse_structured_discuss_agenda(_discuss_agenda())
+    assert result is not None
+    assert result.research_required is False
+    assert result.research_questions == ()
+
+
+def test_parse_structured_discuss_agenda_research_round_trip():
+    text = _discuss_agenda_with_research(
+        research_required=True,
+        research_questions=["Is Gemini CLI still available for enterprise users?"],
+    )
+    result = parse_structured_discuss_agenda(text)
+    assert result is not None
+    assert result.research_required is True
+    assert result.research_questions == (
+        "Is Gemini CLI still available for enterprise users?",
+    )
+
+
+def test_parse_structured_discuss_agenda_accepts_explicit_no_research():
+    text = _discuss_agenda_with_research(research_required=False, research_questions=[])
+    result = parse_structured_discuss_agenda(text)
+    assert result is not None
+    assert result.research_required is False
+    assert result.research_questions == ()
+
+
+def test_parse_structured_discuss_agenda_rejects_required_without_questions():
+    text = _discuss_agenda_with_research(research_required=True, research_questions=[])
+    with pytest.raises(AgentLoopError, match="research_questions must be non-empty"):
+        parse_structured_discuss_agenda(text)
+
+
+def test_parse_structured_discuss_agenda_rejects_questions_without_required():
+    text = _discuss_agenda_with_research(
+        research_required=None, research_questions=["A question?"]
+    )
+    with pytest.raises(AgentLoopError, match="requires research_required"):
+        parse_structured_discuss_agenda(text)
+
+
+def test_parse_structured_discuss_agenda_rejects_non_bool_research_required():
+    text = _discuss_agenda_with_research(research_required="yes", research_questions=["Q?"])
+    with pytest.raises(AgentLoopError, match="must be a boolean"):
+        parse_structured_discuss_agenda(text)


### PR DESCRIPTION
Fixes #477 (follow-up stage from #467).

## What

Adds a discuss-mode research policy threaded from CLI → config → prompts → structured protocol → round metadata → rendered comments. Research is performed by the debater agents themselves; the orchestrator instructs them per mode, enforces sourced facts in the `discuss_review` schema, lets the analyzer emit a shared research brief, and renders sourced facts vs. judgment explicitly.

## Modes

- `none` (default): prompts explicitly forbid online research; plain and analyzer discuss mode stay network-independent.
- `required`: every debater must research before answering. The structured response must carry a `research` object whose `status` is `sourced`, `unavailable`, or `inconclusive` (`not-needed` is rejected); `sourced` requires non-empty `sourced_facts` of `{fact, source}` pairs. Enforced by validation with the existing repair pass as fallback.
- `auto`: debaters self-decide using conservative documented triggers (current vendor/product behavior, pricing, quotas, model availability, laws/policies, dependency behavior, market/tool comparisons) and report `not-needed` when no trigger applies. With `--discuss-analyzer`, the analyzer also emits `research_required`/`research_questions`; the orchestrator forwards those to the next round's debaters as a shared research brief so parallel turns do not duplicate work.

## Key implementation points

- All new JSON keys are optional at parse time, so legacy transcripts, plain mode, and `none` mode are untouched; resume decoding of already-posted votes stays lenient (`research_mode=None`), so rerunning a transcript started under a different policy never fails on old comments.
- Debater comments show a `Research:` status line and a "Sourced facts" section. Final summaries add a "Research" section keeping debater-cited facts distinct from agent judgment, with explicit sentences for unnecessary, unreported, unavailable, or inconclusive research.
- The research mode in effect rides in each posted comment's `AGENT_LOOP_META` metadata.
- Consensus detection is unchanged: research fields never affect vote equality.
- The repair prompt gains schema notes, rules, and a worked example so repair preserves (never invents or strips) research fields.
- README.md and docs/local_agent_loop.md document the flag, modes, triggers, and guardrails.

## Tests

New coverage: CLI parsing and config validation; protocol parse/validate matrix (sourced facts, statuses, required-mode enforcement, agenda brief consistency); prompt content per mode incl. shared research brief; rendering of sourced-facts-vs-judgment and gap cases; end-to-end discuss runs for required research (incl. repair restore and repair-failure), auto no-research, auto research-needed brief propagation, unavailable research, metadata recording, and mixed-mode resume leniency.

Full suite: `python3 -m pytest tests/ -q` → 1271 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)