### PR TITLE
Clarify pending CI approval guidance

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -835,7 +835,7 @@ agent-loop pr 123 \
 
 When enabled, the tool waits for the configured GitHub check-run to pass before merging. Local `--test-command` is an additional local gate, not a replacement for CI. By default, `--test-command` also runs after coder-created or coder-updated changes before reviewer rounds, so reviewers are less likely to spend rounds on code that already fails the configured local test command. Use `--no-pre-review-tests` to keep `--test-command` as a post-approval gate only.
 
-Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. With `--auto-merge`, the loop instead keeps waiting for the configured check-run to resolve before merging, as before.
+Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps waiting for the configured check-run to resolve before merging, as before.
 
 ## Agent Permission Flags
 

--- a/src/coding_review_agent_loop/checks.py
+++ b/src/coding_review_agent_loop/checks.py
@@ -90,8 +90,7 @@ def _pending_ci_stop_guidance(state: str) -> str:
         "unavailable": "Wait for GitHub check status to become available.",
     }[state]
     return (
-        "This run cannot confirm the PR is merge-ready yet because "
-        f"{_pending_ci_status_summary(state)}. "
+        "This run cannot confirm the PR is merge-ready yet. "
         f"{wait} If checks pass, you can merge manually; no rerun is required. "
         "Rerun only if you want agent-loop to re-check or automate the final step. "
         "If checks fail, inspect/fix the failure or rerun so the loop can drive a fix."

--- a/src/coding_review_agent_loop/checks.py
+++ b/src/coding_review_agent_loop/checks.py
@@ -69,14 +69,33 @@ def _pending_ci_stop_message(pr_number: int, state: str, details: list[str]) -> 
     lines = [
         headline,
         "",
-        "This is an external wait, not actionable coder feedback, so no new follow-up "
-        "round was started. Rerun once GitHub checks complete (or check status can be "
-        "confirmed) to finish approval.",
+        _pending_ci_stop_guidance(state),
         "",
     ]
     lines.extend(f"- {detail}" for detail in details)
     lines.extend(["", "-- coding-review-agent-loop"])
     return "\n".join(lines)
+
+
+def _pending_ci_status_summary(state: str) -> str:
+    return {
+        "pending": "GitHub checks are still pending",
+        "unavailable": "GitHub check status is unavailable",
+    }[state]
+
+
+def _pending_ci_stop_guidance(state: str) -> str:
+    wait = {
+        "pending": "Wait for CI.",
+        "unavailable": "Wait for GitHub check status to become available.",
+    }[state]
+    return (
+        "This run cannot confirm the PR is merge-ready yet because "
+        f"{_pending_ci_status_summary(state)}. "
+        f"{wait} If checks pass, you can merge manually; no rerun is required. "
+        "Rerun only if you want agent-loop to re-check or automate the final step. "
+        "If checks fail, inspect/fix the failure or rerun so the loop can drive a fix."
+    )
 
 
 def _pr_check_details(pr_checks: PullRequestChecks) -> list[str]:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -165,6 +165,8 @@ from .workdir_guard import (
 )
 from .checks import (
     _format_pr_checks_comment,
+    _pending_ci_status_summary,
+    _pending_ci_stop_guidance,
     _pending_ci_stop_message,
     _pr_check_blocking_review,
     _pr_check_details,
@@ -4216,9 +4218,10 @@ def run_pr_loop(
                                 "coder follow-up round",
                             )
                             print(
-                                f"PR #{pr_number} approved by "
-                                f"{format_agent_list(configured_reviewers)}; GitHub checks are "
-                                f"{pr_checks.state}. Rerun after CI completes."
+                                f"PR #{pr_number} was approved by "
+                                f"{format_agent_list(configured_reviewers)}, but "
+                                f"{_pending_ci_status_summary(pr_checks.state)}. "
+                                f"{_pending_ci_stop_guidance(pr_checks.state)}"
                             )
                             return 0
                         # --auto-merge: post the informational comment, then fall

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -58,6 +58,17 @@ from agent_loop_helpers import (
 )
 
 
+def _assert_pending_ci_stop_guidance(text):
+    assert "If checks pass, you can merge manually; no rerun is required." in text
+    assert (
+        "Rerun only if you want agent-loop to re-check or automate the final step."
+        in text
+    )
+    assert "If checks fail, inspect/fix the failure or rerun so the loop can drive a fix." in text
+    assert "Rerun after CI completes." not in text
+    assert "Rerun once GitHub checks complete" not in text
+
+
 def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
     runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
     config = make_config(
@@ -787,6 +798,8 @@ def test_pr_loop_downgrades_pending_ci_only_blocking_review_without_auto_merge(t
     assert "### Blocking issues" not in review_comment
     stop_comment = runner.comments[-1]
     assert stop_comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+    _assert_pending_ci_stop_guidance(stop_comment)
+    assert "Required checks not yet reporting: test" in stop_comment
 
 def test_pr_loop_downgrades_pending_ci_only_blocking_review_with_auto_merge(tmp_path):
     runner = FakeRunner(
@@ -848,7 +861,7 @@ def test_pr_loop_keeps_blocking_review_when_mixed_with_real_finding(tmp_path):
     followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
     assert "Missing null check in models.py" in followup_prompt
 
-def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(tmp_path):
+def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(tmp_path, capsys):
     runner = FakeRunner(
         codex_outputs=["Looks good locally.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
         pr_check_runs_payload={"check_runs": []},
@@ -865,8 +878,16 @@ def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(
     )
     stop_comment = runner.comments[-1]
     assert stop_comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
-    assert "external wait" in stop_comment
+    _assert_pending_ci_stop_guidance(stop_comment)
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    captured = capsys.readouterr()
+    assert (
+        "PR #77 was approved by Codex, but GitHub checks are still pending. "
+        "This run cannot confirm the PR is merge-ready yet because GitHub checks "
+        "are still pending."
+        in captured.out
+    )
+    _assert_pending_ci_stop_guidance(captured.out)
 
 def test_pr_loop_summarizes_approved_followups_before_pending_check_stop(tmp_path):
     runner = FakeRunner(
@@ -888,6 +909,7 @@ def test_pr_loop_summarizes_approved_followups_before_pending_check_stop(tmp_pat
     assert "<!-- AGENT_APPROVED_FOLLOWUPS: pr=77 head=abc123 mode=summarize -->" in runner.comments[1]
     assert runner.comments[2].startswith("GitHub PR checks are still pending for PR #77.")
     assert runner.comments[3].startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+    _assert_pending_ci_stop_guidance(runner.comments[3])
 
 def test_pr_loop_summary_marker_has_single_blank_line_before_footer_marker(tmp_path):
     runner = FakeRunner(
@@ -934,6 +956,9 @@ def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_stop(
     assert runner.comments[3].startswith(
         "Reviewers approved PR #77, but GitHub check status is unavailable."
     )
+    assert "because GitHub check status is unavailable" in runner.comments[3]
+    assert "Wait for GitHub check status to become available." in runner.comments[3]
+    _assert_pending_ci_stop_guidance(runner.comments[3])
 
 def test_pr_loop_skips_duplicate_approved_followup_issue_creation_when_marker_exists(tmp_path):
     runner = FakeRunner(
@@ -3685,4 +3710,3 @@ def test_pr_loop_dispute_note_is_visible_to_reviewer_in_next_round(tmp_path):
     )
     assert disputed_item is not None
     assert any(CODER_DISPUTE_NOTE_PREFIX in note for note in disputed_item.notes)
-

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -59,6 +59,7 @@ from agent_loop_helpers import (
 
 
 def _assert_pending_ci_stop_guidance(text):
+    assert "This run cannot confirm the PR is merge-ready yet." in text
     assert "If checks pass, you can merge manually; no rerun is required." in text
     assert (
         "Rerun only if you want agent-loop to re-check or automate the final step."
@@ -67,6 +68,8 @@ def _assert_pending_ci_stop_guidance(text):
     assert "If checks fail, inspect/fix the failure or rerun so the loop can drive a fix." in text
     assert "Rerun after CI completes." not in text
     assert "Rerun once GitHub checks complete" not in text
+    assert "because GitHub checks are still pending" not in text
+    assert "because GitHub check status is unavailable" not in text
 
 
 def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
@@ -883,8 +886,7 @@ def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(
     captured = capsys.readouterr()
     assert (
         "PR #77 was approved by Codex, but GitHub checks are still pending. "
-        "This run cannot confirm the PR is merge-ready yet because GitHub checks "
-        "are still pending."
+        "This run cannot confirm the PR is merge-ready yet."
         in captured.out
     )
     _assert_pending_ci_stop_guidance(captured.out)
@@ -956,7 +958,6 @@ def test_pr_loop_creates_approved_followup_issues_before_unavailable_check_stop(
     assert runner.comments[3].startswith(
         "Reviewers approved PR #77, but GitHub check status is unavailable."
     )
-    assert "because GitHub check status is unavailable" in runner.comments[3]
     assert "Wait for GitHub check status to become available." in runner.comments[3]
     _assert_pending_ci_stop_guidance(runner.comments[3])
 


### PR DESCRIPTION
## Summary
- clarify approved-but-pending/unavailable check stop comments with manual merge and optional rerun guidance
- update terminal summary to use the same guidance instead of implying rerun is required
- document the optional rerun/manual merge behavior for non-auto-merge runs

Fixes #483

## Tests
- python -m pytest tests/test_orchestrator_pr.py -q (failed: python command not found)
- python3 -m pytest tests/test_orchestrator_pr.py -q (passed)
- python3 -m pytest (passed)