### PR TITLE
Resume implementation reruns from an existing PR instead of duplicating

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -247,6 +247,17 @@ The modes are:
   `agent-loop issue <child>`. Older decomposition summaries without this marker
   are treated as not yet handed off, so the first child handoff is recorded once.
 
+Before invoking the coder for an approved-plan implementation, the
+orchestrator also checks GitHub directly for an already-open PR that
+references the target issue, independent of any handoff marker. This closes a
+crash window that a marker-only check cannot cover: if implementation created
+a PR but the run aborted afterward — before the `AGENT_PLAN_ONE_SHOT_IMPL`
+handoff comment (or the first PR round-metadata comment) could be posted — a
+rerun still resumes PR review on that PR instead of invoking the coder again
+and creating a duplicate. If more than one open PR references the issue, the
+orchestrator raises an error instead of guessing which one to resume; close or
+merge the extra PR and rerun `agent-loop pr <number>` directly.
+
 `--implement-after-approval` is a compatibility shortcut for
 `--plan-execution-mode implement-one-shot`. It requires `--plan-first` and is
 not compatible with any other explicit `--plan-execution-mode` value.

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -280,6 +280,68 @@ def validate_pr_body_does_not_close_issue(
     )
 
 
+def find_open_pr_referencing_issue(
+    runner: Runner, *, config: AgentLoopConfig, issue_number: int
+) -> int | None:
+    """Find an open PR whose body already references `issue_number`.
+
+    Used to resume PR review instead of re-invoking the coder when a prior
+    implementation attempt created a PR but the run aborted before recording
+    any handoff marker or comment (#495): the marker-based resume checks only
+    help once the marker exists, so a rerun otherwise has no trace of the PR
+    and would invoke the coder again, creating a duplicate (as happened with
+    #492/#494).
+    """
+    if config.dry_run:
+        return None
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "pr",
+            "list",
+            "--repo",
+            config.repo,
+            "--state",
+            "open",
+            "--json",
+            "number,body",
+            "--limit",
+            "100",
+        ],
+        cwd=active_workdir(config),
+    )
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    reference_re = re.compile(ISSUE_REFERENCE_RE_TEMPLATE % (issue_number, issue_number), re.I)
+    matches: list[int] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        body = _optional_str(item.get("body")) or ""
+        if not reference_re.search(body):
+            continue
+        number = item.get("number")
+        if isinstance(number, int):
+            matches.append(number)
+    if not matches:
+        return None
+    if len(matches) > 1:
+        joined = ", ".join(f"#{n}" for n in sorted(matches))
+        raise AgentLoopError(
+            f"Multiple open PRs ({joined}) reference issue #{issue_number}; cannot automatically "
+            "determine which to resume. Close or merge the duplicate PR(s), then rerun "
+            "`agent-loop pr <number>` directly to continue review on the correct one."
+        )
+    return matches[0]
+
+
 def _parse_pr_metadata(
     data: dict[str, object], *, config: AgentLoopConfig, pr_number: int
 ) -> PullRequestMetadata:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -48,6 +48,7 @@ from .github import (
     IssueContext,
     PullRequestChecks,
     PullRequestReviewContext,
+    find_open_pr_referencing_issue,
     get_issue_context,
     get_pr_checks,
     get_pr_review_context,
@@ -2637,6 +2638,56 @@ def _implement_approved_issue(
 ) -> int:
     coder_name = agent_display_name(config.coder)
     plan_hash = approved_plan_hash(approved_plan)
+
+    # A prior implementation attempt may have created a PR and then aborted
+    # before recording any handoff marker/comment (e.g. the #493 test-report
+    # false positive, which produced the duplicate PR #494 for #492). Check
+    # GitHub directly for an already-open PR referencing this issue before
+    # invoking the coder again (#495).
+    existing_pr_number = find_open_pr_referencing_issue(
+        runner, config=config, issue_number=issue_number
+    )
+    if existing_pr_number is not None:
+        log(
+            config,
+            f"Existing implementation PR #{existing_pr_number} found for issue #{issue_number} "
+            f"/ approved plan {plan_hash}; resuming PR review instead of invoking {coder_name}.",
+        )
+        validate_pr_references_issue(
+            runner,
+            config=config,
+            pr_number=existing_pr_number,
+            issue_number=issue_number,
+        )
+        if staged_parent_issue is not None:
+            validate_pr_body_does_not_close_issue(
+                runner,
+                config=config,
+                pr_number=existing_pr_number,
+                issue_number=staged_parent_issue,
+            )
+        if one_shot_parent_issue is not None:
+            resumed_pr_context = get_pr_review_context(
+                runner, config=config, pr_number=existing_pr_number
+            )
+            post_one_shot_impl_handoff_comment(
+                runner,
+                config=config,
+                parent_issue=one_shot_parent_issue,
+                mode="implement-one-shot",
+                plan_hash=plan_hash,
+                plan_subject=plan_subject or "",
+                pr_number=existing_pr_number,
+                pr_head_sha=resumed_pr_context.metadata.head_sha,
+            )
+        return run_pr_loop(
+            runner,
+            pr_number=existing_pr_number,
+            config=config,
+            issue_context=issue_context,
+            usage_context=usage_context,
+        )
+
     salvage_summary = latest_salvage_summary(
         config.log_dir,
         repo=config.repo,

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -234,6 +234,7 @@ class FakeRunner(Runner):
         public_response_outputs=None,
         advance_git_head_on_pr=True,
         search_issues_payload=None,
+        open_prs_payload=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -317,6 +318,11 @@ class FakeRunner(Runner):
         # at a time when a list of lists is provided, otherwise reused as-is.
         self.search_issues_payload = search_issues_payload
         self.search_issues_calls = []
+        # Results returned by `gh pr list --state open` calls, used to fake
+        # `find_open_pr_referencing_issue` (#495). A list of dicts with
+        # number/body keys; defaults to no open PRs found.
+        self.open_prs_payload = open_prs_payload if open_prs_payload is not None else []
+        self.open_prs_calls = 0
         self._agent_pr_counter = 0
         self._agent_command_seen = False
         # Parallel discuss debaters (#475) call run_with_log from worker
@@ -694,6 +700,10 @@ class FakeRunner(Runner):
             else:
                 results = payload or []
             return CommandResult(cmd, cwd_path, json_dumps(results), "", 0)
+
+        if cmd[:3] == ["gh", "pr", "list"]:
+            self.open_prs_calls += 1
+            return CommandResult(cmd, cwd_path, json_dumps(self.open_prs_payload), "", 0)
 
         if cmd[:3] == ["gh", "pr", "view"]:
             if "--jq" in cmd and ".headRefOid" in cmd:

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -1849,6 +1849,161 @@ def test_issue_loop_plan_first_one_shot_rerun_pr_missing_issue_reference(tmp_pat
     assert "rerun the orchestrator as `agent-loop pr 77` to continue the review" in str(excinfo.value)
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
+def test_issue_loop_plan_first_one_shot_resumes_existing_pr_after_crash_before_handoff_comment(tmp_path):
+    """Reproduces #492/#494: implementation created a PR but the run aborted before
+    posting any handoff marker/comment (e.g. the #493 test-report false positive). A
+    rerun must resume PR review on the existing PR instead of invoking the coder again,
+    which is what previously produced the duplicate PR #494 (#495).
+    """
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+    )
+    config = make_config(tmp_path)
+
+    assert (
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+        == 0
+    )
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    handoff_comments = [c for c in runner.comments if "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in c]
+    assert len(handoff_comments) == 1
+    assert f"Plan hash: {approved_plan_hash(plan)}" in handoff_comments[0]
+    assert "PR #77" in handoff_comments[0]
+
+def test_issue_loop_plan_first_one_shot_resume_existing_pr_logs_clear_message(tmp_path, capsys):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        open_prs_payload=[{"number": 492, "body": "Fixes #56"}],
+    )
+    config = make_config(tmp_path, quiet=False)
+
+    assert (
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+        == 0
+    )
+
+    output = capsys.readouterr().err
+    assert (
+        f"Existing implementation PR #492 found for issue #56 / approved plan {approved_plan_hash(plan)}; "
+        "resuming PR review instead of invoking Claude." in output
+    )
+
+def test_issue_loop_plan_first_one_shot_rerun_raises_on_ambiguous_existing_prs(tmp_path):
+    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    runner = FakeRunner(
+        issue_comments=[
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:00Z",
+                "body": _attach_round_metadata(
+                    plan,
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="coder",
+                        agent="Claude",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                    ),
+                ),
+            },
+            {
+                "author": {"login": "bot"},
+                "createdAt": "2026-05-23T00:00:01Z",
+                "body": _attach_round_metadata(
+                    "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                    PostedRoundMetadata(
+                        flow="plan",
+                        role="reviewer",
+                        agent="Codex",
+                        round_number=1,
+                        subject=_plan_subject(plan),
+                        state="approved",
+                    ),
+                ),
+            },
+        ],
+        open_prs_payload=[
+            {"number": 492, "body": "Fixes #56"},
+            {"number": 494, "body": "Closes #56"},
+        ],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match=r"Multiple open PRs \(#492, #494\)"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
 def test_codex_issue_loop_creates_pr_then_claude_approves(tmp_path):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -1,7 +1,11 @@
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError
-from coding_review_agent_loop.github import IssueComment, validate_pr_body_does_not_close_issue
+from coding_review_agent_loop.github import (
+    IssueComment,
+    find_open_pr_referencing_issue,
+    validate_pr_body_does_not_close_issue,
+)
 from coding_review_agent_loop.split_materialization import (
     MAX_SPLIT_CHILDREN,
     dedupe_split_stage_proposals,
@@ -377,3 +381,55 @@ def test_validate_pr_body_does_not_close_issue_skips_in_dry_run(tmp_path):
     runner = FakeRunner(pr_payload={"body": "Fixes #56"})
     config = make_config(tmp_path, dry_run=True)
     validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def test_find_open_pr_referencing_issue_returns_none_when_no_match(tmp_path):
+    runner = FakeRunner(open_prs_payload=[{"number": 12, "body": "Unrelated change."}])
+    config = make_config(tmp_path)
+    assert find_open_pr_referencing_issue(runner, config=config, issue_number=56) is None
+
+
+def test_find_open_pr_referencing_issue_returns_none_when_no_open_prs(tmp_path):
+    runner = FakeRunner(open_prs_payload=[])
+    config = make_config(tmp_path)
+    assert find_open_pr_referencing_issue(runner, config=config, issue_number=56) is None
+
+
+def test_find_open_pr_referencing_issue_matches_direct_reference(tmp_path):
+    runner = FakeRunner(
+        open_prs_payload=[
+            {"number": 12, "body": "Unrelated change."},
+            {"number": 492, "body": "Implements the approved plan.\n\nFixes #476"},
+        ]
+    )
+    config = make_config(tmp_path)
+    assert find_open_pr_referencing_issue(runner, config=config, issue_number=476) == 492
+
+
+def test_find_open_pr_referencing_issue_matches_issue_url_reference(tmp_path):
+    runner = FakeRunner(
+        open_prs_payload=[
+            {"number": 492, "body": "See https://github.com/OWNER/REPO/issues/476 for context."},
+        ]
+    )
+    config = make_config(tmp_path)
+    assert find_open_pr_referencing_issue(runner, config=config, issue_number=476) == 492
+
+
+def test_find_open_pr_referencing_issue_raises_on_ambiguous_matches(tmp_path):
+    runner = FakeRunner(
+        open_prs_payload=[
+            {"number": 492, "body": "Fixes #476"},
+            {"number": 494, "body": "Closes #476"},
+        ]
+    )
+    config = make_config(tmp_path)
+    with pytest.raises(AgentLoopError, match=r"Multiple open PRs \(#492, #494\)"):
+        find_open_pr_referencing_issue(runner, config=config, issue_number=476)
+
+
+def test_find_open_pr_referencing_issue_skips_in_dry_run(tmp_path):
+    runner = FakeRunner(open_prs_payload=[{"number": 492, "body": "Fixes #476"}])
+    config = make_config(tmp_path, dry_run=True)
+    assert find_open_pr_referencing_issue(runner, config=config, issue_number=476) is None
+    assert runner.open_prs_calls == 0


### PR DESCRIPTION
## Summary

- Before invoking the coder for an approved-plan implementation, `_implement_approved_issue` now checks GitHub directly (`find_open_pr_referencing_issue`) for an already-open PR referencing the target issue, independent of any handoff marker/comment.
- This closes the crash window that produced #492/#494: a prior implementation attempt created a PR but the run aborted (the #493 test-report false positive) before the `AGENT_PLAN_ONE_SHOT_IMPL` handoff comment could be posted, so a rerun had no trace of the PR and invoked the coder again, creating a duplicate.
- On resume it validates the found PR the same way a freshly-created one is validated, posts the one-shot handoff comment (so later reruns hit the cheap marker-based check), and transitions straight into `run_pr_loop` instead of re-implementing.
- If more than one open PR references the issue, it raises a clear error instead of guessing which to resume.
- Documented the new safety net in `docs/local_agent_loop.md`.

Fixes #495

## Test plan

- [x] `python3 -m pytest tests/ -q` — 1367 passed
- [x] New unit tests for `find_open_pr_referencing_issue` in `tests/test_split_materialization.py` (no match, no open PRs, direct `#N` reference, `/issues/N` reference, ambiguous multi-match error, dry-run skip)
- [x] New integration tests in `tests/test_orchestrator_issue.py` reproducing the #492/#494 sequence: plan approved, no handoff comment posted, existing open PR found → resumes PR review without invoking the coder, posts the handoff comment, logs the clear resume message, and raises on ambiguous multiple matches

-- Anthropic Claude