### PR TITLE
Add parallel debater execution for discuss mode (#475)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,46 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-research auto
 ```
 
+Pass `--discuss-parallel` to run same-round debaters concurrently instead of
+sequentially. Prompts are built from shared pre-round state before any debater
+launches and comments are posted only after every debater in the round
+finishes, so same-round debaters never see each other's in-progress output;
+the analyzer, consensus detection, and the round summary still run only after
+that synchronization point. Parallel mode requires a distinct workdir per
+debater — even with `--allow-shared-dir`, which is not honored between
+concurrently scheduled debaters because concurrent git/tool activity in one
+worktree can corrupt it (the analyzer or coder may still share a debater's
+directory). Sequential execution remains the default; keep it if you are
+concerned about concurrent quota/API pressure. On Ctrl-C, the orchestrator
+kills all in-flight debater process groups before exiting.
+
+Two companion flags control per-turn failure handling in both sequential and
+parallel discuss runs:
+
+- `--discuss-debater-timeout SECONDS` (default: none) puts a wall-clock limit
+  on each debater turn. A timed-out turn is killed (whole process group),
+  never retried as transient, and treated per the failure policy with failure
+  category `timeout`.
+- `--discuss-on-debater-failure fail|partial` (default: `fail`) sets the
+  policy when a debater turn fails or times out. `fail` aborts the run after
+  in-flight debaters settle (successful votes are still posted so a rerun
+  resumes them). `partial` continues the round when at least two debaters
+  produced votes: the failed debater is recorded in the round summary under
+  "Debater failures" (and in the summary's resume metadata), appears as a
+  `failed` entry in the round history, and gets a fresh turn in the next
+  round on resume. A partial round never declares final consensus — even if
+  all surviving debaters agree — so a partial final round ends in a
+  `needs-human` deadlock.
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity --reviewer claude \
+  --discuss-analyzer claude \
+  --discuss-parallel \
+  --discuss-debater-timeout 1800 \
+  --discuss-on-debater-failure partial
+```
+
 If reviewers still disagree after the configured debate rounds, the final
 round-summary comment is marked `deadlock`, uses the `needs-human` outcome, and
 summarizes each final position and the core disagreement. `split` proposals
@@ -667,7 +707,7 @@ The test suite is split across focused modules for faster, targeted runs:
 | `tests/test_backends.py` | Claude, Gemini, and Codex backend output parsing and normalization |
 | `tests/test_protocol.py` | Protocol parsing and validation (parse_review, parse_plan_review, structured payloads) |
 | `tests/test_comment_rendering.py` | Comment rendering (render_canonical_plan_steps, render_public_agent_comment, etc.) |
-| `tests/test_discuss_loop.py` | Discuss mode loop tests (per-round comments, debate/deadlock, idempotent and mid-round/multi-round resume, split proposals) |
+| `tests/test_discuss_loop.py` | Discuss mode loop tests (per-round comments, debate/deadlock, idempotent and mid-round/multi-round resume, split proposals, parallel debaters, debater timeout/failure policy) |
 | `tests/test_skill_helpers.py` | Skill helper function tests |
 | `tests/test_skill_loop.py` | Skill loop integration tests |
 | `tests/test_transient.py` | Transient error detection tests |

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -492,6 +492,67 @@ Rendering keeps sourced facts distinct from judgment:
   research policy never fails on old comments; enforcement applies only to
   newly invoked debaters.
 
+### Parallel debater execution
+
+`--discuss-parallel` runs same-round debaters concurrently instead of one
+after another:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity --reviewer claude \
+  --discuss-analyzer claude \
+  --discuss-parallel \
+  --discuss-debater-timeout 1800 \
+  --discuss-on-debater-failure partial
+```
+
+Execution model:
+
+- Every pending debater's prompt is built up front from shared pre-round state
+  (issue context, prior-round votes, the analyzer agenda), then all pending
+  turns are submitted to a thread pool. Debater comments are posted only after
+  every turn settles — from the main thread, in configured `--reviewer`
+  order — so same-round debaters never see each other's in-progress output.
+- The analyzer, consensus detection, and the round summary run only after that
+  debater synchronization point.
+- Resume works unchanged: already-posted round votes are reused without
+  re-invoking their debaters, and when every configured debater's vote resumes
+  from comments, no thread pool is constructed at all.
+- Log files are isolated per turn: debater logs end in
+  `-<agent>-discuss-r<N>.log` and analyzer logs in
+  `-<agent>-discuss-analyzer-r<N>.log`; response files already use a
+  per-invocation UUID.
+- Parallel mode requires a distinct workdir per debater and rejects the run
+  otherwise — deliberately not bypassed by `--allow-shared-dir`, because
+  concurrent git/tool activity in a single worktree can corrupt it. The
+  analyzer (or the coder) may still share a debater's directory since it runs
+  only after the synchronization point.
+- Ctrl-C kills all in-flight debater process groups, waits for the workers to
+  settle, and re-raises, so no agent subprocesses are orphaned.
+- Sequential execution remains the default; prefer it when concurrent
+  quota/API pressure across providers is a concern.
+
+Two companion flags apply in both sequential and parallel discuss runs:
+
+- `--discuss-debater-timeout SECONDS` (default: none) bounds each debater
+  turn's wall-clock time. On expiry the agent's whole process group is killed
+  (SIGTERM, then SIGKILL after a short grace); the turn is classified with
+  failure category `timeout` and is never retried as transient, since a kill
+  deadline is not a provider hiccup.
+- `--discuss-on-debater-failure fail|partial` (default: `fail`) is the
+  failure/timeout policy:
+  - `fail` aborts the run after in-flight debaters settle. Successful votes
+    are posted first so a rerun resumes them instead of re-invoking.
+  - `partial` continues the round when at least two debaters produced votes
+    (otherwise the run aborts as with `fail`). The failed debater appears in
+    the round summary under "Debater failures" with its failure category, is
+    recorded in the summary's `AGENT_LOOP_META` metadata (so resume treats the
+    missing comment as accounted for and reconstructs an internal `failed`
+    placeholder in the round history), and gets a fresh turn in the next
+    round. A partial round never declares final consensus — the placeholder
+    vote can never match real outcomes — so a partial final round ends in a
+    `needs-human` deadlock, with the failures noted in the summary.
+
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the
 detected `OWNER/REPO`. Pass `--repo` explicitly when running outside the target

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -152,6 +152,8 @@ class AntigravityBackend:
         session_id: str | None = None,
         run_id: str | None = None,
         role: str | None = None,
+        label: str | None = None,
+        timeout_seconds: float | None = None,
         log_path_override: Path | None = None,
     ) -> AgentResult:
         import json, fcntl  # Unix-only (fcntl); imported here so the module loads on Windows
@@ -170,7 +172,9 @@ class AntigravityBackend:
                 args += ["--conversation", session_id]
             # The prompt is the value of --print (must be last), not a positional.
             args += ["--print", prompt_text]
-            log_path = log_path_override or agent_log_path(config, "antigravity", run_id=run_id)
+            log_path = log_path_override or agent_log_path(
+                config, "antigravity", run_id=run_id, label=label
+            )
             log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
             # agy reads GEMINI.md from the workdir as high-priority system context before
             # the model sees the prompt. Injecting a single-shot session rule prevents
@@ -264,10 +268,10 @@ class AntigravityBackend:
                                     check=False,
                                     env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
                                     use_pty=True,
-                                    **(
-                                        {"timeout_seconds": config.repair_timeout_seconds}
+                                    timeout_seconds=(
+                                        config.repair_timeout_seconds
                                         if role == "repair"
-                                        else {}
+                                        else timeout_seconds
                                     ),
                                 )
                             finally:
@@ -312,6 +316,7 @@ class AntigravityBackend:
                                 check=False,
                                 env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
                                 use_pty=True,
+                                timeout_seconds=timeout_seconds,
                             )
                         finally:
                             if gemini_md_path.exists():

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -59,6 +59,8 @@ class AgentBackend(Protocol):
         session_id: str | None = None,
         run_id: str | None = None,
         role: str | None = None,
+        label: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> AgentResult: ...
 
 

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -108,6 +108,8 @@ class ClaudeBackend:
         session_id: str | None = None,
         run_id: str | None = None,
         role: str | None = None,
+        label: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> AgentResult:
         response_path = public_response_path(config, "claude")
         args = [config.claude_cmd, "--print", "--output-format", "json", *config.claude_args]
@@ -118,7 +120,7 @@ class ClaudeBackend:
         if session_id:
             args += ["--resume", session_id]
         args.append(with_public_response_file_instruction(prompt, response_path))
-        log_path = agent_log_path(config, "claude", run_id=run_id)
+        log_path = agent_log_path(config, "claude", run_id=run_id, label=label)
         log(config, f"Starting Claude in {config.claude_dir}; log: {log_path}; response: {response_path}")
         result = runner.run_with_log(
             args,
@@ -128,6 +130,7 @@ class ClaudeBackend:
             progress_interval_seconds=config.progress_interval_seconds,
             check=False,
             env={"AGENT_LOOP_WORKDIR": str(config.claude_dir.resolve())},
+            timeout_seconds=timeout_seconds,
         )
         log(config, f"Claude finished; log: {log_path}")
         message_text, new_session_id, usage, raw_usage, model_detected = _parse_claude_output(result.stdout)

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -239,8 +239,10 @@ class CodexBackend:
         session_id: str | None = None,
         run_id: str | None = None,
         role: str | None = None,
+        label: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> AgentResult:
-        log_path = agent_log_path(config, "codex", run_id=run_id)
+        log_path = agent_log_path(config, "codex", run_id=run_id, label=label)
         response_path = public_response_path(config, "codex")
         prompt_with_response_file = with_public_response_file_instruction(prompt, response_path)
         log(
@@ -294,6 +296,7 @@ class CodexBackend:
                 progress_interval_seconds=config.progress_interval_seconds,
                 check=False,
                 env={"AGENT_LOOP_WORKDIR": str(config.codex_dir.resolve())},
+                timeout_seconds=timeout_seconds,
             )
             response_file_text = read_public_response_file(response_path)
             message_text = _read_codex_message_file(Path(output_path)) or result.stdout

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -193,6 +193,8 @@ class GeminiBackend:
         session_id: str | None = None,
         run_id: str | None = None,
         role: str | None = None,
+        label: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> AgentResult:
         # Gemini CLI only allows file writes inside the trusted workspace (or
         # its own private temp dir, whose path we do not know ahead of time).
@@ -204,7 +206,7 @@ class GeminiBackend:
             "gemini",
             root=_gemini_public_response_root(config.gemini_dir),
         )
-        log_path = agent_log_path(config, "gemini", run_id=run_id)
+        log_path = agent_log_path(config, "gemini", run_id=run_id, label=label)
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")
         if date.today() >= GEMINI_CONSUMER_CUTOFF - timedelta(days=_GEMINI_CUTOFF_WARN_AHEAD_DAYS):
             log(config, f"Gemini CLI advisory: {_GEMINI_MIGRATION_GUIDANCE}")
@@ -230,6 +232,7 @@ class GeminiBackend:
             progress_interval_seconds=config.progress_interval_seconds,
             check=False,
             env={"AGENT_LOOP_WORKDIR": str(config.gemini_dir.resolve())},
+            timeout_seconds=timeout_seconds,
         )
         log(config, f"Gemini finished; log: {log_path}")
         retired_failure = result.returncode != 0 and _gemini_retirement_signal(result.stdout or "")

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -88,5 +88,16 @@ def run_agent_result(
     session_id: str | None = None,
     run_id: str | None = None,
     role: str | None = None,
+    label: str | None = None,
+    timeout_seconds: float | None = None,
 ) -> AgentResult:
-    return get_backend(agent).run(runner, config, prompt, session_id=session_id, run_id=run_id, role=role)
+    return get_backend(agent).run(
+        runner,
+        config,
+        prompt,
+        session_id=session_id,
+        run_id=run_id,
+        role=role,
+        label=label,
+        timeout_seconds=timeout_seconds,
+    )

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -468,6 +468,39 @@ def build_parser() -> argparse.ArgumentParser:
             "tool comparisons."
         ),
     )
+    discuss.add_argument(
+        "--discuss-parallel",
+        action="store_true",
+        help=(
+            "Run same-round debaters concurrently instead of sequentially. The "
+            "analyzer and summary still run only after every debater finishes "
+            "(or the failure policy fires). Requires a distinct workdir per "
+            "debater, even with --allow-shared-dir."
+        ),
+    )
+    discuss.add_argument(
+        "--discuss-debater-timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Wall-clock limit for each debater turn in seconds (default: none). "
+            "A timed-out debater is treated per --discuss-on-debater-failure "
+            "with failure category 'timeout'."
+        ),
+    )
+    discuss.add_argument(
+        "--discuss-on-debater-failure",
+        choices=("fail", "partial"),
+        default="fail",
+        help=(
+            "Policy when a debater turn fails or times out (default: fail). "
+            "'fail' aborts the run after in-flight debaters settle; 'partial' "
+            "continues the round when at least two debaters produced votes and "
+            "records the failures in the round summary. A partial round never "
+            "declares final consensus."
+        ),
+    )
     add_common(discuss)
 
     return parser

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -788,6 +788,26 @@ def _render_discuss_research_section(
     return lines
 
 
+def _render_discuss_failed_debater_lines(
+    failed_debaters: Sequence[tuple[str, str]],
+    *,
+    is_final: bool = False,
+) -> list[str]:
+    """Surface failed/timed-out debaters in the round summary (#475)."""
+    if not failed_debaters:
+        return []
+    lines = ["", "### Debater failures", ""]
+    for name, category in failed_debaters:
+        lines.append(f"- {name}: no vote this round ({category})")
+    if is_final:
+        lines.append("")
+        lines.append(
+            "This round completed with partial results, so it cannot declare "
+            "final consensus."
+        )
+    return lines
+
+
 def render_discuss_round_summary_comment(
     *,
     is_final: bool,
@@ -801,6 +821,7 @@ def render_discuss_round_summary_comment(
     analyzer_agenda: ParsedDiscussAgenda | None = None,
     analyzer_name: str | None = None,
     research_mode: str | None = None,
+    failed_debaters: Sequence[tuple[str, str]] = (),
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -824,6 +845,7 @@ def render_discuss_round_summary_comment(
         for vote in reviewer_votes:
             rationale = vote.rationale.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {vote.reviewer} | {vote.outcome} | {rationale} |")
+        lines.extend(_render_discuss_failed_debater_lines(failed_debaters))
         if split_proposals:
             lines.append("")
             lines.append("### Proposed sub-issues raised this round")
@@ -869,6 +891,7 @@ def render_discuss_round_summary_comment(
     for vote in reviewer_votes:
         rationale = vote.rationale.replace("|", "\\|").replace("\n", " ")
         lines.append(f"| {vote.reviewer} | {vote.outcome} | {rationale} |")
+    lines.extend(_render_discuss_failed_debater_lines(failed_debaters, is_final=True))
     rebuttal_votes = [vote for vote in reviewer_votes if vote.rebuttal]
     if rebuttal_votes:
         lines.append("")

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -43,6 +43,9 @@ DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3 Flash",)
 # validation, and the prompt builders all derive from this set.
 DISCUSS_RESEARCH_MODES: frozenset[str] = frozenset({"none", "required", "auto"})
 
+# Discuss-mode debater failure policy values (#475).
+DISCUSS_DEBATER_FAILURE_MODES: frozenset[str] = frozenset({"fail", "partial"})
+
 
 @dataclass(frozen=True)
 class AgentLoopConfig:
@@ -108,6 +111,15 @@ class AgentLoopConfig:
     # "required" enforces sourced external facts from every debater, "auto"
     # lets debaters/analyzer decide using conservative triggers.
     discuss_research: str = "none"
+    # Parallel debater execution for discuss mode (#475). Opt-in; sequential
+    # stays the default to avoid surprise quota pressure.
+    discuss_parallel: bool = False
+    # Per-debater-turn wall-clock limit in seconds; None disables the limit.
+    discuss_debater_timeout: float | None = None
+    # What to do when a debater turn fails or times out: "fail" aborts the run
+    # (today's behavior); "partial" continues the round with >= 2 surviving
+    # votes and records the failure in the round summary.
+    discuss_on_debater_failure: str = "fail"
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -134,6 +146,11 @@ class AgentLoopConfig:
         if self.discuss_research not in DISCUSS_RESEARCH_MODES:
             rendered = ", ".join(f"'{mode}'" for mode in sorted(DISCUSS_RESEARCH_MODES))
             raise AgentLoopError(f"--discuss-research must be one of: {rendered}.")
+        if self.discuss_on_debater_failure not in DISCUSS_DEBATER_FAILURE_MODES:
+            rendered = ", ".join(f"'{mode}'" for mode in sorted(DISCUSS_DEBATER_FAILURE_MODES))
+            raise AgentLoopError(f"--discuss-on-debater-failure must be one of: {rendered}.")
+        if self.discuss_debater_timeout is not None and self.discuss_debater_timeout <= 0:
+            raise AgentLoopError("--discuss-debater-timeout must be greater than zero seconds.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -775,6 +792,9 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         repair_timeout_seconds=getattr(args, "repair_timeout_seconds", 120),
         discuss_analyzer=getattr(args, "discuss_analyzer", None),
         discuss_research=getattr(args, "discuss_research", "none") or "none",
+        discuss_parallel=getattr(args, "discuss_parallel", False),
+        discuss_debater_timeout=getattr(args, "discuss_debater_timeout", None),
+        discuss_on_debater_failure=getattr(args, "discuss_on_debater_failure", "fail") or "fail",
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/errors.py
+++ b/src/coding_review_agent_loop/errors.py
@@ -28,6 +28,19 @@ class UnknownPriorItemDispositionError(AgentLoopError):
         super().__init__(message)
 
 
+class AgentInvocationError(AgentLoopError):
+    """Raised when an agent invocation fails after retries/repair.
+
+    Carries the failure category (`transient`, `non-retryable`, `deterministic`,
+    `timeout`, ...) so callers such as the discuss debater failure policy can
+    surface it in summaries and metadata without re-parsing the message.
+    """
+
+    def __init__(self, message: str, *, failure_category: str | None = None) -> None:
+        super().__init__(message)
+        self.failure_category = failure_category
+
+
 class QuotaResetExceededError(AgentLoopError):
     """Raised when a rate-limit reset time exceeds the auto-retry threshold.
 

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -22,10 +22,17 @@ def new_run_id() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
 
 
-def agent_log_path(config: AgentLoopConfig, agent: str, *, run_id: str | None = None) -> Path:
+def agent_log_path(
+    config: AgentLoopConfig,
+    agent: str,
+    *,
+    run_id: str | None = None,
+    label: str | None = None,
+) -> Path:
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     prefix = f"{run_id}-" if run_id else ""
-    return config.log_dir / f"{prefix}{stamp}-{agent}.log"
+    suffix = f"-{label}" if label else ""
+    return config.log_dir / f"{prefix}{stamp}-{agent}{suffix}.log"
 
 
 def run_usage_summary_path(config: AgentLoopConfig, run_id: str) -> Path:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -9,10 +9,12 @@ import re
 import sys
 import zoneinfo
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace as dataclasses_replace
+from pathlib import Path
 
 from .agents.base import AgentName, AgentResult
-from .agents.registry import agent_display_name, run_agent_result
+from .agents.registry import agent_display_name, get_backend, run_agent_result
 from .config import (
     AgentLoopConfig,
     ensure_agent_workdirs,
@@ -36,7 +38,12 @@ from .decomposition import (
     post_one_shot_impl_handoff_comment,
     post_phase_implementation_handoff_comment,
 )
-from .errors import AgentLoopError, QuotaResetExceededError, UnknownPriorItemDispositionError
+from .errors import (
+    AgentInvocationError,
+    AgentLoopError,
+    QuotaResetExceededError,
+    UnknownPriorItemDispositionError,
+)
 from .github import (
     IssueContext,
     PullRequestChecks,
@@ -77,9 +84,12 @@ from .prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from .protocol import (
+    DISCUSS_FAILED_OUTCOME,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
+    failed_discuss_review_category,
+    failed_discuss_review_placeholder,
     ParsedPlanReview,
     ParsedReview,
     PUBLIC_RESPONSE_MARKER,
@@ -820,7 +830,7 @@ def _format_invalid_agent_response_error(
     category: str | None = None,
 ) -> str:
     exit_context = ""
-    if result is not None and result.returncode != 0:
+    if result is not None and result.returncode not in (0, None):
         exit_context = f" Agent exit code: {result.returncode}."
     log_context = _agent_log_context(log_paths)
     category_hint = ""
@@ -830,6 +840,8 @@ def _format_invalid_agent_response_error(
         category_hint = " Failure category: non-retryable (check credentials or billing)."
     elif category == "deterministic":
         category_hint = " Failure category: deterministic (may require a code fix)."
+    elif category == "timeout":
+        category_hint = " Failure category: timeout (the agent exceeded the configured time limit)."
     classification_text = (result.raw_output or result.text or "") if result is not None else ""
     suggestion = _failure_suggestion(category, reason, agent_name, classification_text=classification_text)
     suggestion_line = f"\n{suggestion}" if suggestion else ""
@@ -960,6 +972,8 @@ def _run_validated_agent(
     repair_allowed_prior_item_ids: Sequence[str] | None = None,
     ledger_incomplete: bool = False,
     role: str | None = None,
+    label: str | None = None,
+    timeout_seconds: float | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -978,6 +992,8 @@ def _run_validated_agent(
             session_id=session_id,
             run_id=usage_context.run_id if usage_context is not None else None,
             role=role,
+            label=label,
+            timeout_seconds=timeout_seconds,
         )
         last_result = result
         if result.log_path is not None:
@@ -995,6 +1011,16 @@ def _run_validated_agent(
             )
 
         should_retry = False
+        if result.returncode is None:
+            # Timed out (returncode=None from Runner.run_with_log). Detected
+            # before transient classification: a kill deadline is not a
+            # provider hiccup, so retrying or repairing would only waste the
+            # same wall-clock budget again (#475).
+            limit = f" after {timeout_seconds:g}s" if timeout_seconds is not None else ""
+            last_error = f"agent command timed out{limit}"
+            last_classification_text = ""
+            last_failure_category = "timeout"
+            break
         if result.returncode != 0:
             last_error = f"agent command exited with {result.returncode}"
             classification_text = _agent_failure_classification_text(result, phase="command")
@@ -1413,7 +1439,7 @@ def _run_validated_agent(
                 continue
         break
 
-    raise AgentLoopError(
+    raise AgentInvocationError(
         _format_invalid_agent_response_error(
             agent_name=agent_name,
             marker_description=marker_description,
@@ -1421,7 +1447,8 @@ def _run_validated_agent(
             result=last_result,
             log_paths=log_paths,
             category=last_failure_category,
-        )
+        ),
+        failure_category=last_failure_category,
     )
 
 
@@ -3624,6 +3651,7 @@ def _run_discuss_analyzer(
             use_repair=True,
             repair_expected_kind="discuss_agenda",
             role="reviewer",
+            label=f"discuss-analyzer-r{round_number}",
         )
     except QuotaResetExceededError:
         raise
@@ -3650,6 +3678,121 @@ def _run_discuss_analyzer(
             "forwarding as-is",
         )
     return parsed, response.text
+
+
+@dataclass(frozen=True)
+class _DiscussDebaterTurnResult:
+    """Outcome of one debater turn: a validated response or a captured failure.
+
+    Worker threads in the parallel path return these instead of raising, so
+    exceptions never cross the thread boundary; the main thread applies the
+    failure policy after all futures settle (#475).
+    """
+
+    reviewer_name: str
+    response: ValidatedAgentResponse | None = None
+    error: AgentLoopError | None = None
+
+    @property
+    def failure_category(self) -> str:
+        return getattr(self.error, "failure_category", None) or "error"
+
+
+def _ensure_parallel_discuss_workdirs(config: AgentLoopConfig) -> None:
+    """Reject shared workdirs among concurrently scheduled debaters (#475).
+
+    Deliberately NOT bypassed by --allow-shared-dir: concurrent git/tool
+    activity from two agents in one worktree can race and corrupt it. The
+    analyzer (or the coder) may still share a debater's directory because it
+    runs only after the debater synchronization point.
+    """
+    from .config import reviewers as _reviewers
+
+    seen: dict[Path, AgentName] = {}
+    for reviewer in _reviewers(config):
+        path = get_backend(reviewer).workdir(config).resolve()
+        other = seen.get(path)
+        if other is not None:
+            raise AgentLoopError(
+                "--discuss-parallel requires a distinct workdir per debater: "
+                f"{agent_display_name(other)} and {agent_display_name(reviewer)} "
+                f"both resolve to {path}. Use separate clones/worktrees per debater "
+                "or drop --discuss-parallel; --allow-shared-dir does not lift this "
+                "requirement."
+            )
+        seen[path] = reviewer
+
+
+def _run_discuss_debater_turn(
+    runner: Runner,
+    *,
+    reviewer: AgentName,
+    reviewer_name: str,
+    config: AgentLoopConfig,
+    prompt: str,
+    round_number: int,
+    usage_context: RunUsageContext,
+) -> ValidatedAgentResponse:
+    """Run one debater turn from a prebuilt prompt.
+
+    Never posts to GitHub or mutates shared round state, so it is safe to call
+    from a worker thread; the caller posts the comment after the round's
+    synchronization point.
+    """
+    return _run_validated_agent(
+        runner,
+        agent=reviewer,
+        config=config,
+        prompt=prompt,
+        marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+        validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
+            text, reviewer=r, round_number=rn, research_mode=config.discuss_research
+        ),
+        usage_context=usage_context,
+        use_repair=True,
+        repair_expected_kind="discuss_review",
+        role="reviewer",
+        label=f"discuss-r{round_number}",
+        timeout_seconds=config.discuss_debater_timeout,
+    )
+
+
+def _post_discuss_debater_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    reviewer_name: str,
+    parsed: ParsedDiscussReview,
+    response: ValidatedAgentResponse,
+    round_number: int,
+    subject: str,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body=_attach_round_metadata(
+            render_public_agent_comment(
+                kind="discuss_review",
+                parsed=parsed,
+                agent=reviewer_name,
+                config=config,
+                model_used=response.model_used,
+                round_number=round_number,
+            ),
+            PostedRoundMetadata(
+                flow="discuss",
+                role="debater",
+                agent=reviewer_name,
+                round_number=round_number,
+                subject=subject,
+                raw_structured_coder_response=response.text,
+                model_used=response.model_used,
+                research_mode=config.discuss_research,
+            ),
+        ),
+    )
 
 
 def _run_discuss_loop(
@@ -3735,9 +3878,19 @@ def _run_discuss_loop(
         )
         final_round_number = len(round_history)
         final_votes = round_history[-1]
+        # A resumed partial round (#475) may carry placeholder votes; keep the
+        # vote table to real positions and surface the rest as failures.
+        final_successful_votes = [
+            vote for vote in final_votes if vote.outcome != DISCUSS_FAILED_OUTCOME
+        ]
+        final_failed_debaters = tuple(
+            (vote.reviewer, failed_discuss_review_category(vote))
+            for vote in final_votes
+            if vote.outcome == DISCUSS_FAILED_OUTCOME
+        )
         summary_body = render_discuss_round_summary_comment(
             round_number=final_round_number,
-            reviewer_votes=final_votes,
+            reviewer_votes=final_successful_votes,
             is_final=True,
             subject=subject,
             outcome="needs-human",
@@ -3747,6 +3900,7 @@ def _run_discuss_loop(
             analyzer_agenda=prior_analyzer_agenda,
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
+            failed_debaters=final_failed_debaters,
         )
         post_issue_comment(
             runner,
@@ -3764,6 +3918,7 @@ def _run_discuss_loop(
                     consensus_kind="deadlock",
                     agenda=(),
                     research_mode=config.discuss_research,
+                    failed_debaters=final_failed_debaters,
                 ),
             ),
         )
@@ -3775,7 +3930,9 @@ def _run_discuss_loop(
         return 0
     for round_number in range(start_round_number, max_round_number + 1):
         prior_round_votes = round_history[-1] if round_history else []
-        reviewer_votes: list[ParsedDiscussReview] = []
+        votes_by_name: dict[str, ParsedDiscussReview] = {}
+        failures_by_name: dict[str, _DiscussDebaterTurnResult] = {}
+        pending: list[AgentName] = []
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             resumed_vote = (
@@ -3787,72 +3944,189 @@ def _run_discuss_loop(
                     f"discuss: resuming {reviewer_name}'s posted round {round_number} position "
                     f"on issue #{issue_number}",
                 )
-                reviewer_votes.append(resumed_vote)
-                continue
+                votes_by_name[reviewer_name] = resumed_vote
+            else:
+                pending.append(reviewer)
+
+        def _build_debater_prompt(reviewer: AgentName) -> str:
+            return build_discuss_review_prompt(
+                issue_number,
+                config,
+                reviewer=reviewer,
+                memory=memory,
+                issue_context=prompt_issue_context,
+                round_number=round_number,
+                prior_round_votes=prior_round_votes,
+                prior_round_agenda=prior_round_agenda,
+                analyzer_agenda=prior_analyzer_agenda,
+                research_mode=config.discuss_research,
+            )
+
+        if config.discuss_parallel and pending:
+            # Same-round debaters run concurrently; prompts are built up front
+            # from shared pre-round state and comments are posted only after
+            # every future settles, so no debater can see a co-debater's
+            # in-progress round-N output. Zero-pending resumes skip this branch
+            # entirely (no executor is constructed).
+            prompts = {
+                agent_display_name(reviewer): _build_debater_prompt(reviewer)
+                for reviewer in pending
+            }
+            pending_names = [agent_display_name(reviewer) for reviewer in pending]
             log(
                 config,
-                f"discuss: invoking {reviewer_name} on issue #{issue_number} "
-                f"(round {round_number})",
+                f"discuss: invoking {', '.join(pending_names)} in parallel on "
+                f"issue #{issue_number} (round {round_number})",
             )
-            response = _run_validated_agent(
-                runner,
-                agent=reviewer,
-                config=config,
-                prompt=build_discuss_review_prompt(
-                    issue_number,
-                    config,
-                    reviewer=reviewer,
-                    memory=memory,
-                    issue_context=prompt_issue_context,
-                    round_number=round_number,
-                    prior_round_votes=prior_round_votes,
-                    prior_round_agenda=prior_round_agenda,
-                    analyzer_agenda=prior_analyzer_agenda,
-                    research_mode=config.discuss_research,
-                ),
-                marker_description="<!-- AGENT_PLAN_STATE: approved -->",
-                validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
-                    text, reviewer=r, round_number=rn, research_mode=config.discuss_research
-                ),
-                usage_context=usage_context,
-                use_repair=True,
-                repair_expected_kind="discuss_review",
-                role="reviewer",
-            )
-            parsed = response.marker_value
-            assert isinstance(parsed, ParsedDiscussReview)
-            post_issue_comment(
-                runner,
-                config=config,
-                issue_number=issue_number,
-                body=_attach_round_metadata(
-                    render_public_agent_comment(
-                        kind="discuss_review",
-                        parsed=parsed,
-                        agent=reviewer_name,
+
+            def _debater_worker(reviewer: AgentName, reviewer_name: str) -> _DiscussDebaterTurnResult:
+                try:
+                    response = _run_discuss_debater_turn(
+                        runner,
+                        reviewer=reviewer,
+                        reviewer_name=reviewer_name,
                         config=config,
-                        model_used=response.model_used,
+                        prompt=prompts[reviewer_name],
                         round_number=round_number,
-                    ),
-                    PostedRoundMetadata(
-                        flow="discuss",
-                        role="debater",
-                        agent=reviewer_name,
+                        usage_context=usage_context,
+                    )
+                except AgentLoopError as exc:
+                    # Includes QuotaResetExceededError: captured here and
+                    # re-raised on the main thread with priority.
+                    return _DiscussDebaterTurnResult(reviewer_name=reviewer_name, error=exc)
+                return _DiscussDebaterTurnResult(reviewer_name=reviewer_name, response=response)
+
+            executor = ThreadPoolExecutor(
+                max_workers=len(pending), thread_name_prefix=f"discuss-r{round_number}"
+            )
+            try:
+                futures = {
+                    agent_display_name(reviewer): executor.submit(
+                        _debater_worker, reviewer, agent_display_name(reviewer)
+                    )
+                    for reviewer in pending
+                }
+                # The analyzer synchronization point: wait for every debater.
+                turn_results = {name: future.result() for name, future in futures.items()}
+            except KeyboardInterrupt:
+                # Workers never receive the terminal SIGINT; kill their agent
+                # process groups so their wait loops return and the shutdown
+                # below completes promptly, then propagate the interrupt.
+                runner.terminate_active_processes()
+                raise
+            finally:
+                executor.shutdown(wait=True, cancel_futures=True)
+            for name in pending_names:
+                turn = turn_results[name]
+                if turn.error is None:
+                    parsed = turn.response.marker_value
+                    assert isinstance(parsed, ParsedDiscussReview)
+                    _post_discuss_debater_comment(
+                        runner,
+                        config=config,
+                        issue_number=issue_number,
+                        reviewer_name=name,
+                        parsed=parsed,
+                        response=turn.response,
                         round_number=round_number,
                         subject=subject,
-                        raw_structured_coder_response=response.text,
-                        model_used=response.model_used,
-                        research_mode=config.discuss_research,
-                    ),
-                ),
+                    )
+                    votes_by_name[name] = parsed
+                else:
+                    failures_by_name[name] = turn
+            # Successful votes are posted above even when the round is about
+            # to abort, so a rerun resumes them instead of re-invoking.
+            for name in pending_names:
+                turn = failures_by_name.get(name)
+                if turn is not None and isinstance(turn.error, QuotaResetExceededError):
+                    raise turn.error
+            if failures_by_name and config.discuss_on_debater_failure == "fail":
+                raise next(iter(failures_by_name.values())).error
+        else:
+            for reviewer in pending:
+                reviewer_name = agent_display_name(reviewer)
+                log(
+                    config,
+                    f"discuss: invoking {reviewer_name} on issue #{issue_number} "
+                    f"(round {round_number})",
+                )
+                try:
+                    response = _run_discuss_debater_turn(
+                        runner,
+                        reviewer=reviewer,
+                        reviewer_name=reviewer_name,
+                        config=config,
+                        prompt=_build_debater_prompt(reviewer),
+                        round_number=round_number,
+                        usage_context=usage_context,
+                    )
+                except QuotaResetExceededError:
+                    raise
+                except AgentLoopError as exc:
+                    if config.discuss_on_debater_failure == "fail":
+                        raise
+                    failures_by_name[reviewer_name] = _DiscussDebaterTurnResult(
+                        reviewer_name=reviewer_name, error=exc
+                    )
+                    log(
+                        config,
+                        f"discuss: {reviewer_name} failed round {round_number} "
+                        f"({failures_by_name[reviewer_name].failure_category}); continuing "
+                        "per --discuss-on-debater-failure=partial",
+                    )
+                    continue
+                parsed = response.marker_value
+                assert isinstance(parsed, ParsedDiscussReview)
+                _post_discuss_debater_comment(
+                    runner,
+                    config=config,
+                    issue_number=issue_number,
+                    reviewer_name=reviewer_name,
+                    parsed=parsed,
+                    response=response,
+                    round_number=round_number,
+                    subject=subject,
+                )
+                votes_by_name[reviewer_name] = parsed
+
+        failed_debaters: list[tuple[str, str]] = []
+        reviewer_votes: list[ParsedDiscussReview] = []
+        for reviewer in configured_reviewers:
+            reviewer_name = agent_display_name(reviewer)
+            vote = votes_by_name.get(reviewer_name)
+            if vote is not None:
+                reviewer_votes.append(vote)
+                continue
+            failure = failures_by_name[reviewer_name]
+            category = failure.failure_category
+            failed_debaters.append((reviewer_name, category))
+            reviewer_votes.append(failed_discuss_review_placeholder(reviewer_name, category))
+        if failed_debaters:
+            # Reached only under the "partial" policy: continue when at least
+            # two debaters produced votes; a partial round can never declare
+            # final consensus because the placeholder outcome differs.
+            if len(votes_by_name) < 2:
+                log(
+                    config,
+                    "discuss: --discuss-on-debater-failure=partial requires at least two "
+                    f"successful debater votes in round {round_number}, got {len(votes_by_name)}",
+                )
+                raise next(iter(failures_by_name.values())).error
+            log(
+                config,
+                f"discuss: continuing round {round_number} with partial results; failed "
+                "debater(s): "
+                + ", ".join(f"{name} ({category})" for name, category in failed_debaters),
             )
-            reviewer_votes.append(parsed)
+        successful_votes = [
+            vote for vote in reviewer_votes if vote.outcome != DISCUSS_FAILED_OUTCOME
+        ]
         round_history.append(reviewer_votes)
         consensus = _detect_discuss_consensus(reviewer_votes)
         is_final = consensus is not None or round_number == max_round_number
         if consensus is None:
             outcome = "needs-human"
-            round_split_proposals: list[str] = _merge_discuss_split_proposals(reviewer_votes)
+            round_split_proposals: list[str] = _merge_discuss_split_proposals(successful_votes)
             consensus_kind = "deadlock" if is_final else None
         else:
             outcome, round_split_proposals = consensus
@@ -3875,7 +4149,9 @@ def _run_discuss_loop(
             )
         summary_body = render_discuss_round_summary_comment(
             round_number=round_number,
-            reviewer_votes=reviewer_votes,
+            # The vote table and agenda draw from real positions only; failed
+            # debaters surface in the dedicated failures section instead.
+            reviewer_votes=successful_votes,
             is_final=is_final,
             subject=subject,
             outcome=outcome if is_final else None,
@@ -3888,8 +4164,9 @@ def _run_discuss_loop(
             analyzer_agenda=prior_analyzer_agenda if is_final else next_analyzer_agenda,
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
+            failed_debaters=tuple(failed_debaters),
         )
-        agenda = () if is_final else tuple(_render_discuss_agenda_lines(reviewer_votes))
+        agenda = () if is_final else tuple(_render_discuss_agenda_lines(successful_votes))
         post_issue_comment(
             runner,
             config=config,
@@ -3907,6 +4184,7 @@ def _run_discuss_loop(
                     agenda=agenda,
                     analyzer_response=analyzer_response_raw,
                     research_mode=config.discuss_research,
+                    failed_debaters=tuple(failed_debaters),
                 ),
             ),
         )
@@ -3938,6 +4216,8 @@ def run_discuss_loop(
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
     try:
+        if config.discuss_parallel:
+            _ensure_parallel_discuss_workdirs(config)
         config = resolve_base_branch(config, runner)
         ensure_agent_workdirs(config, runner)
         log(config, f"discuss: validating issue #{issue_number}")

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -254,6 +254,27 @@ DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-huma
 DISCUSS_ANALYZER_FRAMING_VALUES = frozenset({"accurate", "misframed"})
 DISCUSS_RESEARCH_STATUS_VALUES = frozenset({"sourced", "not-needed", "unavailable", "inconclusive"})
 
+# Internal-only outcome for debaters that failed or timed out in a partial
+# round (#475). Deliberately NOT in DISCUSS_OUTCOME_VALUES: real agent
+# responses cannot claim it. Placeholders are built only by the orchestrator
+# and by resume; their presence in a round blocks false-positive consensus.
+DISCUSS_FAILED_OUTCOME = "failed"
+
+
+def failed_discuss_review_placeholder(reviewer: str, category: str) -> ParsedDiscussReview:
+    return ParsedDiscussReview(
+        outcome=DISCUSS_FAILED_OUTCOME,
+        rationale=f"did not respond this round ({category})",
+        split_proposals=(),
+        reviewer=reviewer,
+    )
+
+
+def failed_discuss_review_category(vote: ParsedDiscussReview) -> str:
+    """Recover the failure category from a placeholder vote's rationale."""
+    match = re.fullmatch(r"did not respond this round \((.+)\)", vote.rationale)
+    return match.group(1) if match else vote.rationale
+
 
 @dataclass(frozen=True)
 class DiscussAgendaDisagreement:

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -19,6 +19,7 @@ from .protocol import (
     ParsedDiscussReview,
     ReviewItemDisposition,
     UnresolvedReviewItem,
+    failed_discuss_review_placeholder,
     parse_structured_discuss_agenda,
     parse_structured_discuss_review,
 )
@@ -52,6 +53,10 @@ class PostedRoundMetadata:
     # Discuss research policy in effect when the comment was posted (#477).
     # None on non-discuss flows and legacy comments.
     research_mode: str | None = None
+    # Debaters that failed or timed out in a partial round (#475), as
+    # (display name, failure category) pairs on the round summary. Resume
+    # treats these debaters' missing comments as accounted for.
+    failed_debaters: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -148,6 +153,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "agenda": list(metadata.agenda),
         "analyzer_response": metadata.analyzer_response,
         "research_mode": metadata.research_mode,
+        "failed_debaters": [list(pair) for pair in metadata.failed_debaters],
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -198,6 +204,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
                 str(payload["research_mode"])
                 if payload.get("research_mode") is not None
                 else None
+            ),
+            failed_debaters=tuple(
+                (str(pair[0]), str(pair[1]))
+                for pair in payload.get("failed_debaters", [])
+                if isinstance(pair, (list, tuple)) and len(pair) == 2
             ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
@@ -638,7 +649,14 @@ def _resume_discuss_round(
             if record.metadata.role == "debater":
                 debater_records[record.metadata.agent] = record
         if summary_record is not None:
-            missing = [name for name in configured_reviewer_names if name not in debater_records]
+            # Debaters recorded as failed in a partial round (#475) post no
+            # comment; their summary metadata accounts for the gap.
+            failed_by_name = dict(summary_record.metadata.failed_debaters)
+            missing = [
+                name
+                for name in configured_reviewer_names
+                if name not in debater_records and name not in failed_by_name
+            ]
             if missing:
                 raise AgentLoopError(
                     "Discuss round metadata is inconsistent: round "
@@ -647,6 +665,8 @@ def _resume_discuss_round(
                 )
             votes = tuple(
                 _decode_discuss_vote(debater_records[name], round_number=round_number)
+                if name in debater_records
+                else failed_discuss_review_placeholder(name, failed_by_name[name])
                 for name in configured_reviewer_names
             )
             round_history.append(votes)

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -55,6 +56,13 @@ class Runner:
         self.dry_run = dry_run
         self._resolved_commands: dict[str, str] = {}
         self._command_override_flags: dict[str, str] = {}
+        # Parallel discuss debaters call run_with_log from worker threads (#475):
+        # guard the command caches and keep a registry of live agent processes so
+        # the main thread can kill them on KeyboardInterrupt.
+        self._commands_lock = threading.Lock()
+        self._active_procs_lock = threading.Lock()
+        self._active_procs: dict[int, subprocess.Popen] = {}
+        self._interrupted = False
 
     def remember_agent_command(
         self,
@@ -63,8 +71,48 @@ class Runner:
         override_flag: str,
     ) -> None:
         """Retain preflight evidence for a later spawn-time PATH race."""
-        self._resolved_commands[command] = resolved_path
-        self._command_override_flags[command] = override_flag
+        with self._commands_lock:
+            self._resolved_commands[command] = resolved_path
+            self._command_override_flags[command] = override_flag
+
+    def _register_active_process(self, proc: subprocess.Popen) -> None:
+        with self._active_procs_lock:
+            self._active_procs[proc.pid] = proc
+
+    def _unregister_active_process(self, proc: subprocess.Popen) -> None:
+        with self._active_procs_lock:
+            self._active_procs.pop(proc.pid, None)
+
+    @staticmethod
+    def _terminate_process_group(proc: subprocess.Popen) -> None:
+        """killpg TERM, short grace, then killpg KILL; tolerate an exited group."""
+        try:
+            os.killpg(proc.pid, 15)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, 9)
+            except ProcessLookupError:
+                pass
+            proc.wait()
+
+    def terminate_active_processes(self) -> None:
+        """Kill every registered agent process group and refuse new spawns.
+
+        Called from the main thread on KeyboardInterrupt while parallel discuss
+        debaters run in worker threads: killing the process groups unblocks the
+        workers' wait loops so executor shutdown returns promptly, and the
+        interrupted flag stops in-flight retry logic from spawning replacements.
+        """
+        self._interrupted = True
+        with self._active_procs_lock:
+            procs = list(self._active_procs.values())
+        for proc in procs:
+            if proc.poll() is None:
+                self._terminate_process_group(proc)
 
     def _missing_command_error(self, command: str) -> AgentLoopError:
         override_flag = self._command_override_flags.get(command)
@@ -93,7 +141,8 @@ class Runner:
         command = cmd[0]
         resolved = shutil.which(command)
         if resolved is not None:
-            self._resolved_commands[command] = resolved
+            with self._commands_lock:
+                self._resolved_commands[command] = resolved
 
         for attempt in range(1, _SPAWN_ATTEMPTS + 1):
             try:
@@ -102,9 +151,10 @@ class Runner:
                 if os.path.isabs(command):
                     raise self._missing_command_error(command) from exc
                 current = shutil.which(command)
-                if current is not None:
-                    self._resolved_commands[command] = current
-                candidate = current or self._resolved_commands.get(command)
+                with self._commands_lock:
+                    if current is not None:
+                        self._resolved_commands[command] = current
+                    candidate = current or self._resolved_commands.get(command)
                 if not self._is_dangling_symlink(candidate):
                     raise self._missing_command_error(command) from exc
                 if attempt == _SPAWN_ATTEMPTS:
@@ -128,6 +178,10 @@ class Runner:
             if input_text:
                 print(input_text)
             return CommandResult(cmd, cwd, "", "", 0)
+        if self._interrupted:
+            raise AgentLoopError(
+                "Runner is shutting down after an interrupt; refusing to start new commands."
+            )
 
         proc = subprocess.run(
             cmd,
@@ -164,6 +218,10 @@ class Runner:
         if self.dry_run:
             print(f"[dry-run] ({cwd}) {' '.join(cmd)}")
             return CommandResult(cmd, cwd, "", "", 0)
+        if self._interrupted:
+            raise AgentLoopError(
+                "Runner is shutting down after an interrupt; refusing to start new commands."
+            )
 
         log_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_log_dir_ignored(log_path.parent)
@@ -179,6 +237,7 @@ class Runner:
                 timeout_seconds=timeout_seconds,
             )
         started = time.monotonic()
+        deadline = started + timeout_seconds if timeout_seconds is not None else None
         next_progress = started + progress_interval_seconds
         header = f"$ {' '.join(cmd)}\n\n"
         with log_path.open("w", encoding="utf-8") as log_file:
@@ -187,6 +246,8 @@ class Runner:
             # stderr=subprocess.STDOUT merges stderr into the log file.
             # All agent backends (Claude, Codex, Gemini) use run_with_log,
             # so stderr capture is uniform across them (issue #266).
+            # start_new_session isolates the child's process group so timeout
+            # and interrupt handling can killpg the whole tree (#475).
             proc = self._spawn_with_retry(
                 cmd,
                 lambda: subprocess.Popen(
@@ -196,15 +257,23 @@ class Runner:
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     text=True,
+                    start_new_session=True,
                     env={**os.environ, **env} if env is not None else None,
                 ),
             )
+            self._register_active_process(proc)
             try:
                 while True:
                     returncode = proc.poll()
                     if returncode is not None:
                         break
                     now = time.monotonic()
+                    if deadline is not None and now >= deadline:
+                        # returncode=None marks the timeout for callers, matching
+                        # the pty branch.
+                        self._terminate_process_group(proc)
+                        returncode = None
+                        break
                     if now >= next_progress:
                         elapsed = int(now - started)
                         print(
@@ -214,15 +283,17 @@ class Runner:
                             flush=True,
                         )
                         next_progress = now + progress_interval_seconds
-                    time.sleep(1)
+                    if deadline is not None:
+                        time.sleep(min(1.0, max(0.05, deadline - now)))
+                    else:
+                        time.sleep(1)
             except KeyboardInterrupt:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait()
+                # The child runs in its own session and no longer receives the
+                # terminal SIGINT; kill its whole process group instead.
+                self._terminate_process_group(proc)
                 raise
+            finally:
+                self._unregister_active_process(proc)
 
         full_output = log_path.read_text(encoding="utf-8")
         output = full_output[len(header):] if full_output.startswith(header) else full_output
@@ -293,24 +364,14 @@ class Runner:
             assert allocated_fds is not None
             master_fd, slave_fd = allocated_fds
             os.close(slave_fd)
+            self._register_active_process(proc)
             try:
                 timed_out = False
                 while True:
                     now = time.monotonic()
                     if deadline is not None and now >= deadline and proc.poll() is None:
                         timed_out = True
-                        try:
-                            os.killpg(proc.pid, 15)
-                        except ProcessLookupError:
-                            pass
-                        try:
-                            proc.wait(timeout=2)
-                        except subprocess.TimeoutExpired:
-                            try:
-                                os.killpg(proc.pid, 9)
-                            except ProcessLookupError:
-                                pass
-                            proc.wait()
+                        self._terminate_process_group(proc)
                     if timed_out:
                         wait_seconds = 0.1
                     elif deadline is not None:
@@ -342,14 +403,12 @@ class Runner:
                         )
                         next_progress = now + progress_interval_seconds
             except KeyboardInterrupt:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait()
+                # The child runs in its own session and does not receive the
+                # terminal SIGINT; kill its whole process group instead.
+                self._terminate_process_group(proc)
                 raise
             finally:
+                self._unregister_active_process(proc)
                 os.close(master_fd)
             returncode = None if timed_out else proc.wait()
 

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -185,6 +186,8 @@ class RunUsageContext:
     summary_path: Path
     records: list[UsageCallRecord] = field(default_factory=list)
     _next_call_id: int = 1
+    # Parallel discuss debaters add records from worker threads (#475).
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
 
     def add_record(
         self,
@@ -202,21 +205,22 @@ class RunUsageContext:
         log_path: str | None = None,
         fallback_planned: bool | None = None,
     ) -> UsageCallRecord:
-        record = UsageCallRecord(
-            call_id=self._next_call_id,
-            agent=agent,
-            session_id=session_id,
-            returncode=returncode,
-            usage=usage,
-            raw_backend_usage=raw_backend_usage,
-            role=role,
-            model=model,
-            outcome=outcome,
-            log_path=log_path,
-            fallback_planned=fallback_planned,
-        )
-        self._next_call_id += 1
-        self.records.append(record)
+        with self._lock:
+            record = UsageCallRecord(
+                call_id=self._next_call_id,
+                agent=agent,
+                session_id=session_id,
+                returncode=returncode,
+                usage=usage,
+                raw_backend_usage=raw_backend_usage,
+                role=role,
+                model=model,
+                outcome=outcome,
+                log_path=log_path,
+                fallback_planned=fallback_planned,
+            )
+            self._next_call_id += 1
+            self.records.append(record)
         return record
 
     def totals(self) -> UsageTotals:

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -285,6 +286,10 @@ class FakeRunner(Runner):
         self.public_response_outputs = list(public_response_outputs or [])
         self.advance_git_head_on_pr = advance_git_head_on_pr
         self._agent_pr_counter = 0
+        # Parallel discuss debaters (#475) call run_with_log from worker
+        # threads; scripted outputs stay keyed per agent, but the shared
+        # bookkeeping (commands, comments, response files) needs a lock.
+        self._scripted_lock = threading.RLock()
 
     def _normalize_legacy_agent_output(self, output: str, prompt: str) -> str:
         stripped = output.lstrip()
@@ -445,6 +450,15 @@ class FakeRunner(Runner):
         use_pty=False,
         timeout_seconds=None,
     ):
+        with self._scripted_lock:
+            return self._run_with_log_locked(
+                args,
+                cwd=cwd,
+                log_path=log_path,
+                check=check,
+            )
+
+    def _run_with_log_locked(self, args, *, cwd, log_path, check):
         cmd, cwd_path = self._record_command(args, cwd)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_log_dir_ignored(log_path.parent)
@@ -511,6 +525,10 @@ class FakeRunner(Runner):
         return self.run(args, cwd=cwd, check=check)
 
     def run(self, args, *, cwd, input_text=None, check=True, env=None):
+        with self._scripted_lock:
+            return self._run_locked(args, cwd=cwd, check=check)
+
+    def _run_locked(self, args, *, cwd, check):
         cmd, cwd_path = self._record_command(args, cwd)
 
         if cmd[:1] == ["claude"]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3195,7 +3195,18 @@ def test_reviewer_and_coder_call_sites_pass_correct_role(tmp_path):
     config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
     captured_roles: list = []
 
-    def mock_run(runner, *, agent, config, prompt, session_id=None, run_id=None, role=None):
+    def mock_run(
+        runner,
+        *,
+        agent,
+        config,
+        prompt,
+        session_id=None,
+        run_id=None,
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    ):
         captured_roles.append(role)
         return AgentResult(text="ok")
 
@@ -3245,7 +3256,17 @@ def test_run_agent_result_passes_role_to_backend(tmp_path, monkeypatch):
         def default_args(self, *, dangerous):
             return ()
 
-        def run(self, runner, config, prompt, session_id=None, run_id=None, role=None):
+        def run(
+            self,
+            runner,
+            config,
+            prompt,
+            session_id=None,
+            run_id=None,
+            role=None,
+            label=None,
+            timeout_seconds=None,
+        ):
             captured["role"] = role
             return AgentResult(text="ok")
 

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -147,6 +147,7 @@ def _seed_summary_comment(
     split_proposals: list[str] | None = None,
     agenda: tuple[str, ...] = (),
     analyzer_response: str | None = None,
+    failed_debaters: tuple[tuple[str, str], ...] = (),
 ) -> dict:
     """Build an issue-comment payload matching what `_run_discuss_loop` posts for a round summary."""
     body = render_discuss_round_summary_comment(
@@ -158,6 +159,7 @@ def _seed_summary_comment(
         consensus_kind=consensus_kind,
         round_history=round_history,
         split_proposals=split_proposals,
+        failed_debaters=failed_debaters,
     )
     body = _attach_round_metadata(
         body,
@@ -171,6 +173,7 @@ def _seed_summary_comment(
             consensus_kind=consensus_kind,
             agenda=agenda,
             analyzer_response=analyzer_response,
+            failed_debaters=failed_debaters,
         ),
     )
     return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
@@ -1512,3 +1515,560 @@ def test_discuss_loop_resume_is_lenient_about_prior_votes_without_research(tmp_p
     final = runner.comments[-1]
     assert "Consensus: Implement" in final
     assert "Research policy: `required`." in final
+
+
+# --- parallel debater execution tests (#475) ---
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import coding_review_agent_loop.orchestrator as orchestrator_module
+from coding_review_agent_loop.runner import CommandResult, Runner
+
+from agent_loop_helpers import read_usage_summary
+
+
+def test_discuss_loop_cli_parser_accepts_parallel_flags():
+    from coding_review_agent_loop.cli import build_parser
+
+    args = build_parser().parse_args(
+        [
+            "discuss", "56", "--repo", "OWNER/REPO",
+            "--discuss-parallel",
+            "--discuss-debater-timeout", "900",
+            "--discuss-on-debater-failure", "partial",
+        ]
+    )
+    assert args.discuss_parallel is True
+    assert args.discuss_debater_timeout == 900.0
+    assert args.discuss_on_debater_failure == "partial"
+    plain = build_parser().parse_args(["discuss", "56", "--repo", "OWNER/REPO"])
+    assert plain.discuss_parallel is False
+    assert plain.discuss_debater_timeout is None
+    assert plain.discuss_on_debater_failure == "fail"
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(
+            ["discuss", "56", "--repo", "OWNER/REPO", "--discuss-on-debater-failure", "retry"]
+        )
+
+
+def test_discuss_loop_config_rejects_invalid_failure_policy_and_timeout(tmp_path):
+    with pytest.raises(AgentLoopError, match="--discuss-on-debater-failure must be one of"):
+        make_config(tmp_path, reviewer=("codex", "gemini"), discuss_on_debater_failure="retry")
+    with pytest.raises(AgentLoopError, match="--discuss-debater-timeout must be greater than zero"):
+        make_config(tmp_path, reviewer=("codex", "gemini"), discuss_debater_timeout=0)
+
+
+class _ConcurrencyProbeRunner(FakeRunner):
+    """Each debater blocks until the other has started: deadlocks (then fails
+    fast via the wait timeout) unless same-round debaters truly overlap."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.codex_started = threading.Event()
+        self.gemini_started = threading.Event()
+        self.overlap_confirmed = True
+
+    def run_with_log(self, args, *, cwd, **kwargs):
+        cmd = [str(arg) for arg in args]
+        if cmd[:2] == ["codex", "exec"]:
+            self.codex_started.set()
+            if not self.gemini_started.wait(timeout=10):
+                self.overlap_confirmed = False
+        elif cmd[:1] == ["gemini"]:
+            self.gemini_started.set()
+            if not self.codex_started.wait(timeout=10):
+                self.overlap_confirmed = False
+        return super().run_with_log(args, cwd=cwd, **kwargs)
+
+
+def test_discuss_parallel_runs_same_round_debaters_concurrently(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = _ConcurrencyProbeRunner(
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_parallel=True)
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert runner.overlap_confirmed, "same-round debaters did not run concurrently"
+    assert len(runner.comments) == 3
+    assert "Round 1: Codex position" in runner.comments[0]
+    assert "Round 1: Gemini position" in runner.comments[1]
+    assert "Consensus: Implement" in runner.comments[2]
+
+
+def test_discuss_parallel_matches_sequential_output(tmp_path):
+    """Parity: the parallel happy path posts the same comments as sequential."""
+    outputs = {
+        "codex": [
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(
+                outcome="implement", rationale="Still scoped.", rebuttal="Holding.",
+            ),
+        ],
+        "gemini": [
+            _discuss_review_text(outcome="do-not-implement", rationale="Out of scope."),
+            _discuss_review_text(
+                outcome="implement", rationale="Convinced.", rebuttal="Conceding.",
+            ),
+        ],
+    }
+    sequential_runner = FakeRunner(
+        codex_outputs=list(outputs["codex"]), gemini_outputs=list(outputs["gemini"])
+    )
+    sequential_config = make_config(
+        tmp_path / "seq", reviewer=("codex", "gemini"), log_dir=tmp_path / "seq" / "logs"
+    )
+    parallel_runner = FakeRunner(
+        codex_outputs=list(outputs["codex"]), gemini_outputs=list(outputs["gemini"])
+    )
+    parallel_config = make_config(
+        tmp_path / "par",
+        reviewer=("codex", "gemini"),
+        log_dir=tmp_path / "par" / "logs",
+        discuss_parallel=True,
+    )
+
+    assert run_discuss_loop(sequential_runner, issue_number=56, config=sequential_config, discuss_max_rounds=1) == 0
+    assert run_discuss_loop(parallel_runner, issue_number=56, config=parallel_config, discuss_max_rounds=1) == 0
+
+    assert parallel_runner.comments == sequential_runner.comments
+    assert "Consensus: Implement" in parallel_runner.comments[-1]
+
+
+class _EventOrderRunner(FakeRunner):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.events = []
+        self._events_lock = threading.Lock()
+
+    def _event_name(self, cmd):
+        if cmd[:2] == ["codex", "exec"]:
+            return "codex"
+        if cmd[:1] == ["gemini"]:
+            return "gemini"
+        if cmd[:1] == ["claude"]:
+            return "analyzer" if "Summarize debate round" in " ".join(cmd) else "claude"
+        return None
+
+    def run_with_log(self, args, *, cwd, **kwargs):
+        cmd = [str(arg) for arg in args]
+        name = self._event_name(cmd)
+        if name is not None:
+            with self._events_lock:
+                self.events.append(f"{name}-start")
+        result = super().run_with_log(args, cwd=cwd, **kwargs)
+        if name is not None:
+            with self._events_lock:
+                self.events.append(f"{name}-end")
+        return result
+
+
+def test_discuss_parallel_analyzer_waits_for_debater_synchronization_point(tmp_path):
+    runner = _EventOrderRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(
+                outcome="implement", rationale="Still scoped.", rebuttal="Holding.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="Out of scope."),
+            _discuss_review_text(
+                outcome="do-not-implement", rationale="Still out.", rebuttal="Holding.",
+                analyzer_framing="accurate",
+            ),
+        ],
+        claude_outputs=[_discuss_agenda_text()],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude", discuss_parallel=True
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    analyzer_start = runner.events.index("analyzer-start")
+    assert runner.events.index("codex-end") < analyzer_start
+    assert runner.events.index("gemini-end") < analyzer_start
+    # Debater comments post after the sync point, in configured order, before
+    # the round summary.
+    assert "Round 1: Codex position" in runner.comments[0]
+    assert "Round 1: Gemini position" in runner.comments[1]
+    assert "Round 1 summary" in runner.comments[2]
+
+
+def test_discuss_parallel_fail_policy_raises_after_round_settles_and_posts_survivors(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[("gemini exploded", 1)],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_parallel=True, agent_max_retries=0
+    )
+
+    with pytest.raises(AgentLoopError, match="Gemini"):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+    # The surviving debater's comment is posted before the abort so a rerun
+    # resumes it, and no round summary is posted.
+    assert len(runner.comments) == 1
+    assert "Round 1: Codex position" in runner.comments[0]
+
+
+def test_discuss_parallel_partial_policy_continues_round_and_records_failure(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        codex_outputs=[implement_text],
+        claude_outputs=[implement_text],
+        gemini_outputs=[("gemini exploded", 1)],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini", "claude"),
+        discuss_parallel=True,
+        discuss_on_debater_failure="partial",
+        agent_max_retries=0,
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    # Codex and Claude posted; Gemini did not.
+    assert len(runner.comments) == 3
+    final = runner.comments[-1]
+    # A partial round never declares consensus even though all successful
+    # debaters voted `implement`.
+    assert "Consensus: Needs Human Review (Deadlock)" in final
+    assert "Consensus: Implement" not in final
+    assert "### Debater failures" in final
+    assert "Gemini: no vote this round (deterministic)" in final
+    assert "cannot declare final consensus" in final
+    # The placeholder is visible in round history and recorded in metadata.
+    assert "Codex: `implement`, Gemini: `failed`, Claude: `implement`" in final
+    summary_raw = runner.issue_comments[-1]["body"]
+    metadata = _decode_round_metadata(ROUND_RESUME_MARKER_RE.search(summary_raw).group("payload"))
+    assert metadata.failed_debaters == (("Gemini", "deterministic"),)
+
+
+def test_discuss_sequential_partial_policy_applies_without_parallel_flag(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(
+        codex_outputs=[("codex exploded", 1)],
+        gemini_outputs=[implement_text],
+        claude_outputs=[implement_text],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini", "claude"),
+        discuss_on_debater_failure="partial",
+        agent_max_retries=0,
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    final = runner.comments[-1]
+    assert "### Debater failures" in final
+    assert "Codex: no vote this round (deterministic)" in final
+
+
+def test_discuss_partial_policy_requires_two_successful_votes(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_review_text(outcome="implement")],
+        gemini_outputs=[("gemini exploded", 1)],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        discuss_parallel=True,
+        discuss_on_debater_failure="partial",
+        agent_max_retries=0,
+    )
+
+    with pytest.raises(AgentLoopError, match="Gemini"):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+    # The lone surviving vote is still posted for resume; no summary follows.
+    assert len(runner.comments) == 1
+    assert "Round 1: Codex position" in runner.comments[0]
+
+
+def test_discuss_partial_round_resumes_from_failed_debater_metadata(tmp_path):
+    subject = _issue_subject()
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini", "claude"),
+        discuss_on_debater_failure="partial",
+    )
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    claude_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="Out of scope.", split_proposals=(), reviewer="Claude")
+    seeded = [
+        _seed_debater_comment(reviewer="Codex", round_number=1, subject=subject, outcome="implement", rationale="Scoped.", config=config),
+        _seed_debater_comment(reviewer="Claude", round_number=1, subject=subject, outcome="do-not-implement", rationale="Out of scope.", config=config),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, claude_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=("- Codex held `implement`: Scoped.", "- Claude held `do-not-implement`: Out of scope."),
+            failed_debaters=(("Gemini", "timeout"),),
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement", rationale="Agreed.", rebuttal="Conceding.",
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+        claude_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    # Round 2 re-invokes all three debaters (the failed one gets a fresh turn)
+    # without re-running round 1 or raising the completeness error.
+    assert len(runner.comments) == 4
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Round 1: Codex: `implement`, Gemini: `failed`, Claude: `do-not-implement`" in final
+    round2_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(round2_commands) == 3
+    # Round-2 debate prompts surface the placeholder position.
+    for command in round2_commands:
+        assert "Gemini: `failed`" in " ".join(command)
+
+
+def test_discuss_resume_still_raises_when_missing_debater_has_no_failure_metadata(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini", "claude"))
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    claude_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="Out of scope.", split_proposals=(), reviewer="Claude")
+    seeded = [
+        _seed_debater_comment(reviewer="Codex", round_number=1, subject=subject, outcome="implement", rationale="Scoped.", config=config),
+        _seed_debater_comment(reviewer="Claude", round_number=1, subject=subject, outcome="do-not-implement", rationale="Out of scope.", config=config),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, claude_vote_r1],
+            is_final=False,
+            subject=subject,
+            agenda=("- Codex held `implement`: Scoped.",),
+        ),
+    ]
+    runner = FakeRunner(issue_comments=seeded, codex_outputs=[], gemini_outputs=[], claude_outputs=[])
+
+    with pytest.raises(AgentLoopError, match="metadata is inconsistent"):
+        run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+
+def test_discuss_parallel_zero_pending_resume_skips_executor(tmp_path, monkeypatch):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_parallel=True)
+    seeded = [
+        _seed_debater_comment(reviewer="Codex", round_number=1, subject=subject, outcome="implement", rationale="Scoped.", config=config),
+        _seed_debater_comment(reviewer="Gemini", round_number=1, subject=subject, outcome="implement", rationale="Agreed.", config=config),
+    ]
+    runner = FakeRunner(issue_comments=seeded, codex_outputs=[], gemini_outputs=[])
+
+    def _fail_executor(*args, **kwargs):
+        raise AssertionError("ThreadPoolExecutor must not be constructed on a zero-pending resume")
+
+    monkeypatch.setattr(orchestrator_module, "ThreadPoolExecutor", _fail_executor)
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.comments) == 1
+    assert "Consensus: Implement" in runner.comments[0]
+
+
+class _TimeoutSimulatingRunner(FakeRunner):
+    """Simulates Runner.run_with_log's timeout contract (returncode=None) for gemini."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.gemini_invocations = 0
+
+    def run_with_log(self, args, *, cwd, **kwargs):
+        cmd = [str(arg) for arg in args]
+        if cmd[:1] == ["gemini"]:
+            self.gemini_invocations += 1
+            assert kwargs.get("timeout_seconds") == 45.0
+            return CommandResult(cmd, Path(cwd), "", "", None)
+        return super().run_with_log(args, cwd=cwd, **kwargs)
+
+
+def test_discuss_debater_timeout_is_partial_result_without_transient_retries(tmp_path):
+    implement_text = _discuss_review_text(outcome="implement")
+    runner = _TimeoutSimulatingRunner(
+        codex_outputs=[implement_text],
+        claude_outputs=[implement_text],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini", "claude"),
+        discuss_parallel=True,
+        discuss_on_debater_failure="partial",
+        discuss_debater_timeout=45.0,
+        agent_max_retries=2,
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    # A timeout is not transient: exactly one invocation despite retries being
+    # configured.
+    assert runner.gemini_invocations == 1
+    final = runner.comments[-1]
+    assert "### Debater failures" in final
+    assert "Gemini: no vote this round (timeout)" in final
+    summary_raw = runner.issue_comments[-1]["body"]
+    metadata = _decode_round_metadata(ROUND_RESUME_MARKER_RE.search(summary_raw).group("payload"))
+    assert metadata.failed_debaters == (("Gemini", "timeout"),)
+
+
+def test_discuss_parallel_rejects_shared_debater_workdirs_even_with_allow_shared_dir(tmp_path):
+    shared = tmp_path / "shared"
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        codex_dir=shared,
+        gemini_dir=shared,
+        allow_shared_dir=True,
+        discuss_parallel=True,
+    )
+    runner = FakeRunner(codex_outputs=[], gemini_outputs=[])
+
+    with pytest.raises(AgentLoopError, match="distinct workdir per debater"):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert len(runner.comments) == 0
+
+
+def test_discuss_parallel_artifacts_are_isolated_by_round_and_agent(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(outcome="implement", rationale="Still.", rebuttal="Holding.", analyzer_framing="accurate"),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="No."),
+            _discuss_review_text(outcome="implement", rationale="Now yes.", rebuttal="Conceding.", analyzer_framing="accurate"),
+        ],
+        claude_outputs=[_discuss_agenda_text()],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude", discuss_parallel=True
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    log_names = sorted(p.name for p in config.log_dir.glob("*.log"))
+    assert len([n for n in log_names if n.endswith("-codex-discuss-r1.log")]) == 1
+    assert len([n for n in log_names if n.endswith("-gemini-discuss-r1.log")]) == 1
+    assert len([n for n in log_names if n.endswith("-codex-discuss-r2.log")]) == 1
+    assert len([n for n in log_names if n.endswith("-gemini-discuss-r2.log")]) == 1
+    assert len([n for n in log_names if n.endswith("-claude-discuss-analyzer-r1.log")]) == 1
+    assert len(log_names) == len(set(log_names))
+    # Usage records from parallel calls are all present with unique call ids.
+    summary = read_usage_summary(config.log_dir)
+    call_ids = [record["call_id"] for record in summary["calls"]]
+    assert len(call_ids) == len(set(call_ids))
+    assert len(call_ids) == 5
+
+
+# --- non-pty Runner timeout tests (#475) ---
+
+
+def test_runner_non_pty_timeout_returns_none_and_keeps_log(tmp_path):
+    log_path = tmp_path / "logs" / "timeout.log"
+    started = time.monotonic()
+    result = Runner().run_with_log(
+        [sys.executable, "-c", "import sys,time; print('partial output', flush=True); time.sleep(30)"],
+        cwd=tmp_path,
+        log_path=log_path,
+        label="timeout-test",
+        progress_interval_seconds=300,
+        check=False,
+        timeout_seconds=0.3,
+    )
+
+    assert result.returncode is None
+    assert time.monotonic() - started < 10
+    assert "partial output" in result.stdout
+    assert "partial output" in log_path.read_text(encoding="utf-8")
+
+
+def test_runner_non_pty_timeout_kills_whole_process_group(tmp_path):
+    pid_file = tmp_path / "grandchild.pid"
+    log_path = tmp_path / "logs" / "group-timeout.log"
+    result = Runner().run_with_log(
+        ["bash", "-c", f"sleep 30 & echo $! > {pid_file}; wait"],
+        cwd=tmp_path,
+        log_path=log_path,
+        label="group-timeout-test",
+        progress_interval_seconds=300,
+        check=False,
+        timeout_seconds=0.3,
+    )
+
+    assert result.returncode is None
+    grandchild_pid = int(pid_file.read_text(encoding="utf-8").strip())
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(grandchild_pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    os.kill(grandchild_pid, 9)
+    pytest.fail("grandchild process survived the process-group kill")
+
+
+def test_discuss_parallel_non_final_partial_round_continues_to_next_round(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Scoped."),
+            _discuss_review_text(outcome="implement", rationale="Still scoped.", rebuttal="Holding."),
+        ],
+        claude_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Agreed."),
+            _discuss_review_text(outcome="implement", rationale="Still agreed.", rebuttal="Holding."),
+        ],
+        gemini_outputs=[
+            ("gemini exploded", 1),
+            _discuss_review_text(outcome="implement", rationale="Back online.", rebuttal="Joining."),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini", "claude"),
+        discuss_parallel=True,
+        discuss_on_debater_failure="partial",
+        agent_max_retries=0,
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    # Round 1: codex + claude comments, then a non-final partial summary.
+    round1_summary = runner.comments[2]
+    assert "Round 1 summary: Consensus Pending" in round1_summary
+    assert "### Debater failures" in round1_summary
+    assert "Gemini: no vote this round (deterministic)" in round1_summary
+    # Round 2: the failed debater gets a fresh turn; all three converge.
+    final = runner.comments[-1]
+    assert "Consensus: Implement" in final
+    assert "Consensus kind: `converged` after round 2." in final
+    assert "Round 1: Codex: `implement`, Gemini: `failed`, Claude: `implement`" in final
+    assert "Round 2: Codex: `implement`, Gemini: `implement`, Claude: `implement`" in final


### PR DESCRIPTION
Implements the approved plan for #475: same-round discuss debaters can run concurrently around the analyzer synchronization point, with an explicit timeout and failure policy.

Fixes #475

## What's in this PR

### New CLI flags (discuss mode)

- `--discuss-parallel` (opt-in; sequential stays the default): runs pending same-round debaters in a `ThreadPoolExecutor`. Prompts are built up front from shared pre-round state and debater comments post only after every future settles, from the main thread, in configured `--reviewer` order — so same-round debaters never see each other's in-progress output, and the analyzer/consensus/summary run only after the synchronization point. When every vote resumes from posted comments, no executor is constructed.
- `--discuss-debater-timeout SECONDS` (default: none): wall-clock limit per debater turn, enforced in both sequential and parallel modes. On expiry the agent's process group is killed and the turn is classified with the new non-transient, non-repairable `timeout` failure category (no retry/repair burns the same budget again).
- `--discuss-on-debater-failure fail|partial` (default: `fail`): `fail` aborts after in-flight debaters settle, posting survivor votes first so a rerun resumes them. `partial` continues the round with >= 2 successful votes, records failures in the round summary ("Debater failures" section) and in `AGENT_LOOP_META` metadata, and represents failed debaters as internal `failed` placeholder votes. `QuotaResetExceededError` is re-raised on the main thread with priority under either policy.

### Correctness guarantees from the plan review dispositions

- **Partial rounds are resume-compatible** (items 1/7): `PostedRoundMetadata` gains `failed_debaters: tuple[tuple[str, str], ...]`; `_resume_discuss_round` treats debaters listed there as accounted for and reconstructs placeholder votes, raising the inconsistency error only for names absent from both debater comments and failure metadata. Legacy summaries decode to an empty tuple.
- **No false consensus** (item 9): the placeholder outcome `failed` is deliberately NOT added to `DISCUSS_OUTCOME_VALUES` (real responses cannot claim it), and its presence makes `_detect_discuss_consensus` return None, so a partial final round deadlocks to `needs-human`.
- **Shared-workdir rejection** (items 2/11): parallel discuss rejects any two debaters resolving to the same workdir, explicitly not bypassed by `--allow-shared-dir`; the analyzer/coder may still share a debater's dir since they run after the sync point.
- **Label/timeout plumbing** (items 3/10): `agent_log_path` gains `label` (`discuss-r{N}` for debaters, `discuss-analyzer-r{N}` for the analyzer); `label`/`timeout_seconds` plumb through the `AgentBackend` protocol, all four backends, `run_agent_result`, and `_run_validated_agent`. Defaults preserve existing filenames; response files already use per-invocation UUIDs.
- **Timeout classification** (item 4): `_run_validated_agent` detects `returncode is None` before the exit-code branch and breaks out with category `timeout`.
- **Zero-pending resume** (item 5): computed `pending` first; an empty set skips the executor and proceeds with resumed votes (tested via a monkeypatched `ThreadPoolExecutor` that fails on construction).
- **Non-pty process-group handling** (item 6): the non-pty `run_with_log` branch gains `start_new_session=True`, deadline enforcement mirroring the pty branch (killpg TERM → grace → KILL, `ProcessLookupError`-guarded), and its KeyboardInterrupt handler uses the same process-group kill.
- **Ctrl-C with the executor** (item 8): `Runner` keeps a lock-guarded registry of active `Popen` objects; on KeyboardInterrupt the main thread calls `terminate_active_processes()` (which also refuses new spawns), unblocking worker wait loops so `executor.shutdown(wait=True, cancel_futures=True)` returns promptly before re-raising.
- **Thread safety**: `RunUsageContext.add_record` and the Runner command caches are lock-guarded; GitHub writes and round-state mutation stay main-thread-only by construction.

### Docs and tests

- README.md and docs/local_agent_loop.md document the three flags, the partial/needs-human semantics, the shared-workdir rejection, and Ctrl-C behavior.
- 18 new tests in `tests/test_discuss_loop.py` (plus a thread-safe `FakeRunner`): CLI/config validation, true concurrency via `threading.Event` coordination, analyzer synchronization and comment ordering, `fail` and `partial` policies (parallel and sequential), timeout without transient retries, partial-round resume (positive and negative), zero-pending resume, shared-workdir rejection with `--allow-shared-dir`, artifact/log/usage isolation, no-false-consensus, sequential/parallel parity, and direct non-pty `Runner.run_with_log` timeout tests (returncode `None`, process-group kill, no orphaned grandchild).

## Tests

`python3 -m pytest tests/ -q` — 1289 passed (includes the 18 new #475 tests; two existing mocks in `tests/test_agent_loop.py` were extended to accept the new `label`/`timeout_seconds` kwargs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Anthropic Claude