### PR TITLE
Add salvage artifacts for failed coder runs

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1040,6 +1040,17 @@ file is the public answer the orchestrator will validate and post. Empty
 response files, missing markers, or diagnostics-only stdout fail locally instead
 of being posted to GitHub.
 
+When a mutating coder implementation run reaches a terminal failure with a
+non-empty tracked diff, the orchestrator writes local salvage artifacts under
+`<log_dir>/salvage/<run>-<agent>-<scope>/`. That directory contains
+`partial.patch`, `changed-files.txt`, `diff-stat.txt`, best-effort
+`diff-check.txt`, `salvage-summary.md`, and `metadata.json`. The run log and
+local error point to the artifact directory. These artifacts are incomplete
+failure diagnostics only: they are not posted as a successful response, and a
+later rerun injects only the latest matching salvage summary into the coder
+prompt so the next attempt can cherry-pick or ignore it selectively. The
+orchestrator never auto-applies the patch.
+
 If strict structured-response validation fails, the log may show a repair pass:
 `schema validation failed ... attempting repair pass`, followed by either
 `repair pass recovered malformed response` or `repair pass produced invalid

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -901,7 +901,7 @@ def _capture_failed_run_salvage(
             required_marker=marker_description,
             result=result,
         )
-    except AgentLoopError as exc:
+    except (AgentLoopError, OSError) as exc:
         log(
             config,
             f"{agent_name}: salvage capture failed ({exc}); preserving original agent failure",

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -125,6 +125,13 @@ from .repair import (
     strip_unknown_prior_item_dispositions,
 )
 from .runner import Runner
+from .salvage import (
+    SalvageArtifacts,
+    SalvageContext,
+    capture_salvage_artifacts,
+    format_salvage_artifacts_for_error,
+    latest_salvage_summary,
+)
 from .transient import (
     NON_RETRYABLE_AGENT_OUTPUT_RE,
     TRANSIENT_AGENT_OUTPUT_RE,
@@ -266,6 +273,8 @@ PUBLIC_RESPONSE_TRANSIENT_DIAGNOSTIC_RE = re.compile(
     r")",
     re.I | re.S,
 )
+ISSUE_IMPLEMENTATION_SALVAGE_SCOPE = "issue-implementation"
+APPROVED_PLAN_IMPLEMENTATION_SALVAGE_SCOPE = "approved-plan-implementation"
 
 # Threshold above which a rate-limit reset time causes an immediate exit
 # rather than a silent wait (5 minutes).
@@ -855,6 +864,54 @@ def _format_invalid_agent_response_error(
     )
 
 
+def _compact_failure_reason(reason: str, classification_text: str) -> str:
+    detail = classification_text.strip()
+    if not detail or detail == reason:
+        return reason
+    lines = detail.splitlines()
+    if len(lines) > 20:
+        detail = "\n".join(lines[-20:])
+    if len(detail) > 4000:
+        detail = detail[-4000:]
+    return f"{reason}; diagnostic:\n{detail}"
+
+
+def _capture_failed_run_salvage(
+    *,
+    runner: Runner,
+    config: AgentLoopConfig,
+    agent_name: str,
+    salvage_context: SalvageContext | None,
+    failure_category: str,
+    failure_reason: str,
+    classification_text: str,
+    marker_description: str,
+    result: AgentResult | None,
+) -> SalvageArtifacts | None:
+    if salvage_context is None:
+        return None
+    try:
+        artifacts = capture_salvage_artifacts(
+            runner,
+            checkout=active_workdir(config),
+            log_dir=config.log_dir,
+            context=salvage_context,
+            failure_category=failure_category,
+            failure_reason=_compact_failure_reason(failure_reason, classification_text),
+            required_marker=marker_description,
+            result=result,
+        )
+    except AgentLoopError as exc:
+        log(
+            config,
+            f"{agent_name}: salvage capture failed ({exc}); preserving original agent failure",
+        )
+        return None
+    if artifacts is not None:
+        log(config, f"{agent_name}: salvage artifacts written to {artifacts.directory}")
+    return artifacts
+
+
 def _agent_failure_classification_text(
     result: AgentResult,
     *,
@@ -974,6 +1031,7 @@ def _run_validated_agent(
     role: str | None = None,
     label: str | None = None,
     timeout_seconds: float | None = None,
+    salvage_context: SalvageContext | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     log_paths: list[object] = []
@@ -1423,10 +1481,24 @@ def _run_validated_agent(
                 if reset_secs is not None and reset_secs > LONG_RESET_THRESHOLD_SECONDS:
                     duration_str = _format_reset_duration(reset_secs)
                     at_str = _format_reset_at_utc(reset_secs)
-                    raise QuotaResetExceededError(
+                    message = (
                         f"{agent_name} quota exhausted. Reset in {duration_str} (at {at_str}). "
                         "Rerun when quota resets, or switch to a different API key / model."
                     )
+                    artifacts = _capture_failed_run_salvage(
+                        runner=runner,
+                        config=config,
+                        agent_name=agent_name,
+                        salvage_context=salvage_context,
+                        failure_category=last_failure_category,
+                        failure_reason=message,
+                        classification_text=classification_text,
+                        marker_description=marker_description,
+                        result=last_result,
+                    )
+                    if artifacts is not None:
+                        message += format_salvage_artifacts_for_error(artifacts)
+                    raise QuotaResetExceededError(message)
             if attempt < max_attempts:
                 delay = _retry_delay(config, attempt)
                 category = last_failure_category
@@ -1439,17 +1511,28 @@ def _run_validated_agent(
                 continue
         break
 
-    raise AgentInvocationError(
-        _format_invalid_agent_response_error(
-            agent_name=agent_name,
-            marker_description=marker_description,
-            reason=last_error,
-            result=last_result,
-            log_paths=log_paths,
-            category=last_failure_category,
-        ),
+    artifacts = _capture_failed_run_salvage(
+        runner=runner,
+        config=config,
+        agent_name=agent_name,
+        salvage_context=salvage_context,
         failure_category=last_failure_category,
+        failure_reason=last_error,
+        classification_text=last_classification_text,
+        marker_description=marker_description,
+        result=last_result,
     )
+    message = _format_invalid_agent_response_error(
+        agent_name=agent_name,
+        marker_description=marker_description,
+        reason=last_error,
+        result=last_result,
+        log_paths=log_paths,
+        category=last_failure_category,
+    )
+    if artifacts is not None:
+        message += format_salvage_artifacts_for_error(artifacts)
+    raise AgentInvocationError(message, failure_category=last_failure_category)
 
 
 def _require_pr_number(text: str) -> int:
@@ -1674,6 +1757,14 @@ def _implement_approved_issue(
     plan_subject: str | None = None,
 ) -> int:
     coder_name = agent_display_name(config.coder)
+    plan_hash = approved_plan_hash(approved_plan)
+    salvage_summary = latest_salvage_summary(
+        config.log_dir,
+        repo=config.repo,
+        issue_number=issue_number,
+        scope=APPROVED_PLAN_IMPLEMENTATION_SALVAGE_SCOPE,
+        approved_plan_hash=plan_hash,
+    )
     sync_coder_base_before_implementation(config, runner)
     log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
     assigned_head_before = _read_assigned_workdir_head(runner, config)
@@ -1687,6 +1778,7 @@ def _implement_approved_issue(
             config,
             memory,
             issue_context=issue_context,
+            salvage_summary=salvage_summary,
         ),
         session_id=coder_session_id,
         marker_description="<!-- AGENT_PR: <number> --> or PR URL",
@@ -1698,6 +1790,14 @@ def _implement_approved_issue(
             full_omission_fallback="Fetch the issue discussion directly before implementing.",
         ),
         usage_context=usage_context,
+        salvage_context=SalvageContext(
+            repo=config.repo,
+            issue_number=issue_number,
+            scope=APPROVED_PLAN_IMPLEMENTATION_SALVAGE_SCOPE,
+            agent=config.coder,
+            run_id=usage_context.run_id,
+            approved_plan_hash=plan_hash,
+        ),
     )
     coder_output = coder_response.text
     validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
@@ -1722,7 +1822,7 @@ def _implement_approved_issue(
             config=config,
             parent_issue=one_shot_parent_issue,
             mode="implement-one-shot",
-            plan_hash=approved_plan_hash(approved_plan),
+            plan_hash=plan_hash,
             plan_subject=plan_subject or "",
             pr_number=pr_number,
             pr_head_sha=initial_pr_context.metadata.head_sha,
@@ -2558,11 +2658,23 @@ def run_issue_loop(
 
         sync_coder_base_before_implementation(config, runner)
         assigned_head_before = _read_assigned_workdir_head(runner, config)
+        salvage_summary = latest_salvage_summary(
+            config.log_dir,
+            repo=config.repo,
+            issue_number=issue_number,
+            scope=ISSUE_IMPLEMENTATION_SALVAGE_SCOPE,
+        )
         coder_response = _run_validated_agent(
             runner,
             agent=config.coder,
             config=config,
-            prompt=build_issue_prompt(issue_number, config, memory, issue_context=issue_context),
+            prompt=build_issue_prompt(
+                issue_number,
+                config,
+                memory,
+                issue_context=issue_context,
+                salvage_summary=salvage_summary,
+            ),
             marker_description="<!-- AGENT_PR: <number> --> or PR URL",
             validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
                 text,
@@ -2572,6 +2684,13 @@ def run_issue_loop(
                 full_omission_fallback="Fetch the issue discussion directly before implementing.",
             ),
             usage_context=usage_context,
+            salvage_context=SalvageContext(
+                repo=config.repo,
+                issue_number=issue_number,
+                scope=ISSUE_IMPLEMENTATION_SALVAGE_SCOPE,
+                agent=config.coder,
+                run_id=usage_context.run_id,
+            ),
         )
         coder_output = coder_response.text
         coder_session_id = coder_response.session_id

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -838,11 +838,27 @@ def _issue_pr_reference_guidance(issue_number: int) -> str:
     )
 
 
+def _salvage_summary_block(salvage_summary: str | None) -> str:
+    if not salvage_summary:
+        return ""
+    return f"""Previous failed implementation attempt salvage:
+
+The previous attempt failed. The local salvage summary below may contain useful
+partial work, but it is incomplete context only. Do not infer a successful
+response or PR from it. Do not auto-apply the patch; cherry-pick or ignore it
+selectively, and validate any reused changes yourself.
+
+{salvage_summary}
+
+"""
+
+
 def build_issue_prompt(
     issue_number: int,
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    salvage_summary: str | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -865,6 +881,7 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 )}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
+{_salvage_summary_block(salvage_summary)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
 you create the PR. Use blocking here to hand the PR to {reviewer_name} for review. Do not place
@@ -1406,6 +1423,7 @@ def build_issue_implementation_prompt(
     config: AgentLoopConfig,
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
+    salvage_summary: str | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -1429,6 +1447,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 )}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
+{_salvage_summary_block(salvage_summary)}
 
 Approved implementation plan:
 

--- a/src/coding_review_agent_loop/salvage.py
+++ b/src/coding_review_agent_loop/salvage.py
@@ -1,0 +1,387 @@
+"""Local salvage artifacts for failed mutating agent runs."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .agents.base import AgentName, AgentResult
+from .errors import AgentLoopError
+from .runner import ensure_log_dir_ignored
+
+if TYPE_CHECKING:
+    from .runner import Runner
+
+
+@dataclass(frozen=True)
+class SalvageContext:
+    repo: str
+    issue_number: int | None
+    scope: str
+    agent: AgentName
+    run_id: str | None = None
+    approved_plan_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class SalvageArtifacts:
+    directory: Path
+    patch_path: Path
+    changed_files_path: Path
+    diff_stat_path: Path
+    diff_check_path: Path
+    summary_path: Path
+    metadata_path: Path
+    summary: str
+
+
+class SalvageCaptureError(AgentLoopError):
+    """Raised when mandatory salvage inspection fails."""
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "unknown"
+
+
+def _artifact_dir(log_dir: Path, context: SalvageContext, created_at_ns: int) -> Path:
+    run_id = _slug(context.run_id or str(created_at_ns))
+    base = (
+        log_dir
+        / "salvage"
+        / f"{run_id}-{_slug(context.agent)}-{_slug(context.scope)}"
+    )
+    if not base.exists():
+        return base
+    for index in range(2, 1000):
+        candidate = base.with_name(f"{base.name}-{index}")
+        if not candidate.exists():
+            return candidate
+    raise SalvageCaptureError(f"Unable to allocate a unique salvage directory under {base.parent}")
+
+
+def _required_git_output(
+    runner: Runner,
+    checkout: Path,
+    args: tuple[str, ...],
+    *,
+    label: str,
+) -> str:
+    result = runner.run(("git", *args), cwd=checkout, check=False)
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "").strip()
+        suffix = f": {details}" if details else ""
+        raise SalvageCaptureError(
+            f"git {' '.join(args)} failed while collecting {label} "
+            f"(exit {result.returncode}){suffix}"
+        )
+    return result.stdout
+
+
+def _best_effort_diff_check(runner: Runner, checkout: Path) -> tuple[str, int | None]:
+    try:
+        result = runner.run(("git", "diff", "--check"), cwd=checkout, check=False)
+    except AgentLoopError as exc:
+        return f"git diff --check could not run: {exc}\n", None
+
+    output = ""
+    if result.stdout:
+        output += result.stdout
+    if result.stderr:
+        if output and not output.endswith("\n"):
+            output += "\n"
+        output += result.stderr
+    if not output:
+        output = "git diff --check produced no output.\n"
+    elif not output.endswith("\n"):
+        output += "\n"
+    return output, result.returncode
+
+
+def _write_text(path: Path, text: str, *, trailing_newline: bool = True) -> None:
+    if trailing_newline and text and not text.endswith("\n"):
+        text += "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def _summary_text(
+    *,
+    context: SalvageContext,
+    artifacts_dir: Path,
+    patch_path: Path,
+    changed_files_path: Path,
+    diff_stat_path: Path,
+    diff_check_path: Path,
+    metadata_path: Path,
+    failure_category: str,
+    failure_reason: str,
+    required_marker: str,
+    result: AgentResult | None,
+    status_text: str,
+    diff_check_returncode: int | None,
+) -> str:
+    response_file_missing = result is None or result.response_file_text is None
+    response_status = (
+        "missing; stdout or agent message fallback was not a valid successful response"
+        if response_file_missing
+        else "present but failed validation"
+    )
+    returncode = "none" if result is None or result.returncode is None else str(result.returncode)
+    log_path = str(result.log_path) if result is not None and result.log_path is not None else "(none)"
+    diff_check_status = (
+        "not run"
+        if diff_check_returncode is None
+        else "passed"
+        if diff_check_returncode == 0
+        else f"reported diagnostics (exit {diff_check_returncode})"
+    )
+    untracked_note = ""
+    if any(line.startswith("??") for line in status_text.splitlines()):
+        untracked_note = (
+            "\n- Untracked files appear in `changed-files.txt`; `partial.patch` "
+            "contains only `git diff HEAD --binary` output."
+        )
+    approved_hash_line = (
+        f"\n- Approved plan hash: `{context.approved_plan_hash}`"
+        if context.approved_plan_hash
+        else ""
+    )
+    return f"""# Salvage Summary
+
+The {context.agent} agent failed before producing a valid public response. No
+successful response, review result, or pull request should be inferred from this
+artifact.
+
+This patch is incomplete context only. A later attempt may cherry-pick or ignore
+it selectively, but must not treat it as validated, complete, or automatically
+applicable.
+
+- Repository: `{context.repo}`
+- Issue: `{context.issue_number if context.issue_number is not None else "unknown"}`
+- Scope: `{context.scope}`
+- Agent: `{context.agent}`{approved_hash_line}
+- Failure category: `{failure_category}`
+- Failure reason: {failure_reason}
+- Agent exit code: `{returncode}`
+- Attempt log: `{log_path}`
+- Public response file: {response_status}
+- Required marker: `{required_marker}`
+- Required marker status: missing or invalid; the failed response did not satisfy this requirement.
+- `git diff --check`: {diff_check_status}{untracked_note}
+
+## Local Artifacts
+
+- Salvage directory: `{artifacts_dir}`
+- Partial patch: `{patch_path}`
+- Changed files/status: `{changed_files_path}`
+- Diff stat: `{diff_stat_path}`
+- Diff check: `{diff_check_path}`
+- Metadata: `{metadata_path}`
+"""
+
+
+def capture_salvage_artifacts(
+    runner: Runner,
+    *,
+    checkout: Path,
+    log_dir: Path,
+    context: SalvageContext,
+    failure_category: str,
+    failure_reason: str,
+    required_marker: str,
+    result: AgentResult | None,
+) -> SalvageArtifacts | None:
+    """Capture cheap local diagnostics for a failed mutating implementation run.
+
+    Returns None when the checkout has no tracked/staged diff against HEAD. This
+    intentionally avoids turning untracked-only work into a misleading patch.
+    """
+
+    diff_text = _required_git_output(
+        runner,
+        checkout,
+        ("diff", "HEAD", "--binary"),
+        label="partial patch",
+    )
+    if not diff_text.strip():
+        return None
+
+    status_text = _required_git_output(
+        runner,
+        checkout,
+        ("status", "--short"),
+        label="changed file status",
+    )
+    diff_stat_text = _required_git_output(
+        runner,
+        checkout,
+        ("diff", "--stat", "HEAD"),
+        label="diff stat",
+    )
+    diff_check_text, diff_check_returncode = _best_effort_diff_check(runner, checkout)
+
+    created_at_ns = time.time_ns()
+    created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ensure_log_dir_ignored(log_dir)
+    artifacts_dir = _artifact_dir(log_dir, context, created_at_ns)
+    artifacts_dir.mkdir(parents=True, exist_ok=False)
+
+    patch_path = artifacts_dir / "partial.patch"
+    changed_files_path = artifacts_dir / "changed-files.txt"
+    diff_stat_path = artifacts_dir / "diff-stat.txt"
+    diff_check_path = artifacts_dir / "diff-check.txt"
+    summary_path = artifacts_dir / "salvage-summary.md"
+    metadata_path = artifacts_dir / "metadata.json"
+
+    _write_text(patch_path, diff_text, trailing_newline=False)
+    _write_text(changed_files_path, status_text or "(no status output)\n")
+    _write_text(diff_stat_path, diff_stat_text or "(no diff stat output)\n")
+    _write_text(diff_check_path, diff_check_text)
+
+    summary = _summary_text(
+        context=context,
+        artifacts_dir=artifacts_dir,
+        patch_path=patch_path,
+        changed_files_path=changed_files_path,
+        diff_stat_path=diff_stat_path,
+        diff_check_path=diff_check_path,
+        metadata_path=metadata_path,
+        failure_category=failure_category,
+        failure_reason=failure_reason,
+        required_marker=required_marker,
+        result=result,
+        status_text=status_text,
+        diff_check_returncode=diff_check_returncode,
+    )
+    _write_text(summary_path, summary)
+
+    metadata: dict[str, Any] = {
+        "schema_version": 1,
+        "created_at": created_at,
+        "created_at_ns": created_at_ns,
+        "repo": context.repo,
+        "issue_number": context.issue_number,
+        "scope": context.scope,
+        "agent": context.agent,
+        "run_id": context.run_id,
+        "approved_plan_hash": context.approved_plan_hash,
+        "failure_category": failure_category,
+        "failure_reason": failure_reason,
+        "required_marker": required_marker,
+        "response_file_missing": result is None or result.response_file_text is None,
+        "returncode": None if result is None else result.returncode,
+        "attempt_log": None if result is None or result.log_path is None else str(result.log_path),
+        "directory": str(artifacts_dir),
+        "partial_patch": str(patch_path),
+        "changed_files": str(changed_files_path),
+        "diff_stat": str(diff_stat_path),
+        "diff_check": str(diff_check_path),
+        "diff_check_returncode": diff_check_returncode,
+        "summary": str(summary_path),
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return SalvageArtifacts(
+        directory=artifacts_dir,
+        patch_path=patch_path,
+        changed_files_path=changed_files_path,
+        diff_stat_path=diff_stat_path,
+        diff_check_path=diff_check_path,
+        summary_path=summary_path,
+        metadata_path=metadata_path,
+        summary=summary,
+    )
+
+
+def format_salvage_artifacts_for_error(artifacts: SalvageArtifacts) -> str:
+    return (
+        "\nSalvage artifacts:\n"
+        f"- directory: {artifacts.directory}\n"
+        f"- summary: {artifacts.summary_path}\n"
+        f"- patch: {artifacts.patch_path}"
+    )
+
+
+def _metadata_matches(
+    metadata: dict[str, Any],
+    *,
+    repo: str,
+    issue_number: int,
+    scope: str,
+    approved_plan_hash: str | None,
+) -> bool:
+    if metadata.get("repo") != repo:
+        return False
+    try:
+        metadata_issue = int(metadata.get("issue_number"))
+    except (TypeError, ValueError):
+        return False
+    if metadata_issue != issue_number:
+        return False
+    if metadata.get("scope") != scope:
+        return False
+    metadata_hash = metadata.get("approved_plan_hash")
+    if approved_plan_hash is not None:
+        return metadata_hash == approved_plan_hash
+    return metadata_hash in (None, "")
+
+
+def latest_salvage_summary(
+    log_dir: Path,
+    *,
+    repo: str,
+    issue_number: int,
+    scope: str,
+    approved_plan_hash: str | None = None,
+) -> str | None:
+    root = log_dir / "salvage"
+    if not root.is_dir():
+        return None
+
+    newest: tuple[int, Path, str] | None = None
+    for metadata_path in root.glob("**/metadata.json"):
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(metadata, dict):
+            continue
+        if not _metadata_matches(
+            metadata,
+            repo=repo,
+            issue_number=issue_number,
+            scope=scope,
+            approved_plan_hash=approved_plan_hash,
+        ):
+            continue
+        raw_summary_path = metadata.get("summary")
+        summary_path = (
+            Path(raw_summary_path)
+            if isinstance(raw_summary_path, str) and raw_summary_path
+            else metadata_path.with_name("salvage-summary.md")
+        )
+        if not summary_path.is_absolute():
+            summary_path = metadata_path.parent / summary_path
+        try:
+            summary = summary_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not summary:
+            continue
+        try:
+            created_at_ns = int(metadata.get("created_at_ns"))
+        except (TypeError, ValueError):
+            try:
+                created_at_ns = metadata_path.stat().st_mtime_ns
+            except OSError:
+                continue
+        candidate = (created_at_ns, metadata_path, summary)
+        if newest is None or candidate[:2] > newest[:2]:
+            newest = candidate
+
+    return None if newest is None else newest[2]

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -219,6 +219,17 @@ class FakeRunner(Runner):
         changed_files=None,
         diff_returncode=0,
         diff_stderr="",
+        git_diff="",
+        git_diff_stat=None,
+        git_diff_check="",
+        git_diff_check_returncode=0,
+        git_diff_check_stderr="",
+        post_agent_git_status=None,
+        post_agent_git_diff=None,
+        post_agent_git_diff_stat=None,
+        post_agent_git_diff_check=None,
+        post_agent_git_diff_check_returncode=None,
+        post_agent_git_diff_check_stderr=None,
         issue_urls=None,
         public_response_outputs=None,
         advance_git_head_on_pr=True,
@@ -282,10 +293,26 @@ class FakeRunner(Runner):
         self.changed_files = changed_files or ["src/coding_review_agent_loop/cli.py"]
         self.diff_returncode = diff_returncode
         self.diff_stderr = diff_stderr
+        self.git_diff = git_diff
+        self.git_diff_stat = (
+            git_diff_stat
+            if git_diff_stat is not None
+            else (" src/coding_review_agent_loop/cli.py | 1 +\n" if git_diff else "")
+        )
+        self.git_diff_check = git_diff_check
+        self.git_diff_check_returncode = git_diff_check_returncode
+        self.git_diff_check_stderr = git_diff_check_stderr
+        self.post_agent_git_status = post_agent_git_status
+        self.post_agent_git_diff = post_agent_git_diff
+        self.post_agent_git_diff_stat = post_agent_git_diff_stat
+        self.post_agent_git_diff_check = post_agent_git_diff_check
+        self.post_agent_git_diff_check_returncode = post_agent_git_diff_check_returncode
+        self.post_agent_git_diff_check_stderr = post_agent_git_diff_check_stderr
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
         self.advance_git_head_on_pr = advance_git_head_on_pr
         self._agent_pr_counter = 0
+        self._agent_command_seen = False
         # Parallel discuss debaters (#475) call run_with_log from worker
         # threads; scripted outputs stay keyed per agent, but the shared
         # bookkeeping (commands, comments, response files) needs a lock.
@@ -437,6 +464,45 @@ class FakeRunner(Runner):
         self._agent_pr_counter += 1
         self.git_head = f"{self.git_head}-agent-{self._agent_pr_counter}"
 
+    def _mark_agent_command_seen(self) -> None:
+        self._agent_command_seen = True
+
+    def _current_git_status(self) -> str:
+        if self._agent_command_seen and self.post_agent_git_status is not None:
+            return self.post_agent_git_status
+        return self.git_status
+
+    def _current_git_diff(self) -> str:
+        if self._agent_command_seen and self.post_agent_git_diff is not None:
+            return self.post_agent_git_diff
+        return self.git_diff
+
+    def _current_git_diff_stat(self) -> str:
+        if self._agent_command_seen and self.post_agent_git_diff_stat is not None:
+            return self.post_agent_git_diff_stat
+        return self.git_diff_stat
+
+    def _current_git_diff_check(self) -> str:
+        if self._agent_command_seen and self.post_agent_git_diff_check is not None:
+            return self.post_agent_git_diff_check
+        return self.git_diff_check
+
+    def _current_git_diff_check_returncode(self) -> int:
+        if (
+            self._agent_command_seen
+            and self.post_agent_git_diff_check_returncode is not None
+        ):
+            return self.post_agent_git_diff_check_returncode
+        return self.git_diff_check_returncode
+
+    def _current_git_diff_check_stderr(self) -> str:
+        if (
+            self._agent_command_seen
+            and self.post_agent_git_diff_check_stderr is not None
+        ):
+            return self.post_agent_git_diff_check_stderr
+        return self.git_diff_check_stderr
+
     def run_with_log(
         self,
         args,
@@ -469,6 +535,7 @@ class FakeRunner(Runner):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             self._maybe_advance_git_head_for_agent_pr(output)
+            self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
@@ -490,6 +557,7 @@ class FakeRunner(Runner):
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
             self._maybe_advance_git_head_for_agent_pr(public_response)
+            self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
@@ -507,6 +575,7 @@ class FakeRunner(Runner):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             self._maybe_advance_git_head_for_agent_pr(output)
+            self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
@@ -519,6 +588,7 @@ class FakeRunner(Runner):
                 stdout, returncode = output
             self._maybe_write_public_response_file(cmd)
             self._maybe_advance_git_head_for_agent_pr(stdout)
+            self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{stdout}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
@@ -536,6 +606,7 @@ class FakeRunner(Runner):
             if isinstance(output, str):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_advance_git_head_for_agent_pr(output)
+            self._mark_agent_command_seen()
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
         if cmd[:2] == ["codex", "exec"]:
@@ -555,6 +626,7 @@ class FakeRunner(Runner):
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
             self._maybe_advance_git_head_for_agent_pr(public_response)
+            self._mark_agent_command_seen()
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 
         if cmd[:3] == ["gh", "pr", "comment"]:
@@ -698,6 +770,23 @@ class FakeRunner(Runner):
         if cmd[:2] == ["git", "ls-files"]:
             return CommandResult(cmd, cwd_path, "\n".join(self.tracked_files) + "\n", "", 0)
 
+        if cmd == ["git", "diff", "HEAD", "--binary"]:
+            stdout = self._current_git_diff() if self.diff_returncode == 0 else ""
+            return CommandResult(cmd, cwd_path, stdout, self.diff_stderr, self.diff_returncode)
+
+        if cmd == ["git", "diff", "--stat", "HEAD"]:
+            stdout = self._current_git_diff_stat() if self.diff_returncode == 0 else ""
+            return CommandResult(cmd, cwd_path, stdout, self.diff_stderr, self.diff_returncode)
+
+        if cmd == ["git", "diff", "--check"]:
+            return CommandResult(
+                cmd,
+                cwd_path,
+                self._current_git_diff_check(),
+                self._current_git_diff_check_stderr(),
+                self._current_git_diff_check_returncode(),
+            )
+
         if cmd[:3] == ["git", "diff", "--name-only"]:
             stdout = "\n".join(self.changed_files) + "\n" if self.diff_returncode == 0 else ""
             return CommandResult(cmd, cwd_path, stdout, self.diff_stderr, self.diff_returncode)
@@ -706,7 +795,10 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, f"{self.git_remote}\n", "", 0)
 
         if cmd[:3] == ["git", "status", "--porcelain"]:
-            return CommandResult(cmd, cwd_path, self.git_status, "", 0)
+            return CommandResult(cmd, cwd_path, self._current_git_status(), "", 0)
+
+        if cmd[:3] == ["git", "status", "--short"]:
+            return CommandResult(cmd, cwd_path, self._current_git_status(), "", 0)
 
         if cmd[:3] == ["gh", "repo", "clone"]:
             Path(cmd[4]).mkdir(parents=True, exist_ok=True)

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -6,6 +6,7 @@ import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
 from coding_review_agent_loop.decomposition import approved_plan_hash, format_one_shot_impl_handoff_comment
+from coding_review_agent_loop.errors import QuotaResetExceededError
 from coding_review_agent_loop.github import get_issue_context
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
@@ -19,6 +20,7 @@ from coding_review_agent_loop.prompts import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
 )
 from coding_review_agent_loop.protocol import UnresolvedReviewItem
+from coding_review_agent_loop.salvage import latest_salvage_summary
 from agent_loop_helpers import (
     FakeRunner,
     command_index,
@@ -2046,3 +2048,170 @@ def test_issue_loop_plan_first_one_shot_rerun_resumes_pr_loop(tmp_path):
     assert len(claude_calls) == 0
     assert any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
 
+
+def _salvage_dirs(config):
+    salvage_root = config.log_dir / "salvage"
+    if not salvage_root.exists():
+        return []
+    return sorted(path for path in salvage_root.iterdir() if path.is_dir())
+
+
+def test_failed_issue_implementation_with_diff_writes_salvage_artifacts(tmp_path):
+    patch_text = (
+        "diff --git a/src/coding_review_agent_loop/cli.py b/src/coding_review_agent_loop/cli.py\n"
+        "--- a/src/coding_review_agent_loop/cli.py\n"
+        "+++ b/src/coding_review_agent_loop/cli.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    runner = FakeRunner(
+        claude_outputs=[("quota exceeded; reset in 10m", 1)],
+        post_agent_git_status=" M src/coding_review_agent_loop/cli.py\n?? scratch-note.md\n",
+        post_agent_git_diff=patch_text,
+        post_agent_git_diff_stat=" src/coding_review_agent_loop/cli.py | 2 +-\n",
+        post_agent_git_diff_check="src/coding_review_agent_loop/cli.py:1: trailing whitespace.\n",
+        post_agent_git_diff_check_returncode=2,
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(QuotaResetExceededError) as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert "Salvage artifacts:" in str(excinfo.value)
+    salvage_dir = _salvage_dirs(config)[0]
+    assert str(salvage_dir) in str(excinfo.value)
+    assert (salvage_dir / "partial.patch").read_text(encoding="utf-8") == patch_text
+    assert "?? scratch-note.md" in (salvage_dir / "changed-files.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "2 +-" in (salvage_dir / "diff-stat.txt").read_text(encoding="utf-8")
+    assert "trailing whitespace" in (salvage_dir / "diff-check.txt").read_text(
+        encoding="utf-8"
+    )
+
+    summary = (salvage_dir / "salvage-summary.md").read_text(encoding="utf-8")
+    assert "No\nsuccessful response, review result, or pull request should be inferred" in summary
+    assert "Public response file: missing" in summary
+    assert "Required marker status: missing or invalid" in summary
+    assert "Untracked files appear in `changed-files.txt`" in summary
+
+    metadata = json.loads((salvage_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["repo"] == "OWNER/REPO"
+    assert metadata["issue_number"] == 56
+    assert metadata["scope"] == "issue-implementation"
+    assert metadata["agent"] == "claude"
+    assert metadata["failure_category"] == "transient"
+    assert metadata["response_file_missing"] is True
+    assert metadata["diff_check_returncode"] == 2
+
+
+def test_failed_issue_implementation_without_diff_writes_no_salvage_patch(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Created local notes but forgot the required marker."],
+        post_agent_git_status=" M src/coding_review_agent_loop/cli.py\n",
+        post_agent_git_diff="",
+    )
+    config = make_config(tmp_path, agent_max_retries=0)
+
+    with pytest.raises(AgentLoopError):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert _salvage_dirs(config) == []
+
+
+def _write_salvage_summary(
+    config,
+    *,
+    name,
+    summary,
+    created_at_ns,
+    issue_number=56,
+    scope="issue-implementation",
+    approved_plan_hash_value=None,
+):
+    salvage_dir = config.log_dir / "salvage" / name
+    salvage_dir.mkdir(parents=True)
+    summary_path = salvage_dir / "salvage-summary.md"
+    summary_path.write_text(summary, encoding="utf-8")
+    metadata = {
+        "schema_version": 1,
+        "created_at_ns": created_at_ns,
+        "repo": config.repo,
+        "issue_number": issue_number,
+        "scope": scope,
+        "agent": "claude",
+        "approved_plan_hash": approved_plan_hash_value,
+        "summary": str(summary_path),
+    }
+    (salvage_dir / "metadata.json").write_text(
+        json.dumps(metadata, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_issue_implementation_rerun_prompt_includes_latest_salvage_summary(tmp_path):
+    config = make_config(tmp_path)
+    _write_salvage_summary(
+        config,
+        name="old",
+        summary="old failed attempt summary",
+        created_at_ns=1,
+    )
+    _write_salvage_summary(
+        config,
+        name="new",
+        summary="new failed attempt summary\nPartial patch: `/tmp/new.patch`",
+        created_at_ns=2,
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    coder_prompt = next(
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "Fix GitHub issue #56" in cmd[-1]
+    )
+    assert "Previous failed implementation attempt salvage:" in coder_prompt
+    assert "new failed attempt summary" in coder_prompt
+    assert "old failed attempt summary" not in coder_prompt
+    assert "Do not auto-apply the patch" in coder_prompt
+    assert "cherry-pick or ignore it" in coder_prompt
+    assert "selectively" in coder_prompt
+
+
+def test_latest_salvage_summary_filters_approved_plan_hash(tmp_path):
+    config = make_config(tmp_path)
+    plan_hash = approved_plan_hash("Plan:\n- Current.")
+    _write_salvage_summary(
+        config,
+        name="old-plan",
+        summary="stale approved-plan summary",
+        created_at_ns=5,
+        scope="approved-plan-implementation",
+        approved_plan_hash_value=approved_plan_hash("Plan:\n- Old."),
+    )
+    _write_salvage_summary(
+        config,
+        name="current-plan",
+        summary="current approved-plan summary",
+        created_at_ns=4,
+        scope="approved-plan-implementation",
+        approved_plan_hash_value=plan_hash,
+    )
+
+    summary = latest_salvage_summary(
+        config.log_dir,
+        repo=config.repo,
+        issue_number=56,
+        scope="approved-plan-implementation",
+        approved_plan_hash=plan_hash,
+    )
+
+    assert summary == "current approved-plan summary"

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+import coding_review_agent_loop.orchestrator as orchestrator_module
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
 from coding_review_agent_loop.decomposition import approved_plan_hash, format_one_shot_impl_handoff_comment
 from coding_review_agent_loop.errors import QuotaResetExceededError
@@ -2104,6 +2105,30 @@ def test_failed_issue_implementation_with_diff_writes_salvage_artifacts(tmp_path
     assert metadata["failure_category"] == "transient"
     assert metadata["response_file_missing"] is True
     assert metadata["diff_check_returncode"] == 2
+
+
+def test_failed_issue_implementation_salvage_oserror_preserves_original_failure(
+    tmp_path, capsys, monkeypatch
+):
+    runner = FakeRunner(
+        claude_outputs=[("quota exceeded; reset in 10m", 1)],
+        post_agent_git_diff="diff --git a/file.txt b/file.txt\n",
+    )
+    config = make_config(tmp_path, quiet=False)
+
+    def fail_capture(*args, **kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(orchestrator_module, "capture_salvage_artifacts", fail_capture)
+
+    with pytest.raises(QuotaResetExceededError) as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert "quota exhausted" in str(excinfo.value)
+    assert "Rerun when quota resets" in str(excinfo.value)
+    assert "simulated disk full" not in str(excinfo.value)
+    assert _salvage_dirs(config) == []
+    assert "salvage capture failed (simulated disk full)" in capsys.readouterr().err
 
 
 def test_failed_issue_implementation_without_diff_writes_no_salvage_patch(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -114,6 +114,35 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
         assert "Do not `cd` into sibling, home, deployment, or duplicate clones" in prompt
         assert "`pwd` and `git status --branch --short`" in prompt
 
+
+def test_issue_prompts_include_salvage_guardrail_block(tmp_path):
+    config = make_config(tmp_path)
+    salvage_summary = (
+        "# Salvage Summary\n\n"
+        "The previous attempt failed.\n\n"
+        "- Partial patch: `/tmp/coding-review-agent-loop/logs/salvage/run/partial.patch`"
+    )
+
+    prompts = [
+        build_issue_prompt(56, config, salvage_summary=salvage_summary),
+        build_issue_implementation_prompt(
+            56,
+            "1. Implement the approved plan.",
+            config,
+            salvage_summary=salvage_summary,
+        ),
+    ]
+
+    for prompt in prompts:
+        assert "Previous failed implementation attempt salvage:" in prompt
+        assert "The previous attempt failed." in prompt
+        assert "incomplete context only" in prompt
+        assert "Do not infer a successful\nresponse or PR" in prompt
+        assert "Do not auto-apply the patch" in prompt
+        assert "cherry-pick or ignore it\nselectively" in prompt
+        assert "partial.patch" in prompt
+
+
 def test_reviewer_prompts_use_reviewer_assigned_workdir_rule(tmp_path):
     config = make_config(
         tmp_path,


### PR DESCRIPTION
## Summary
- add local salvage artifact capture for failed mutating issue implementation runs with non-empty tracked diffs
- include latest matching salvage summary in direct and approved-plan implementation prompts without auto-applying patches
- record metadata, status, diff stat, diff-check diagnostics, and explicit non-successful summary text

Fixes #473

## Tests
- python -m pytest tests/test_orchestrator_issue.py tests/test_prompts.py -k salvage (failed: python not found)
- python3 -m pytest tests/test_orchestrator_issue.py tests/test_prompts.py -k salvage (passed)
- python3 -m pytest (passed)
- git diff --check (passed)