### PR TITLE
Do not promote PR review summary prose into a separate unresolved item

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2365,7 +2365,8 @@ def _describe_pr_review_outcome(parsed_review: ParsedReview, *, has_blocking_sum
     if parsed_review.state == "approved":
         return "approved"
     has_same_pr = bool(parsed_review.followups.same_pr)
-    if has_blocking_summary and has_same_pr:
+    has_blocking_findings = bool(parsed_review.blocking_items) or has_blocking_summary
+    if has_blocking_findings and has_same_pr:
         return "blocking with blocking findings and same-PR follow-ups"
     if has_same_pr:
         return "blocking with same-PR follow-ups"
@@ -4110,7 +4111,10 @@ def run_pr_loop(
                         reviewer_name=reviewer_name,
                     )
                 blocking_summary = parsed_review.summary
-                has_blocking_summary = _should_record_new_blocking_item(
+                has_structured_blocking_content = bool(
+                    parsed_review.blocking_items or parsed_review.followups.same_pr
+                )
+                has_blocking_summary = not has_structured_blocking_content and _should_record_new_blocking_item(
                     blocking_summary,
                     had_prior_items=bool(prior_unresolved_items),
                     had_dispositions=bool(parsed_review.dispositions),
@@ -4122,7 +4126,19 @@ def run_pr_loop(
                 )
                 if review_state == "blocking":
                     if resumed_record is None:
-                        if has_blocking_summary:
+                        if parsed_review.blocking_items:
+                            for blocking_item in parsed_review.blocking_items:
+                                tracked_item = _next_unresolved_item(
+                                    item_number=next_unresolved_item_number,
+                                    reviewer=blocking_item.reviewer,
+                                    source_round=round_number,
+                                    text=blocking_item.text,
+                                    status="blocking",
+                                )
+                                round_new_unresolved_items.append(tracked_item)
+                                reviewer_new_unresolved_items.append(tracked_item)
+                                next_unresolved_item_number += 1
+                        elif has_blocking_summary:
                             tracked_item = _next_unresolved_item(
                                 item_number=next_unresolved_item_number,
                                 reviewer=reviewer_name,

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -264,8 +264,17 @@ def _validate_structured_coder_followup_items(
     *,
     unresolved_items: Sequence[UnresolvedReviewItem],
 ) -> None:
-    expected_ids = [
+    allowed_ids = [
         item.item_id for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+    ]
+    # Future follow-ups are informational carry-forwards, not actionable this round --
+    # they are not shown in the same-PR-only follow-up prompt, so the coder cannot
+    # always classify them into addressed/remaining/disputed. Allow (but do not
+    # require) referencing them when they are shown in the general prompt.
+    required_ids = [
+        item.item_id
+        for item in unresolved_items
+        if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID and item.status != "future"
     ]
     listed_ids = [*parsed.addressed_items, *parsed.remaining_items, *parsed.disputed_items]
     duplicates = sorted({item_id for item_id in listed_ids if listed_ids.count(item_id) > 1})
@@ -274,13 +283,13 @@ def _validate_structured_coder_followup_items(
             "Coder follow-up listed unresolved reviewer item IDs more than once: "
             + ", ".join(duplicates)
         )
-    unknown = sorted(set(listed_ids) - set(expected_ids))
+    unknown = sorted(set(listed_ids) - set(allowed_ids))
     if unknown:
         raise AgentLoopError(
             "Coder follow-up referenced unknown unresolved reviewer item IDs: "
             + ", ".join(unknown)
         )
-    missing = sorted(set(expected_ids) - set(listed_ids))
+    missing = sorted(set(required_ids) - set(listed_ids))
     if missing:
         raise AgentLoopError(
             "Coder follow-up did not classify all unresolved reviewer items into "

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -840,14 +840,17 @@ def test_pr_loop_keeps_blocking_review_when_mixed_with_real_finding(tmp_path):
             structured_pr_review(
                 state="approved",
                 summary="Codex final approval.",
-                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
             ),
         ],
         claude_outputs=[
             structured_coder_followup(
                 state="blocking",
                 summary="Added the missing null check.",
-                addressed_items=["item-1"],
+                addressed_items=["item-1", "item-2"],
                 remaining_items=[],
             ),
         ],
@@ -863,6 +866,7 @@ def test_pr_loop_keeps_blocking_review_when_mixed_with_real_finding(tmp_path):
     assert review_comment.startswith("**Review verdict:** Blocking")
     followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
     assert "Missing null check in models.py" in followup_prompt
+    assert "GitHub check `test` is still pending/in_progress." in followup_prompt
 
 def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(tmp_path, capsys):
     runner = FakeRunner(
@@ -1098,13 +1102,13 @@ def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(t
             "<!-- AGENT_STATE: blocking -->\n"
             "-- Google Gemini",
             "LGTM."
-            + prior_item_dispositions("[item-1] resolved", "[item-2] resolved")
+            + prior_item_dispositions("[item-1] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- Google Gemini",
         ],
         codex_outputs=[
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
             "LGTM."
-            + prior_item_dispositions("[item-1] resolved", "[item-2] resolved")
+            + prior_item_dispositions("[item-1] resolved")
             + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         claude_outputs=["Fixed review.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
@@ -1119,10 +1123,17 @@ def test_pr_loop_keeps_blocking_review_when_future_followups_are_misclassified(t
 
     assert runner.comments[0].startswith("**Review verdict:** Blocking\n\nStill blocked.")
     assert "Consider a broader cleanup later." not in runner.comments[0]
+    # Only the same-PR item ("Tighten the reset helper.") is tracked -- the
+    # blocking summary prose ("Still blocked.") is never itemized when a
+    # same_pr_followups entry already represents the actionable concern, so
+    # this routes through the lean same-PR-only coder prompt.
     followup_prompt = next(
-        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"] and "Address the review below" in cmd[-1]
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "Tighten the reset helper." in cmd[-1]
     )
-    assert "Still blocked." in followup_prompt
+    assert "Address the follow-up items below" in followup_prompt
+    assert "Still blocked." not in followup_prompt
 
 def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
     runner = FakeRunner(
@@ -2136,7 +2147,9 @@ def test_pr_loop_posts_human_readable_item_labels_in_new_and_prior_sections(tmp_
         "-- OpenAI Codex"
     )
 
-def test_pr_loop_tracks_only_summary_when_blocking_items_phrase_the_issue_differently(tmp_path):
+def test_pr_loop_tracks_blocking_items_text_not_summary_when_they_differ(tmp_path):
+    """The tracked unresolved item must use the blocking_items bullet text, not the
+    summary prose, so summary is never itemized when blocking_items is populated."""
     runner = FakeRunner(
         claude_outputs=["Implemented fixes.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
         codex_outputs=[
@@ -2153,8 +2166,8 @@ def test_pr_loop_tracks_only_summary_when_blocking_items_phrase_the_issue_differ
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     second_coder_prompt = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]][0]
-    assert "Needs one more regression test before merge." in second_coder_prompt
-    assert "Add the mixed-history resume case" not in second_coder_prompt
+    assert "Add the mixed-history resume case to `tests/test_agent_loop.py`." in second_coder_prompt
+    assert "Needs one more regression test before merge." not in second_coder_prompt
     assert runner.comments[0] == (
         "**Review verdict:** Blocking\n\n"
         "Needs one more regression test before merge.\n\n"
@@ -2162,6 +2175,135 @@ def test_pr_loop_tracks_only_summary_when_blocking_items_phrase_the_issue_differ
         "- Add the mixed-history resume case to `tests/test_agent_loop.py`.\n"
         "<!-- AGENT_STATE: blocking -->\n"
         "-- OpenAI Codex"
+    )
+    second_review_prompt = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["codex"]][1]
+    assert "[item-1]" in second_review_prompt
+    assert "Add the mixed-history resume case to `tests/test_agent_loop.py`." in second_review_prompt
+
+def test_pr_loop_same_pr_only_review_does_not_duplicate_summary_as_blocking_item(tmp_path):
+    """Regression test for issue #501 / llm-dialectic PR #257: a blocking review whose
+    summary prose restates the same concern as its lone same_pr_followups entry must
+    produce exactly one tracked item (the same-PR follow-up), not a second,
+    summary-derived blocking item."""
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="The PR is docs-only; the new audit doc contains stale path references.",
+                same_pr_followups=[
+                    "Update docs/SECURITY_FINDINGS.md references to docs/audit/SECURITY_FINDINGS.md."
+                ],
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Stale references fixed.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Updated the stale path references.",
+                addressed_items=["item-1"],
+                remaining_items=[],
+            ),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer="codex",
+        max_rounds=2,
+        approved_followups="fix-and-summarize",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert (
+        "Update docs/SECURITY_FINDINGS.md references to docs/audit/SECURITY_FINDINGS.md."
+        in followup_prompt
+    )
+    assert "The PR is docs-only" not in followup_prompt
+    # Routed through the lean same-PR-only prompt, confirming no separate blocking
+    # item was created alongside the same-PR item.
+    assert "Address the follow-up items below" in followup_prompt
+
+def test_pr_loop_creates_one_tracked_item_per_blocking_items_entry(tmp_path):
+    """Each blocking_items entry gets its own tracked item; the summary is never
+    itemized when blocking_items is populated."""
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Two separate problems found.",
+                blocking_items=[
+                    "Fix the null pointer dereference in parser.py.",
+                    "Add missing docstring to the public API.",
+                ],
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Both issues fixed.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Fixed both issues.",
+                addressed_items=["item-1", "item-2"],
+                remaining_items=[],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "[item-1]" in followup_prompt
+    assert "[item-2]" in followup_prompt
+    assert "Fix the null pointer dereference in parser.py." in followup_prompt
+    assert "Add missing docstring to the public API." in followup_prompt
+    assert "Two separate problems found." not in followup_prompt
+
+def test_pr_loop_falls_back_to_summary_item_when_no_structured_fields_present(tmp_path):
+    """When a blocking review has neither blocking_items nor same_pr_followups, the
+    summary must still become the tracked item so a genuine blocking verdict is not
+    silently dropped from the ledger."""
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="I have concerns about this approach but cannot pinpoint a specific line.",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Satisfied after discussion.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Clarified the approach.",
+                addressed_items=["item-1"],
+                remaining_items=[],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert (
+        "I have concerns about this approach but cannot pinpoint a specific line."
+        in followup_prompt
     )
 
 def test_resume_pr_round_reparses_orchestrator_rendered_blocking_issues_comment():


### PR DESCRIPTION
## Summary

- Fixes #501: a blocking PR review's `summary` prose was previously always tracked as its own unresolved ledger item (`item-1`) whenever `blocking_items` was empty, duplicating the finding when it was already represented by `same_pr_followups` (or by `blocking_items` itself, whose bullets were being ignored in favor of `summary` text). This produced the item-1/item-2 duplication observed on llm-dialectic PR #257.
- Each `blocking_items` entry now becomes its own tracked item, mirroring how `same_pr_followups`/`future_followups` already work. `summary` is only ever used as a single fallback item when **both** `blocking_items` and `same_pr_followups` are empty, so a genuine blocking verdict is never silently dropped from the ledger.
- Side effect (also fixed): a same-PR-only blocking review now correctly routes through the lean same-PR-only coder prompt instead of the general "found blocking issues" prompt, since it's no longer artificially paired with a spurious blocking item.
- Related fix: the coder follow-up validator no longer *requires* classifying "future" carry-forward items (they're never shown in the same-PR-only prompt), though it still tolerates referencing them when the general prompt does show them.

## Test plan

- [x] `python -m pytest tests/test_orchestrator_pr.py -q` (118 passed)
- [x] `python -m pytest tests/ -q` (1358 passed, including 3 new regression tests: PR #257 pattern, multiple `blocking_items` entries producing discrete items, and the both-empty fallback)
- [x] Updated two pre-existing tests whose assertions encoded the old (buggy) summary-collapsing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)