### PR TITLE
Materialize split discuss outcomes and plan-first deferred stages into follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ over-cap response is rejected and must be consolidated, not truncated. This cap
 is separate from the approved-review follow-up issue cap used by
 `--approved-followups`.
 
+If the approved plan narrows scope (via a structured `deferred_stages` field,
+or a prior discuss `split` consensus), pass `--materialize-split-issues` to
+file each remaining stage as its own linked child issue instead of leaving it
+as unfiled text — default is off, and the orchestrator always warns explicitly
+when stages would otherwise go unfiled. When a parent's stages are already
+fully materialized, `--implement-after-approval` hands implementation off to
+the specific child the plan covers (via a unique title match or an explicit
+`--split-stage <child>` flag) instead of treating the whole parent as solved,
+and the resulting PR is required to use `Refs #<parent>` rather than a closing
+keyword against it. See [`docs/local_agent_loop.md`](docs/local_agent_loop.md#split-issue-materialization)
+for details.
+
 Provide a one-off task directly when there is no issue yet:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -251,6 +251,11 @@ The modes are:
 `--plan-execution-mode implement-one-shot`. It requires `--plan-first` and is
 not compatible with any other explicit `--plan-execution-mode` value.
 
+If the plan narrows scope (via `deferred_stages` or a prior discuss `split`
+consensus), see [Split issue materialization](#split-issue-materialization)
+below for how those follow-up stages are filed (or warned about) and how
+`implement-one-shot` targets the correct stage instead of the whole parent.
+
 Generated child issues are self-contained: each body includes the parent issue
 link, the relevant approved parent-plan slice, constraints/invariants,
 dependency notes, scope and non-goals, rollout risk, validation/soak
@@ -552,6 +557,97 @@ Two companion flags apply in both sequential and parallel discuss runs:
     round. A partial round never declares final consensus — the placeholder
     vote can never match real outcomes — so a partial final round ends in a
     `needs-human` deadlock, with the failures noted in the summary.
+
+### Split issue materialization
+
+By default, a discuss `split` consensus or a plan-first plan that narrows
+scope leaves its proposed follow-up stages as text in issue comments — easy to
+miss, especially when `--implement-after-approval` proceeds straight into
+implementing one stage. Pass `--materialize-split-issues` (on `discuss` or
+`issue`) to file each remaining stage as its own linked child GitHub issue
+instead:
+
+```bash
+agent-loop discuss 467 --repo OWNER/REPO --materialize-split-issues
+agent-loop issue 467 --repo OWNER/REPO --plan-first --implement-after-approval \
+  --materialize-split-issues
+```
+
+Default is off. Whether or not the flag is set, the orchestrator always warns
+explicitly when split follow-ups would otherwise go unfiled — in the discuss
+final summary, the plan-approval summary, and the CLI log — so the gap can't
+hide in a neutral listing.
+
+Two structured signals drive materialization; free-form prose narrowing is
+never enough to auto-create issues:
+
+- **Discuss `split` proposals.** When every debater's final vote is `split`,
+  the merged `split_proposals` from that round are the remaining stages (a
+  discuss run implements nothing, so every proposal is unfiled/unimplemented).
+- **Plan `deferred_stages`.** A coder's structured `plan_revision` or initial
+  `plan_state` response may declare an optional `deferred_stages` array of
+  `{"title", "summary"}` objects for scope the plan intentionally leaves out.
+  Declared stages render into the canonical plan under a `### Deferred stages
+  (not in this plan)` heading, so they carry into subject hashing, stored plan
+  state, reviewer prompts, and resume. In `--plan-first` mode, the stage the
+  approved plan actually covers is never filed as a child — only the
+  `deferred_stages` (plus any not-yet-covered discuss split proposals from an
+  earlier `discuss` run on the same issue) are remaining stages.
+- If neither signal is present but the approved plan's text still looks like
+  it narrows scope (mentions "stage 1 of", "first stage", "out of scope",
+  "separate issue", or "follow-up issue"), the orchestrator posts a
+  heuristic-only warning. It never files issues from this signal alone.
+
+Each child issue is created with a deterministic title
+(`[#<parent> stage] <proposal title>`), a `Part of #<parent>` first line, the
+proposal text, the split rationale from the debaters who voted `split` (when
+available), links to sibling stages already materialized, and execution
+instructions to run `agent-loop issue <child>` and never use a closing keyword
+against the parent. Every child body carries a durable
+`AGENT_SPLIT_CHILD: parent=<N> key=<hash>` HTML-comment marker.
+
+Materialization is idempotent and crash-safe:
+
+- The parent issue accumulates a single `<!-- AGENT_DISCUSS_SPLIT: ... -->`
+  marker recording every known child (title, key, issue number/URL, and
+  whether it was `created` or `adopted`); a rerun that finds every current
+  proposal already covered by that marker performs zero GitHub writes.
+- If a prior run crashed after creating some child issues but before posting
+  the marker, the next run searches existing issues
+  (`gh issue list --search '"[#<parent> stage]" in:title'`) before creating
+  anything, adopts any match into the metadata instead of duplicating it, and
+  files only the remaining stages.
+- Proposals are deduplicated by a normalized-title key across the whole
+  parent, not just within one run, so subject-hash drift between a discuss
+  consensus and a later plan-first run never refiles the same stage twice.
+- Materialization is capped at 8 child issues per parent; over-cap stages are
+  skipped with a logged note rather than silently dropped or endlessly
+  retried.
+- `--dry-run` previews `gh issue create`/`gh issue list --search` commands
+  without writing any state.
+
+When a parent's proposals were already fully materialized into child issues
+(from an earlier `discuss` run, or a prior `--plan-first` run on the same
+issue), a later `issue --plan-first --implement-after-approval` run on that
+parent must resolve which child stage the approved plan implements before
+handing off implementation — it never implements the parent as a monolith in
+that case. Resolution is a unique normalized-title match between the plan and
+a child's title, or an explicit `--split-stage <child-issue-number>` flag when
+the match is ambiguous or missing:
+
+```bash
+agent-loop issue 467 --repo OWNER/REPO --plan-first --implement-after-approval \
+  --split-stage 480
+```
+
+The resolution is recorded in an `<!-- AGENT_SPLIT_STAGE_HANDOFF: ... -->`
+parent comment marker so reruns reuse it instead of re-resolving. The staged
+implementation prompt then instructs the coder to use `Closes #<child>` plus
+`Refs #<parent>` in the PR body — never a closing keyword against the parent —
+and `validate_pr_body_does_not_close_issue` rejects a PR body that uses
+`Fixes`/`Closes`/`Resolves` against the parent while other stages remain
+unfiled or unimplemented, with an actionable error to edit the PR body and
+rerun `agent-loop pr <n>`.
 
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -398,6 +398,26 @@ def build_parser() -> argparse.ArgumentParser:
             "Defaults to plan-only unless --implement-after-approval is used."
         ),
     )
+    issue.add_argument(
+        "--materialize-split-issues",
+        action="store_true",
+        help=(
+            "File a linked child GitHub issue for each remaining discuss `split` proposal "
+            "or plan `deferred_stages` entry instead of leaving them as unfiled text "
+            "(default: off, warning-only)."
+        ),
+    )
+    issue.add_argument(
+        "--split-stage",
+        type=int,
+        default=None,
+        metavar="CHILD_ISSUE_NUMBER",
+        help=(
+            "When the parent issue's split proposals were already fully materialized into "
+            "child issues, explicitly select which child stage this run implements instead "
+            "of relying on a unique plan-title match."
+        ),
+    )
     add_common(issue)
 
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
@@ -499,6 +519,14 @@ def build_parser() -> argparse.ArgumentParser:
             "continues the round when at least two debaters produced votes and "
             "records the failures in the round summary. A partial round never "
             "declares final consensus."
+        ),
+    )
+    discuss.add_argument(
+        "--materialize-split-issues",
+        action="store_true",
+        help=(
+            "On a `split` consensus, file a linked child GitHub issue for each proposed "
+            "sub-issue instead of leaving them as unfiled text (default: off, warning-only)."
         ),
     )
     add_common(discuss)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -16,6 +16,7 @@ from .protocol import (
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
     PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SIGNATURE_RE,
+    DeferredStage,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
     ParsedPlanReview,
@@ -207,6 +208,22 @@ def render_canonical_plan_steps(plan_steps: Sequence[str]) -> str:
     return "\n".join(f"{index}. {step}" for index, step in enumerate(plan_steps, start=1))
 
 
+def render_deferred_stages_section(deferred_stages: Sequence[DeferredStage]) -> str | None:
+    """Render declared deferred stages so they carry into the plan's markdown.
+
+    Deferred stages must survive canonical-plan rendering (#476): they feed
+    subject hashing, stored plan state, reviewer prompts, and resume, so
+    scope narrowing stays a mechanical signal instead of prose reviewers
+    might miss.
+    """
+    if not deferred_stages:
+        return None
+    lines = ["### Deferred stages (not in this plan)"]
+    for stage in deferred_stages:
+        lines.append(f"- {stage.title}: {stage.summary}")
+    return "\n".join(lines)
+
+
 def render_canonical_plan_revision(
     parsed_revision: StructuredPlanRevision,
     prior_items: Sequence[UnresolvedReviewItem],
@@ -232,6 +249,9 @@ def render_canonical_plan_revision(
             ]
         )
     )
+    deferred_section = render_deferred_stages_section(parsed_revision.deferred_stages)
+    if deferred_section:
+        sections.append(deferred_section)
     return "\n\n".join(sections)
 
 
@@ -506,9 +526,12 @@ def _render_public_plan_state_comment(
         "## Plan",
         parsed_plan.summary.strip(),
         "\n".join(["### Plan steps", render_canonical_plan_steps(parsed_plan.plan_steps)]),
-        f"<!-- AGENT_PLAN_STATE: {parsed_plan.state} -->",
-        f"-- {_comment_signature(agent, config, model_used)}",
     ]
+    deferred_section = render_deferred_stages_section(parsed_plan.deferred_stages)
+    if deferred_section:
+        sections.append(deferred_section)
+    sections.append(f"<!-- AGENT_PLAN_STATE: {parsed_plan.state} -->")
+    sections.append(f"-- {_comment_signature(agent, config, model_used)}")
     return "\n\n".join(section for section in sections if section)
 
 

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from .decomposition import _decode_json_payload, _encode_json_payload
 from .errors import AgentLoopError
 from .agents.registry import agent_display_name, agent_signature
 from .protocol import (
@@ -215,13 +216,50 @@ def render_deferred_stages_section(deferred_stages: Sequence[DeferredStage]) -> 
     subject hashing, stored plan state, reviewer prompts, and resume, so
     scope narrowing stays a mechanical signal instead of prose reviewers
     might miss.
+
+    The human-readable `- {title}: {summary}` bullets are for reviewers; they
+    are NOT what resume parses back, because a title containing its own colon
+    (e.g. "Stage 2: API follow-up") would corrupt a naive split-on-first-colon
+    parse. An `AGENT_DEFERRED_STAGES` HTML-comment marker carries the
+    structured title/summary pairs verbatim so they round-trip exactly
+    regardless of their text content (#492 review).
     """
     if not deferred_stages:
         return None
     lines = ["### Deferred stages (not in this plan)"]
     for stage in deferred_stages:
         lines.append(f"- {stage.title}: {stage.summary}")
+    lines.append(f"<!-- AGENT_DEFERRED_STAGES: {_encode_deferred_stages_marker(deferred_stages)} -->")
     return "\n".join(lines)
+
+
+def _encode_deferred_stages_marker(deferred_stages: Sequence[DeferredStage]) -> str:
+    return _encode_json_payload(
+        {"stages": [{"title": stage.title, "summary": stage.summary} for stage in deferred_stages]}
+    )
+
+
+DEFERRED_STAGES_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_DEFERRED_STAGES:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+
+
+def decode_deferred_stages_marker(encoded: str) -> tuple[DeferredStage, ...]:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_DEFERRED_STAGES")
+    stages_payload = payload.get("stages")
+    if not isinstance(stages_payload, list):
+        raise AgentLoopError("Invalid AGENT_DEFERRED_STAGES payload.")
+    stages: list[DeferredStage] = []
+    for entry in stages_payload:
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("title"), str)
+            or not isinstance(entry.get("summary"), str)
+        ):
+            raise AgentLoopError("Invalid AGENT_DEFERRED_STAGES payload.")
+        stages.append(DeferredStage(title=entry["title"], summary=entry["summary"]))
+    return tuple(stages)
 
 
 def render_canonical_plan_revision(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -120,6 +120,16 @@ class AgentLoopConfig:
     # (today's behavior); "partial" continues the round with >= 2 surviving
     # votes and records the failure in the round summary.
     discuss_on_debater_failure: str = "fail"
+    # Materialize discuss `split` proposals and plan-first `deferred_stages`
+    # into linked child GitHub issues (#476). Default off (warning-only) so
+    # existing runs keep today's behavior; the orchestrator always warns when
+    # split follow-ups would otherwise remain unfiled.
+    materialize_split_issues: bool = False
+    # Explicit selected-stage resolution for `issue --plan-execution-mode
+    # implement-one-shot` when a parent's split proposals were already fully
+    # materialized into child issues (#476). None means resolve by unique
+    # title match instead.
+    split_stage: int | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -795,6 +805,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         discuss_parallel=getattr(args, "discuss_parallel", False),
         discuss_debater_timeout=getattr(args, "discuss_debater_timeout", None),
         discuss_on_debater_failure=getattr(args, "discuss_on_debater_failure", "fail") or "fail",
+        materialize_split_issues=getattr(args, "materialize_split_issues", False),
+        split_stage=getattr(args, "split_stage", None),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -788,7 +788,17 @@ def _format_plan_approval_summary_with_followups(
                 ]
             )
         else:
-            lines.extend(["", "Approved plan future follow-ups:", ""])
+            lines.extend(
+                [
+                    "",
+                    "Approved plan future follow-ups:",
+                    "",
+                    "These are summarized only; they are NOT filed as GitHub issues. Rerun with "
+                    "`--approved-followups issue` (or `fix-and-issue`) to file them, or file them "
+                    "manually.",
+                    "",
+                ]
+            )
             for followup in reconciliation.selected_groups:
                 reviewers = ", ".join(followup.reviewers)
                 lines.append(f"- {_followup_main_text(followup.text)} ({reviewers})")

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -222,11 +222,13 @@ def validate_pr_references_issue(
 
 
 # Matches a GitHub auto-close keyword immediately followed by an issue reference,
-# e.g. "Closes #12", "fixed #12", "resolves owner/repo#12". Used to keep staged
-# implementation PRs from accidentally auto-closing the parent issue while
-# other split stages remain unimplemented (#476).
+# e.g. "Closes #12", "fixed #12", "resolves owner/repo#12", or
+# "closes https://github.com/owner/repo/issues/12" (GitHub also treats a full
+# issue URL as a closing reference). Used to keep staged implementation PRs
+# from accidentally auto-closing the parent issue while other split stages
+# remain unimplemented (#476, #492 review).
 _CLOSE_KEYWORD_ISSUE_RE_TEMPLATE = (
-    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:%s#%d|#%d)\b"
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:%s#%d|#%d|\S*/issues/%d)\b"
 )
 
 
@@ -264,7 +266,8 @@ def validate_pr_body_does_not_close_issue(
     data = json.loads(result.stdout or "{}")
     body = _optional_str(data.get("body")) or ""
     close_re = re.compile(
-        _CLOSE_KEYWORD_ISSUE_RE_TEMPLATE % (re.escape(config.repo), issue_number, issue_number),
+        _CLOSE_KEYWORD_ISSUE_RE_TEMPLATE
+        % (re.escape(config.repo), issue_number, issue_number, issue_number),
         re.I,
     )
     if not close_re.search(body):

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -51,6 +51,14 @@ class IssueContext:
 
 
 @dataclass(frozen=True)
+class FoundIssue:
+    number: int | None
+    title: str | None
+    url: str | None
+    body: str | None
+
+
+@dataclass(frozen=True)
 class HumanReviewRequirement:
     source_type: str
     author: str | None
@@ -210,6 +218,62 @@ def validate_pr_references_issue(
         f"Edit the PR description on GitHub to include `Fixes #{issue_number}` or another direct "
         f"issue reference, then rerun the orchestrator as `agent-loop pr {pr_number}` to continue "
         "the review."
+    )
+
+
+# Matches a GitHub auto-close keyword immediately followed by an issue reference,
+# e.g. "Closes #12", "fixed #12", "resolves owner/repo#12". Used to keep staged
+# implementation PRs from accidentally auto-closing the parent issue while
+# other split stages remain unimplemented (#476).
+_CLOSE_KEYWORD_ISSUE_RE_TEMPLATE = (
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:%s#%d|#%d)\b"
+)
+
+
+def validate_pr_body_does_not_close_issue(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    issue_number: int,
+) -> None:
+    """Reject a staged-implementation PR body that would auto-close `issue_number`.
+
+    Used when split/deferred stages remain unfiled or unimplemented for the
+    parent issue (#476): a PR implementing only one stage must not use
+    `Fixes`/`Closes`/`Resolves` against the parent, or the parent would close
+    while other stages remain outstanding. `Refs #N` (or any non-closing
+    reference) is fine and is validated separately by
+    `validate_pr_references_issue`.
+    """
+    if config.dry_run:
+        return
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            "body,url",
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    body = _optional_str(data.get("body")) or ""
+    close_re = re.compile(
+        _CLOSE_KEYWORD_ISSUE_RE_TEMPLATE % (re.escape(config.repo), issue_number, issue_number),
+        re.I,
+    )
+    if not close_re.search(body):
+        return
+    raise AgentLoopError(
+        f"PR #{pr_number} body uses a closing keyword (Closes/Fixes/Resolves) against parent "
+        f"issue #{issue_number}, but other split stages remain unfiled or unimplemented. Edit the "
+        f"PR description to use a non-closing reference (e.g. `Refs #{issue_number}`) instead, then "
+        f"rerun `agent-loop pr {pr_number}` to continue the review."
     )
 
 
@@ -816,6 +880,83 @@ def create_issue(
             os.unlink(path)
         except FileNotFoundError:
             pass
+
+
+def search_issues(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    search: str,
+    state: str = "all",
+) -> tuple[FoundIssue, ...]:
+    """Search issues in `config.repo`, used to recover from a create-then-crash window (#476).
+
+    Split-issue materialization posts its idempotency marker only after every
+    child issue is created; if the process crashes between a `create_issue`
+    call and posting that marker, a rerun must find already-created children
+    instead of duplicating them. This wraps `gh issue list --search` for that
+    recovery pass. Dry-run returns an empty tuple so the dry-run
+    materialization path still previews creations instead of "adopting"
+    nothing.
+    """
+    log(config, f"Searching GitHub issues in {config.repo}: {search}")
+    if config.dry_run:
+        runner.run(
+            [
+                config.gh_cmd,
+                "issue",
+                "list",
+                "--repo",
+                config.repo,
+                "--search",
+                search,
+                "--state",
+                state,
+                "--json",
+                "number,title,url,body",
+            ],
+            cwd=active_workdir(config),
+        )
+        return ()
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "issue",
+            "list",
+            "--repo",
+            config.repo,
+            "--search",
+            search,
+            "--state",
+            state,
+            "--json",
+            "number,title,url,body",
+        ],
+        cwd=active_workdir(config),
+    )
+    raw = result.stdout.strip()
+    if not raw:
+        return ()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(payload, list):
+        return ()
+    found: list[FoundIssue] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        number = item.get("number")
+        found.append(
+            FoundIssue(
+                number=int(number) if isinstance(number, int) else None,
+                title=_optional_str(item.get("title")),
+                url=_optional_str(item.get("url")),
+                body=_optional_str(item.get("body")),
+            )
+        )
+    return tuple(found)
 
 
 def get_pr_head_sha(runner: Runner, config: AgentLoopConfig, pr_number: int) -> str:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1842,6 +1842,19 @@ def _handle_plan_first_split_scope(
     """
     current_deferred_stages = _extract_current_deferred_stages(current_plan)
     prior_discuss_proposals = _prior_discuss_split_proposals(issue_context, config=config)
+    if current_deferred_stages:
+        # This plan structurally declares its own deferred_stages, so it keeps
+        # a primary scope on the parent (the implement-one-shot branch below
+        # never hands that scope off to a child in this case). If a prior
+        # discuss split proposal names that same primary scope, it must be
+        # excluded here rather than filed as a duplicate child issue for work
+        # the parent PR is about to implement and close directly (#492 review).
+        plan_own_key = split_stage_proposal_from_text(_plan_first_line(current_plan)).key
+        prior_discuss_proposals = [
+            proposal
+            for proposal in prior_discuss_proposals
+            if split_stage_proposal_from_text(proposal).key != plan_own_key
+        ]
     remaining_proposals = dedupe_split_stage_proposals(
         [split_stage_proposal_from_deferred_stage(stage) for stage in current_deferred_stages]
         + [split_stage_proposal_from_text(proposal) for proposal in prior_discuss_proposals]

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2667,13 +2667,30 @@ def _run_plan_first_loop(
                 # already fully materialized into child issues (discuss `split` or a prior
                 # plan-first run), implementation must target the child the approved plan
                 # actually covers instead of treating the whole parent as solved.
+                #
+                # This does NOT apply when the approved plan itself structurally declares
+                # `deferred_stages`: that plan keeps its own primary scope on the parent and
+                # only files the *remainder* as children (`_handle_plan_first_split_scope`),
+                # so the parent is never one of the materialized children. Skipping stage
+                # resolution here also fixes a rerun/resume regression (#492 review): once
+                # such a plan's own one-shot handoff is posted on the parent, a later rerun
+                # would otherwise see the freshly materialized children, find no stage-handoff
+                # marker, and fail to match the plan's own title against a sibling stage's
+                # title, raising instead of resuming the already-handed-off parent PR.
                 target_issue_number = issue_number
                 target_issue_context = issue_context
                 staged_parent_issue: int | None = None
+                current_plan_declares_own_deferred_stages = bool(
+                    _extract_current_deferred_stages(current_plan)
+                )
                 split_metadata = find_existing_split_materialization(
                     issue_context.comments, parent_issue=issue_number
                 )
-                if split_metadata is not None and split_metadata.children:
+                if (
+                    split_metadata is not None
+                    and split_metadata.children
+                    and not current_plan_declares_own_deferred_stages
+                ):
                     stage_handoff = find_existing_split_stage_handoff(
                         issue_context.comments, parent_issue=issue_number, plan_hash=plan_hash
                     )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -172,6 +172,7 @@ from .checks import (
     run_pre_review_tests,
 )
 from .comment_rendering import (
+    DEFERRED_STAGES_MARKER_RE,
     ITEM_SUMMARY_LIMIT,
     _append_before_trailing_metadata,
     _format_unresolved_item_label,
@@ -184,6 +185,7 @@ from .comment_rendering import (
     _render_public_review_comment,
     _replace_structured_section,
     _review_freeform_summary_text,
+    decode_deferred_stages_marker,
     normalize_freeform_signature,
     render_discuss_round_summary_comment,
     render_public_agent_comment,
@@ -1752,6 +1754,15 @@ def _extract_current_deferred_stages(current_plan: str) -> tuple[DeferredStage, 
         structured = None
     if structured is not None:
         return structured.deferred_stages
+    # The canonical markdown carries an AGENT_DEFERRED_STAGES marker with the
+    # exact structured title/summary pairs (#492 review): a title containing
+    # its own colon (e.g. "Stage 2: API follow-up") would corrupt the
+    # human-readable `- {title}: {summary}` bullets if split on the first
+    # colon, so the marker is authoritative and the prose is parsed only as a
+    # fallback for text that predates it.
+    marker_match = DEFERRED_STAGES_MARKER_RE.search(current_plan)
+    if marker_match:
+        return decode_deferred_stages_marker(marker_match.group("payload"))
     match = _DEFERRED_STAGES_SECTION_RE.search(current_plan)
     if not match:
         return ()

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1828,10 +1828,18 @@ def _handle_plan_first_split_scope(
     current_plan: str,
     plan_subject: str,
     issue_context: IssueContext,
-) -> None:
+) -> bool:
     """Materialize (or warn about) split/deferred stages before implementation
     handoff (#476), so a plan-first run that narrows scope to one stage cannot
-    silently leave the rest unfiled (the #467/#474 gap)."""
+    silently leave the rest unfiled (the #467/#474 gap).
+
+    Returns True when this call may have posted a fresh `AGENT_DISCUSS_SPLIT`
+    materialization comment on the parent (#492 review): the caller must then
+    refetch `issue_context` before any downstream logic (e.g. implement-one-shot
+    selected-stage resolution) reads issue comments, since the in-memory
+    `issue_context.comments` snapshot predates this call and would otherwise
+    look stale and hide children materialized moments earlier in this same run.
+    """
     current_deferred_stages = _extract_current_deferred_stages(current_plan)
     prior_discuss_proposals = _prior_discuss_split_proposals(issue_context, config=config)
     remaining_proposals = dedupe_split_stage_proposals(
@@ -1848,7 +1856,7 @@ def _handle_plan_first_split_scope(
                 proposals=remaining_proposals,
                 issue_comments=issue_context.comments,
             )
-            return
+            return True
         log(
             config,
             f"Planning issue #{issue_number}: split follow-ups remain unfiled; rerun with "
@@ -1864,18 +1872,18 @@ def _handle_plan_first_split_scope(
                 subject=plan_subject,
                 proposals=remaining_proposals,
             )
-        return
+        return False
     if current_deferred_stages or prior_discuss_proposals:
-        return
+        return False
     if not _plan_text_suggests_narrowing(current_plan):
-        return
+        return False
     log(
         config,
         f"Planning issue #{issue_number}: approved plan text suggests scope narrowing "
         "but no `deferred_stages` or discuss split proposals were declared or filed.",
     )
     if has_unfiled_split_warning(issue_context.comments, issue_number=issue_number, subject=plan_subject):
-        return
+        return False
     post_issue_comment(
         runner,
         config=config,
@@ -1896,6 +1904,7 @@ def _handle_plan_first_split_scope(
             ]
         ),
     )
+    return False
 
 
 def _read_assigned_workdir_head(runner: Runner, config: AgentLoopConfig) -> str | None:
@@ -2570,7 +2579,7 @@ def _run_plan_first_loop(
                 sources=approved_future_followup_sources,
                 allow_issue_filing=mode in {"implement-one-shot", "implement-by-phase"},
             )
-            _handle_plan_first_split_scope(
+            split_scope_materialized = _handle_plan_first_split_scope(
                 runner,
                 issue_number=issue_number,
                 config=config,
@@ -2578,6 +2587,12 @@ def _run_plan_first_loop(
                 plan_subject=plan_subject,
                 issue_context=issue_context,
             )
+            if split_scope_materialized:
+                # Refetch so downstream logic (selected-stage resolution below,
+                # decomposition, etc.) sees the `AGENT_DISCUSS_SPLIT` comment
+                # this call may have just posted, instead of the stale
+                # pre-materialization snapshot (#492 review).
+                issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
             if mode == "plan-only":
                 print(
                     f"Issue #{issue_number} plan approved by {format_agent_list(configured_reviewers)}."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -57,8 +57,26 @@ from .github import (
     post_pr_comment,
     validate_open_issue,
     validate_open_pr,
+    validate_pr_body_does_not_close_issue,
     validate_pr_references_issue,
     wait_for_ci,
+)
+from .split_materialization import (
+    DISCUSS_SPLIT_MARKER_RE,
+    SPLIT_STAGE_HANDOFF_MARKER_RE,
+    UNFILED_SPLIT_WARNING_MARKER_RE,
+    MaterializedSplitChild,
+    SplitStageProposal,
+    dedupe_split_stage_proposals,
+    find_existing_split_materialization,
+    find_existing_split_stage_handoff,
+    has_unfiled_split_warning,
+    materialize_split_proposals,
+    post_split_stage_handoff_comment,
+    post_unfiled_split_warning,
+    resolve_selected_stage_child,
+    split_stage_proposal_from_deferred_stage,
+    split_stage_proposal_from_text,
 )
 from .logging import log, new_run_id, run_usage_summary_path
 from .memory import AgentMemoryContext, prepare_agent_memory
@@ -85,6 +103,7 @@ from .prompts import (
 )
 from .protocol import (
     DISCUSS_FAILED_OUTCOME,
+    DeferredStage,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
@@ -200,6 +219,7 @@ from .round_state import (
     ResumedRoundSelection,
     ResumedReviewRound,
     _attach_round_metadata,
+    _decode_discuss_vote,
     _decode_round_metadata,
     _deserialize_disposition,
     _deserialize_unresolved_item,
@@ -1708,6 +1728,176 @@ def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
     return "blocking with blocking plan issues"
 
 
+_DEFERRED_STAGES_SECTION_RE = re.compile(
+    r"^###\s*Deferred stages \(not in this plan\)\s*$",
+    re.M,
+)
+_NEXT_HEADING_RE = re.compile(r"^#{1,6}\s", re.M)
+_PLAN_NARROWING_PHRASE_RE = re.compile(
+    r"\b(stage \d+ of|first stage|out of scope|separate issue|follow-up issue|future issue)\b",
+    re.I,
+)
+
+
+def _extract_current_deferred_stages(current_plan: str) -> tuple[DeferredStage, ...]:
+    """Recover declared `deferred_stages` from the current plan text (#476).
+
+    `current_plan` is either the raw structured `plan_state` JSON response (the
+    initial round, never revised) or the canonical revision markdown (after a
+    `plan_revision` round), so both forms are checked.
+    """
+    try:
+        structured = validate_structured_plan_state(current_plan)
+    except AgentLoopError:
+        structured = None
+    if structured is not None:
+        return structured.deferred_stages
+    match = _DEFERRED_STAGES_SECTION_RE.search(current_plan)
+    if not match:
+        return ()
+    section = current_plan[match.end():]
+    next_heading = _NEXT_HEADING_RE.search(section)
+    if next_heading:
+        section = section[: next_heading.start()]
+    stages: list[DeferredStage] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        title_and_summary = stripped[2:]
+        title, _sep, summary = title_and_summary.partition(":")
+        stages.append(DeferredStage(title=title.strip(), summary=summary.strip()))
+    return tuple(stages)
+
+
+def _prior_discuss_split_proposals(
+    issue_context: IssueContext, *, config: AgentLoopConfig
+) -> list[str]:
+    """Recover proposals from a prior discuss `split` consensus on this issue (#476).
+
+    Used by plan-first narrowing so a plan built on top of an earlier discuss
+    split still files (or warns about) the stages the plan itself doesn't
+    cover, even when discuss-mode materialization was never run.
+    """
+    records = _extract_round_metadata_records(issue_context.comments, flow="discuss")
+    final_summaries = [
+        record for record in records if record.metadata.role == "summary" and record.metadata.is_final
+    ]
+    if not final_summaries:
+        return []
+    latest = final_summaries[-1]
+    if latest.metadata.split_proposals:
+        return list(latest.metadata.split_proposals)
+    recovered = _recover_final_discuss_split_proposals(
+        issue_context,
+        subject=latest.metadata.subject,
+        configured_reviewers=reviewers(config),
+    )
+    return list(recovered[0]) if recovered else []
+
+
+def _plan_text_suggests_narrowing(plan_text: str) -> bool:
+    return bool(_PLAN_NARROWING_PHRASE_RE.search(plan_text))
+
+
+def _plan_first_line(plan_text: str) -> str:
+    """A title-like string for `plan_text`, used for split-stage title matching.
+
+    For the initial (never-revised) `plan_state` round, `plan_text` is the raw
+    structured JSON response rather than rendered markdown, so its natural
+    "title" is the structured `summary` field, not its literal first line.
+    """
+    try:
+        structured = validate_structured_plan_state(plan_text)
+    except AgentLoopError:
+        structured = None
+    if structured is not None:
+        return structured.summary
+    for line in plan_text.splitlines():
+        stripped = line.strip().lstrip("#").strip()
+        if stripped:
+            return stripped
+    return plan_text.strip()
+
+
+def _handle_plan_first_split_scope(
+    runner: Runner,
+    *,
+    issue_number: int,
+    config: AgentLoopConfig,
+    current_plan: str,
+    plan_subject: str,
+    issue_context: IssueContext,
+) -> None:
+    """Materialize (or warn about) split/deferred stages before implementation
+    handoff (#476), so a plan-first run that narrows scope to one stage cannot
+    silently leave the rest unfiled (the #467/#474 gap)."""
+    current_deferred_stages = _extract_current_deferred_stages(current_plan)
+    prior_discuss_proposals = _prior_discuss_split_proposals(issue_context, config=config)
+    remaining_proposals = dedupe_split_stage_proposals(
+        [split_stage_proposal_from_deferred_stage(stage) for stage in current_deferred_stages]
+        + [split_stage_proposal_from_text(proposal) for proposal in prior_discuss_proposals]
+    )
+    if remaining_proposals:
+        if config.materialize_split_issues:
+            materialize_split_proposals(
+                runner,
+                config=config,
+                parent_issue=issue_number,
+                subject=plan_subject,
+                proposals=remaining_proposals,
+                issue_comments=issue_context.comments,
+            )
+            return
+        log(
+            config,
+            f"Planning issue #{issue_number}: split follow-ups remain unfiled; rerun with "
+            "--materialize-split-issues or file them manually.",
+        )
+        if not has_unfiled_split_warning(
+            issue_context.comments, issue_number=issue_number, subject=plan_subject
+        ):
+            post_unfiled_split_warning(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                subject=plan_subject,
+                proposals=remaining_proposals,
+            )
+        return
+    if current_deferred_stages or prior_discuss_proposals:
+        return
+    if not _plan_text_suggests_narrowing(current_plan):
+        return
+    log(
+        config,
+        f"Planning issue #{issue_number}: approved plan text suggests scope narrowing "
+        "but no `deferred_stages` or discuss split proposals were declared or filed.",
+    )
+    if has_unfiled_split_warning(issue_context.comments, issue_number=issue_number, subject=plan_subject):
+        return
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body="\n".join(
+            [
+                "### Possible unfiled scope narrowing",
+                "",
+                "The approved plan's text appears to narrow scope (mentions a stage, "
+                "follow-up issue, or out-of-scope work), but no `deferred_stages` were "
+                "structurally declared and no discuss split proposals exist for this issue. "
+                "If this plan intentionally defers work, declare it via `deferred_stages` in a "
+                "future revision or file the follow-up issue(s) manually. This is a heuristic "
+                "warning only; the orchestrator never auto-creates issues from prose.",
+                "",
+                f"<!-- AGENT_SPLIT_UNFILED_WARNING: issue={issue_number} subject={plan_subject} -->",
+                "-- coding-review-agent-loop",
+            ]
+        ),
+    )
+
+
 def _read_assigned_workdir_head(runner: Runner, config: AgentLoopConfig) -> str | None:
     result = runner.run(
         ("git", "rev-parse", "HEAD"),
@@ -1755,6 +1945,7 @@ def _implement_approved_issue(
     usage_context: RunUsageContext,
     one_shot_parent_issue: int | None = None,
     plan_subject: str | None = None,
+    staged_parent_issue: int | None = None,
 ) -> int:
     coder_name = agent_display_name(config.coder)
     plan_hash = approved_plan_hash(approved_plan)
@@ -1779,6 +1970,7 @@ def _implement_approved_issue(
             memory,
             issue_context=issue_context,
             salvage_summary=salvage_summary,
+            staged_parent_issue=staged_parent_issue,
         ),
         session_id=coder_session_id,
         marker_description="<!-- AGENT_PR: <number> --> or PR URL",
@@ -1815,6 +2007,13 @@ def _implement_approved_issue(
         pr_number=pr_number,
         issue_number=issue_number,
     )
+    if staged_parent_issue is not None:
+        validate_pr_body_does_not_close_issue(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            issue_number=staged_parent_issue,
+        )
     initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
     if one_shot_parent_issue is not None:
         post_one_shot_impl_handoff_comment(
@@ -2371,6 +2570,14 @@ def _run_plan_first_loop(
                 sources=approved_future_followup_sources,
                 allow_issue_filing=mode in {"implement-one-shot", "implement-by-phase"},
             )
+            _handle_plan_first_split_scope(
+                runner,
+                issue_number=issue_number,
+                config=config,
+                current_plan=current_plan,
+                plan_subject=plan_subject,
+                issue_context=issue_context,
+            )
             if mode == "plan-only":
                 print(
                     f"Issue #{issue_number} plan approved by {format_agent_list(configured_reviewers)}."
@@ -2455,9 +2662,59 @@ def _run_plan_first_loop(
             if mode == "implement-one-shot":
                 plan_hash = approved_plan_hash(current_plan)
                 plan_subject = _plan_subject(current_plan)
+
+                # Selected-stage handoff (#476): when the parent's split proposals were
+                # already fully materialized into child issues (discuss `split` or a prior
+                # plan-first run), implementation must target the child the approved plan
+                # actually covers instead of treating the whole parent as solved.
+                target_issue_number = issue_number
+                target_issue_context = issue_context
+                staged_parent_issue: int | None = None
+                split_metadata = find_existing_split_materialization(
+                    issue_context.comments, parent_issue=issue_number
+                )
+                if split_metadata is not None and split_metadata.children:
+                    stage_handoff = find_existing_split_stage_handoff(
+                        issue_context.comments, parent_issue=issue_number, plan_hash=plan_hash
+                    )
+                    if stage_handoff is not None:
+                        selected_child = next(
+                            (
+                                child
+                                for child in split_metadata.children
+                                if child.number == stage_handoff.child_issue_number
+                            ),
+                            None,
+                        )
+                        if selected_child is None or selected_child.number is None:
+                            raise AgentLoopError(
+                                f"Recorded split-stage handoff for issue #{issue_number} references "
+                                "a child issue that is no longer in the materialized split metadata; "
+                                "manual recovery required."
+                            )
+                    else:
+                        selected_child = resolve_selected_stage_child(
+                            split_metadata.children,
+                            parent_issue=issue_number,
+                            plan_title_or_subject=_plan_first_line(current_plan),
+                            split_stage_flag=config.split_stage,
+                        )
+                        post_split_stage_handoff_comment(
+                            runner,
+                            config=config,
+                            parent_issue=issue_number,
+                            plan_hash=plan_hash,
+                            child=selected_child,
+                        )
+                    target_issue_number = selected_child.number
+                    target_issue_context = get_issue_context(
+                        runner, config=config, issue_number=target_issue_number
+                    )
+                    staged_parent_issue = issue_number
+
                 existing_handoff = find_existing_one_shot_impl_handoff(
-                    issue_context.comments,
-                    parent_issue=issue_number,
+                    target_issue_context.comments,
+                    parent_issue=target_issue_number,
                     plan_hash=plan_hash,
                     mode="implement-one-shot",
                 )
@@ -2469,7 +2726,7 @@ def _run_plan_first_loop(
                     except AgentLoopError:
                         raise AgentLoopError(
                             f"PR #{existing_handoff.pr_number} recorded in the one-shot handoff "
-                            f"for issue #{issue_number} cannot be found in {config.repo}. "
+                            f"for issue #{target_issue_number} cannot be found in {config.repo}. "
                             f"Verify the PR exists and rerun "
                             f"`agent-loop pr {existing_handoff.pr_number}` directly to continue, "
                             "or remove the handoff comment from the issue and rerun to re-implement."
@@ -2477,40 +2734,48 @@ def _run_plan_first_loop(
                     if pr_state == "OPEN":
                         log(
                             config,
-                            f"Issue #{issue_number}: resuming PR #{existing_handoff.pr_number} "
+                            f"Issue #{target_issue_number}: resuming PR #{existing_handoff.pr_number} "
                             "review for already-handed-off plan",
                         )
                         validate_pr_references_issue(
                             runner,
                             config=config,
                             pr_number=existing_handoff.pr_number,
-                            issue_number=issue_number,
+                            issue_number=target_issue_number,
                         )
+                        if staged_parent_issue is not None:
+                            validate_pr_body_does_not_close_issue(
+                                runner,
+                                config=config,
+                                pr_number=existing_handoff.pr_number,
+                                issue_number=staged_parent_issue,
+                            )
                         return run_pr_loop(
                             runner,
                             pr_number=existing_handoff.pr_number,
                             config=config,
-                            issue_context=issue_context,
+                            issue_context=target_issue_context,
                             usage_context=usage_context,
                         )
                     else:
                         print(
-                            f"Issue #{issue_number} approved plan was handed off to "
+                            f"Issue #{target_issue_number} approved plan was handed off to "
                             f"PR #{existing_handoff.pr_number}, which is "
                             f"{pr_state.lower()}. Nothing to resume."
                         )
                         return 0
                 return _implement_approved_issue(
                     runner,
-                    issue_number=issue_number,
+                    issue_number=target_issue_number,
                     approved_plan=current_plan,
                     config=config,
                     memory=memory,
-                    issue_context=issue_context,
+                    issue_context=target_issue_context,
                     coder_session_id=coder_session_id,
                     usage_context=usage_context,
-                    one_shot_parent_issue=issue_number,
+                    one_shot_parent_issue=target_issue_number,
                     plan_subject=plan_subject,
+                    staged_parent_issue=staged_parent_issue,
                 )
             raise AgentLoopError(f"Unknown plan execution mode: {mode}")
 
@@ -3676,6 +3941,16 @@ DISCUSS_CONSENSUS_MARKER_RE = re.compile(
 def _is_bot_authored_discuss_comment(body: str) -> bool:
     if DISCUSS_CONSENSUS_MARKER_RE.search(body):
         return True
+    # Split-materialization comments (#476) can land on the same issue a
+    # discuss run is evaluating (the parent and the discuss subject are the
+    # same issue); they must not perturb subject hashing or be forwarded to
+    # debaters as fresh human discussion on a later rerun.
+    if (
+        DISCUSS_SPLIT_MARKER_RE.search(body)
+        or UNFILED_SPLIT_WARNING_MARKER_RE.search(body)
+        or SPLIT_STAGE_HANDOFF_MARKER_RE.search(body)
+    ):
+        return True
     match = ROUND_RESUME_MARKER_RE.search(body)
     if match is None:
         return False
@@ -3719,6 +3994,99 @@ def _detect_discuss_consensus(
         return None
     split_proposals = _merge_discuss_split_proposals(votes) if outcome == "split" else []
     return outcome, split_proposals
+
+
+def _handle_discuss_split_outcome(
+    runner: Runner,
+    *,
+    issue_number: int,
+    config: AgentLoopConfig,
+    subject: str,
+    split_proposals: Sequence[str],
+    final_votes: Sequence[ParsedDiscussReview],
+    issue_comments: Sequence[object],
+    post_warning_comment: bool,
+) -> None:
+    """Materialize (or warn about) a discuss `split` consensus's proposed sub-issues (#476).
+
+    Called both when the final summary is freshly posted and on a resumed/
+    already-final run, so enabling `--materialize-split-issues` on a rerun
+    still files the proposals instead of leaving them stuck in comments.
+    Idempotent: `materialize_split_proposals` finds prior children via the
+    parent marker and creates nothing when they already cover every proposal.
+    """
+    if not split_proposals:
+        return
+    proposals = dedupe_split_stage_proposals(
+        [split_stage_proposal_from_text(proposal) for proposal in split_proposals]
+    )
+    if config.materialize_split_issues:
+        rationale = tuple(
+            (vote.reviewer, vote.rationale) for vote in final_votes if vote.outcome == "split"
+        )
+        materialize_split_proposals(
+            runner,
+            config=config,
+            parent_issue=issue_number,
+            subject=subject,
+            proposals=proposals,
+            rationale=rationale,
+            issue_comments=issue_comments,
+        )
+        return
+    log(
+        config,
+        f"discuss: split follow-ups are NOT filed as issues for #{issue_number}; rerun with "
+        "--materialize-split-issues or file them manually.",
+    )
+    if post_warning_comment and not has_unfiled_split_warning(
+        issue_comments, issue_number=issue_number, subject=subject
+    ):
+        post_unfiled_split_warning(
+            runner,
+            config=config,
+            issue_number=issue_number,
+            subject=subject,
+            proposals=proposals,
+        )
+
+
+def _recover_final_discuss_split_proposals(
+    issue_context: IssueContext,
+    *,
+    subject: str,
+    configured_reviewers: Sequence[AgentName],
+) -> tuple[list[str], list[ParsedDiscussReview]] | None:
+    """Legacy fallback (#476): reconstruct final-round votes and merged split
+    proposals from debater comment metadata when `PostedRoundMetadata` has no
+    `split_proposals` recorded on the final summary (comments posted before
+    this field existed)."""
+    records = _extract_round_metadata_records(issue_context.comments, flow="discuss")
+    subject_records = [record for record in records if record.metadata.subject == subject]
+    if not subject_records:
+        return None
+    final_round_number = max(record.metadata.round_number for record in subject_records)
+    debater_records = [
+        record
+        for record in subject_records
+        if record.metadata.round_number == final_round_number and record.metadata.role == "debater"
+    ]
+    if not debater_records:
+        return None
+    configured_reviewer_names = [agent_display_name(agent) for agent in configured_reviewers]
+    by_name = {record.metadata.agent: record for record in debater_records}
+    final_votes: list[ParsedDiscussReview] = []
+    for name in configured_reviewer_names:
+        record = by_name.get(name)
+        if record is None:
+            continue
+        final_votes.append(_decode_discuss_vote(record, round_number=final_round_number))
+    if not final_votes:
+        return None
+    consensus = _detect_discuss_consensus(final_votes)
+    if consensus is None or consensus[0] != "split":
+        return None
+    return consensus[1], final_votes
 
 
 def _run_discuss_analyzer(
@@ -3927,18 +4295,55 @@ def _run_discuss_loop(
         raise AgentLoopError("--discuss-max-rounds must be zero or greater.")
     issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
     subject = _discuss_subject(issue_context)
-    for comment in issue_context.comments or []:
-        body = comment.body or ""
-        m = DISCUSS_CONSENSUS_MARKER_RE.search(body)
-        if m and m.group(1).lower() == subject:
-            log(config, f"discuss: found matching consensus comment for issue #{issue_number}; skipping")
-            return 0
     configured_reviewers = list(_reviewers(config))
     resume_state = _resume_discuss_round(
         issue_context.comments, subject=subject, configured_reviewers=configured_reviewers
     )
-    if resume_state is not None and resume_state.done:
-        log(config, f"discuss: found matching round-summary comment for issue #{issue_number}; skipping")
+
+    def _resolve_final_split_proposals() -> tuple[list[str], Sequence[ParsedDiscussReview]] | None:
+        # Resuming (or already-final) reruns must materialize a split consensus
+        # instead of silently skipping (#476): prefer the split proposals
+        # recorded directly on the final summary metadata, and fall back to
+        # reconstructing them from debater comment metadata for legacy
+        # summaries that predate the `split_proposals` field.
+        if resume_state is not None and resume_state.done and resume_state.round_history:
+            final_votes = resume_state.round_history[-1]
+            consensus = _detect_discuss_consensus(list(final_votes))
+            if consensus is not None and consensus[0] == "split" and consensus[1]:
+                return consensus[1], final_votes
+        return _recover_final_discuss_split_proposals(
+            issue_context, subject=subject, configured_reviewers=configured_reviewers
+        )
+
+    already_final = False
+    for comment in issue_context.comments or []:
+        body = comment.body or ""
+        m = DISCUSS_CONSENSUS_MARKER_RE.search(body)
+        if m and m.group(1).lower() == subject:
+            already_final = True
+            break
+    if already_final or (resume_state is not None and resume_state.done):
+        log(config, f"discuss: found matching consensus for issue #{issue_number}; skipping debate")
+        recovered = _resolve_final_split_proposals()
+        if recovered is not None:
+            split_proposals, final_votes = recovered
+            _handle_discuss_split_outcome(
+                runner,
+                issue_number=issue_number,
+                config=config,
+                subject=subject,
+                split_proposals=split_proposals,
+                final_votes=final_votes,
+                issue_comments=issue_context.comments,
+                post_warning_comment=False,
+            )
+        elif config.materialize_split_issues:
+            log(
+                config,
+                f"discuss: issue #{issue_number} has a final consensus comment but no "
+                "recoverable split-proposal metadata; nothing to materialize (or this was not "
+                "a `split` consensus).",
+            )
         return 0
     memory = prepare_agent_memory(runner, config)
     analyzer = config.discuss_analyzer
@@ -4304,6 +4709,7 @@ def _run_discuss_loop(
                     analyzer_response=analyzer_response_raw,
                     research_mode=config.discuss_research,
                     failed_debaters=tuple(failed_debaters),
+                    split_proposals=tuple(round_split_proposals) if is_final else (),
                 ),
             ),
         )
@@ -4313,6 +4719,17 @@ def _run_discuss_loop(
                 f"discuss: posted final summary comment for issue #{issue_number} "
                 f"(outcome: {outcome}; kind: {consensus_kind})",
             )
+            if outcome == "split":
+                _handle_discuss_split_outcome(
+                    runner,
+                    issue_number=issue_number,
+                    config=config,
+                    subject=subject,
+                    split_proposals=round_split_proposals,
+                    final_votes=successful_votes,
+                    issue_comments=issue_context.comments,
+                    post_warning_comment=True,
+                )
             return 0
         log(
             config,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -748,10 +748,21 @@ Use this mandatory structured JSON response format:
     "Update `src/coding_review_agent_loop/protocol.py` to hard-fail invalid structured plan payloads after JSON-prefix detection.",
     "Normalize structured plan rendering and metadata-backed resume behavior in `src/coding_review_agent_loop/orchestrator.py`.",
     "Extend prompts and targeted tests for structured planning flows."
+  ],
+  "deferred_stages": [
+    {"title": "Follow-up stage title", "summary": "One-sentence scope this plan intentionally leaves out."}
   ]
 }
 <!-- AGENT_PLAN_STATE: blocking -->
 -- coder signature shown in the volatile tail
+
+If the plan intentionally narrows scope (mentions a later stage, follow-up
+issue, or explicitly out-of-scope work), declare EVERY such stage in the
+optional `deferred_stages` field instead of leaving it only in prose; omit the
+field entirely (or use an empty list) when the plan covers full scope. The
+orchestrator uses `deferred_stages` to file or warn about unfiled follow-up
+work before implementation, so undeclared narrowing can leave scope silently
+untracked once this plan's PR merges.
 
 The orchestrator will normalize structured plan revisions into canonical
 markdown for stored plan state, reviewer prompts, subject hashing, and resume.
@@ -835,6 +846,24 @@ def _issue_pr_reference_guidance(issue_number: int) -> str:
     return (
         f"In the pull request body, include `Fixes #{issue_number}` or another direct "
         f"reference to issue #{issue_number} so GitHub links the PR back to the issue.\n"
+    )
+
+
+def _staged_issue_pr_reference_guidance(issue_number: int, *, staged_parent_issue: int) -> str:
+    """PR-reference guidance for a staged implementation (#476).
+
+    Used when `issue_number` is one split/deferred stage of `staged_parent_issue`
+    and other stages remain unfiled or unimplemented: the PR must close only the
+    stage issue, and must NOT use a closing keyword against the parent, or the
+    parent would auto-close while the other stages are still outstanding.
+    """
+    return (
+        f"This PR implements one stage (#{issue_number}) split out of parent issue "
+        f"#{staged_parent_issue}; other stages may remain unfiled or unimplemented. In the pull "
+        f"request body, include `Closes #{issue_number}` (or another direct reference to "
+        f"#{issue_number}) plus `Refs #{staged_parent_issue}`. Do NOT use a closing keyword "
+        f"(Fixes/Closes/Resolves) against #{staged_parent_issue} — that would auto-close the "
+        "parent while other stages remain outstanding.\n"
     )
 
 
@@ -1424,6 +1453,7 @@ def build_issue_implementation_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     salvage_summary: str | None = None,
+    staged_parent_issue: int | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -1431,6 +1461,11 @@ def build_issue_implementation_prompt(
         issue_context,
         requirement_scope="implementation requirements",
         full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
+    pr_reference_guidance = (
+        _staged_issue_pr_reference_guidance(issue_number, staged_parent_issue=staged_parent_issue)
+        if staged_parent_issue is not None
+        else _issue_pr_reference_guidance(issue_number)
     )
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 
@@ -1440,7 +1475,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
-{_issue_pr_reference_guidance(issue_number)}
+{pr_reference_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
     requirement_label="implementation requirements",

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -199,6 +199,18 @@ class StructuredCoderFollowup:
 
 
 @dataclass(frozen=True)
+class DeferredStage:
+    """A stage the plan intentionally leaves out of the current scope (#476).
+
+    Declared by the coder in structured plan responses so scope narrowing is a
+    mechanical signal instead of prose the orchestrator would have to guess at.
+    """
+
+    title: str
+    summary: str
+
+
+@dataclass(frozen=True)
 class StructuredPlanRevision:
     schema_version: int
     kind: str
@@ -206,6 +218,7 @@ class StructuredPlanRevision:
     summary: str
     prior_plan_item_dispositions: tuple[ReviewItemDisposition, ...]
     plan_steps: tuple[str, ...]
+    deferred_stages: tuple[DeferredStage, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -215,6 +228,7 @@ class StructuredPlanState:
     state: str
     summary: str
     plan_steps: tuple[str, ...]
+    deferred_stages: tuple[DeferredStage, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -654,6 +668,37 @@ def _expect_optional_string_list(
         item_context=item_context,
         min_length=min_length,
     )
+
+
+def _expect_deferred_stage_list(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> tuple[DeferredStage, ...]:
+    value = payload.get(field_name, [])
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    stages: list[DeferredStage] = []
+    seen_title_keys: set[str] = set()
+    for index, item in enumerate(value):
+        item_context = f"{context} at index {index}"
+        item_payload = _expect_object(item, context=item_context)
+        _expect_exact_keys(item_payload, context=item_context, required={"title", "summary"})
+        title = _expect_non_empty_string(item_payload["title"], context=f"{item_context}.title")
+        title_key = " ".join(title.lower().split())
+        if title_key in seen_title_keys:
+            raise AgentLoopError(f"{context} has a duplicate stage title: {title!r}.")
+        seen_title_keys.add(title_key)
+        stages.append(
+            DeferredStage(
+                title=title,
+                summary=_expect_non_empty_string(
+                    item_payload["summary"], context=f"{item_context}.summary"
+                ),
+            )
+        )
+    return tuple(stages)
 
 
 def _expect_state(value: object, *, context: str) -> str:
@@ -1396,6 +1441,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
             "prior_plan_item_dispositions",
             "plan_steps",
         },
+        optional={"deferred_stages"},
     )
     state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
     if state != "blocking":
@@ -1414,6 +1460,9 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         item_context="plan_revision.plan_steps",
         min_length=1,
     )
+    deferred_stages = _expect_deferred_stage_list(
+        payload, "deferred_stages", context="plan_revision.deferred_stages"
+    )
     return StructuredPlanRevision(
         schema_version=1,
         kind="plan_revision",
@@ -1421,6 +1470,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         summary=summary,
         prior_plan_item_dispositions=dispositions,
         plan_steps=plan_steps,
+        deferred_stages=deferred_stages,
     )
 
 
@@ -1437,7 +1487,7 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
         payload,
         context="plan_state",
         required={"kind", "summary", "plan_steps"},
-        optional={"schema_version", "state"},
+        optional={"schema_version", "state", "deferred_stages"},
     )
     if "state" in payload:
         _expect_state(payload["state"], context="plan_state.state")
@@ -1451,6 +1501,9 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
             context="plan_state.plan_steps",
             item_context="plan_state.plan_steps",
             min_length=1,
+        ),
+        deferred_stages=_expect_deferred_stage_list(
+            payload, "deferred_stages", context="plan_state.deferred_stages"
         ),
     )
 

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -57,6 +57,11 @@ class PostedRoundMetadata:
     # (display name, failure category) pairs on the round summary. Resume
     # treats these debaters' missing comments as accounted for.
     failed_debaters: tuple[tuple[str, str], ...] = ()
+    # Merged discuss split proposals recorded on a final summary comment
+    # (#476), so a resumed run can materialize them into child issues without
+    # having to reconstruct them from debater comment metadata. Empty on
+    # non-final, non-split, and legacy comments.
+    split_proposals: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -154,6 +159,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "analyzer_response": metadata.analyzer_response,
         "research_mode": metadata.research_mode,
         "failed_debaters": [list(pair) for pair in metadata.failed_debaters],
+        "split_proposals": list(metadata.split_proposals),
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -210,6 +216,7 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
                 for pair in payload.get("failed_debaters", [])
                 if isinstance(pair, (list, tuple)) and len(pair) == 2
             ),
+            split_proposals=tuple(str(item) for item in payload.get("split_proposals", [])),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -341,8 +341,23 @@ def materialize_split_proposals(
     if not to_resolve:
         return existing
 
-    capped = to_resolve[:MAX_SPLIT_CHILDREN]
-    skipped = to_resolve[MAX_SPLIT_CHILDREN:]
+    # Remaining capacity is derived from children already recorded in the
+    # parent's cumulative metadata, not just this call's unresolved proposals,
+    # so repeated reruns with the same over-cap proposal set cannot keep
+    # filing new children past MAX_SPLIT_CHILDREN (#492 review).
+    remaining_capacity = max(0, MAX_SPLIT_CHILDREN - len(known_by_key))
+    capped = to_resolve[:remaining_capacity]
+    skipped = to_resolve[remaining_capacity:]
+
+    if not capped:
+        skipped_titles = ", ".join(proposal.title for proposal in skipped)
+        log(
+            config,
+            f"Split materialization for issue #{parent_issue}: skipped {len(skipped)} "
+            f"stage(s) by cap (MAX_SPLIT_CHILDREN={MAX_SPLIT_CHILDREN}, already at cap): "
+            f"{skipped_titles}",
+        )
+        return existing
 
     adopted_by_key = _adopt_from_search(
         runner, config=config, parent_issue=parent_issue, remaining=capped

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -1,0 +1,601 @@
+"""Materialize discuss `split` proposals and plan `deferred_stages` into child issues (#476).
+
+When a discuss consensus lands on `outcome: split`, or an approved plan-first
+plan narrows scope via `deferred_stages`, the proposed follow-up work should
+not remain text buried in issue comments: it should become concrete GitHub
+issues linked back to the parent, so an implementation run that scopes down to
+one stage cannot silently leave the rest unfiled.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .config import AgentLoopConfig
+from .decomposition import _decode_json_payload, _encode_json_payload, _issue_number_from_url
+from .errors import AgentLoopError
+from .github import FoundIssue, create_issue, post_issue_comment, search_issues
+from .logging import log
+from .protocol import DeferredStage
+from .runner import Runner
+
+MAX_SPLIT_CHILDREN = 8
+
+DISCUSS_SPLIT_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_DISCUSS_SPLIT:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+SPLIT_CHILD_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_SPLIT_CHILD:\s*parent=(?P<parent>\d+)\s+key=(?P<key>[0-9a-f]{64})\s*-->",
+    re.I,
+)
+SPLIT_STAGE_HANDOFF_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_SPLIT_STAGE_HANDOFF:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+UNFILED_SPLIT_WARNING_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_SPLIT_UNFILED_WARNING:\s*issue=(?P<issue>\d+)\s+subject=(?P<subject>\S+)\s*-->",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class SplitStageProposal:
+    """A candidate follow-up stage, normalized from either a discuss split
+    proposal (free text) or a plan's declared `deferred_stages` entry."""
+
+    title: str
+    body: str
+    key: str
+
+
+@dataclass(frozen=True)
+class MaterializedSplitChild:
+    title: str
+    key: str
+    url: str | None
+    number: int | None
+    origin: str  # "created" or "adopted"
+
+
+@dataclass(frozen=True)
+class SplitMaterializationMetadata:
+    parent_issue: int
+    subject: str
+    children: tuple[MaterializedSplitChild, ...]
+    selected_stage: int | None = None
+
+
+@dataclass(frozen=True)
+class SplitStageHandoffMetadata:
+    parent_issue: int
+    plan_hash: str
+    child_issue_number: int
+    child_issue_url: str | None
+
+
+def _normalize_stage_key(text: str) -> str:
+    key = re.sub(r"`([^`]+)`", r"\1", text)
+    key = re.sub(r"\*\*([^*]+)\*\*", r"\1", key)
+    key = re.sub(r"[_*#>]+", " ", key)
+    key = re.sub(r"[^\w\s]+", " ", key.lower())
+    return " ".join(key.split())
+
+
+def _stage_key(title: str) -> str:
+    return hashlib.sha256(_normalize_stage_key(title).encode("utf-8")).hexdigest()
+
+
+def split_stage_proposal_from_text(text: str) -> SplitStageProposal:
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), text.strip())
+    title = " ".join(first_line.split())
+    return SplitStageProposal(title=title, body=text.strip(), key=_stage_key(title))
+
+
+def split_stage_proposal_from_deferred_stage(stage: DeferredStage) -> SplitStageProposal:
+    return SplitStageProposal(title=stage.title, body=stage.summary, key=_stage_key(stage.title))
+
+
+def dedupe_split_stage_proposals(
+    proposals: Sequence[SplitStageProposal],
+) -> list[SplitStageProposal]:
+    seen: set[str] = set()
+    deduped: list[SplitStageProposal] = []
+    for proposal in proposals:
+        if proposal.key in seen:
+            continue
+        seen.add(proposal.key)
+        deduped.append(proposal)
+    return deduped
+
+
+def _child_issue_title(parent_issue: int, proposal: SplitStageProposal) -> str:
+    return f"[#{parent_issue} stage] {proposal.title}"[:120]
+
+
+def _strip_child_title_prefix(title: str, parent_issue: int) -> str:
+    prefix = f"[#{parent_issue} stage] "
+    return title[len(prefix):] if title.startswith(prefix) else title
+
+
+def _sibling_lines(children: Sequence[MaterializedSplitChild]) -> list[str]:
+    if not children:
+        return ["- None yet."]
+    lines = []
+    for child in children:
+        ref = child.url or (f"#{child.number}" if child.number is not None else "unavailable")
+        lines.append(f"- {child.title}: {ref}")
+    return lines
+
+
+def _format_child_issue_body(
+    *,
+    parent_issue: int,
+    proposal: SplitStageProposal,
+    rationale: Sequence[tuple[str, str]],
+    siblings_so_far: Sequence[MaterializedSplitChild],
+) -> str:
+    lines = [
+        f"Part of #{parent_issue}",
+        "",
+        f"Child stage issue split out of parent #{parent_issue}.",
+        "",
+        "## Proposed scope",
+        proposal.body,
+        "",
+        "## Split rationale from parent discussion",
+    ]
+    if rationale:
+        for reviewer, text in rationale:
+            lines.append(f"- {reviewer}: {text}")
+    else:
+        lines.append("- No structured rationale was recorded; see the parent issue discussion.")
+    lines.extend(
+        [
+            "",
+            "## Other stages split from the same parent",
+            *_sibling_lines(siblings_so_far),
+            "",
+            "## Execution instructions",
+            f"Run `agent-loop issue <this issue number>` to implement this stage in its own PR. "
+            "Keep the PR scoped to this stage. Do not use closing keywords "
+            f"(Closes/Fixes/Resolves) against parent #{parent_issue}; reference it with `Refs #{parent_issue}` "
+            "instead so the parent stays open until every stage is implemented.",
+            "",
+            f"<!-- AGENT_SPLIT_CHILD: parent={parent_issue} key={proposal.key} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _encode_split_metadata(metadata: SplitMaterializationMetadata) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "subject": metadata.subject,
+            "children": [
+                {
+                    "title": child.title,
+                    "key": child.key,
+                    "url": child.url,
+                    "number": child.number,
+                    "origin": child.origin,
+                }
+                for child in metadata.children
+            ],
+            "selected_stage": metadata.selected_stage,
+        }
+    )
+
+
+def _decode_split_metadata(encoded: str) -> SplitMaterializationMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_DISCUSS_SPLIT")
+    children_payload = payload.get("children")
+    if not isinstance(children_payload, list):
+        raise AgentLoopError("Invalid AGENT_DISCUSS_SPLIT payload.")
+    children: list[MaterializedSplitChild] = []
+    for child in children_payload:
+        if not isinstance(child, dict) or not isinstance(child.get("title"), str):
+            raise AgentLoopError("Invalid AGENT_DISCUSS_SPLIT payload.")
+        number = child.get("number")
+        children.append(
+            MaterializedSplitChild(
+                title=str(child["title"]),
+                key=str(child.get("key") or _stage_key(str(child["title"]))),
+                url=child.get("url") if isinstance(child.get("url"), str) else None,
+                number=int(number) if isinstance(number, int) else None,
+                origin=str(child.get("origin") or "created"),
+            )
+        )
+    try:
+        selected_stage = payload.get("selected_stage")
+        return SplitMaterializationMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            subject=str(payload["subject"]),
+            children=tuple(children),
+            selected_stage=int(selected_stage) if isinstance(selected_stage, int) else None,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_DISCUSS_SPLIT payload.") from exc
+
+
+def find_existing_split_materialization(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+) -> SplitMaterializationMetadata | None:
+    """Return the latest recorded split-materialization state for `parent_issue`.
+
+    Each materialization comment records the FULL cumulative set of known
+    children (not just newly created ones), so the latest marker for a parent
+    is always a complete snapshot regardless of which `subject` produced it.
+    This is what makes per-parent normalized-title dedupe hold even when the
+    subject hash drifts between a discuss consensus and a later plan-first
+    run (#476).
+    """
+    found: SplitMaterializationMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in DISCUSS_SPLIT_MARKER_RE.finditer(body):
+            metadata = _decode_split_metadata(match.group("payload"))
+            if metadata.parent_issue == parent_issue:
+                found = metadata
+    return found
+
+
+def format_split_materialization_summary(
+    *,
+    parent_issue: int,
+    metadata: SplitMaterializationMetadata,
+) -> str:
+    lines = [
+        f"Split follow-up stages materialized for issue #{parent_issue}.",
+        "",
+        "| Stage | Child issue | Origin |",
+        "| --- | --- | --- |",
+    ]
+    for child in metadata.children:
+        ref = child.url or (f"#{child.number}" if child.number is not None else "Created issue URL unavailable from GitHub CLI output.")
+        lines.append(f"| {child.title} | {ref} | {child.origin} |")
+    lines.extend(
+        [
+            "",
+            "Every stage above has a GitHub child issue linked back to this parent. "
+            "Continue a stage with `agent-loop issue <child issue number>`.",
+            "",
+            f"<!-- AGENT_DISCUSS_SPLIT: {_encode_split_metadata(metadata)} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _adopt_from_search(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    remaining: Sequence[SplitStageProposal],
+) -> dict[str, FoundIssue]:
+    """Crash-window recovery: look for children created before a prior run
+    crashed between `create_issue` and posting the parent marker (#476)."""
+    if not remaining:
+        return {}
+    results = search_issues(
+        runner,
+        config=config,
+        search=f'"[#{parent_issue} stage]" in:title',
+        state="all",
+    )
+    by_key: dict[str, FoundIssue] = {}
+    remaining_keys = {proposal.key for proposal in remaining}
+    for found in results:
+        if not found.title:
+            continue
+        marker_match = SPLIT_CHILD_MARKER_RE.search(found.body or "")
+        if marker_match and int(marker_match.group("parent")) == parent_issue:
+            key = marker_match.group("key")
+        else:
+            # Fallback for results missing the AGENT_SPLIT_CHILD body marker
+            # (e.g. `gh issue list --search` didn't return a body): titles are
+            # created as `[#<parent> stage] <proposal title>`, so strip that
+            # prefix before hashing to match a bare proposal key.
+            key = _stage_key(_strip_child_title_prefix(found.title, parent_issue))
+        if key in remaining_keys and key not in by_key:
+            by_key[key] = found
+    return by_key
+
+
+def materialize_split_proposals(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    subject: str,
+    proposals: Sequence[SplitStageProposal],
+    rationale: Sequence[tuple[str, str]] = (),
+    issue_comments: Sequence[object] = (),
+) -> SplitMaterializationMetadata | None:
+    """File one child issue per remaining stage in `proposals`, idempotently.
+
+    `proposals` must already exclude the stage the current run is
+    implementing (if any) — materialization only ever files REMAINING stages,
+    never the selected one. Returns None when there is nothing to file.
+    """
+    deduped = dedupe_split_stage_proposals(proposals)
+    if not deduped:
+        return None
+
+    existing = find_existing_split_materialization(issue_comments, parent_issue=parent_issue)
+    known_by_key: dict[str, MaterializedSplitChild] = (
+        {child.key: child for child in existing.children} if existing is not None else {}
+    )
+    to_resolve = [proposal for proposal in deduped if proposal.key not in known_by_key]
+
+    if not to_resolve:
+        return existing
+
+    capped = to_resolve[:MAX_SPLIT_CHILDREN]
+    skipped = to_resolve[MAX_SPLIT_CHILDREN:]
+
+    adopted_by_key = _adopt_from_search(
+        runner, config=config, parent_issue=parent_issue, remaining=capped
+    )
+
+    new_children: list[MaterializedSplitChild] = []
+    resolved_so_far: list[MaterializedSplitChild] = list(known_by_key.values())
+
+    for proposal in capped:
+        found = adopted_by_key.get(proposal.key)
+        if found is not None:
+            child = MaterializedSplitChild(
+                title=proposal.title,
+                key=proposal.key,
+                url=found.url,
+                number=found.number,
+                origin="adopted",
+            )
+            new_children.append(child)
+            resolved_so_far.append(child)
+            continue
+        issue_url = create_issue(
+            runner,
+            config=config,
+            title=_child_issue_title(parent_issue, proposal),
+            body=_format_child_issue_body(
+                parent_issue=parent_issue,
+                proposal=proposal,
+                rationale=rationale,
+                siblings_so_far=resolved_so_far,
+            ),
+        )
+        child = MaterializedSplitChild(
+            title=proposal.title,
+            key=proposal.key,
+            url=issue_url,
+            number=_issue_number_from_url(issue_url),
+            origin="created",
+        )
+        new_children.append(child)
+        resolved_so_far.append(child)
+
+    if skipped:
+        skipped_titles = ", ".join(proposal.title for proposal in skipped)
+        # Not filed; surfaced via log only, matching decomposition's cap note style.
+        log(
+            config,
+            f"Split materialization for issue #{parent_issue}: skipped {len(skipped)} "
+            f"stage(s) by cap (MAX_SPLIT_CHILDREN={MAX_SPLIT_CHILDREN}): {skipped_titles}",
+        )
+
+    all_children = tuple(known_by_key.values()) + tuple(new_children)
+    metadata = SplitMaterializationMetadata(
+        parent_issue=parent_issue,
+        subject=subject,
+        children=all_children,
+        selected_stage=existing.selected_stage if existing is not None else None,
+    )
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=parent_issue,
+        body=format_split_materialization_summary(parent_issue=parent_issue, metadata=metadata),
+    )
+    return metadata
+
+
+def _encode_stage_handoff_metadata(metadata: SplitStageHandoffMetadata) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "plan_hash": metadata.plan_hash,
+            "child_issue_number": metadata.child_issue_number,
+            "child_issue_url": metadata.child_issue_url,
+        }
+    )
+
+
+def _decode_stage_handoff_metadata(encoded: str) -> SplitStageHandoffMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_SPLIT_STAGE_HANDOFF")
+    try:
+        child_issue_url = payload.get("child_issue_url")
+        return SplitStageHandoffMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            plan_hash=str(payload["plan_hash"]),
+            child_issue_number=int(payload["child_issue_number"]),
+            child_issue_url=child_issue_url if isinstance(child_issue_url, str) else None,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_SPLIT_STAGE_HANDOFF payload.") from exc
+
+
+def find_existing_split_stage_handoff(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+    plan_hash: str,
+) -> SplitStageHandoffMetadata | None:
+    found: SplitStageHandoffMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in SPLIT_STAGE_HANDOFF_MARKER_RE.finditer(body):
+            metadata = _decode_stage_handoff_metadata(match.group("payload"))
+            if metadata.parent_issue == parent_issue and metadata.plan_hash == plan_hash:
+                found = metadata
+    return found
+
+
+def resolve_selected_stage_child(
+    children: Sequence[MaterializedSplitChild],
+    *,
+    parent_issue: int,
+    plan_title_or_subject: str,
+    split_stage_flag: int | None,
+) -> MaterializedSplitChild:
+    """Resolve which already-materialized child the approved plan implements.
+
+    Every proposal was already filed as a child (discuss materialized
+    everything up front), so an implement run on the parent must pick one:
+    either the explicit `--split-stage <child>` flag, or a unique
+    normalized-key match between the plan's subject/title and a child title.
+    """
+    if split_stage_flag is not None:
+        for child in children:
+            if child.number == split_stage_flag:
+                return child
+        raise AgentLoopError(
+            f"--split-stage {split_stage_flag} does not match any child issue materialized "
+            f"from parent #{parent_issue}. Known children: "
+            + ", ".join(f"#{child.number}" for child in children if child.number is not None)
+        )
+    plan_key = _stage_key(plan_title_or_subject)
+    matches = [child for child in children if child.key == plan_key]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise AgentLoopError(
+            f"Could not resolve which materialized child stage of #{parent_issue} this approved "
+            "plan implements (no title match). Run `agent-loop issue <child>` for the stage you "
+            "want, or rerun with --split-stage <child>."
+        )
+    raise AgentLoopError(
+        f"Ambiguous match between the approved plan and materialized child stages of #{parent_issue}. "
+        "Run `agent-loop issue <child>` for the stage you want, or rerun with --split-stage <child>."
+    )
+
+
+def format_split_stage_handoff_comment(
+    *,
+    parent_issue: int,
+    plan_hash: str,
+    child: MaterializedSplitChild,
+) -> str:
+    if child.number is None:
+        raise AgentLoopError(
+            "Cannot record split-stage implementation handoff because the child issue number "
+            "is unavailable."
+        )
+    metadata = SplitStageHandoffMetadata(
+        parent_issue=parent_issue,
+        plan_hash=plan_hash,
+        child_issue_number=child.number,
+        child_issue_url=child.url,
+    )
+    ref = child.url or f"#{child.number}"
+    lines = [
+        f"Approved plan implementation for issue #{parent_issue} handed off to split stage: {ref}.",
+        "",
+        f"Stage: {child.title}",
+        "",
+        "Parent reruns will not automatically re-run this child implementation. "
+        f"Resume directly with `agent-loop issue {child.number}`.",
+        "",
+        f"<!-- AGENT_SPLIT_STAGE_HANDOFF: {_encode_stage_handoff_metadata(metadata)} -->",
+        "-- coding-review-agent-loop",
+    ]
+    return "\n".join(lines)
+
+
+def post_split_stage_handoff_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    plan_hash: str,
+    child: MaterializedSplitChild,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=parent_issue,
+        body=format_split_stage_handoff_comment(
+            parent_issue=parent_issue, plan_hash=plan_hash, child=child
+        ),
+    )
+
+
+def format_unfiled_split_warning(proposals: Sequence[SplitStageProposal]) -> str:
+    """Explicit UNFILED warning so the #467/#474 gap can't hide in a neutral listing (#476)."""
+    lines = [
+        "### Split follow-ups are NOT filed as issues",
+        "",
+        "The following stage(s) remain unfiled as GitHub issues:",
+        "",
+    ]
+    lines.extend(f"- {proposal.title}" for proposal in proposals)
+    lines.extend(
+        [
+            "",
+            "Rerun with `--materialize-split-issues` to file them as child issues linked back to "
+            "this parent, or file them manually. Without filing, this scope will not be tracked "
+            "once the current stage's PR is implemented.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _unfiled_split_warning_marker(issue_number: int, subject: str) -> str:
+    return f"<!-- AGENT_SPLIT_UNFILED_WARNING: issue={issue_number} subject={subject} -->"
+
+
+def has_unfiled_split_warning(
+    comments: Sequence[object],
+    *,
+    issue_number: int,
+    subject: str,
+) -> bool:
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in UNFILED_SPLIT_WARNING_MARKER_RE.finditer(body):
+            if int(match.group("issue")) == issue_number and match.group("subject") == subject:
+                return True
+    return False
+
+
+def post_unfiled_split_warning(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    subject: str,
+    proposals: Sequence[SplitStageProposal],
+) -> None:
+    body = "\n".join(
+        [
+            format_unfiled_split_warning(proposals),
+            "",
+            _unfiled_split_warning_marker(issue_number, subject),
+            "-- coding-review-agent-loop",
+        ]
+    )
+    post_issue_comment(runner, config=config, issue_number=issue_number, body=body)

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -233,6 +233,7 @@ class FakeRunner(Runner):
         issue_urls=None,
         public_response_outputs=None,
         advance_git_head_on_pr=True,
+        search_issues_payload=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -311,6 +312,11 @@ class FakeRunner(Runner):
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
         self.advance_git_head_on_pr = advance_git_head_on_pr
+        # Results returned by the next `gh issue list --search` call (#476).
+        # A list of dicts with number/title/url/body keys; consumed one call
+        # at a time when a list of lists is provided, otherwise reused as-is.
+        self.search_issues_payload = search_issues_payload
+        self.search_issues_calls = []
         self._agent_pr_counter = 0
         self._agent_command_seen = False
         # Parallel discuss debaters (#475) call run_with_log from worker
@@ -679,6 +685,16 @@ class FakeRunner(Runner):
                 issue_url = self.issue_urls.pop(0)
             return CommandResult(cmd, cwd_path, f"{issue_url or ''}\n", "", 0)
 
+        if cmd[:3] == ["gh", "issue", "list"]:
+            search = cmd[cmd.index("--search") + 1] if "--search" in cmd else ""
+            self.search_issues_calls.append(search)
+            payload = self.search_issues_payload
+            if payload and isinstance(payload, list) and payload and isinstance(payload[0], list):
+                results = payload.pop(0) if payload else []
+            else:
+                results = payload or []
+            return CommandResult(cmd, cwd_path, json_dumps(results), "", 0)
+
         if cmd[:3] == ["gh", "pr", "view"]:
             if "--jq" in cmd and ".headRefOid" in cmd:
                 return CommandResult(cmd, cwd_path, "abc123\n", "", 0)
@@ -912,18 +928,20 @@ def structured_plan_revision(
     plan_steps: list[str] | None = None,
     reviewer: str = "Anthropic Claude",
     human_requirements: str = "",
+    deferred_stages: list[dict[str, str]] | None = None,
 ) -> str:
+    payload = {
+        "schema_version": 1,
+        "kind": "plan_revision",
+        "state": "blocking",
+        "summary": summary,
+        "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
+        "plan_steps": plan_steps or ["Update the plan.", "Run the relevant tests."],
+    }
+    if deferred_stages is not None:
+        payload["deferred_stages"] = deferred_stages
     return (
-        json.dumps(
-            {
-                "schema_version": 1,
-                "kind": "plan_revision",
-                "state": "blocking",
-                "summary": summary,
-                "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
-                "plan_steps": plan_steps or ["Update the plan.", "Run the relevant tests."],
-            }
-        )
+        json.dumps(payload)
         + human_requirements
         + "\n<!-- AGENT_PLAN_STATE: blocking -->\n"
         + f"-- {reviewer}"
@@ -936,17 +954,19 @@ def structured_plan_state(
     summary: str = "Implementation plan.",
     plan_steps: list[str] | None = None,
     reviewer: str = "Anthropic Claude",
+    deferred_stages: list[dict[str, str]] | None = None,
 ) -> str:
+    payload = {
+        "schema_version": 1,
+        "kind": "plan_state",
+        "state": state,
+        "summary": summary,
+        "plan_steps": plan_steps or ["Update the code.", "Run the relevant tests."],
+    }
+    if deferred_stages is not None:
+        payload["deferred_stages"] = deferred_stages
     return (
-        json.dumps(
-            {
-                "schema_version": 1,
-                "kind": "plan_state",
-                "state": state,
-                "summary": summary,
-                "plan_steps": plan_steps or ["Update the code.", "Run the relevant tests."],
-            }
-        )
+        json.dumps(payload)
         + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n"
         + f"-- {reviewer}"
     )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2424,6 +2424,43 @@ def test_round_metadata_round_trip_preserves_canonical_plan():
     assert _decode_round_metadata(_encode_round_metadata(metadata)).canonical_plan == metadata.canonical_plan
 
 
+def test_round_metadata_round_trip_preserves_split_proposals():
+    metadata = PostedRoundMetadata(
+        flow="discuss",
+        role="summary",
+        agent="Orchestrator",
+        round_number=1,
+        subject="abc",
+        is_final=True,
+        split_proposals=("Auth flow", "Billing flow"),
+    )
+
+    decoded = _decode_round_metadata(_encode_round_metadata(metadata))
+
+    assert decoded.split_proposals == metadata.split_proposals
+
+
+def test_decode_old_round_metadata_defaults_split_proposals_to_empty():
+    payload = {
+        "flow": "discuss",
+        "role": "summary",
+        "agent": "Orchestrator",
+        "round_number": 1,
+        "subject": "abc",
+        "prior_items": [],
+        "dispositions": [],
+        "new_items": [],
+        "state": None,
+        "canonical_plan": None,
+        "raw_structured_coder_response": None,
+    }
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+
+    assert _decode_round_metadata(encoded).split_proposals == ()
+
+
 def test_round_metadata_round_trip_preserves_compact_prior_summaries():
     metadata = PostedRoundMetadata(
         flow="plan",

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -4,6 +4,7 @@ Tests for render_canonical_plan_steps, render_canonical_plan_revision,
 render_public_agent_comment, _render_public_*_comment, and related functions.
 """
 import json
+import re
 
 import pytest
 
@@ -13,13 +14,16 @@ from coding_review_agent_loop.comment_rendering import (
     _render_public_plan_review_comment,
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
+    decode_deferred_stages_marker,
     normalize_freeform_signature,
+    render_deferred_stages_section,
     render_discuss_round_summary_comment,
 )
 from coding_review_agent_loop.protocol import ParsedDiscussReview
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     ITEM_SUMMARY_LIMIT,
+    _extract_current_deferred_stages,
     _format_unresolved_item_label,
     _render_public_review_comment,
     _review_freeform_summary_text,
@@ -28,6 +32,7 @@ from coding_review_agent_loop.orchestrator import (
     render_public_agent_comment,
 )
 from coding_review_agent_loop.protocol import (
+    DeferredStage,
     ReviewItemDisposition,
     UnresolvedReviewItem,
     parse_pr_review,
@@ -53,6 +58,51 @@ from agent_loop_helpers import (
 def test_render_canonical_plan_steps_numbers_items():
     assert render_canonical_plan_steps(("Update protocol.py.", "Add tests.")) == (
         "1. Update protocol.py.\n2. Add tests."
+    )
+
+
+def test_render_deferred_stages_section_marker_round_trips_colon_in_title():
+    """A title containing its own colon must not be corrupted: the human
+    readable `- {title}: {summary}` bullet is not what gets parsed back, an
+    AGENT_DEFERRED_STAGES marker carrying the exact structured pairs is
+    (#492 review)."""
+    stages = (
+        DeferredStage(title="Stage 2: API follow-up", summary="Split out the API work."),
+        DeferredStage(title="Billing", summary="Reconcile invoices."),
+    )
+
+    section = render_deferred_stages_section(stages)
+
+    assert "- Stage 2: API follow-up: Split out the API work." in section
+    marker_match = re.search(r"<!--\s*AGENT_DEFERRED_STAGES:\s*(?P<payload>\S+)\s*-->", section)
+    assert marker_match is not None
+    assert decode_deferred_stages_marker(marker_match.group("payload")) == stages
+
+
+def test_extract_current_deferred_stages_recovers_colon_title_from_canonical_markdown():
+    revision = validate_structured_plan_revision(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Implement the core parser change.",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": ["Update the parser."],
+                "deferred_stages": [
+                    {"title": "Stage 2: API follow-up", "summary": "Split out the API work."}
+                ],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    assert revision is not None
+    canonical = render_canonical_plan_revision(revision, ())
+
+    recovered = _extract_current_deferred_stages(canonical)
+
+    assert recovered == (
+        DeferredStage(title="Stage 2: API follow-up", summary="Split out the API work."),
     )
 
 

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -403,10 +403,74 @@ def test_discuss_loop_split_consensus_includes_proposals(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config)
 
     assert result == 0
-    posted = runner.comments[-1]
+    posted = runner.comments[-2]
     assert "Consensus: Split" in posted
     assert "Auth flow" in posted
     assert "Authorization checks" in posted
+    # --materialize-split-issues defaults off, so the orchestrator posts an
+    # explicit unfiled-split warning after the final summary (#476) instead of
+    # silently leaving the proposals as unfiled text.
+    warning = runner.comments[-1]
+    assert "NOT filed as issues" in warning
+    assert "Auth flow" in warning
+    assert "Authorization checks" in warning
+
+
+def test_discuss_loop_split_consensus_materializes_child_issues_when_enabled(tmp_path):
+    split_text = _discuss_review_text(
+        outcome="split",
+        rationale="Too broad.",
+        split_proposals=["Auth flow", "Authorization checks"],
+    )
+    runner = FakeRunner(
+        codex_outputs=[split_text],
+        gemini_outputs=[split_text],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.issues) == 2
+    assert runner.issues[0]["title"] == "[#56 stage] Auth flow"
+    assert runner.issues[1]["title"] == "[#56 stage] Authorization checks"
+    assert "Too broad." in runner.issues[0]["body"]
+    assert "Refs #56" in runner.issues[0]["body"]
+    final_summary = runner.comments[-2]
+    assert "Consensus: Split" in final_summary
+    parent_summary = runner.comments[-1]
+    assert "<!-- AGENT_DISCUSS_SPLIT:" in parent_summary
+    assert "https://github.com/OWNER/REPO/issues/101" in parent_summary
+    assert "https://github.com/OWNER/REPO/issues/102" in parent_summary
+
+
+def test_discuss_loop_split_consensus_rerun_materializes_nothing_new(tmp_path):
+    split_text = _discuss_review_text(
+        outcome="split",
+        rationale="Too broad.",
+        split_proposals=["Auth flow"],
+    )
+    runner = FakeRunner(
+        codex_outputs=[split_text],
+        gemini_outputs=[split_text],
+        issue_urls=["https://github.com/OWNER/REPO/issues/101"],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+    assert run_discuss_loop(runner, issue_number=56, config=config) == 0
+    assert len(runner.issues) == 1
+
+    # A second run reuses the same FakeRunner, which already accumulated the
+    # posted comments (with their AGENT_LOOP_META metadata) from the first
+    # run in `issue_comments`; it must find the existing consensus and
+    # materialization markers and create nothing new.
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.issues) == 1
 
 
 def test_discuss_loop_converges_after_debate(tmp_path):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -21,6 +21,7 @@ from coding_review_agent_loop.orchestrator import (
 )
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
+    DeferredStage,
     DISCUSS_ANALYZER_FRAMING_VALUES,
     DISCUSS_OUTCOME_VALUES,
     DISCUSS_RESEARCH_STATUS_VALUES,
@@ -2344,6 +2345,76 @@ def test_validate_structured_plan_revision_accepts_v1_payload():
         ("item-1", "resolved")
     ]
     assert parsed.plan_steps == ("Update protocol.py.", "Add regression tests.")
+
+
+def test_validate_structured_plan_revision_accepts_deferred_stages():
+    revision = structured_plan_revision(
+        deferred_stages=[
+            {"title": "Auth flow overhaul", "summary": "Split out follow-up work."}
+        ],
+    )
+
+    parsed = validate_structured_plan_revision(revision)
+
+    assert parsed is not None
+    assert parsed.deferred_stages == (
+        DeferredStage(title="Auth flow overhaul", summary="Split out follow-up work."),
+    )
+
+
+def test_validate_structured_plan_revision_defaults_deferred_stages_to_empty():
+    revision = structured_plan_revision()
+
+    parsed = validate_structured_plan_revision(revision)
+
+    assert parsed is not None
+    assert parsed.deferred_stages == ()
+
+
+def test_validate_structured_plan_revision_rejects_duplicate_deferred_stage_title():
+    revision = structured_plan_revision(
+        deferred_stages=[
+            {"title": "Auth flow", "summary": "First."},
+            {"title": "auth   flow", "summary": "Second, duplicate title."},
+        ],
+    )
+
+    with pytest.raises(AgentLoopError, match="duplicate stage title"):
+        validate_structured_plan_revision(revision)
+
+
+def test_validate_structured_plan_state_accepts_deferred_stages():
+    plan_state = structured_plan_state(
+        deferred_stages=[{"title": "Billing follow-up", "summary": "Out of scope for now."}],
+    )
+
+    parsed = validate_structured_plan_state(plan_state)
+
+    assert parsed is not None
+    assert parsed.deferred_stages == (
+        DeferredStage(title="Billing follow-up", summary="Out of scope for now."),
+    )
+
+
+def test_render_canonical_plan_revision_includes_deferred_stages_section():
+    revision = structured_plan_revision(
+        deferred_stages=[{"title": "Auth flow overhaul", "summary": "Split out follow-up work."}],
+    )
+    parsed = validate_structured_plan_revision(revision)
+
+    canonical = render_canonical_plan_revision(parsed, ())
+
+    assert "### Deferred stages (not in this plan)" in canonical
+    assert "Auth flow overhaul: Split out follow-up work." in canonical
+
+
+def test_render_canonical_plan_revision_omits_deferred_stages_section_when_absent():
+    revision = structured_plan_revision()
+    parsed = validate_structured_plan_revision(revision)
+
+    canonical = render_canonical_plan_revision(parsed, ())
+
+    assert "Deferred stages" not in canonical
 
 
 def test_validate_plan_revision_response_rejects_marker_only_markdown():

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -183,6 +183,45 @@ def test_materialize_split_proposals_caps_at_max_children(tmp_path):
     assert len(metadata.children) == MAX_SPLIT_CHILDREN
 
 
+def test_materialize_split_proposals_rerun_does_not_exceed_cap(tmp_path):
+    """A rerun with the same over-cap proposal set must not keep filing new
+    children past MAX_SPLIT_CHILDREN: remaining capacity must be computed from
+    children already recorded in the parent's cumulative metadata, not just
+    the proposals this call still considers unresolved (#492 review)."""
+    proposals = [split_stage_proposal_from_text(f"Stage {i}") for i in range(MAX_SPLIT_CHILDREN + 3)]
+    config = make_config(tmp_path)
+
+    first_runner = FakeRunner(
+        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + i}" for i in range(MAX_SPLIT_CHILDREN)]
+    )
+    first_metadata = materialize_split_proposals(
+        first_runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        issue_comments=(),
+    )
+    assert len(first_metadata.children) == MAX_SPLIT_CHILDREN
+    parent_summary_comment = _comment(first_runner.comments[-1])
+
+    # Rerun with the identical over-cap proposal set, seeded with the parent
+    # comment history left behind by the first run.
+    second_runner = FakeRunner()
+    second_metadata = materialize_split_proposals(
+        second_runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        issue_comments=[parent_summary_comment],
+    )
+
+    assert second_runner.issues == []
+    assert second_metadata.children == first_metadata.children
+    assert len(second_metadata.children) == MAX_SPLIT_CHILDREN
+
+
 def test_materialize_split_proposals_returns_none_for_no_proposals(tmp_path):
     runner = FakeRunner()
     config = make_config(tmp_path)

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -1,0 +1,340 @@
+import pytest
+
+from coding_review_agent_loop.cli import AgentLoopError
+from coding_review_agent_loop.github import IssueComment, validate_pr_body_does_not_close_issue
+from coding_review_agent_loop.split_materialization import (
+    MAX_SPLIT_CHILDREN,
+    dedupe_split_stage_proposals,
+    find_existing_split_materialization,
+    find_existing_split_stage_handoff,
+    format_split_stage_handoff_comment,
+    format_unfiled_split_warning,
+    has_unfiled_split_warning,
+    materialize_split_proposals,
+    post_split_stage_handoff_comment,
+    resolve_selected_stage_child,
+    split_stage_proposal_from_deferred_stage,
+    split_stage_proposal_from_text,
+)
+from coding_review_agent_loop.protocol import DeferredStage
+from agent_loop_helpers import FakeRunner, make_config
+
+
+def _comment(body: str) -> IssueComment:
+    return IssueComment(author="bot", created_at="2026-05-23T00:00:00Z", body=body)
+
+
+def test_split_stage_proposal_from_text_uses_first_line_as_title():
+    proposal = split_stage_proposal_from_text("Auth flow overhaul\n\nMore detail below.")
+    assert proposal.title == "Auth flow overhaul"
+    assert "More detail below." in proposal.body
+
+
+def test_split_stage_proposal_from_deferred_stage_uses_title_and_summary():
+    stage = DeferredStage(title="Billing follow-up", summary="Split billing reconciliation out.")
+    proposal = split_stage_proposal_from_deferred_stage(stage)
+    assert proposal.title == "Billing follow-up"
+    assert proposal.body == "Split billing reconciliation out."
+
+
+def test_dedupe_split_stage_proposals_keeps_first_occurrence():
+    proposals = [
+        split_stage_proposal_from_text("Auth flow"),
+        split_stage_proposal_from_text("auth   FLOW"),
+        split_stage_proposal_from_text("Billing flow"),
+    ]
+    deduped = dedupe_split_stage_proposals(proposals)
+    assert [p.title for p in deduped] == ["Auth flow", "Billing flow"]
+
+
+def test_materialize_split_proposals_creates_children_with_markers(tmp_path):
+    runner = FakeRunner(
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ]
+    )
+    config = make_config(tmp_path)
+    proposals = [
+        split_stage_proposal_from_text("Auth flow"),
+        split_stage_proposal_from_text("Billing flow"),
+    ]
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        rationale=[("OpenAI Codex", "Too broad for one PR.")],
+        issue_comments=(),
+    )
+
+    assert metadata is not None
+    assert len(runner.issues) == 2
+    assert runner.issues[0]["title"] == "[#56 stage] Auth flow"
+    body0 = runner.issues[0]["body"]
+    assert "Part of #56" in body0
+    assert "Too broad for one PR." in body0
+    assert "Refs #56" in body0
+    assert "Do not use closing keywords" in body0
+    assert "<!-- AGENT_SPLIT_CHILD: parent=56 key=" in body0
+    # Second child's body lists the first as a sibling.
+    body1 = runner.issues[1]["body"]
+    assert "Auth flow" in body1
+
+    assert [child.origin for child in metadata.children] == ["created", "created"]
+    parent_summary = runner.comments[-1]
+    assert "<!-- AGENT_DISCUSS_SPLIT:" in parent_summary
+    assert "https://github.com/OWNER/REPO/issues/101" in parent_summary
+    assert "https://github.com/OWNER/REPO/issues/102" in parent_summary
+
+
+def test_materialize_split_proposals_rerun_with_existing_marker_creates_nothing(tmp_path):
+    runner = FakeRunner(
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ]
+    )
+    config = make_config(tmp_path)
+    proposals = [
+        split_stage_proposal_from_text("Auth flow"),
+        split_stage_proposal_from_text("Billing flow"),
+    ]
+    first = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        issue_comments=(),
+    )
+    prior_comments = (_comment(runner.comments[-1]),)
+
+    second = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        issue_comments=prior_comments,
+    )
+
+    assert len(runner.issues) == 2  # no new issues created
+    assert len(runner.comments) == 1  # no new parent comment posted
+    assert second == first
+
+
+def test_materialize_split_proposals_partial_failure_adopts_existing_child(tmp_path):
+    proposal_auth = split_stage_proposal_from_text("Auth flow")
+    proposal_billing = split_stage_proposal_from_text("Billing flow")
+    runner = FakeRunner(
+        issue_urls=["https://github.com/OWNER/REPO/issues/102"],
+        search_issues_payload=[
+            {
+                "number": 101,
+                "title": "[#56 stage] Auth flow",
+                "url": "https://github.com/OWNER/REPO/issues/101",
+                "body": f"Part of #56\n\n<!-- AGENT_SPLIT_CHILD: parent=56 key={proposal_auth.key} -->",
+            }
+        ],
+    )
+    config = make_config(tmp_path)
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=[proposal_auth, proposal_billing],
+        issue_comments=(),
+    )
+
+    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
+    # Only the unmatched (billing) proposal was created; auth was adopted.
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "[#56 stage] Billing flow"
+    origins = {child.title: child.origin for child in metadata.children}
+    assert origins["Auth flow"] == "adopted"
+    assert origins["Billing flow"] == "created"
+    parent_summary = runner.comments[-1]
+    assert "https://github.com/OWNER/REPO/issues/101" in parent_summary
+    assert "adopted" in parent_summary
+
+
+def test_materialize_split_proposals_caps_at_max_children(tmp_path):
+    proposals = [split_stage_proposal_from_text(f"Stage {i}") for i in range(MAX_SPLIT_CHILDREN + 3)]
+    runner = FakeRunner(
+        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + i}" for i in range(MAX_SPLIT_CHILDREN)]
+    )
+    config = make_config(tmp_path)
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        issue_comments=(),
+    )
+
+    assert len(runner.issues) == MAX_SPLIT_CHILDREN
+    assert len(metadata.children) == MAX_SPLIT_CHILDREN
+
+
+def test_materialize_split_proposals_returns_none_for_no_proposals(tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path)
+    assert (
+        materialize_split_proposals(
+            runner, config=config, parent_issue=56, subject="s", proposals=(), issue_comments=()
+        )
+        is None
+    )
+
+
+def test_materialize_split_proposals_dry_run_previews_search_and_create(tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, dry_run=True)
+    proposals = [split_stage_proposal_from_text("Auth flow")]
+
+    materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+        issue_comments=(),
+    )
+
+    # Dry-run still previews the `gh issue list --search` and `gh issue create`
+    # commands (so the materialization path is visible), it just never
+    # persists application-level state outside of GitHub CLI echo commands.
+    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
+    assert len(runner.issues) == 1
+
+
+def test_find_existing_split_materialization_rejects_invalid_marker():
+    with pytest.raises(AgentLoopError, match="Invalid AGENT_DISCUSS_SPLIT payload"):
+        find_existing_split_materialization(
+            (_comment("<!-- AGENT_DISCUSS_SPLIT: not-valid-base64 -->"),),
+            parent_issue=56,
+        )
+
+
+def test_format_unfiled_split_warning_lists_titles():
+    proposals = [split_stage_proposal_from_text("Auth flow"), split_stage_proposal_from_text("Billing flow")]
+    warning = format_unfiled_split_warning(proposals)
+    assert "NOT filed as issues" in warning
+    assert "Auth flow" in warning
+    assert "Billing flow" in warning
+    assert "--materialize-split-issues" in warning
+
+
+def test_has_unfiled_split_warning_matches_issue_and_subject():
+    body = (
+        "### Split follow-ups are NOT filed as issues\n\n"
+        "<!-- AGENT_SPLIT_UNFILED_WARNING: issue=56 subject=abc123 -->\n"
+        "-- coding-review-agent-loop"
+    )
+    assert has_unfiled_split_warning((_comment(body),), issue_number=56, subject="abc123")
+    assert not has_unfiled_split_warning((_comment(body),), issue_number=56, subject="different")
+    assert not has_unfiled_split_warning((_comment(body),), issue_number=99, subject="abc123")
+
+
+def test_resolve_selected_stage_child_by_split_stage_flag():
+    from coding_review_agent_loop.split_materialization import MaterializedSplitChild
+
+    children = (
+        MaterializedSplitChild(title="Auth flow", key="k1", url=None, number=101, origin="created"),
+        MaterializedSplitChild(title="Billing flow", key="k2", url=None, number=102, origin="created"),
+    )
+    selected = resolve_selected_stage_child(
+        children, parent_issue=56, plan_title_or_subject="Something else entirely", split_stage_flag=102
+    )
+    assert selected.number == 102
+
+
+def test_resolve_selected_stage_child_rejects_unknown_split_stage_flag():
+    from coding_review_agent_loop.split_materialization import MaterializedSplitChild
+
+    children = (MaterializedSplitChild(title="Auth flow", key="k1", url=None, number=101, origin="created"),)
+    with pytest.raises(AgentLoopError, match="does not match any child issue"):
+        resolve_selected_stage_child(
+            children, parent_issue=56, plan_title_or_subject="Auth flow", split_stage_flag=999
+        )
+
+
+def test_resolve_selected_stage_child_by_unique_title_match():
+    proposal = split_stage_proposal_from_text("Auth flow")
+    from coding_review_agent_loop.split_materialization import MaterializedSplitChild
+
+    children = (
+        MaterializedSplitChild(title="Auth flow", key=proposal.key, url=None, number=101, origin="created"),
+        MaterializedSplitChild(title="Billing flow", key="other-key", url=None, number=102, origin="created"),
+    )
+    selected = resolve_selected_stage_child(
+        children, parent_issue=56, plan_title_or_subject="Auth flow", split_stage_flag=None
+    )
+    assert selected.number == 101
+
+
+def test_resolve_selected_stage_child_fails_without_match_or_flag():
+    from coding_review_agent_loop.split_materialization import MaterializedSplitChild
+
+    children = (MaterializedSplitChild(title="Auth flow", key="k1", url=None, number=101, origin="created"),)
+    with pytest.raises(AgentLoopError, match="--split-stage"):
+        resolve_selected_stage_child(
+            children, parent_issue=56, plan_title_or_subject="Something unrelated", split_stage_flag=None
+        )
+
+
+def test_split_stage_handoff_comment_roundtrip(tmp_path):
+    from coding_review_agent_loop.split_materialization import MaterializedSplitChild
+
+    runner = FakeRunner()
+    config = make_config(tmp_path)
+    child = MaterializedSplitChild(
+        title="Auth flow",
+        key="k1",
+        url="https://github.com/OWNER/REPO/issues/101",
+        number=101,
+        origin="created",
+    )
+    post_split_stage_handoff_comment(runner, config=config, parent_issue=56, plan_hash="hash1", child=child)
+
+    posted = runner.comments[-1]
+    assert "handed off to split stage" in posted
+    comments = (_comment(posted),)
+    found = find_existing_split_stage_handoff(comments, parent_issue=56, plan_hash="hash1")
+    assert found is not None
+    assert found.child_issue_number == 101
+    assert find_existing_split_stage_handoff(comments, parent_issue=56, plan_hash="different") is None
+
+
+def test_format_split_stage_handoff_comment_requires_child_number():
+    from coding_review_agent_loop.split_materialization import MaterializedSplitChild
+
+    child = MaterializedSplitChild(title="Auth flow", key="k1", url=None, number=None, origin="created")
+    with pytest.raises(AgentLoopError, match="child issue number is unavailable"):
+        format_split_stage_handoff_comment(parent_issue=56, plan_hash="hash1", child=child)
+
+
+def test_validate_pr_body_does_not_close_issue_rejects_closing_keyword(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Closes #56\n\nRefs #56"})
+    config = make_config(tmp_path)
+    with pytest.raises(AgentLoopError, match="closing keyword"):
+        validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def test_validate_pr_body_does_not_close_issue_accepts_refs_only(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Closes #99\n\nRefs #56"})
+    config = make_config(tmp_path)
+    validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def test_validate_pr_body_does_not_close_issue_skips_in_dry_run(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Fixes #56"})
+    config = make_config(tmp_path, dry_run=True)
+    validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -1,0 +1,203 @@
+"""Integration tests for plan-first split/deferred-stage materialization and
+the selected-stage implementation handoff (#476)."""
+import pytest
+
+from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
+from coding_review_agent_loop.github import validate_pr_body_does_not_close_issue
+from coding_review_agent_loop.split_materialization import (
+    MaterializedSplitChild,
+    SplitMaterializationMetadata,
+    format_split_materialization_summary,
+    split_stage_proposal_from_text,
+)
+from agent_loop_helpers import (
+    FakeRunner,
+    command_index,
+    make_config,
+    structured_plan_review,
+    structured_plan_state,
+    structured_pr_review,
+)
+
+
+def _existing_split_children_comment() -> dict:
+    metadata = SplitMaterializationMetadata(
+        parent_issue=56,
+        subject="prior-discuss-subject",
+        children=(
+            MaterializedSplitChild(
+                title="Auth flow",
+                key=split_stage_proposal_from_text("Auth flow").key,
+                url="https://github.com/OWNER/REPO/issues/101",
+                number=101,
+                origin="created",
+            ),
+            MaterializedSplitChild(
+                title="Billing flow",
+                key=split_stage_proposal_from_text("Billing flow").key,
+                url="https://github.com/OWNER/REPO/issues/102",
+                number=102,
+                origin="created",
+            ),
+        ),
+    )
+    return {
+        "author": {"login": "bot"},
+        "createdAt": "2026-05-23T00:00:00Z",
+        "body": format_split_materialization_summary(parent_issue=56, metadata=metadata),
+    }
+
+
+def test_plan_first_no_prior_split_materializes_deferred_stages_before_implementation(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(
+                state="blocking",
+                summary="Implement the core parser change.",
+                deferred_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
+            ),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/99"],
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "[#56 stage] Auth flow"
+    materialize_index = command_index(runner.commands, ["gh", "issue", "create"])
+    pr_create_index = command_index(runner.commands, ["claude", "--print"], start=materialize_index)
+    assert materialize_index < pr_create_index
+    assert any("<!-- AGENT_DISCUSS_SPLIT:" in comment for comment in runner.comments)
+    # The parent's own plan covers everything except the deferred stage, so
+    # its own PR still closes the parent issue normally (default PR body
+    # scripted by FakeRunner is "Fixes #56").
+    assert "Fixes #56" in runner.pr_payload["body"]
+
+
+def test_plan_first_no_prior_split_warns_when_materialization_disabled(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(
+                state="blocking",
+                summary="Implement the core parser change.",
+                deferred_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
+            ),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+    )
+    config = make_config(tmp_path)  # materialize_split_issues defaults False
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    assert runner.issues == []
+    assert any("NOT filed as issues" in comment and "Auth flow" in comment for comment in runner.comments)
+
+
+def test_plan_first_selected_stage_handoff_by_unique_title_match(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(state="blocking", summary="Auth flow"),
+            "Implemented the auth-flow stage.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_comments=[_existing_split_children_comment()],
+        pr_payload={"body": "Closes #101\n\nRefs #56"},
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    # No new child issues: both stages were already materialized before this run.
+    assert runner.issues == []
+    assert any("<!-- AGENT_SPLIT_STAGE_HANDOFF:" in comment for comment in runner.comments)
+    stage_handoff = next(c for c in runner.comments if "<!-- AGENT_SPLIT_STAGE_HANDOFF:" in c)
+    assert "handed off to split stage" in stage_handoff
+    # The implementation prompt sent to the coder must target the resolved
+    # child (#101) and instruct staged Closes/Refs wording, not Fixes on the parent.
+    implement_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    implementation_prompt = implement_calls[1][-1]
+    assert "issue #101" in implementation_prompt
+    assert "Closes #101" in implementation_prompt
+    assert "Refs #56" in implementation_prompt
+    assert "Do NOT use a closing keyword" in implementation_prompt
+
+
+def test_plan_first_selected_stage_handoff_via_split_stage_flag(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            # Plan text/summary does not uniquely match either child title, so
+            # resolution must come from --split-stage.
+            structured_plan_state(state="blocking", summary="Some unrelated plan summary"),
+            "Implemented the billing stage.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_comments=[_existing_split_children_comment()],
+        pr_payload={"body": "Closes #102\n\nRefs #56"},
+    )
+    config = make_config(tmp_path, materialize_split_issues=True, split_stage=102)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    stage_handoff = next(c for c in runner.comments if "<!-- AGENT_SPLIT_STAGE_HANDOFF:" in c)
+    assert "issues/102" in stage_handoff
+
+
+def test_plan_first_selected_stage_ambiguous_without_flag_raises(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(state="blocking", summary="Some unrelated plan summary"),
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+        ],
+        issue_comments=[_existing_split_children_comment()],
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    with pytest.raises(AgentLoopError, match="--split-stage"):
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+
+
+def test_validate_pr_body_does_not_close_issue_rejects_parent_fixes_for_staged_pr(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Fixes #56"})
+    config = make_config(tmp_path)
+    with pytest.raises(AgentLoopError, match="closing keyword"):
+        validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -367,8 +367,87 @@ def test_plan_first_materializes_prior_discuss_split_and_hands_off_in_same_run(t
     assert "Refs #56" in implementation_prompt
 
 
+def test_plan_first_excludes_own_scope_from_prior_discuss_proposals(tmp_path):
+    """A prior `discuss` split named both `Auth flow` and `Billing flow`, but
+    was never materialized. The approved plan implements `Auth flow` directly
+    on the parent and structurally declares `Billing flow` as its own
+    `deferred_stages` remainder. Only `Billing flow` (the true remainder) may
+    be filed as a child issue: filing `Auth flow` too would create a
+    duplicate child for scope the parent PR is about to implement and close
+    directly, since a plan with its own `deferred_stages` never hands off to
+    a selected-stage child (#492 review)."""
+    plan = structured_plan_state(
+        state="blocking",
+        summary="Auth flow",
+        deferred_stages=[{"title": "Billing flow", "summary": "Split follow-up out."}],
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            plan,
+            "Implemented the auth-flow scope.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-20T00:00:00Z",
+                "body": _attach_round_metadata(
+                    "Discuss consensus: split this into stages.\n-- coding-review-agent-loop",
+                    PostedRoundMetadata(
+                        flow="discuss",
+                        role="summary",
+                        agent="coding-review-agent-loop",
+                        round_number=1,
+                        subject="prior-discuss-subject",
+                        is_final=True,
+                        split_proposals=("Auth flow", "Billing flow"),
+                    ),
+                ),
+            },
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/102"],
+        pr_payload={"body": "Fixes #56"},
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    # Only the true remainder is filed; the plan's own covered scope is not
+    # filed as a duplicate child.
+    assert [issue["title"] for issue in runner.issues] == ["[#56 stage] Billing flow"]
+    # No selected-stage handoff: the parent PR implements and closes Auth
+    # flow directly, since the plan declares its own deferred_stages.
+    assert not any("<!-- AGENT_SPLIT_STAGE_HANDOFF:" in comment for comment in runner.comments)
+    assert "Fixes #56" in runner.pr_payload["body"]
+
+
 def test_validate_pr_body_does_not_close_issue_rejects_parent_fixes_for_staged_pr(tmp_path):
     runner = FakeRunner(pr_payload={"body": "Fixes #56"})
     config = make_config(tmp_path)
     with pytest.raises(AgentLoopError, match="closing keyword"):
         validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def test_validate_pr_body_does_not_close_issue_rejects_full_issue_url(tmp_path):
+    """GitHub also treats a closing keyword followed by a full issue URL as an
+    auto-close reference, e.g. `Closes https://github.com/OWNER/REPO/issues/56`;
+    the close-keyword guard must reject that form too, not just `#56` /
+    `owner/repo#56` (#492 review)."""
+    runner = FakeRunner(pr_payload={"body": "Closes https://github.com/OWNER/REPO/issues/56"})
+    config = make_config(tmp_path)
+    with pytest.raises(AgentLoopError, match="closing keyword"):
+        validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def test_validate_pr_body_does_not_close_issue_accepts_refs_url(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Refs https://github.com/OWNER/REPO/issues/56"})
+    config = make_config(tmp_path)
+    validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -24,6 +24,7 @@ from agent_loop_helpers import (
     command_index,
     make_config,
     structured_plan_review,
+    structured_plan_revision,
     structured_plan_state,
     structured_pr_review,
 )
@@ -92,6 +93,53 @@ def test_plan_first_no_prior_split_materializes_deferred_stages_before_implement
     # its own PR still closes the parent issue normally (default PR body
     # scripted by FakeRunner is "Fixes #56").
     assert "Fixes #56" in runner.pr_payload["body"]
+
+
+def test_plan_first_deferred_stage_title_with_colon_round_trips_through_canonical_markdown(tmp_path):
+    """A revised plan's `deferred_stages` are carried in `current_plan` as the
+    canonical revision markdown (not the raw structured JSON), which renders
+    each stage as a human-readable `- {title}: {summary}` bullet. A title that
+    itself contains a colon (e.g. "Stage 2: API follow-up") must still
+    round-trip exactly through materialization instead of being corrupted by
+    a naive split-on-first-colon parse (#492 review)."""
+    runner = FakeRunner(
+        claude_outputs=[
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_revision(
+                summary="Implement the core parser change.",
+                deferred_stages=[
+                    {"title": "Stage 2: API follow-up", "summary": "Split out the API work."}
+                ],
+            ),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Needs a revision.",
+                blocking_plan_issues=["Needs a revision."],
+            ),
+            structured_plan_review(
+                state="approved",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/101"],
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "[#56 stage] Stage 2: API follow-up"
+    assert "Part of #56" in runner.issues[0]["body"]
+    assert "Split out the API work." in runner.issues[0]["body"]
 
 
 def test_plan_first_no_prior_split_warns_when_materialization_disabled(tmp_path):

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -297,6 +297,76 @@ def test_plan_first_deferred_stage_rerun_resumes_parent_one_shot_handoff(tmp_pat
     assert not any("<!-- AGENT_SPLIT_STAGE_HANDOFF:" in comment for comment in runner.comments)
 
 
+def test_plan_first_materializes_prior_discuss_split_and_hands_off_in_same_run(tmp_path):
+    """A prior `discuss` run chose `split` but never materialized. Running
+    `issue --plan-first --implement-after-approval --materialize-split-issues`
+    on the parent with a plan that itself covers one of those split proposals
+    (no `deferred_stages` declared) must, within this SAME run: file every
+    proposal as a child issue, then still resolve and hand off implementation
+    to the specific child the approved plan covers — not fall back to
+    implementing the parent as a monolith because stage resolution read a
+    stale pre-materialization issue-comments snapshot (#492 review)."""
+    plan = structured_plan_state(state="blocking", summary="Auth flow")
+    runner = FakeRunner(
+        claude_outputs=[
+            plan,
+            "Implemented the auth-flow stage.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-20T00:00:00Z",
+                "body": _attach_round_metadata(
+                    "Discuss consensus: split this into stages.\n-- coding-review-agent-loop",
+                    PostedRoundMetadata(
+                        flow="discuss",
+                        role="summary",
+                        agent="coding-review-agent-loop",
+                        round_number=1,
+                        subject="prior-discuss-subject",
+                        is_final=True,
+                        split_proposals=("Auth flow", "Billing flow"),
+                    ),
+                ),
+            },
+        ],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+        pr_payload={"body": "Closes #101\n\nRefs #56"},
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    # Both split proposals were filed as children in this run...
+    assert {issue["title"] for issue in runner.issues} == {
+        "[#56 stage] Auth flow",
+        "[#56 stage] Billing flow",
+    }
+    # ...and this same run still resolved and handed off to the specific
+    # child ("Auth flow" -> #101) the approved plan covers, instead of
+    # implementing the parent as a monolith.
+    assert any("<!-- AGENT_SPLIT_STAGE_HANDOFF:" in comment for comment in runner.comments)
+    stage_handoff = next(c for c in runner.comments if "<!-- AGENT_SPLIT_STAGE_HANDOFF:" in c)
+    assert "handed off to split stage" in stage_handoff
+    implement_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    implementation_prompt = implement_calls[1][-1]
+    assert "issue #101" in implementation_prompt
+    assert "Closes #101" in implementation_prompt
+    assert "Refs #56" in implementation_prompt
+
+
 def test_validate_pr_body_does_not_close_issue_rejects_parent_fixes_for_staged_pr(tmp_path):
     runner = FakeRunner(pr_payload={"body": "Fixes #56"})
     config = make_config(tmp_path)

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -3,7 +3,16 @@ the selected-stage implementation handoff (#476)."""
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
+from coding_review_agent_loop.decomposition import (
+    approved_plan_hash,
+    format_one_shot_impl_handoff_comment,
+)
 from coding_review_agent_loop.github import validate_pr_body_does_not_close_issue
+from coding_review_agent_loop.orchestrator import (
+    PostedRoundMetadata,
+    _attach_round_metadata,
+    _plan_subject,
+)
 from coding_review_agent_loop.split_materialization import (
     MaterializedSplitChild,
     SplitMaterializationMetadata,
@@ -194,6 +203,98 @@ def test_plan_first_selected_stage_ambiguous_without_flag_raises(tmp_path):
         run_issue_loop(
             runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
         )
+
+
+def test_plan_first_deferred_stage_rerun_resumes_parent_one_shot_handoff(tmp_path):
+    """A parent plan that declares its own `deferred_stages` keeps its primary
+    scope on the parent; materializing the deferred remainder as a child issue
+    must not make a rerun mistake the parent's own already-handed-off one-shot
+    PR for an unresolved selected-stage handoff (#492 review)."""
+    plan = structured_plan_state(
+        state="blocking",
+        summary="Implement the core parser change.",
+        deferred_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
+    )
+    plan_subject = _plan_subject(plan)
+    plan_hash = approved_plan_hash(plan)
+    split_metadata = SplitMaterializationMetadata(
+        parent_issue=56,
+        subject=plan_subject,
+        children=(
+            MaterializedSplitChild(
+                title="Auth flow",
+                key=split_stage_proposal_from_text("Auth flow").key,
+                url="https://github.com/OWNER/REPO/issues/101",
+                number=101,
+                origin="created",
+            ),
+        ),
+    )
+    handoff = format_one_shot_impl_handoff_comment(
+        parent_issue=56,
+        mode="implement-one-shot",
+        plan_hash=plan_hash,
+        plan_subject=plan_subject,
+        pr_number=77,
+        pr_head_sha="abc123",
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=plan_subject,
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=plan_subject,
+                        state="approved",
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:02Z",
+                "body": format_split_materialization_summary(parent_issue=56, metadata=split_metadata),
+            },
+            {"author": {"login": "bot"}, "createdAt": "2026-05-23T00:00:03Z", "body": handoff},
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    # Resumes the parent's own PR #77 review directly; no re-implementation,
+    # no new child issues, and no selected-stage handoff.
+    assert runner.issues == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert not any("<!-- AGENT_SPLIT_STAGE_HANDOFF:" in comment for comment in runner.comments)
 
 
 def test_validate_pr_body_does_not_close_issue_rejects_parent_fixes_for_staged_pr(tmp_path):


### PR DESCRIPTION
## Summary

- Add `--materialize-split-issues` (on `discuss` and `issue`) so a discuss `split` consensus, or a plan-first plan's declared `deferred_stages`, files one linked child GitHub issue per remaining stage instead of leaving them as unfiled text in comments. Default is off; the orchestrator always posts (or logs, on resume) an explicit "NOT filed as issues" warning when stages would otherwise go unfiled, so the #467/#474 gap can't hide in a neutral listing.
- New `deferred_stages` field on the structured `plan_revision`/`plan_state` schemas lets the coder declare narrowed-out scope mechanically; declared stages render into the canonical plan under a `### Deferred stages (not in this plan)` heading so they carry into subject hashing, resume, and reviewer prompts. A conservative text-heuristic backstop warns (never files) when a plan's prose narrows scope without a structured declaration or a discuss split.
- Materialization is idempotent and crash-safe: a cumulative `AGENT_DISCUSS_SPLIT` parent marker records every known child (created or adopted), per-child bodies carry a durable `AGENT_SPLIT_CHILD` marker, and a new `github.search_issues` helper (`gh issue list --search`) recovers from a crash between `create_issue` calls and posting the parent marker instead of duplicating children. Capped at 8 children per parent.
- Selected-stage handoff: when a parent's proposals were already fully materialized into child issues, `issue --plan-first --implement-after-approval` resolves which child the approved plan implements (unique title match, or explicit `--split-stage <child>`), records an `AGENT_SPLIT_STAGE_HANDOFF` marker, and hands implementation off to that child. The resulting PR is required (`validate_pr_body_does_not_close_issue`) to use `Refs #<parent>` instead of a closing keyword against the parent, so a staged PR can't accidentally close unimplemented parent scope.

## Test plan

- [x] `python -m pytest` (1332 passed) run against a fresh `pip install -e '.[dev]'` venv, matching CI
- [x] New unit tests for the `split_materialization` module: creation, idempotent rerun, partial-failure adoption via search, cap behavior, dry-run
- [x] New integration tests: discuss `split` materialization + rerun idempotency, plan-first `deferred_stages` materialization/warning with no prior discuss split, selected-stage handoff by title match and by `--split-stage`, ambiguous-without-flag failure, staged PR closing-keyword guardrail
- [x] Protocol/round-state roundtrip tests for `deferred_stages` and `PostedRoundMetadata.split_proposals` (including legacy-payload decoding)
- [x] `docs/local_agent_loop.md` and `README.md` updated with the new flags and marker semantics

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)