### PR TITLE
Materialize split discuss outcomes and plan-first deferred stages into follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,25 @@ over-cap response is rejected and must be consolidated, not truncated. This cap
 is separate from the approved-review follow-up issue cap used by
 `--approved-followups`.
 
+When a discuss `split` consensus or a plan's declared `deferred_stages` leaves
+follow-up scope unfiled, pass `--materialize-split-issues` (to `discuss` or
+`issue --plan-first`) to file one child issue per remaining stage instead of
+leaving it as prose:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO --materialize-split-issues
+agent-loop issue 123 --repo OWNER/REPO --plan-first --implement-after-approval \
+  --materialize-split-issues
+```
+
+Default is off; without it, the discuss/plan summaries post an explicit
+warning that follow-ups remain unfiled. Once every proposal has a child
+issue, an `implement-one-shot` run resolves which child the approved plan
+implements (`--split-stage <child-issue>` if more than one was materialized)
+and the coder is instructed to close that child while only referencing — not
+closing — the parent. See `docs/local_agent_loop.md` for the full marker and
+idempotency details.
+
 Provide a one-off task directly when there is no issue yet:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -553,6 +553,59 @@ Two companion flags apply in both sequential and parallel discuss runs:
     vote can never match real outcomes — so a partial final round ends in a
     `needs-human` deadlock, with the failures noted in the summary.
 
+### Materializing split follow-ups
+
+When a discuss consensus is `split`, or an approved plan intentionally
+narrows scope and declares `deferred_stages`, the proposed follow-up work
+otherwise survives only as prose in a comment. `--materialize-split-issues`
+files each remaining stage as its own child GitHub issue instead:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO --materialize-split-issues
+agent-loop issue 123 --repo OWNER/REPO --plan-first --implement-after-approval \
+  --materialize-split-issues
+```
+
+- Default is off. Without the flag, the final discuss summary and the
+  plan-approval summary both post an explicit warning that split follow-ups
+  remain **unfiled**, so the #467/#474 scenario (a first-stage PR landing
+  while later stages are only described in comments) can't happen silently.
+- Each child issue gets a deterministic title `[#<parent> stage] <title>`, a
+  `Part of #<parent>` reference, the split rationale, sibling links, and a
+  durable `<!-- AGENT_SPLIT_CHILD: parent=<N> key=<hash> -->` body marker.
+  The parent records everything in a single `<!-- AGENT_DISCUSS_SPLIT: ... -->`
+  comment marker.
+- **Idempotent reruns**: a rerun first looks for the parent's
+  `AGENT_DISCUSS_SPLIT` marker (matched by parent issue number, not subject —
+  so materializing follow-up comments on the parent don't themselves cause a
+  subject-hash rerun of the whole debate). If no parent marker is found yet,
+  it searches `gh issue list --search` for children matching the deterministic
+  title/marker before creating anything, so a crash between creating a child
+  issue and posting the parent marker never produces a duplicate. Proposals
+  whose normalized text already matches an existing child are treated as
+  already filed.
+- **Only remaining stages are ever materialized.** A discuss run implements
+  nothing, so every merged proposal is filed. A plan-first run only files the
+  plan's declared `deferred_stages` — the stage the plan itself implements is
+  never filed as a child of itself.
+- **`deferred_stages`**: when a plan revision or plan-state response narrows
+  scope, the coder declares every deferred stage in a structured
+  `deferred_stages` field (`{"title": ..., "summary": ...}`), which the
+  orchestrator renders into a `### Deferred stages (not in this plan)` section
+  of the canonical plan. This is a purely additive, optional field — plans
+  without it behave exactly as before.
+- **Selected-stage handoff**: once a parent's split proposals are fully
+  materialized, an `implement-one-shot` run must resolve which child issue
+  the approved plan implements. If exactly one child was ever materialized,
+  it's chosen automatically; otherwise pass `--split-stage <child-issue>`
+  explicitly. The resolution is recorded in an
+  `<!-- AGENT_SPLIT_STAGE_HANDOFF: ... -->` parent comment so reruns don't
+  re-resolve it, and the coder is instructed to write `Closes #<child>` plus
+  `Refs #<parent>` in the PR body — never a closing keyword against the
+  parent, since other stages of it remain unimplemented. The orchestrator
+  enforces this: a PR body that uses `Fixes`/`Closes`/`Resolves` against the
+  parent while stages remain is rejected until the description is edited.
+
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the
 detected `OWNER/REPO`. Pass `--repo` explicitly when running outside the target

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -398,6 +398,27 @@ def build_parser() -> argparse.ArgumentParser:
             "Defaults to plan-only unless --implement-after-approval is used."
         ),
     )
+    issue.add_argument(
+        "--materialize-split-issues",
+        action="store_true",
+        help=(
+            "File split follow-up stages (from a prior discuss split consensus or the "
+            "approved plan's declared deferred stages) as child GitHub issues before "
+            "implementation. Default off: unfiled stages are surfaced as explicit "
+            "warnings instead."
+        ),
+    )
+    issue.add_argument(
+        "--split-stage",
+        type=int,
+        default=None,
+        metavar="CHILD_ISSUE",
+        help=(
+            "With --plan-first implementation on a parent whose split children were "
+            "already materialized, declare which child issue the approved plan "
+            "implements instead of relying on title matching."
+        ),
+    )
     add_common(issue)
 
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
@@ -476,6 +497,16 @@ def build_parser() -> argparse.ArgumentParser:
             "analyzer and summary still run only after every debater finishes "
             "(or the failure policy fires). Requires a distinct workdir per "
             "debater, even with --allow-shared-dir."
+        ),
+    )
+    discuss.add_argument(
+        "--materialize-split-issues",
+        action="store_true",
+        help=(
+            "When the discuss consensus is `split`, create one child GitHub issue per "
+            "proposed sub-issue and record them on the parent. Default off: the final "
+            "summary warns that split follow-ups remain unfiled. Rerunning on an issue "
+            "that already reached a split consensus materializes idempotently."
         ),
     )
     discuss.add_argument(

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -16,6 +16,7 @@ from .protocol import (
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
     PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SIGNATURE_RE,
+    DeferredStage,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
     ParsedPlanReview,
@@ -207,6 +208,20 @@ def render_canonical_plan_steps(plan_steps: Sequence[str]) -> str:
     return "\n".join(f"{index}. {step}" for index, step in enumerate(plan_steps, start=1))
 
 
+def render_deferred_stages_section(deferred_stages: Sequence[DeferredStage]) -> str:
+    """Render declared deferred stages into the canonical plan markdown (#476).
+
+    The section rides along in stored plan state and subject hashing so plan
+    approval can materialize or warn about the stages the plan leaves out.
+    """
+    return "\n".join(
+        [
+            "### Deferred stages (not in this plan)",
+            *[f"- {stage.title}: {stage.summary}" for stage in deferred_stages],
+        ]
+    )
+
+
 def render_canonical_plan_revision(
     parsed_revision: StructuredPlanRevision,
     prior_items: Sequence[UnresolvedReviewItem],
@@ -232,6 +247,8 @@ def render_canonical_plan_revision(
             ]
         )
     )
+    if parsed_revision.deferred_stages:
+        sections.append(render_deferred_stages_section(parsed_revision.deferred_stages))
     return "\n\n".join(sections)
 
 
@@ -506,6 +523,9 @@ def _render_public_plan_state_comment(
         "## Plan",
         parsed_plan.summary.strip(),
         "\n".join(["### Plan steps", render_canonical_plan_steps(parsed_plan.plan_steps)]),
+        render_deferred_stages_section(parsed_plan.deferred_stages)
+        if parsed_plan.deferred_stages
+        else "",
         f"<!-- AGENT_PLAN_STATE: {parsed_plan.state} -->",
         f"-- {_comment_signature(agent, config, model_used)}",
     ]
@@ -822,6 +842,7 @@ def render_discuss_round_summary_comment(
     analyzer_name: str | None = None,
     research_mode: str | None = None,
     failed_debaters: Sequence[tuple[str, str]] = (),
+    unfiled_split_warning: str | None = None,
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -910,6 +931,9 @@ def render_discuss_round_summary_comment(
         lines.append("")
         for proposal in split_proposals:
             lines.append(f"- {proposal}")
+    if unfiled_split_warning:
+        lines.append("")
+        lines.append(unfiled_split_warning)
     if analyzer_agenda is not None:
         heading = "### Analyzer-extracted consensus (not debater-confirmed)"
         if analyzer_name:

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -120,6 +120,12 @@ class AgentLoopConfig:
     # (today's behavior); "partial" continues the round with >= 2 surviving
     # votes and records the failure in the round summary.
     discuss_on_debater_failure: str = "fail"
+    # Materialize split outcomes into child GitHub issues (#476). Default off:
+    # unfiled split follow-ups are surfaced as explicit warnings instead.
+    materialize_split_issues: bool = False
+    # Explicit selected-stage child issue for implement-one-shot on a parent
+    # whose split children were already materialized (#476).
+    split_stage: int | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -151,6 +157,8 @@ class AgentLoopConfig:
             raise AgentLoopError(f"--discuss-on-debater-failure must be one of: {rendered}.")
         if self.discuss_debater_timeout is not None and self.discuss_debater_timeout <= 0:
             raise AgentLoopError("--discuss-debater-timeout must be greater than zero seconds.")
+        if self.split_stage is not None and self.split_stage <= 0:
+            raise AgentLoopError("--split-stage must be a positive issue number.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -795,6 +803,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         discuss_parallel=getattr(args, "discuss_parallel", False),
         discuss_debater_timeout=getattr(args, "discuss_debater_timeout", None),
         discuss_on_debater_failure=getattr(args, "discuss_on_debater_failure", "fail") or "fail",
+        materialize_split_issues=getattr(args, "materialize_split_issues", False),
+        split_stage=getattr(args, "split_stage", None),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -86,9 +86,23 @@ class PullRequestChecks:
     branch_protection_note: str | None = None
 
 
+@dataclass(frozen=True)
+class FoundIssue:
+    number: int | None
+    title: str
+    url: str | None
+    body: str | None
+
+
 PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url,body"
 PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
 ISSUE_REFERENCE_RE_TEMPLATE = r"(?:#%d\b|/issues/%d\b)"
+# GitHub closing keywords (close/fix/resolve families) followed by an issue
+# reference; matching either `#N` (optionally repo-qualified) or the issue URL.
+ISSUE_CLOSING_REFERENCE_RE_TEMPLATE = (
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+"
+    r"(?:[\w.-]+/[\w.-]+#%d\b|#%d\b|https?://github\.com/[\w.-]+/[\w.-]+/issues/%d\b)"
+)
 
 
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
@@ -211,6 +225,102 @@ def validate_pr_references_issue(
         f"issue reference, then rerun the orchestrator as `agent-loop pr {pr_number}` to continue "
         "the review."
     )
+
+
+def validate_pr_body_does_not_close_issue(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    issue_number: int,
+) -> None:
+    """Reject a PR body that would auto-close a parent issue with remaining stages (#476)."""
+    if config.dry_run:
+        return
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            config.repo,
+            "--json",
+            "body,url",
+        ],
+        cwd=active_workdir(config),
+    )
+    data = json.loads(result.stdout or "{}")
+    body = _optional_str(data.get("body")) or ""
+    closing_re = re.compile(
+        ISSUE_CLOSING_REFERENCE_RE_TEMPLATE % (issue_number, issue_number, issue_number),
+        re.I,
+    )
+    if not closing_re.search(body):
+        return
+    raise AgentLoopError(
+        f"PR #{pr_number} uses a closing keyword against issue #{issue_number}, but "
+        f"unimplemented stages of #{issue_number} remain tracked separately. "
+        f"Edit the PR description on GitHub to reference the parent with `Refs #{issue_number}` "
+        f"instead of `Fixes`/`Closes`/`Resolves`, then rerun `agent-loop pr {pr_number}` to "
+        "continue the review."
+    )
+
+
+def search_issues(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    search: str,
+    state: str = "all",
+) -> tuple[FoundIssue, ...]:
+    """Search repo issues via `gh issue list --search` (#476).
+
+    Used to recover child issues created before their parent marker comment was
+    posted. Dry-run echoes the command and reports no matches so materialization
+    previews still show the would-be creations.
+    """
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "issue",
+            "list",
+            "--repo",
+            config.repo,
+            "--search",
+            search,
+            "--state",
+            state,
+            "--json",
+            "number,title,url,body",
+        ],
+        cwd=active_workdir(config),
+    )
+    if config.dry_run:
+        return ()
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return ()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError("Unable to parse `gh issue list` output while searching issues.") from exc
+    if not isinstance(payload, list):
+        raise AgentLoopError("Unable to parse `gh issue list` output while searching issues.")
+    found: list[FoundIssue] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        number = entry.get("number")
+        found.append(
+            FoundIssue(
+                number=number if isinstance(number, int) else None,
+                title=_optional_str(entry.get("title")) or "",
+                url=_optional_str(entry.get("url")),
+                body=_optional_str(entry.get("body")),
+            )
+        )
+    return tuple(found)
 
 
 def _parse_pr_metadata(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -57,6 +57,7 @@ from .github import (
     post_pr_comment,
     validate_open_issue,
     validate_open_pr,
+    validate_pr_body_does_not_close_issue,
     validate_pr_references_issue,
     wait_for_ci,
 )
@@ -67,6 +68,7 @@ from .prompts import (
     CompactPlanTailContext,
     CompactPriorContext,
     CompactPrReviewTailContext,
+    StagedImplementationTarget,
     build_discuss_agenda_prompt,
     build_discuss_review_prompt,
     build_followup_prompt,
@@ -86,6 +88,7 @@ from .prompts import (
 from .protocol import (
     DISCUSS_FAILED_OUTCOME,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
+    DeferredStage,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
     failed_discuss_review_category,
@@ -100,6 +103,7 @@ from .protocol import (
     UnresolvedReviewItem,
     human_requirements_resolved,
     is_clarification_request,
+    parse_deferred_stages,
     parse_human_requirements_acknowledgement,
     parse_agent_state,
     parse_plan_review,
@@ -200,6 +204,7 @@ from .round_state import (
     ResumedRoundSelection,
     ResumedReviewRound,
     _attach_round_metadata,
+    _decode_discuss_vote,
     _decode_round_metadata,
     _deserialize_disposition,
     _deserialize_unresolved_item,
@@ -215,6 +220,14 @@ from .round_state import (
     _serialize_disposition,
     _serialize_unresolved_item,
     _strip_round_metadata,
+)
+from .split_materialization import (
+    SPLIT_MATERIALIZATION_MARKER_RE,
+    find_existing_split_materialization,
+    find_existing_split_stage_handoff,
+    materialize_split_proposals,
+    post_split_stage_handoff_comment,
+    resolve_selected_stage,
 )
 from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
@@ -1755,6 +1768,7 @@ def _implement_approved_issue(
     usage_context: RunUsageContext,
     one_shot_parent_issue: int | None = None,
     plan_subject: str | None = None,
+    staged_target: StagedImplementationTarget | None = None,
 ) -> int:
     coder_name = agent_display_name(config.coder)
     plan_hash = approved_plan_hash(approved_plan)
@@ -1779,6 +1793,7 @@ def _implement_approved_issue(
             memory,
             issue_context=issue_context,
             salvage_summary=salvage_summary,
+            staged_target=staged_target,
         ),
         session_id=coder_session_id,
         marker_description="<!-- AGENT_PR: <number> --> or PR URL",
@@ -1815,6 +1830,13 @@ def _implement_approved_issue(
         pr_number=pr_number,
         issue_number=issue_number,
     )
+    if staged_target is not None:
+        validate_pr_body_does_not_close_issue(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            issue_number=staged_target.parent_issue,
+        )
     initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
     if one_shot_parent_issue is not None:
         post_one_shot_impl_handoff_comment(
@@ -1921,6 +1943,48 @@ def _decompose_approved_plan(
         created=created,
     )
     return created
+
+
+DEFERRED_STAGES_WARNING_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_DEFERRED_STAGES_WARNING:\s*parent=(?P<parent>\d+)\s+plan=(?P<plan>[0-9a-f]+)\s*-->",
+    re.I,
+)
+
+
+def _has_posted_deferred_stages_warning(
+    comments: Sequence[object], *, parent_issue: int, plan_hash: str
+) -> bool:
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in DEFERRED_STAGES_WARNING_MARKER_RE.finditer(body):
+            if int(match.group("parent")) == parent_issue and match.group("plan") == plan_hash:
+                return True
+    return False
+
+
+def _format_deferred_stages_warning(
+    deferred_stages: Sequence[DeferredStage], *, parent_issue: int, plan_hash: str
+) -> str:
+    lines = [
+        f"### Deferred stages not filed for issue #{parent_issue}",
+        "",
+        "The approved plan declares deferred stages that are **not** filed as GitHub issues:",
+        "",
+    ]
+    lines.extend(f"- {stage.title}: {stage.summary}" for stage in deferred_stages)
+    lines.extend(
+        [
+            "",
+            "Rerun with `--materialize-split-issues` to file them as child issues, or file "
+            "them manually before implementing any stage of this issue.",
+            "",
+            f"<!-- AGENT_DEFERRED_STAGES_WARNING: parent={parent_issue} plan={plan_hash} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _run_plan_first_loop(
@@ -2371,6 +2435,46 @@ def _run_plan_first_loop(
                 sources=approved_future_followup_sources,
                 allow_issue_filing=mode in {"implement-one-shot", "implement-by-phase"},
             )
+            deferred_stages = parse_deferred_stages(current_plan)
+            existing_split = find_existing_split_materialization(
+                issue_context.comments, parent_issue=issue_number
+            )
+            if existing_split is None and deferred_stages:
+                if config.materialize_split_issues:
+                    # Use the returned metadata directly rather than re-scanning
+                    # `issue_context.comments`: that snapshot was fetched before
+                    # this call and does not include the marker comment just
+                    # posted, which would otherwise make the selected-stage
+                    # handoff below fall back to the unmaterialized case.
+                    existing_split = materialize_split_proposals(
+                        runner,
+                        config=config,
+                        parent_issue=issue_number,
+                        subject=plan_subject,
+                        proposals=[stage.title for stage in deferred_stages],
+                        issue_comments=issue_context.comments,
+                        rationale_lines=[
+                            f"Approved plan declared deferred stage: {stage.summary}"
+                            for stage in deferred_stages
+                        ],
+                    )
+                elif not _has_posted_deferred_stages_warning(
+                    issue_context.comments, parent_issue=issue_number, plan_hash=plan_hash
+                ):
+                    post_issue_comment(
+                        runner,
+                        config=config,
+                        issue_number=issue_number,
+                        body=_format_deferred_stages_warning(
+                            deferred_stages, parent_issue=issue_number, plan_hash=plan_hash
+                        ),
+                    )
+                    print(
+                        f"Issue #{issue_number}: the approved plan declares deferred stages that "
+                        "are NOT filed as GitHub issues: "
+                        f"{', '.join(stage.title for stage in deferred_stages)}. Rerun with "
+                        "--materialize-split-issues or file them manually."
+                    )
             if mode == "plan-only":
                 print(
                     f"Issue #{issue_number} plan approved by {format_agent_list(configured_reviewers)}."
@@ -2500,6 +2604,34 @@ def _run_plan_first_loop(
                             f"{pr_state.lower()}. Nothing to resume."
                         )
                         return 0
+                staged_target: StagedImplementationTarget | None = None
+                if existing_split is not None and existing_split.children:
+                    selected = resolve_selected_stage(
+                        existing=existing_split, split_stage=config.split_stage
+                    )
+                    if selected.number is None:
+                        raise AgentLoopError(
+                            f"Cannot hand off implementation to stage {selected.title!r} because "
+                            "its child issue number was not available from GitHub CLI output. "
+                            "Verify the child issue manually before rerunning."
+                        )
+                    existing_stage_handoff = find_existing_split_stage_handoff(
+                        issue_context.comments, parent_issue=issue_number, plan_hash=plan_hash
+                    )
+                    if existing_stage_handoff is None:
+                        post_split_stage_handoff_comment(
+                            runner,
+                            config=config,
+                            parent_issue=issue_number,
+                            plan_hash=plan_hash,
+                            child_issue_number=selected.number,
+                            child_issue_url=selected.url,
+                        )
+                    staged_target = StagedImplementationTarget(
+                        parent_issue=issue_number, child_issue=selected.number
+                    )
+                elif deferred_stages:
+                    staged_target = StagedImplementationTarget(parent_issue=issue_number)
                 return _implement_approved_issue(
                     runner,
                     issue_number=issue_number,
@@ -2511,6 +2643,7 @@ def _run_plan_first_loop(
                     usage_context=usage_context,
                     one_shot_parent_issue=issue_number,
                     plan_subject=plan_subject,
+                    staged_target=staged_target,
                 )
             raise AgentLoopError(f"Unknown plan execution mode: {mode}")
 
@@ -3676,6 +3809,11 @@ DISCUSS_CONSENSUS_MARKER_RE = re.compile(
 def _is_bot_authored_discuss_comment(body: str) -> bool:
     if DISCUSS_CONSENSUS_MARKER_RE.search(body):
         return True
+    # Split materialization follow-up comments (#476) are posted on the same
+    # issue after a final discuss consensus; excluding them keeps the subject
+    # hash stable across materialization instead of forcing a full redebate.
+    if SPLIT_MATERIALIZATION_MARKER_RE.search(body):
+        return True
     match = ROUND_RESUME_MARKER_RE.search(body)
     if match is None:
         return False
@@ -3719,6 +3857,161 @@ def _detect_discuss_consensus(
         return None
     split_proposals = _merge_discuss_split_proposals(votes) if outcome == "split" else []
     return outcome, split_proposals
+
+
+DISCUSS_SPLIT_UNFILED_WARNING = (
+    "### Split follow-ups not filed\n\n"
+    "Split follow-ups are **not** filed as GitHub issues. Rerun with "
+    "`--materialize-split-issues` or file the proposed sub-issues manually before "
+    "implementing any stage of this issue."
+)
+
+
+def _discuss_split_rationale_lines(votes: Sequence[ParsedDiscussReview]) -> list[str]:
+    return [f"{vote.reviewer}: {vote.rationale}" for vote in votes if vote.outcome == "split"]
+
+
+def _materialize_or_warn_discuss_split(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    subject: str,
+    proposals: Sequence[str],
+    rationale_lines: Sequence[str],
+    issue_comments: Sequence[object],
+) -> None:
+    if not proposals:
+        return
+    if config.materialize_split_issues:
+        materialize_split_proposals(
+            runner,
+            config=config,
+            parent_issue=issue_number,
+            subject=subject,
+            proposals=proposals,
+            issue_comments=issue_comments,
+            rationale_lines=rationale_lines,
+        )
+        log(
+            config,
+            f"discuss: materialized split proposals into child issues for issue #{issue_number}",
+        )
+    else:
+        log(
+            config,
+            f"discuss: split follow-ups remain unfiled for issue #{issue_number} "
+            "(--materialize-split-issues not set)",
+        )
+
+
+def _recover_discuss_split_state(
+    issue_comments: Sequence[object],
+    *,
+    subject: str,
+    configured_reviewers: Sequence[AgentName],
+    matched_body: str,
+) -> tuple[str | None, list[str], list[str]]:
+    """Best-effort recovery of (outcome, split_proposals, rationale_lines) for an
+    already-finalized discuss consensus (#476).
+
+    Used by the idempotent early-exit paths so a rerun with
+    `--materialize-split-issues` still files follow-ups instead of silently
+    skipping. Tries full round reconstruction first, then the matched summary
+    comment's own round metadata, then a legacy fallback that reconstructs the
+    final round directly from debater comment metadata.
+    """
+    try:
+        resume_state = _resume_discuss_round(
+            issue_comments, subject=subject, configured_reviewers=configured_reviewers
+        )
+    except AgentLoopError:
+        resume_state = None
+    if resume_state is not None and resume_state.done and resume_state.round_history:
+        final_votes = list(resume_state.round_history[-1])
+        consensus = _detect_discuss_consensus(final_votes)
+        if consensus is not None:
+            outcome, proposals = consensus
+            return outcome, proposals, _discuss_split_rationale_lines(final_votes)
+
+    match = ROUND_RESUME_MARKER_RE.search(matched_body)
+    if match is not None:
+        try:
+            metadata = _decode_round_metadata(match.group("payload"))
+        except AgentLoopError:
+            metadata = None
+        if metadata is not None and metadata.is_final and metadata.split_proposals:
+            return "split", list(metadata.split_proposals), []
+
+    if not re.search(r"Consensus:\s*Split", matched_body, re.I):
+        return None, [], []
+
+    records = _extract_round_metadata_records(issue_comments, flow="discuss")
+    subject_debater_records = [
+        record
+        for record in records
+        if record.metadata.subject == subject and record.metadata.role == "debater"
+    ]
+    if subject_debater_records:
+        final_round_number = max(record.metadata.round_number for record in subject_debater_records)
+        final_records = [
+            record
+            for record in subject_debater_records
+            if record.metadata.round_number == final_round_number
+        ]
+        votes: list[ParsedDiscussReview] = []
+        for record in final_records:
+            try:
+                votes.append(_decode_discuss_vote(record, round_number=final_round_number))
+            except AgentLoopError:
+                continue
+        proposals = _merge_discuss_split_proposals(votes)
+        if proposals:
+            return "split", proposals, _discuss_split_rationale_lines(votes)
+    return "split", [], []
+
+
+def _handle_already_finalized_discuss_split(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    subject: str,
+    configured_reviewers: Sequence[AgentName],
+    matched_body: str,
+    issue_comments: Sequence[object],
+) -> None:
+    outcome, proposals, rationale_lines = _recover_discuss_split_state(
+        issue_comments,
+        subject=subject,
+        configured_reviewers=configured_reviewers,
+        matched_body=matched_body,
+    )
+    if outcome != "split":
+        return
+    if not proposals:
+        if config.materialize_split_issues:
+            raise AgentLoopError(
+                f"discuss: issue #{issue_number} reached a `split` consensus but no "
+                "recoverable split proposals were found in the discuss transcript; manual "
+                "filing is required. File the proposed sub-issues manually, or repair the "
+                "discuss transcript and rerun."
+            )
+        log(
+            config,
+            f"discuss: split consensus for issue #{issue_number} has no recoverable "
+            "proposals to materialize",
+        )
+        return
+    _materialize_or_warn_discuss_split(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        subject=subject,
+        proposals=proposals,
+        rationale_lines=rationale_lines,
+        issue_comments=issue_comments,
+    )
 
 
 def _run_discuss_analyzer(
@@ -3927,18 +4220,40 @@ def _run_discuss_loop(
         raise AgentLoopError("--discuss-max-rounds must be zero or greater.")
     issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
     subject = _discuss_subject(issue_context)
+    configured_reviewers = list(_reviewers(config))
     for comment in issue_context.comments or []:
         body = comment.body or ""
         m = DISCUSS_CONSENSUS_MARKER_RE.search(body)
         if m and m.group(1).lower() == subject:
             log(config, f"discuss: found matching consensus comment for issue #{issue_number}; skipping")
+            _handle_already_finalized_discuss_split(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                subject=subject,
+                configured_reviewers=configured_reviewers,
+                matched_body=body,
+                issue_comments=issue_context.comments,
+            )
             return 0
-    configured_reviewers = list(_reviewers(config))
     resume_state = _resume_discuss_round(
         issue_context.comments, subject=subject, configured_reviewers=configured_reviewers
     )
     if resume_state is not None and resume_state.done:
         log(config, f"discuss: found matching round-summary comment for issue #{issue_number}; skipping")
+        final_votes = list(resume_state.round_history[-1]) if resume_state.round_history else []
+        consensus = _detect_discuss_consensus(final_votes)
+        if consensus is not None and consensus[0] == "split":
+            _, proposals = consensus
+            _materialize_or_warn_discuss_split(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                subject=subject,
+                proposals=proposals,
+                rationale_lines=_discuss_split_rationale_lines(final_votes),
+                issue_comments=issue_context.comments,
+            )
         return 0
     memory = prepare_agent_memory(runner, config)
     analyzer = config.discuss_analyzer
@@ -4266,6 +4581,11 @@ def _run_discuss_loop(
                 configured_reviewers=configured_reviewers,
                 usage_context=usage_context,
             )
+        split_unfiled_warning = (
+            DISCUSS_SPLIT_UNFILED_WARNING
+            if is_final and outcome == "split" and round_split_proposals and not config.materialize_split_issues
+            else None
+        )
         summary_body = render_discuss_round_summary_comment(
             round_number=round_number,
             # The vote table and agenda draw from real positions only; failed
@@ -4284,6 +4604,7 @@ def _run_discuss_loop(
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
             failed_debaters=tuple(failed_debaters),
+            unfiled_split_warning=split_unfiled_warning,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(successful_votes))
         post_issue_comment(
@@ -4304,6 +4625,7 @@ def _run_discuss_loop(
                     analyzer_response=analyzer_response_raw,
                     research_mode=config.discuss_research,
                     failed_debaters=tuple(failed_debaters),
+                    split_proposals=tuple(round_split_proposals) if is_final and outcome == "split" else (),
                 ),
             ),
         )
@@ -4313,6 +4635,16 @@ def _run_discuss_loop(
                 f"discuss: posted final summary comment for issue #{issue_number} "
                 f"(outcome: {outcome}; kind: {consensus_kind})",
             )
+            if outcome == "split":
+                _materialize_or_warn_discuss_split(
+                    runner,
+                    config=config,
+                    issue_number=issue_number,
+                    subject=subject,
+                    proposals=round_split_proposals,
+                    rationale_lines=_discuss_split_rationale_lines(successful_votes),
+                    issue_comments=issue_context.comments,
+                )
             return 0
         log(
             config,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -54,6 +54,20 @@ class CompactPrReviewTailContext:
     action: str | None = None
 
 
+@dataclass(frozen=True)
+class StagedImplementationTarget:
+    """Implementation handoff onto one stage of a split/staged issue (#476).
+
+    `child_issue` is the resolved child issue this PR should close, when a
+    prior discuss split already materialized child issues for every proposal.
+    It is None when stages remain only as declared `deferred_stages` that
+    have not (yet) been filed as GitHub issues.
+    """
+
+    parent_issue: int
+    child_issue: int | None = None
+
+
 def format_agent_list(agents: Sequence[AgentName]) -> str:
     names = [agent_display_name(agent) for agent in agents]
     if len(names) == 1:
@@ -717,6 +731,19 @@ object.
 """
 
 
+def _deferred_stages_field_guidance() -> str:
+    return (
+        "If the revised plan intentionally narrows scope and defers stages of the issue to "
+        "separate follow-up issues, declare every deferred stage in the optional "
+        '`deferred_stages` field: `"deferred_stages": [{"title": "Stage name", '
+        '"summary": "What the deferred stage covers."}]`. Declared stages are '
+        "tracked mechanically at plan approval (filed as child issues, or explicitly "
+        "warned about if `--materialize-split-issues` is not set); scope narrowing described "
+        "only in prose leaves follow-up stages untracked and can let a PR close the parent "
+        "issue while real scope remains unimplemented.\n"
+    )
+
+
 def _plan_revision_schema_and_rules() -> str:
     return """Plan revision response protocol
 
@@ -762,7 +789,8 @@ after the JSON object and before the `AGENT_PLAN_STATE` footer. Otherwise, put
 the `AGENT_PLAN_STATE` footer immediately after the JSON. Make the footer state
 match the JSON state, and include only your standalone signature after the
 footer.
-"""
+
+""" + _deferred_stages_field_guidance()
 
 
 def _compact_plan_stable_prefix(
@@ -835,6 +863,24 @@ def _issue_pr_reference_guidance(issue_number: int) -> str:
     return (
         f"In the pull request body, include `Fixes #{issue_number}` or another direct "
         f"reference to issue #{issue_number} so GitHub links the PR back to the issue.\n"
+    )
+
+
+def _staged_issue_pr_reference_guidance(target: StagedImplementationTarget) -> str:
+    if target.child_issue is not None:
+        return (
+            f"This issue has follow-up stages tracked separately from the one you are "
+            f"implementing. In the pull request body, include `Closes #{target.child_issue}` "
+            f"(the stage you are implementing) and `Refs #{target.parent_issue}`. Do NOT use "
+            f"`Fixes`/`Closes`/`Resolves` against #{target.parent_issue} itself — other stages "
+            "of it remain unimplemented and must not be auto-closed by this PR.\n"
+        )
+    return (
+        f"This issue has follow-up stages that are tracked separately (declared as deferred "
+        f"stages, not yet filed as GitHub issues). In the pull request body, include "
+        f"`Refs #{target.parent_issue}`. Do NOT use `Fixes`/`Closes`/`Resolves` against "
+        f"#{target.parent_issue} — other stages of it remain unimplemented and must not be "
+        "auto-closed by this PR.\n"
     )
 
 
@@ -1424,6 +1470,7 @@ def build_issue_implementation_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     salvage_summary: str | None = None,
+    staged_target: StagedImplementationTarget | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -1431,6 +1478,11 @@ def build_issue_implementation_prompt(
         issue_context,
         requirement_scope="implementation requirements",
         full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
+    reference_guidance = (
+        _staged_issue_pr_reference_guidance(staged_target)
+        if staged_target is not None
+        else _issue_pr_reference_guidance(issue_number)
     )
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 
@@ -1440,7 +1492,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
-{_issue_pr_reference_guidance(issue_number)}
+{reference_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
     requirement_label="implementation requirements",

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -69,6 +69,10 @@ HUMAN_REQUIREMENTS_HEADING_RE = _followup_heading_re(r"human requirements")
 PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE = _followup_heading_re(
     r"prior unresolved plan item dispositions"
 )
+DEFERRED_STAGES_HEADING_RE = re.compile(
+    r"^\s*#{2,6}\s+deferred stages\b[^\n]*$",
+    re.I,
+)
 ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
 HTML_COMMENT_RE = re.compile(r"^\s*<!--.*-->\s*$")
 SIGNATURE_RE = re.compile(r"^\s*--\s+\S")
@@ -199,6 +203,19 @@ class StructuredCoderFollowup:
 
 
 @dataclass(frozen=True)
+class DeferredStage:
+    """A stage of the issue the plan intentionally leaves out (#476).
+
+    Declared structurally by the coder when a plan narrows scope, so follow-up
+    stages can be materialized as child issues or explicitly warned about
+    instead of surviving only as prose.
+    """
+
+    title: str
+    summary: str
+
+
+@dataclass(frozen=True)
 class StructuredPlanRevision:
     schema_version: int
     kind: str
@@ -206,6 +223,7 @@ class StructuredPlanRevision:
     summary: str
     prior_plan_item_dispositions: tuple[ReviewItemDisposition, ...]
     plan_steps: tuple[str, ...]
+    deferred_stages: tuple[DeferredStage, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -215,6 +233,7 @@ class StructuredPlanState:
     state: str
     summary: str
     plan_steps: tuple[str, ...]
+    deferred_stages: tuple[DeferredStage, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1377,6 +1396,25 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
     )
 
 
+def _expect_deferred_stages(value: object, *, context: str) -> tuple[DeferredStage, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a list of objects.")
+    stages: list[DeferredStage] = []
+    for index, entry in enumerate(value, start=1):
+        entry_context = f"{context}[{index}]"
+        stage = _expect_object(entry, context=entry_context)
+        _expect_exact_keys(stage, context=entry_context, required={"title", "summary"})
+        stages.append(
+            DeferredStage(
+                title=_expect_non_empty_string(stage["title"], context=f"{entry_context}.title"),
+                summary=_expect_non_empty_string(stage["summary"], context=f"{entry_context}.summary"),
+            )
+        )
+    return tuple(stages)
+
+
 def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | None:
     payload = _extract_structured_plan_revision_payload(text)
     if payload is None:
@@ -1396,6 +1434,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
             "prior_plan_item_dispositions",
             "plan_steps",
         },
+        optional={"deferred_stages"},
     )
     state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
     if state != "blocking":
@@ -1421,6 +1460,9 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         summary=summary,
         prior_plan_item_dispositions=dispositions,
         plan_steps=plan_steps,
+        deferred_stages=_expect_deferred_stages(
+            payload.get("deferred_stages"), context="plan_revision.deferred_stages"
+        ),
     )
 
 
@@ -1437,7 +1479,7 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
         payload,
         context="plan_state",
         required={"kind", "summary", "plan_steps"},
-        optional={"schema_version", "state"},
+        optional={"schema_version", "state", "deferred_stages"},
     )
     if "state" in payload:
         _expect_state(payload["state"], context="plan_state.state")
@@ -1452,7 +1494,49 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
             item_context="plan_state.plan_steps",
             min_length=1,
         ),
+        deferred_stages=_expect_deferred_stages(
+            payload.get("deferred_stages"), context="plan_state.deferred_stages"
+        ),
     )
+
+
+def parse_deferred_stages(plan_text: str) -> tuple[DeferredStage, ...]:
+    """Recover declared deferred stages from stored plan text (#476).
+
+    Stored plan state is either a raw structured plan response (initial
+    `plan_state` JSON) or canonical markdown rendered from a `plan_revision`,
+    where deferred stages appear as bullets under a `### Deferred stages`
+    heading. Freeform plans that adopted the same section parse identically.
+    """
+    for validator in (validate_structured_plan_state, validate_structured_plan_revision):
+        try:
+            parsed = validator(plan_text)
+        except AgentLoopError:
+            parsed = None
+        if parsed is not None:
+            return parsed.deferred_stages
+    stages: list[DeferredStage] = []
+    in_section = False
+    for line in plan_text.splitlines():
+        if DEFERRED_STAGES_HEADING_RE.match(line):
+            in_section = True
+            continue
+        if in_section and (ANY_HEADING_RE.match(line) or SIGNATURE_RE.match(line)):
+            break
+        if not in_section:
+            continue
+        bullet = BULLET_RE.match(line)
+        if bullet is None:
+            continue
+        text = bullet.group("text").strip()
+        if not text:
+            continue
+        title, separator, summary = text.partition(": ")
+        title = title.strip().strip("*").strip()
+        summary = summary.strip() if separator else ""
+        if title:
+            stages.append(DeferredStage(title=title, summary=summary or title))
+    return tuple(stages)
 
 
 def _collect_section_items(

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -57,6 +57,11 @@ class PostedRoundMetadata:
     # (display name, failure category) pairs on the round summary. Resume
     # treats these debaters' missing comments as accounted for.
     failed_debaters: tuple[tuple[str, str], ...] = ()
+    # Merged split proposals recorded on a final split-consensus summary
+    # (#476), so a later `--materialize-split-issues` rerun can file them
+    # without reconstructing debater votes. Empty on non-split and legacy
+    # summaries.
+    split_proposals: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -154,6 +159,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "analyzer_response": metadata.analyzer_response,
         "research_mode": metadata.research_mode,
         "failed_debaters": [list(pair) for pair in metadata.failed_debaters],
+        "split_proposals": list(metadata.split_proposals),
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -209,6 +215,9 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
                 (str(pair[0]), str(pair[1]))
                 for pair in payload.get("failed_debaters", [])
                 if isinstance(pair, (list, tuple)) and len(pair) == 2
+            ),
+            split_proposals=tuple(
+                str(item) for item in payload.get("split_proposals", [])
             ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -1,0 +1,483 @@
+"""Materialize discuss-mode split proposals and plan-first deferred stages into
+concrete follow-up GitHub issues (#476).
+
+A discuss `split` consensus or a plan-first plan that declares deferred stages
+otherwise leaves its follow-up scope only as prose. This module files one
+child issue per remaining stage, links parent and children in both
+directions, and is idempotent across reruns via a durable parent marker plus a
+`gh issue list --search` recovery pass for the create-then-crash window.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .config import AgentLoopConfig
+from .decomposition import _decode_json_payload, _encode_json_payload
+from .errors import AgentLoopError
+from .followups import _normalize_followup_key
+from .github import create_issue, post_issue_comment, search_issues
+from .runner import Runner
+
+MAX_SPLIT_CHILDREN = 8
+
+SPLIT_MATERIALIZATION_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_DISCUSS_SPLIT:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+SPLIT_CHILD_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_SPLIT_CHILD:\s*parent=(?P<parent>\d+)\s+key=(?P<key>[0-9a-f]+)\s*-->",
+    re.I,
+)
+ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)(?:\b|$)|#(\d+)\b")
+
+
+@dataclass(frozen=True)
+class SplitChild:
+    title: str
+    key: str
+    url: str | None
+    number: int | None
+    origin: str  # "created" or "adopted"
+
+
+@dataclass(frozen=True)
+class SplitMaterializationMetadata:
+    parent_issue: int
+    subject: str
+    proposal_titles: tuple[str, ...]
+    children: tuple[SplitChild, ...]
+
+
+def _proposal_key(title: str) -> str:
+    return _normalize_followup_key(title)
+
+
+def _child_key_hash(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
+def _child_issue_title(parent_issue: int, proposal_title: str) -> str:
+    return f"[#{parent_issue} stage] {proposal_title}"[:120]
+
+
+def _issue_number_from_url(issue_url: str | None) -> int | None:
+    if not issue_url:
+        return None
+    match = ISSUE_NUMBER_RE.search(issue_url)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))
+
+
+def _encode_metadata(metadata: SplitMaterializationMetadata) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "subject": metadata.subject,
+            "proposal_titles": list(metadata.proposal_titles),
+            "children": [
+                {
+                    "title": child.title,
+                    "key": child.key,
+                    "url": child.url,
+                    "number": child.number,
+                    "origin": child.origin,
+                }
+                for child in metadata.children
+            ],
+        }
+    )
+
+
+def _decode_metadata(encoded: str) -> SplitMaterializationMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_DISCUSS_SPLIT")
+    children_payload = payload.get("children")
+    if not isinstance(children_payload, list):
+        raise AgentLoopError("Invalid AGENT_DISCUSS_SPLIT payload.")
+    children: list[SplitChild] = []
+    for child in children_payload:
+        if not isinstance(child, dict) or not isinstance(child.get("title"), str):
+            raise AgentLoopError("Invalid AGENT_DISCUSS_SPLIT payload.")
+        url = child.get("url")
+        number = child.get("number")
+        children.append(
+            SplitChild(
+                title=child["title"],
+                key=str(child.get("key") or _proposal_key(child["title"])),
+                url=url if isinstance(url, str) else None,
+                number=number if isinstance(number, int) else None,
+                origin=str(child.get("origin") or "created"),
+            )
+        )
+    try:
+        return SplitMaterializationMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            subject=str(payload.get("subject") or ""),
+            proposal_titles=tuple(str(value) for value in payload.get("proposal_titles", [])),
+            children=tuple(children),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_DISCUSS_SPLIT payload.") from exc
+
+
+def find_existing_split_materialization(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+) -> SplitMaterializationMetadata | None:
+    """Return the latest recorded split materialization for `parent_issue`, if any.
+
+    Matching is by parent issue number only (not subject): a merged proposal's
+    normalized key is stable across subject-hash drift between discuss/plan
+    reruns, so keying off the parent alone is what actually prevents refiling
+    identical proposals after the subject changes.
+    """
+    found: SplitMaterializationMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in SPLIT_MATERIALIZATION_MARKER_RE.finditer(body):
+            metadata = _decode_metadata(match.group("payload"))
+            if metadata.parent_issue == parent_issue:
+                found = metadata
+    return found
+
+
+def _dependency_lines(children: Sequence[SplitChild]) -> list[str]:
+    if not children:
+        return ["- None yet."]
+    lines: list[str] = []
+    for child in children:
+        ref = child.url or (f"#{child.number}" if child.number is not None else None)
+        if ref:
+            lines.append(f"- {child.title}: {ref}")
+        else:
+            lines.append(f"- {child.title}: (issue URL unavailable from GitHub CLI output)")
+    return lines
+
+
+def _format_child_issue_body(
+    *,
+    repo: str,
+    parent_issue: int,
+    proposal_title: str,
+    key: str,
+    rationale_lines: Sequence[str],
+    siblings: Sequence[SplitChild],
+) -> str:
+    parent_url = f"https://github.com/{repo}/issues/{parent_issue}"
+    lines = [
+        f"Part of #{parent_issue}: {parent_url}",
+        "",
+        "## Proposed scope",
+        proposal_title,
+    ]
+    if rationale_lines:
+        lines.extend(["", "## Split rationale", *[f"- {line}" for line in rationale_lines]])
+    lines.extend(
+        [
+            "",
+            "## Sibling stages",
+            *_dependency_lines(siblings),
+            "",
+            "## Execution instructions",
+            f"Run `agent-loop issue <this issue number>` to implement this stage in its own PR. "
+            f"Keep the PR scoped to this stage; reference #{parent_issue} but never use closing "
+            f"keywords (Fixes/Closes/Resolves) against #{parent_issue} — it tracks other stages too.",
+            "",
+            f"<!-- AGENT_SPLIT_CHILD: parent={parent_issue} key={_child_key_hash(key)} -->",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _format_parent_summary(
+    metadata: SplitMaterializationMetadata,
+    *,
+    skipped_by_cap: int,
+) -> str:
+    lines = [
+        f"Split consensus for issue #{metadata.parent_issue} materialized into child issues.",
+        "",
+        "| Stage | Origin | Child issue |",
+        "| --- | --- | --- |",
+    ]
+    for child in metadata.children:
+        ref = child.url or (f"#{child.number}" if child.number is not None else "unavailable")
+        lines.append(f"| {child.title} | {child.origin} | {ref} |")
+    if skipped_by_cap:
+        lines.append("")
+        lines.append(
+            f"{skipped_by_cap} additional proposal(s) were skipped by the "
+            f"MAX_SPLIT_CHILDREN={MAX_SPLIT_CHILDREN} cap; consolidate proposals before rerunning."
+        )
+    lines.extend(
+        [
+            "",
+            "Continue implementation with `agent-loop issue <child issue number>` for the stage "
+            "you want to work on next; this parent issue is not automatically closed by any "
+            "single child's PR.",
+            "",
+            f"<!-- AGENT_DISCUSS_SPLIT: {_encode_metadata(metadata)} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def materialize_split_proposals(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    subject: str,
+    proposals: Sequence[str],
+    issue_comments: Sequence[object],
+    rationale_lines: Sequence[str] = (),
+) -> SplitMaterializationMetadata:
+    """File remaining split-proposal stages as child GitHub issues, idempotently.
+
+    `proposals` must already be exactly the stages this call should cover (the
+    selected/current stage excluded); callers decide what "remaining" means
+    for their flow. Proposals whose normalized key already appears in a prior
+    materialization for this parent are treated as already filed and are
+    neither recreated nor re-adopted.
+    """
+    existing = find_existing_split_materialization(issue_comments, parent_issue=parent_issue)
+    existing_children = list(existing.children) if existing is not None else []
+    seen_keys = {child.key for child in existing_children}
+
+    deduped: list[tuple[str, str]] = []
+    for proposal in proposals:
+        key = _proposal_key(proposal)
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append((proposal, key))
+
+    all_proposal_titles = tuple(
+        dict.fromkeys([*(existing.proposal_titles if existing is not None else ()), *proposals])
+    )
+
+    if not deduped:
+        if existing is not None:
+            return existing
+        return SplitMaterializationMetadata(
+            parent_issue=parent_issue,
+            subject=subject,
+            proposal_titles=all_proposal_titles,
+            children=(),
+        )
+
+    capacity = max(MAX_SPLIT_CHILDREN - len(existing_children), 0)
+    capped = deduped[:capacity]
+    skipped_by_cap = len(deduped) - len(capped)
+
+    adopted: list[SplitChild] = []
+    remaining_to_create: list[tuple[str, str]] = []
+    if capped:
+        search_query = f'"[#{parent_issue} stage]" in:title'
+        found_issues = search_issues(runner, config=config, search=search_query)
+        found_by_key: dict[str, tuple[str | None, int | None]] = {}
+        for found in found_issues:
+            match = SPLIT_CHILD_MARKER_RE.search(found.body or "")
+            if match is not None and int(match.group("parent")) == parent_issue:
+                found_by_key.setdefault(match.group("key"), (found.url, found.number))
+                continue
+            # Body unavailable or marker missing: fall back to normalized-title
+            # matching against the deterministic child title format.
+            title_key = _proposal_key(found.title)
+            found_by_key.setdefault(f"title:{title_key}", (found.url, found.number))
+        for title, key in capped:
+            hashed = _child_key_hash(key)
+            match = found_by_key.get(hashed) or found_by_key.get(f"title:{key}")
+            if match is not None:
+                url, number = match
+                adopted.append(SplitChild(title=title, key=key, url=url, number=number, origin="adopted"))
+            else:
+                remaining_to_create.append((title, key))
+    else:
+        remaining_to_create = []
+
+    created: list[SplitChild] = []
+    siblings_so_far = [*existing_children, *adopted]
+    for title, key in remaining_to_create:
+        body = _format_child_issue_body(
+            repo=config.repo,
+            parent_issue=parent_issue,
+            proposal_title=title,
+            key=key,
+            rationale_lines=rationale_lines,
+            siblings=siblings_so_far,
+        )
+        issue_url = create_issue(
+            runner,
+            config=config,
+            title=_child_issue_title(parent_issue, title),
+            body=body,
+        )
+        child = SplitChild(
+            title=title,
+            key=key,
+            url=issue_url,
+            number=_issue_number_from_url(issue_url),
+            origin="created",
+        )
+        created.append(child)
+        siblings_so_far = [*siblings_so_far, child]
+
+    metadata = SplitMaterializationMetadata(
+        parent_issue=parent_issue,
+        subject=subject,
+        proposal_titles=all_proposal_titles,
+        children=tuple([*existing_children, *adopted, *created]),
+    )
+    if adopted or created:
+        post_issue_comment(
+            runner,
+            config=config,
+            issue_number=parent_issue,
+            body=_format_parent_summary(metadata, skipped_by_cap=skipped_by_cap),
+        )
+    return metadata
+
+
+SPLIT_STAGE_HANDOFF_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_SPLIT_STAGE_HANDOFF:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class SplitStageHandoffMetadata:
+    parent_issue: int
+    plan_hash: str
+    child_issue_number: int
+    child_issue_url: str | None
+
+
+def _encode_stage_handoff_metadata(metadata: SplitStageHandoffMetadata) -> str:
+    return _encode_json_payload(
+        {
+            "parent_issue": metadata.parent_issue,
+            "plan_hash": metadata.plan_hash,
+            "child_issue_number": metadata.child_issue_number,
+            "child_issue_url": metadata.child_issue_url,
+        }
+    )
+
+
+def _decode_stage_handoff_metadata(encoded: str) -> SplitStageHandoffMetadata:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_SPLIT_STAGE_HANDOFF")
+    try:
+        child_issue_url = payload.get("child_issue_url")
+        return SplitStageHandoffMetadata(
+            parent_issue=int(payload["parent_issue"]),
+            plan_hash=str(payload["plan_hash"]),
+            child_issue_number=int(payload["child_issue_number"]),
+            child_issue_url=child_issue_url if isinstance(child_issue_url, str) else None,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_SPLIT_STAGE_HANDOFF payload.") from exc
+
+
+def find_existing_split_stage_handoff(
+    comments: Sequence[object],
+    *,
+    parent_issue: int,
+    plan_hash: str,
+) -> SplitStageHandoffMetadata | None:
+    found: SplitStageHandoffMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in SPLIT_STAGE_HANDOFF_MARKER_RE.finditer(body):
+            metadata = _decode_stage_handoff_metadata(match.group("payload"))
+            if metadata.parent_issue == parent_issue and metadata.plan_hash == plan_hash:
+                found = metadata
+    return found
+
+
+def format_split_stage_handoff_comment(
+    *,
+    parent_issue: int,
+    plan_hash: str,
+    child_issue_number: int,
+    child_issue_url: str | None,
+) -> str:
+    metadata = SplitStageHandoffMetadata(
+        parent_issue=parent_issue,
+        plan_hash=plan_hash,
+        child_issue_number=child_issue_number,
+        child_issue_url=child_issue_url,
+    )
+    child = child_issue_url or f"#{child_issue_number}"
+    lines = [
+        f"Approved plan for issue #{parent_issue} implements stage {child}.",
+        "",
+        f"Plan hash: {plan_hash}",
+        "",
+        "The implementation PR will close this stage's child issue and only reference "
+        f"(not close) #{parent_issue}, since other stages remain tracked separately.",
+        "",
+        f"<!-- AGENT_SPLIT_STAGE_HANDOFF: {_encode_stage_handoff_metadata(metadata)} -->",
+        "-- coding-review-agent-loop",
+    ]
+    return "\n".join(lines)
+
+
+def post_split_stage_handoff_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    parent_issue: int,
+    plan_hash: str,
+    child_issue_number: int,
+    child_issue_url: str | None,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=parent_issue,
+        body=format_split_stage_handoff_comment(
+            parent_issue=parent_issue,
+            plan_hash=plan_hash,
+            child_issue_number=child_issue_number,
+            child_issue_url=child_issue_url,
+        ),
+    )
+
+
+def resolve_selected_stage(
+    *,
+    existing: SplitMaterializationMetadata,
+    split_stage: int | None,
+) -> SplitChild:
+    """Resolve which materialized child the current plan-first run implements (#476).
+
+    Auto-resolves only when exactly one child was ever materialized for this
+    parent; otherwise `--split-stage` must disambiguate. This is deliberately
+    stricter than fuzzy title matching so an implementation run never guesses
+    which stage a plan covers.
+    """
+    if split_stage is not None:
+        for child in existing.children:
+            if child.number == split_stage:
+                return child
+        raise AgentLoopError(
+            f"--split-stage {split_stage} does not match any child issue materialized for "
+            f"parent #{existing.parent_issue}."
+        )
+    if len(existing.children) == 1:
+        return existing.children[0]
+    raise AgentLoopError(
+        f"Issue #{existing.parent_issue} has {len(existing.children)} materialized split "
+        "stages. Run `agent-loop issue <child issue number>` for the stage you want, or "
+        "rerun this issue with --split-stage <child issue number> to select one."
+    )

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -233,6 +233,7 @@ class FakeRunner(Runner):
         issue_urls=None,
         public_response_outputs=None,
         advance_git_head_on_pr=True,
+        search_issues_results=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -309,6 +310,7 @@ class FakeRunner(Runner):
         self.post_agent_git_diff_check_returncode = post_agent_git_diff_check_returncode
         self.post_agent_git_diff_check_stderr = post_agent_git_diff_check_stderr
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
+        self.search_issues_results = list(search_issues_results or [])
         self.public_response_outputs = list(public_response_outputs or [])
         self.advance_git_head_on_pr = advance_git_head_on_pr
         self._agent_pr_counter = 0
@@ -665,6 +667,9 @@ class FakeRunner(Runner):
             )
             return CommandResult(cmd, cwd_path, "", "", 0)
 
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return CommandResult(cmd, cwd_path, json_dumps(self.search_issues_results), "", 0)
+
         if cmd[:3] == ["gh", "issue", "create"]:
             title = cmd[cmd.index("--title") + 1]
             if "--body-file" in cmd:
@@ -912,18 +917,20 @@ def structured_plan_revision(
     plan_steps: list[str] | None = None,
     reviewer: str = "Anthropic Claude",
     human_requirements: str = "",
+    deferred_stages: list[dict[str, str]] | None = None,
 ) -> str:
+    payload = {
+        "schema_version": 1,
+        "kind": "plan_revision",
+        "state": "blocking",
+        "summary": summary,
+        "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
+        "plan_steps": plan_steps or ["Update the plan.", "Run the relevant tests."],
+    }
+    if deferred_stages is not None:
+        payload["deferred_stages"] = deferred_stages
     return (
-        json.dumps(
-            {
-                "schema_version": 1,
-                "kind": "plan_revision",
-                "state": "blocking",
-                "summary": summary,
-                "prior_plan_item_dispositions": prior_plan_item_dispositions or [],
-                "plan_steps": plan_steps or ["Update the plan.", "Run the relevant tests."],
-            }
-        )
+        json.dumps(payload)
         + human_requirements
         + "\n<!-- AGENT_PLAN_STATE: blocking -->\n"
         + f"-- {reviewer}"
@@ -936,17 +943,19 @@ def structured_plan_state(
     summary: str = "Implementation plan.",
     plan_steps: list[str] | None = None,
     reviewer: str = "Anthropic Claude",
+    deferred_stages: list[dict[str, str]] | None = None,
 ) -> str:
+    payload = {
+        "schema_version": 1,
+        "kind": "plan_state",
+        "state": state,
+        "summary": summary,
+        "plan_steps": plan_steps or ["Update the code.", "Run the relevant tests."],
+    }
+    if deferred_stages is not None:
+        payload["deferred_stages"] = deferred_stages
     return (
-        json.dumps(
-            {
-                "schema_version": 1,
-                "kind": "plan_state",
-                "state": state,
-                "summary": summary,
-                "plan_steps": plan_steps or ["Update the code.", "Run the relevant tests."],
-            }
-        )
+        json.dumps(payload)
         + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n"
         + f"-- {reviewer}"
     )

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -1,0 +1,657 @@
+"""Tests for materializing discuss split consensus / plan-first deferred
+stages into follow-up GitHub issues (#476)."""
+import hashlib
+import json
+
+import pytest
+
+from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
+from coding_review_agent_loop.comment_rendering import (
+    render_deferred_stages_section,
+    render_discuss_round_summary_comment,
+)
+from coding_review_agent_loop.github import (
+    FoundIssue,
+    search_issues,
+    validate_pr_body_does_not_close_issue,
+)
+from coding_review_agent_loop.orchestrator import (
+    DISCUSS_SPLIT_UNFILED_WARNING,
+    PostedRoundMetadata,
+    _attach_round_metadata,
+    _discuss_subject,
+    render_public_agent_comment,
+    run_discuss_loop,
+)
+from coding_review_agent_loop.protocol import DeferredStage, ParsedDiscussReview, parse_deferred_stages
+from coding_review_agent_loop.round_state import _decode_round_metadata, _encode_round_metadata
+from coding_review_agent_loop.split_materialization import (
+    SPLIT_CHILD_MARKER_RE,
+    SplitChild,
+    SplitMaterializationMetadata,
+    find_existing_split_materialization,
+    find_existing_split_stage_handoff,
+    materialize_split_proposals,
+    resolve_selected_stage,
+)
+
+from agent_loop_helpers import FakeRunner, make_config, structured_plan_review, structured_plan_state
+
+
+def _discuss_review_text(
+    *,
+    outcome: str = "split",
+    rationale: str = "Too broad.",
+    split_proposals: list[str] | None = None,
+    reviewer: str = "OpenAI Codex",
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_review",
+        "outcome": outcome,
+        "rationale": rationale,
+    }
+    if split_proposals is not None:
+        payload["split_proposals"] = split_proposals
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+
+
+def _issue_subject(title: str = "Fix issue-mode context", body: str = "Original issue body.") -> str:
+    return hashlib.sha256((title + "\n\n" + body).strip().encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# split_materialization.py unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_split_proposals_creates_children_and_parent_marker(tmp_path):
+    runner = FakeRunner(
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ]
+    )
+    config = make_config(tmp_path)
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=["Auth flow", "Authorization checks"],
+        issue_comments=(),
+    )
+
+    assert len(runner.issues) == 2
+    assert runner.issues[0]["title"] == "[#56 stage] Auth flow"
+    assert "Part of #56" in runner.issues[0]["body"]
+    assert SPLIT_CHILD_MARKER_RE.search(runner.issues[0]["body"]) is not None
+    assert "never use closing keywords" in runner.issues[0]["body"]
+    assert metadata.children[0].origin == "created"
+    assert metadata.children[0].number == 101
+    parent_comment = runner.comments[-1]
+    assert "materialized into child issues" in parent_comment
+    assert "<!-- AGENT_DISCUSS_SPLIT:" in parent_comment
+
+
+def test_materialize_split_proposals_second_child_links_sibling(tmp_path):
+    runner = FakeRunner(
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ]
+    )
+    config = make_config(tmp_path)
+
+    materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=["Auth flow", "Authorization checks"],
+        issue_comments=(),
+    )
+
+    assert "https://github.com/OWNER/REPO/issues/101" in runner.issues[1]["body"]
+
+
+def test_materialize_split_proposals_is_idempotent_via_parent_marker(tmp_path):
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/101"])
+    config = make_config(tmp_path)
+    first = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=["Auth flow"],
+        issue_comments=(),
+    )
+    marker_comment = runner.comments[-1]
+
+    class _Comment:
+        def __init__(self, body):
+            self.body = body
+
+    second = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=["Auth flow"],
+        issue_comments=[_Comment(marker_comment)],
+    )
+
+    assert len(runner.issues) == 1
+    assert len(runner.comments) == 1
+    assert second.children == first.children
+
+
+def test_materialize_split_proposals_files_only_new_proposals_when_others_exist(tmp_path):
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/101"])
+    config = make_config(tmp_path)
+    materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=["Auth flow"],
+        issue_comments=(),
+    )
+    marker_comment = runner.comments[-1]
+
+    class _Comment:
+        def __init__(self, body):
+            self.body = body
+
+    runner.issue_urls = ["https://github.com/OWNER/REPO/issues/102"]
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj2",
+        proposals=["Auth flow", "Rate limiting"],
+        issue_comments=[_Comment(marker_comment)],
+    )
+
+    assert len(runner.issues) == 2
+    assert runner.issues[-1]["title"] == "[#56 stage] Rate limiting"
+    assert {child.title for child in metadata.children} == {"Auth flow", "Rate limiting"}
+
+
+def test_materialize_split_proposals_adopts_existing_children_via_search(tmp_path):
+    key_hash = hashlib.sha256("auth flow".encode("utf-8")).hexdigest()[:16]
+    runner = FakeRunner(
+        issue_urls=["https://github.com/OWNER/REPO/issues/102"],
+        search_issues_results=[
+            {
+                "number": 555,
+                "title": "[#56 stage] Auth flow",
+                "url": "https://github.com/OWNER/REPO/issues/555",
+                "body": f"<!-- AGENT_SPLIT_CHILD: parent=56 key={key_hash} -->",
+            }
+        ],
+    )
+    config = make_config(tmp_path)
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=["Auth flow", "Authorization checks"],
+        issue_comments=(),
+    )
+
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "[#56 stage] Authorization checks"
+    origins = {child.title: child.origin for child in metadata.children}
+    assert origins["Auth flow"] == "adopted"
+    assert origins["Authorization checks"] == "created"
+    numbers = {child.title: child.number for child in metadata.children}
+    assert numbers["Auth flow"] == 555
+
+
+def test_materialize_split_proposals_caps_children(tmp_path):
+    runner = FakeRunner(
+        issue_urls=[f"https://github.com/OWNER/REPO/issues/{n}" for n in range(200, 208)]
+    )
+    config = make_config(tmp_path)
+    proposals = [f"Stage {i}" for i in range(10)]
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=config,
+        parent_issue=56,
+        subject="subj",
+        proposals=proposals,
+        issue_comments=(),
+    )
+
+    assert len(metadata.children) == 8
+    assert "skipped by the" in runner.comments[-1]
+
+
+def test_find_existing_split_materialization_matches_by_parent_not_subject(tmp_path):
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/101"])
+    config = make_config(tmp_path)
+    materialize_split_proposals(
+        runner, config=config, parent_issue=56, subject="subj-a", proposals=["Auth flow"], issue_comments=()
+    )
+    marker_comment = runner.comments[-1]
+
+    class _Comment:
+        def __init__(self, body):
+            self.body = body
+
+    found = find_existing_split_materialization([_Comment(marker_comment)], parent_issue=56)
+    assert found is not None
+    assert found.children[0].title == "Auth flow"
+
+    not_found = find_existing_split_materialization([_Comment(marker_comment)], parent_issue=99)
+    assert not_found is None
+
+
+def test_resolve_selected_stage_auto_resolves_single_child():
+    existing = SplitMaterializationMetadata(
+        parent_issue=56,
+        subject="s",
+        proposal_titles=("Auth flow",),
+        children=(SplitChild(title="Auth flow", key="auth flow", url=None, number=101, origin="created"),),
+    )
+    selected = resolve_selected_stage(existing=existing, split_stage=None)
+    assert selected.number == 101
+
+
+def test_resolve_selected_stage_requires_split_stage_when_ambiguous():
+    existing = SplitMaterializationMetadata(
+        parent_issue=56,
+        subject="s",
+        proposal_titles=("Auth flow", "Rate limiting"),
+        children=(
+            SplitChild(title="Auth flow", key="auth flow", url=None, number=101, origin="created"),
+            SplitChild(title="Rate limiting", key="rate limiting", url=None, number=102, origin="created"),
+        ),
+    )
+    with pytest.raises(AgentLoopError, match="--split-stage"):
+        resolve_selected_stage(existing=existing, split_stage=None)
+
+    selected = resolve_selected_stage(existing=existing, split_stage=102)
+    assert selected.title == "Rate limiting"
+
+
+def test_resolve_selected_stage_rejects_unknown_split_stage_number():
+    existing = SplitMaterializationMetadata(
+        parent_issue=56,
+        subject="s",
+        proposal_titles=("Auth flow",),
+        children=(SplitChild(title="Auth flow", key="auth flow", url=None, number=101, origin="created"),),
+    )
+    with pytest.raises(AgentLoopError, match="does not match"):
+        resolve_selected_stage(existing=existing, split_stage=999)
+
+
+# ---------------------------------------------------------------------------
+# github.py unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_search_issues_parses_results(tmp_path):
+    runner = FakeRunner(
+        search_issues_results=[
+            {"number": 5, "title": "T", "url": "https://github.com/OWNER/REPO/issues/5", "body": "b"}
+        ]
+    )
+    config = make_config(tmp_path)
+    found = search_issues(runner, config=config, search="query")
+    assert found == (FoundIssue(number=5, title="T", url="https://github.com/OWNER/REPO/issues/5", body="b"),)
+
+
+def test_search_issues_dry_run_returns_empty(tmp_path):
+    runner = FakeRunner(search_issues_results=[{"number": 5, "title": "T", "url": None, "body": None}])
+    config = make_config(tmp_path, dry_run=True)
+    found = search_issues(runner, config=config, search="query")
+    assert found == ()
+
+
+def test_validate_pr_body_does_not_close_issue_rejects_closing_keyword(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Closes #56\nRefs #99"})
+    config = make_config(tmp_path)
+    with pytest.raises(AgentLoopError, match="closing keyword"):
+        validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def test_validate_pr_body_does_not_close_issue_accepts_refs(tmp_path):
+    runner = FakeRunner(pr_payload={"body": "Closes #99\nRefs #56"})
+    config = make_config(tmp_path)
+    validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+# ---------------------------------------------------------------------------
+# protocol.py: deferred_stages parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_deferred_stages_from_structured_plan_state():
+    text = structured_plan_state(
+        deferred_stages=[{"title": "Stage 2", "summary": "Later work."}],
+    )
+    stages = parse_deferred_stages(text)
+    assert stages == (DeferredStage(title="Stage 2", summary="Later work."),)
+
+
+def test_parse_deferred_stages_from_canonical_markdown_section():
+    text = "\n\n".join(
+        [
+            "Summary text.",
+            "### Plan steps\n1. Do the thing.",
+            render_deferred_stages_section(
+                (DeferredStage(title="Stage 2", summary="Later work."),)
+            ),
+        ]
+    )
+    stages = parse_deferred_stages(text)
+    assert stages == (DeferredStage(title="Stage 2", summary="Later work."),)
+
+
+def test_parse_deferred_stages_empty_when_absent():
+    assert parse_deferred_stages(structured_plan_state()) == ()
+
+
+# ---------------------------------------------------------------------------
+# round_state.py: split_proposals metadata roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_posted_round_metadata_split_proposals_roundtrip():
+    metadata = PostedRoundMetadata(
+        flow="discuss",
+        role="summary",
+        agent="Orchestrator",
+        round_number=1,
+        subject="subj",
+        is_final=True,
+        split_proposals=("Auth flow", "Rate limiting"),
+    )
+    decoded = _decode_round_metadata(_encode_round_metadata(metadata))
+    assert decoded.split_proposals == ("Auth flow", "Rate limiting")
+
+
+def test_posted_round_metadata_split_proposals_defaults_empty_for_legacy_payload():
+    metadata = PostedRoundMetadata(
+        flow="discuss", role="summary", agent="Orchestrator", round_number=1, subject="subj"
+    )
+    encoded = _encode_round_metadata(metadata)
+    import base64
+
+    payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
+    del payload["split_proposals"]
+    legacy_encoded = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+    decoded = _decode_round_metadata(legacy_encoded)
+    assert decoded.split_proposals == ()
+
+
+# ---------------------------------------------------------------------------
+# comment_rendering.py
+# ---------------------------------------------------------------------------
+
+
+def test_render_discuss_round_summary_comment_embeds_unfiled_split_warning():
+    body = render_discuss_round_summary_comment(
+        round_number=1,
+        reviewer_votes=[ParsedDiscussReview(outcome="split", rationale="x", split_proposals=("A",), reviewer="Codex")],
+        is_final=True,
+        subject="subj",
+        outcome="split",
+        consensus_kind="unanimous",
+        split_proposals=["A"],
+        unfiled_split_warning=DISCUSS_SPLIT_UNFILED_WARNING,
+    )
+    assert "Split follow-ups are **not** filed" in body
+
+
+# ---------------------------------------------------------------------------
+# discuss loop integration
+# ---------------------------------------------------------------------------
+
+
+def test_discuss_split_materializes_child_issues_when_flag_enabled(tmp_path):
+    split_text = _discuss_review_text(split_proposals=["Auth flow", "Authorization checks"])
+    runner = FakeRunner(
+        codex_outputs=[split_text],
+        gemini_outputs=[split_text],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.issues) == 2
+    assert "materialized into child issues" in runner.comments[-1]
+    assert "Consensus: Split" in runner.comments[-2]
+
+
+def test_discuss_split_warns_when_flag_disabled(tmp_path):
+    split_text = _discuss_review_text(split_proposals=["Auth flow", "Authorization checks"])
+    runner = FakeRunner(codex_outputs=[split_text], gemini_outputs=[split_text])
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=False)
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.issues) == 0
+    assert "Split follow-ups are **not** filed" in runner.comments[-1]
+
+
+def test_discuss_split_rerun_via_raw_marker_materializes_instead_of_skipping(tmp_path):
+    split_text = _discuss_review_text(split_proposals=["Auth flow", "Authorization checks"])
+    runner = FakeRunner(
+        codex_outputs=[split_text],
+        gemini_outputs=[split_text],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=False)
+    run_discuss_loop(runner, issue_number=56, config=config)
+
+    runner2 = FakeRunner(
+        issue_comments=list(runner.issue_comments),
+        codex_outputs=[],
+        gemini_outputs=[],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/201",
+            "https://github.com/OWNER/REPO/issues/202",
+        ],
+    )
+    config2 = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+
+    result = run_discuss_loop(runner2, issue_number=56, config=config2)
+
+    assert result == 0
+    assert len(runner2.issues) == 2
+    assert "materialized into child issues" in runner2.comments[-1]
+
+
+def test_discuss_split_rerun_after_materialization_is_idempotent(tmp_path):
+    split_text = _discuss_review_text(split_proposals=["Auth flow", "Authorization checks"])
+    runner = FakeRunner(
+        codex_outputs=[split_text],
+        gemini_outputs=[split_text],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+    run_discuss_loop(runner, issue_number=56, config=config)
+
+    runner2 = FakeRunner(
+        issue_comments=list(runner.issue_comments), codex_outputs=[], gemini_outputs=[]
+    )
+    config2 = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+
+    result = run_discuss_loop(runner2, issue_number=56, config=config2)
+
+    assert result == 0
+    assert len(runner2.issues) == 0
+    assert len(runner2.comments) == 0
+
+
+def test_discuss_split_rerun_via_resume_state_done_materializes(tmp_path):
+    """Round metadata is present (not the pre-#476 legacy case) but the fast
+    subject-marker scan is what actually fires; the resume-state fallback
+    path is exercised when the marker text itself is absent but full round
+    metadata resumes as done."""
+    split_text = _discuss_review_text(split_proposals=["Auth flow"])
+    runner = FakeRunner(codex_outputs=[split_text], gemini_outputs=[split_text])
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=False)
+    run_discuss_loop(runner, issue_number=56, config=config)
+
+    # Strip the textual `AGENT_DISCUSS_CONSENSUS` marker from the stored final
+    # summary comment so the fast raw-marker scan can't match, forcing
+    # `_run_discuss_loop` to rely on the full `_resume_discuss_round`
+    # reconstruction (the `resume_state.done` path) instead.
+    stripped_comments = []
+    for comment in runner.issue_comments:
+        body = comment["body"].replace("Consensus: Split", "Consensus: Split (edited)")
+        stripped_comments.append({**comment, "body": body})
+
+    runner2 = FakeRunner(
+        issue_comments=stripped_comments,
+        codex_outputs=[],
+        gemini_outputs=[],
+        issue_urls=["https://github.com/OWNER/REPO/issues/301"],
+    )
+    config2 = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+
+    result = run_discuss_loop(runner2, issue_number=56, config=config2)
+
+    assert result == 0
+    assert len(runner2.issues) == 1
+
+
+# ---------------------------------------------------------------------------
+# plan-first integration: deferred stages + selected-stage handoff
+# ---------------------------------------------------------------------------
+
+
+def _plan_state_with_deferred(state="blocking"):
+    return structured_plan_state(
+        state=state,
+        summary="Scope narrowed to stage 1 only.",
+        plan_steps=["Implement stage 1 helpers.", "Add tests for stage 1."],
+        deferred_stages=[{"title": "Stage 2 follow-up", "summary": "Covers the remaining API surface."}],
+    )
+
+
+def test_plan_first_deferred_stages_materializes_when_flag_enabled(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[_plan_state_with_deferred()],
+        codex_outputs=[structured_plan_review(state="approved")],
+    )
+    config = make_config(
+        tmp_path, plan_execution_mode="plan-only", materialize_split_issues=True
+    )
+    runner.issue_urls = ["https://github.com/OWNER/REPO/issues/601"]
+
+    result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "[#56 stage] Stage 2 follow-up"
+    assert "materialized into child issues" in runner.comments[-1]
+
+
+def test_plan_first_deferred_stages_warns_when_flag_disabled(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[_plan_state_with_deferred()],
+        codex_outputs=[structured_plan_review(state="approved")],
+    )
+    config = make_config(
+        tmp_path, plan_execution_mode="plan-only", materialize_split_issues=False
+    )
+
+    result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    assert len(runner.issues) == 0
+    assert "Deferred stages not filed" in runner.comments[-1]
+    assert "Stage 2 follow-up" in runner.comments[-1]
+
+
+def test_plan_first_selected_stage_handoff_closes_child_refs_parent(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            _plan_state_with_deferred(),
+            "Implemented stage 1.\n<!-- AGENT_PR: 300 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "pr_review",
+                    "state": "approved",
+                    "summary": "LGTM.",
+                    "blocking_items": [],
+                    "same_pr_followups": [],
+                    "future_followups": [],
+                    "prior_item_dispositions": [],
+                }
+            )
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        issue_urls=["https://github.com/OWNER/REPO/issues/601"],
+        pr_payload={
+            "number": 300,
+            "state": "OPEN",
+            "body": "Closes #601\nRefs #56",
+            "headRefName": "f",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [],
+            "reviews": [],
+        },
+    )
+    config = make_config(
+        tmp_path, plan_execution_mode="implement-one-shot", materialize_split_issues=True
+    )
+
+    result = run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert result == 0
+    assert len(runner.issues) == 1
+    handoff_comment = next(c for c in runner.comments if "AGENT_SPLIT_STAGE_HANDOFF" in c)
+    assert "implements stage" in handoff_comment
+    assert "601" in handoff_comment
+
+
+def test_plan_first_staged_pr_body_closing_parent_is_rejected(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            _plan_state_with_deferred(),
+            "Implemented stage 1.\n<!-- AGENT_PR: 300 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[structured_plan_review(state="approved")],
+        issue_urls=["https://github.com/OWNER/REPO/issues/601"],
+        pr_payload={
+            "number": 300,
+            "state": "OPEN",
+            "body": "Closes #601\nCloses #56",
+            "headRefName": "f",
+            "baseRefName": "main",
+            "headRefOid": "abc123",
+            "comments": [],
+            "reviews": [],
+        },
+    )
+    config = make_config(
+        tmp_path, plan_execution_mode="implement-one-shot", materialize_split_issues=True
+    )
+
+    with pytest.raises(AgentLoopError, match="closing keyword"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)


### PR DESCRIPTION
## Summary

- When a discuss `split` consensus (or a plan-first plan that declares
  `deferred_stages`) leaves follow-up scope only as prose, `--materialize-split-issues`
  (on `discuss` and `issue --plan-first`) now files one child GitHub issue per
  remaining stage, with a durable `AGENT_DISCUSS_SPLIT` parent marker,
  per-child `AGENT_SPLIT_CHILD` markers, and a `gh issue list --search`
  recovery pass so a crash between creating a child and posting the parent
  marker never produces a duplicate. Default is off; without the flag, the
  final discuss/plan summaries post an explicit "unfiled" warning instead,
  so the #467/#474 scenario (first-stage PR lands, later stages survive only
  in comments) is impossible to miss.
- Reruns are idempotent: the parent marker is matched by parent issue number
  (not subject), so materialization follow-up comments don't themselves force
  a subject-hash rerun of the whole discuss debate.
- Once every proposal is materialized, an `implement-one-shot` run resolves
  which child issue the approved plan implements (auto-resolved when exactly
  one child exists, otherwise `--split-stage <child-issue>`), records the
  resolution in an `AGENT_SPLIT_STAGE_HANDOFF` marker, and instructs the
  coder to `Closes #<child>` / `Refs #<parent>`. A new
  `validate_pr_body_does_not_close_issue` check rejects a PR body that uses a
  closing keyword against the parent while stages remain.
- The plan-revision/plan-state structured schema gains an optional
  `deferred_stages` field so plan-first narrowing is detected and tracked
  even without a prior discuss split.

## Test plan

- [x] `python -m pytest tests/ -q` — 1324 passed (1295 pre-existing + 29 new)
- [x] Manual end-to-end smoke tests via FakeRunner covering: discuss split
      materialization, flag-off warning, idempotent rerun via both early-exit
      paths, crash-window search-based adoption, plan-first deferred-stage
      materialization/warning, selected-stage handoff, and PR-body guardrail
      rejection.

Fixes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)