### PR TITLE
Add plan-first implementation coder overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,29 @@ is recorded once. If the first phase is `human-action` or `manual-close`, the
 loop creates and reports all child issues but stops so a human can do the
 required work, add a remark/update, and close that child issue.
 
+Plan-first implementation can use a different implementation agent than the
+planning agent. Planning and plan revisions still use `--coder`; the override
+applies only after the plan is approved and implementation begins:
+
+```bash
+agent-loop issue 123 --repo OWNER/REPO --plan-first --implement-after-approval \
+  --coder claude \
+  --implementation-coder codex \
+  --implementation-coder-model gpt-5.5 \
+  --implementation-codex-reasoning-effort high
+```
+
+`--implementation-coder` accepts the same agent names as `--coder`.
+`--implementation-coder-model` sets the selected implementation coder's model
+for the approved-plan implementation only. If `--implementation-coder-model` is
+provided without `--implementation-coder`, the implementation still uses
+`--coder` but with that implementation-only model.
+`--implementation-codex-reasoning-effort` is valid only when the implementation
+coder is Codex, either explicitly with `--implementation-coder codex` or because
+`--coder codex` is the planning and implementation coder. It also requires a
+declared Codex model via `--implementation-coder-model` or `--codex-model` so
+the implementation signature can name the model reliably.
+
 Each generated child issue copies the relevant parent-plan slice, constraints
 and invariants, dependency notes, scope and non-goals, rollout risk,
 validation/soak requirements, automation classification, and instructions for

--- a/docs/audit/CODE_AUDIT_2026-07-05.md
+++ b/docs/audit/CODE_AUDIT_2026-07-05.md
@@ -1,0 +1,159 @@
+# Code Audit — coding-review-agent-loop
+
+**Date:** 2026-07-05
+**Auditor:** Anthropic Claude (Claude Code)
+**Scope:** Full repository at commit `d3faf6c` (main) — `src/coding_review_agent_loop/`, `helpers/`, `tests/`, docs, CI.
+**Method:** Complete read of the security-relevant modules (runner, github, config, agents, workdir_guard, helpers) and targeted reads of the orchestration core; full test suite executed locally; per-module coverage measured with `coverage.py`; documentation cross-checked against code.
+
+---
+
+## Executive Summary
+
+The codebase is in **very good health** — unusually disciplined for a fast-moving solo project (415 commits). Robustness engineering and test discipline are the standout strengths; module size and a duplicated orchestration stack are the main weaknesses. There is one real security finding: skill mode silently applies agent permission-bypass flags that the CLI mode requires explicit opt-in for, contradicting the documentation.
+
+| Dimension | Grade | One-line assessment |
+|-----------|-------|---------------------|
+| Security | **B+** | Excellent subprocess hygiene; skill mode silently bypasses agent sandboxes, and the human-reviewer trust signal is spoofable |
+| Robustness | **A−** | Exceptional failure taxonomy, recovery ladders, and crash-window handling; a few brittle substring classifiers |
+| Testing | **A** | 1,367 tests green in ~60s; CI runs the whole suite opt-out; 82% measured coverage; no lint/type gate |
+| Documentation | **A−** | Comprehensive README/SKILL/docs with rationale everywhere; one accuracy gap (permission flags) |
+| Structure & cleanliness | **B−** | Two 4,000–5,600-line monoliths and a dual CLI/skill orchestration stack; otherwise clean, zero TODOs, no dead code found |
+| **Overall** | **B+** | Ship-worthy; fix the skill-mode permission disclosure now, then invest in decomposition |
+
+**Test run result (2026-07-05):** `1367 passed in 60.49s` — the full suite (which is exactly what CI runs) is green.
+**Coverage (2026-07-05, in-process):** 82% overall; every `src/` module ≥ 76%, most ≥ 88%. The `helpers/` scripts show 0–56% only because tests drive them as subprocesses (see T-2).
+
+The highest-priority finding is **SEC-1** — skill mode hardcodes `--dangerously-bypass-approvals-and-sandbox` (Codex) and `--dangerously-skip-permissions` (Antigravity) while the docs state permission bypasses are opt-in.
+
+---
+
+## 1. Security — B+
+
+### Threat model context
+
+This is a local, single-operator tool: it shells out to the operator's own authenticated CLIs (`gh`, `claude`, `codex`, `gemini`, `agy`) against repos the operator chooses. The findings below matter most when the loop is pointed at a repo where **other people can write issues, comments, or PRs** — every one of those surfaces feeds agent prompts.
+
+### What's done well
+
+- **No shell injection surface.** Every subprocess call in `runner.py`, `github.py`, and the helpers uses list-form argv; there is no `shell=True`, `os.system`, `eval`, or `exec` anywhere (the two `ast.literal_eval` calls in `migrations.py` are the safe variant).
+- **Comment bodies are posted via `--body-file` temp files** (`github.py`), so GitHub-bound content can't be confused with CLI arguments and `NamedTemporaryFile` gives the file 0600 permissions.
+- **No credential handling at all.** The tool never touches API keys or tokens; auth is delegated entirely to the already-authenticated CLIs. Nothing secret is written to state files or logs by design.
+- **Careful workdir stewardship** (`config.py`): agent checkouts are validated against the expected `origin` remote before use; user-owned dirty checkouts are rejected rather than cleaned; only tool-owned default dirs under `/tmp` are ever `reset --hard`/`clean -fd`.
+- **Defense-in-depth against a misbehaving coder:** `workdir_guard.py` rejects coder responses that report tests run outside the assigned checkout, and `validate_assigned_head_advanced` catches a coder that claims a PR without commits in its assigned checkout. (Both validate self-reported text — an accident guard, not an adversarial control, and the docstrings say so.)
+- **Process lifecycle:** agents run in their own session (`start_new_session=True`) with `killpg` on timeout/interrupt; log dirs get an auto-written `.gitignore` so agent transcripts can't be committed into target repos.
+- **CLI mode permission posture is right:** no bypass flags by default; `--dangerous-agent-permissions` is an explicit, documented opt-in (`docs/local_agent_loop.md` § Agent Permission Flags).
+- **Merge is gated:** skill mode never merges (documented "always a human decision"); CLI `--auto-merge` is opt-in and waits on a named CI check.
+
+### Findings
+
+| ID | Severity | Finding |
+|----|----------|---------|
+| SEC-1 | **High** | **Skill mode hardcodes agent permission bypasses, contradicting the docs.** `helpers/run_external.py` builds its config with `codex_args=("--dangerously-bypass-approvals-and-sandbox",)` and `antigravity_args=("--dangerously-skip-permissions",)` unconditionally (lines 304–311), with no flag to opt out. Meanwhile `docs/local_agent_loop.md` states "By default, this standalone package does not pass permission-bypass flags" — true only for CLI mode — and neither `SKILL.md` nor `docs/skill_mode.md` mentions the bypass at all. External agents processing untrusted GitHub content (issue bodies, comments) thus run with sandbox/approvals off, silently. Fix: plumb an explicit `--dangerous-agent-permissions`-equivalent through `skill_runner.py` → `run_external.py` (or at minimum document the current behavior prominently in SKILL.md and skill_mode.md). |
+| SEC-2 | Medium | **The "signed human requirement" signal is spoofable.** `parse_signed_human_requirement_body` (`protocol.py:412`) treats *any* issue/PR comment ending with a standalone `-- Human Reviewer` line as a signed human requirement, and `format_human_requirements` (`prompts.py`) instructs the coder to treat these as "high-priority requirements" that must be implemented or explicitly refused. On a repo where others can comment, any GitHub user can mint such a requirement — a direct prompt-injection escalation channel into a coder that (per SEC-1, in skill mode) runs without a sandbox. Fix options: restrict recognition to an author allowlist (e.g. repo owner / configured logins, checkable from the comment's `authorAssociation`), or document explicitly that the loop must only run on repos where all commenters are trusted. |
+| SEC-3 | Low | **Untrusted GitHub text is embedded verbatim in prompts** (`format_issue_context`, comment blocks) with no data/instruction delimiting (fencing, "content below is data, not instructions" framing). Prompt injection can never be fully prevented, but explicit delimiting measurably raises the bar and is cheap to add to the prompt builders. |
+| SEC-4 | Low | **Public response files live under a shared, predictable `/tmp` path.** `public_response_path` (`agents/base.py`) writes agent responses to `/tmp/coding-review-agent-loop/responses/<repo>/<agent>/<uuid>.md` with default umask permissions, so on a multi-user machine other local users can read review/plan content for private repos (the first user to create the parent directory also owns it). Consider `tempfile.mkdtemp` under the user's `XDG_RUNTIME_DIR`/cache dir, or `chmod 0700` on the base dir. |
+| SEC-5 | Info | `.claude/settings.json` allowlists broad Bash prefixes (`python3 *`, `sed *`, `find *`) for skill sessions. Reasonable for this tool's own development; just note that it applies to any Claude Code session in this directory. |
+
+---
+
+## 2. Robustness — A−
+
+### What's done well
+
+This is the strongest dimension. The codebase treats agent CLIs as hostile weather and it shows:
+
+- **Failure taxonomy with correct retry semantics** (`transient.py`, orchestrator `_failure_category`): transient signals (429, overloaded, quota, timeouts) are retried with backoff; non-retryable signals (auth, billing, dirty checkout) *override* transient matches and are never retried; a wall-clock timeout is deliberately **not** retried ("a kill deadline is not a provider hiccup"); quota exhaustion with a far-future reset exits with a distinct code 3 (`QuotaResetExceededError`) so callers can distinguish "retry later" from "broken".
+- **A structured-response recovery ladder** before anything is declared failed: safe normalizers → envelope/fence cleanup → stdout-marker stripping → plan-revision human-ack reconstruction → an LLM repair pass (`repair.py`, with its own model chain and timeout) → a manual `retry-validate` escape hatch that saves the raw response plus context to a stable repair dir. Recovered responses are re-validated through the same validator, never trusted.
+- **Crash-window recovery everywhere state is created remotely:** split-issue materialization posts its idempotency marker only after all children exist and *adopts* already-created children on rerun (`search_issues`, #476); an aborted implementation run resumes from an open PR that references the issue instead of duplicating it (#495); pending comments are reconciled from session state.
+- **Resume is metadata-driven:** every posted comment carries a single-line base64 `AGENT_LOOP_META` marker; rounds reconstruct deterministically from GitHub comments rather than local state alone, so a crashed process on a different machine can resume.
+- **Process-group correctness under concurrency:** the parallel discuss path registers live processes in a lock-guarded registry, and `KeyboardInterrupt` in the main thread kills every group and poisons the runner against new spawns (#475). The PTY path (needed because `agy` drops output on non-TTY stdout) handles EIO, fd cleanup on spawn failure, and timeout kills.
+- **Reviewer resilience:** an unavailable reviewer marks the round `incomplete` rather than aborting — and a round with a missing reviewer is *never* reported `approved`.
+- **A PATH-race spawn retry** (`_spawn_with_retry`) distinguishes a dangling symlink (e.g. mid-upgrade CLI) from a genuinely missing command, retrying only the former.
+
+### Findings
+
+| ID | Severity | Finding |
+|----|----------|---------|
+| R-1 | Medium | **Free-text transient classification can misfire.** `TRANSIENT_AGENT_OUTPUT_RE` matches words like `\bquota\b`, `timeout`, `overloaded` anywhere in the classified text. The code already bounds what it classifies (`_bounded_failure_classification_text`, public-response-specific rules), but an agent *review* that legitimately discusses rate limiting or timeouts in a failure message path could still be misclassified and retried/suppressed. Worth a regression test corpus of "innocent" texts and, longer term, anchoring on structured error output where the CLIs provide it. |
+| R-2 | Low | **`state_manager._fetch_issue_comments` splits `gh --jq '.[].body'` output on newlines**, so multi-line comment bodies arrive as one fragment per line. This is safe today only because resume consumes single-line base64 `AGENT_LOOP_META` markers — a fragile invariant that deserves a comment, or a switch to JSON output (`--json body`) to get real comment boundaries. |
+| R-3 | Low | **HTTP status classified by substring.** `_fetch_branch_protection_required_checks` (`github.py:504`) detects 404/403 by searching `"404"`/`"403"` in combined stdout+stderr — a check name or URL containing those digits misclassifies. `gh api` exit handling or `--include` status parsing would be exact. |
+| R-4 | Low | `wait_for_ci` sleeps by spawning `runner.run(["sleep", N])` — presumably for dry-run visibility, but it's an odd dependency on an external binary where `time.sleep` (guarded by dry-run) would do. |
+| R-5 | Low | **No version discipline:** `pyproject.toml` has said `0.1.0` across 415 commits, and there are no git tags or releases. `update-agent-loop.sh` (install-by-pull) makes this survivable for the author, but any second user has no way to pin or report a version. |
+
+---
+
+## 3. Testing — A
+
+### What's done well
+
+- **1,367 tests, all passing, in ~60 seconds**, with zero external dependencies (`dependencies = []`; dev needs only pytest). Agent CLIs and `gh` are faked at the process boundary, so the suite runs anywhere.
+- **CI runs `python -m pytest` on the whole tree** (`.github/workflows/ci.yml`) — omission of a new test file is impossible by construction (the exact opt-out design the llm-dialectic audit had to recommend).
+- **Measured coverage is strong where it counts:** `src/` overall lands at 90%+ for the orchestration core (orchestrator 90%, protocol 96%, prompts 96%, repair 95%, round_state 94%, followups 97%). The regression style is disciplined — tests cite the issue numbers they lock down.
+- **The helpers are tested end-to-end as subprocesses** (`tests/test_skill_helpers.py`, 4,147 lines), which exercises argument parsing and exit codes exactly as the skill uses them.
+
+### Findings
+
+| ID | Severity | Finding |
+|----|----------|---------|
+| T-1 | Medium | **No lint or type-check gate.** The code is consistently type-annotated and clean, but nothing enforces it: no ruff/flake8, no mypy/pyright, in CI or config. At this codebase size (22K src lines), a ruff + mypy job is cheap insurance against the classes of bug the test suite can't see (unused imports, unreachable branches, annotation drift). |
+| T-2 | Low | **Helper coverage is invisible.** Because `test_skill_helpers.py` drives `helpers/*.py` via `subprocess.run`, in-process coverage reports 0% for `state_manager`/`gh_ops`/`render_response`/`demo_loop` and 56% for `skill_runner` even though they are tested. Enabling subprocess coverage (`coverage run --parallel` + `COVERAGE_PROCESS_START`) or importing the mains in-process for some tests would make real gaps visible. |
+| T-3 | Low | **No coverage measurement in CI.** Coverage had to be measured manually for this audit; a `coverage` step with a low ratcheting floor would keep the 82% from silently eroding. |
+| T-4 | Low | Several test files are monoliths mirroring the src monoliths (`test_agent_loop.py` 3,955 lines, `test_orchestrator_pr.py` 3,855, `test_skill_helpers.py` 4,147). Fine while green, but they will resist navigation exactly when a refactor (S-1/S-2) needs them most. |
+
+---
+
+## 4. Documentation — A−
+
+### What's done well
+
+- **The README (41KB) is genuinely excellent** for an open-source tool: what it is, who it's for, why not GitHub Actions, honest comparisons with four similar tools, quick start, a real worked example, and a dated, sourced billing note about `claude -p` terms.
+- **`docs/local_agent_loop.md` (1,100+ lines)** documents architecture, every CLI flag, the full response protocol (markers, structured JSON kinds), workdir semantics, and permission flags. **`docs/skill_mode.md` + `SKILL.md`** do the same for skill mode, including round states, resume, reversed roles, and guardrails.
+- **Inline comments explain *why* and cite issues** (`#475`, `#476`, `#495`…) at nearly every non-obvious decision — the PTY rationale in `runner.py` and the crash-window comments in `github.py` are exemplary. This is the practice the llm-dialectic audit praised, applied even more consistently here.
+
+### Findings
+
+| ID | Severity | Finding |
+|----|----------|---------|
+| D-1 | **Medium** | **The permission-flags documentation is wrong for skill mode** (the doc half of SEC-1): `docs/local_agent_loop.md` promises bypasses are opt-in, `SKILL.md`/`docs/skill_mode.md` are silent, and skill mode hardcodes them. Whatever the code resolution of SEC-1, the docs must state the skill-mode posture explicitly. |
+| D-2 | Low | **No CHANGELOG or release notes**, compounding R-5. The commit log is well-written, but a user updating via `update-agent-loop.sh` has no digest of behavior changes. |
+| D-3 | Low | Dated external claims (the Claude billing postponement note, the comparison table) will silently rot; each carries an as-of date, which helps — consider a "last verified" sweep habit. |
+
+---
+
+## 5. Structure & Cleanliness — B−
+
+The code *within* modules is clean: no TODOs/FIXMEs anywhere, no dead code found, small modules (`transient.py`, `workdirs.py`, `errors.py`, `logging.py`, `checks.py`) are exactly the right size, and the agents package is a textbook Protocol-based backend registry. The problem is the top of the size distribution and a structural fork.
+
+| ID | Severity | Finding |
+|----|----------|---------|
+| S-1 | **High** (maintainability) | **`orchestrator.py` is 5,573 lines** spanning at least six responsibilities: failure classification/diagnostics (~1,300 lines), the validated-agent retry/recovery engine (`_run_validated_agent`, ~550 lines of deeply nested conditionals), the plan-first loop, the issue loop, the PR loop, the task loop, and the entire discuss subsystem (~1,500 lines). Natural seams already exist — `failure_classification.py`, `validated_agent.py`, `discuss.py`, `loops/{issue,pr,task}.py` — and the 90% test coverage makes the split mechanical and safe. |
+| S-2 | High (maintainability) | **Dual orchestration stacks.** `helpers/skill_runner.py` (4,224 lines) re-implements round orchestration (reviewer turns, coder turns, resume, repair routing, followups) as a subprocess-driven mirror of `orchestrator.py`, coordinated through JSON files and CLI args. The parity burden is real and already tracked (#294 and successors). Every protocol change now lands twice. Long-term: extract the round engine into a shared library both entry points call, keeping only the session-boundary plumbing in `skill_runner`. |
+| S-3 | Medium | **`helpers/` sits outside the package** and reaches into it via `sys.path.insert(0, .../src)` (`run_external.py:28`, `state_manager.py:61`, `skill_runner.py`), while also importing underscore-private functions from `round_state`. Moving `helpers/` under `src/coding_review_agent_loop/skill/` (they're already invoked as `python -m helpers.x` — a rename plus console-script entries would do) removes the path hacks and makes the private imports honest. |
+| S-4 | Medium | **Repo hygiene:** `update-agent-loop.sh` (referenced by docs) and `.claude/settings.json` are untracked — commit them or ignore them deliberately; the agent workdir directories the tool creates in-repo during dogfooding (`claude/`, `codex/`, `gemini/`, `antigravity/`, including stale April logs under `codex/repo/.agent-loop-logs/`) are neither tracked nor gitignored — add them to `.gitignore` (or point dogfooding workdirs at the default `/tmp` location). |
+| S-5 | Low | `prompts.py` (2,570) and `protocol.py` (2,146) are near their limits; each is at least single-purpose, so they're lower priority than S-1/S-2 — but don't let them absorb the next feature by default. |
+| S-6 | Low | Alembic migration-topology validation (`migrations.py`) is a generic feature but reads as tuned to one consumer project; a one-line module docstring saying when it activates (repo contains `alembic/versions/`) would orient readers. *(It has one — this is satisfied; noted for completeness.)* |
+
+---
+
+## 6. Prioritized Recommendations
+
+**Now (security/correctness):**
+1. **SEC-1 / D-1** — make skill-mode permission bypasses explicit: plumb an opt-in flag through `skill_runner` → `run_external`, or document the hardcoded bypass in SKILL.md/skill_mode.md in bold. This is the only finding where documented behavior and actual behavior disagree on a safety property.
+2. **SEC-2** — gate `-- Human Reviewer` recognition on comment author (owner/allowlist via `authorAssociation`), or document the all-commenters-trusted assumption.
+
+**Next (cheap, high-value):**
+3. **T-1** — add ruff + mypy to CI (start permissive, ratchet).
+4. **SEC-3** — add data/instruction delimiting around embedded GitHub content in the prompt builders.
+5. **S-4** — `.gitignore` the in-repo agent workdirs; commit or ignore `update-agent-loop.sh` and `.claude/settings.json`.
+6. **T-3** — add a coverage step (with subprocess coverage, T-2) and a floor to CI.
+7. **R-2 / R-3** — switch `state_manager` comment fetching to JSON-bounded bodies; classify GitHub API errors by status rather than substring.
+
+**Then (structural, ongoing):**
+8. **S-1** — split `orchestrator.py` along its existing seams (failure classification → validated-agent engine → per-flow loops → discuss).
+9. **S-2** — extract a shared round engine so CLI and skill modes stop diverging (continue #294's direction).
+10. **S-3** — fold `helpers/` into the package and drop the `sys.path` hacks.
+11. **R-5 / D-2** — start tagging versions and keeping a minimal CHANGELOG.
+
+---
+
+*This audit reflects the repository state at commit `d3faf6c` (2026-07-05). Line references may drift as the code evolves.*

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -262,6 +262,28 @@ merge the extra PR and rerun `agent-loop pr <number>` directly.
 `--plan-execution-mode implement-one-shot`. It requires `--plan-first` and is
 not compatible with any other explicit `--plan-execution-mode` value.
 
+Approved-plan implementation can switch to a different coder after planning:
+
+```bash
+agent-loop issue 56 --repo OWNER/REPO --plan-first --implement-after-approval \
+  --coder claude \
+  --implementation-coder codex \
+  --implementation-coder-model gpt-5.5 \
+  --implementation-codex-reasoning-effort high
+```
+
+Planning and plan revisions always use `--coder`; the `--implementation-*`
+flags apply only after reviewers approve the plan and the run enters
+implementation. `--implementation-coder` accepts the same values as `--coder`.
+`--implementation-coder-model` sets that implementation coder's model only for
+the approved-plan implementation. When `--implementation-coder-model` is set
+without `--implementation-coder`, implementation keeps using `--coder` but with
+the implementation-only model. `--implementation-codex-reasoning-effort` can
+only be used when the implementation coder is Codex, either explicitly via
+`--implementation-coder codex` or implicitly via `--coder codex`; it also
+requires `--implementation-coder-model` or `--codex-model` so the Codex
+implementation signature can name the model reliably.
+
 If the plan narrows scope (via `deferred_stages` or a prior discuss `split`
 consensus), see [Split issue materialization](#split-issue-materialization)
 below for how those follow-up stages are filed (or warned about) and how

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -116,6 +116,32 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--max-rounds", type=int, default=5)
         subparser.add_argument("--auto-merge", action="store_true")
         subparser.add_argument("--dry-run", action="store_true")
+        subparser.add_argument(
+            "--implementation-coder",
+            type=normalize_agent_name,
+            choices=("claude", "codex", "gemini", "antigravity"),
+            default=None,
+            help=(
+                "With issue --plan-first implementation, use this coder only after the "
+                "plan is approved. Planning still uses --coder."
+            ),
+        )
+        subparser.add_argument(
+            "--implementation-coder-model",
+            default="",
+            help=(
+                "Model to use for approved implementation and PR follow-up. If "
+                "--implementation-coder is omitted, applies to --coder."
+            ),
+        )
+        subparser.add_argument(
+            "--implementation-codex-reasoning-effort",
+            default="",
+            help=(
+                "Codex reasoning effort to use with --implementation-coder codex during "
+                "approved implementation and PR follow-up."
+            ),
+        )
         subparser.add_argument("--claude-cmd", default="claude")
         subparser.add_argument("--codex-cmd", default="codex")
         subparser.add_argument("--gemini-cmd", default="gemini")
@@ -557,11 +583,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     runner = Runner(dry_run=args.dry_run)
     try:
         config = config_from_args(args, runner)
+        implementation_override_requested = (
+            args.implementation_coder is not None
+            or args.implementation_coder_model
+            or args.implementation_codex_reasoning_effort
+        )
+        if args.command != "issue" and implementation_override_requested:
+            raise AgentLoopError("--implementation-coder options are only supported with issue --plan-first.")
         if args.command == "issue":
             if args.implement_after_approval and not args.plan_first:
                 raise AgentLoopError("--implement-after-approval requires --plan-first.")
             if args.plan_execution_mode and not args.plan_first:
                 raise AgentLoopError("--plan-execution-mode requires --plan-first.")
+            if implementation_override_requested and not args.plan_first:
+                raise AgentLoopError("--implementation-coder options require --plan-first.")
+            implementation_coder = args.implementation_coder or args.coder
+            if args.implementation_codex_reasoning_effort and implementation_coder != "codex":
+                raise AgentLoopError(
+                    "--implementation-codex-reasoning-effort requires --implementation-coder codex "
+                    "or --coder codex."
+                )
             plan_execution_mode = args.plan_execution_mode
             if plan_execution_mode is None:
                 plan_execution_mode = (

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -597,12 +597,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 raise AgentLoopError("--plan-execution-mode requires --plan-first.")
             if implementation_override_requested and not args.plan_first:
                 raise AgentLoopError("--implementation-coder options require --plan-first.")
-            implementation_coder = args.implementation_coder or args.coder
-            if args.implementation_codex_reasoning_effort and implementation_coder != "codex":
-                raise AgentLoopError(
-                    "--implementation-codex-reasoning-effort requires --implementation-coder codex "
-                    "or --coder codex."
-                )
             plan_execution_mode = args.plan_execution_mode
             if plan_execution_mode is None:
                 plan_execution_mode = (

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -159,6 +159,16 @@ class AgentLoopConfig:
             object.__setattr__(self, "implementation_coder", self.coder)
         if self.implementation_codex_reasoning_effort and self.implementation_coder != "codex":
             raise AgentLoopError("--implementation-codex-reasoning-effort requires --implementation-coder codex.")
+        if (
+            self.implementation_codex_reasoning_effort
+            and self.implementation_coder == "codex"
+            and not (self.implementation_coder_model or self.codex_model)
+        ):
+            raise AgentLoopError(
+                "--implementation-codex-reasoning-effort requires "
+                "--implementation-coder-model or --codex-model so the implementation "
+                "signature can reliably name the Codex model."
+            )
         ensure_no_model_arg_conflicts(self)
         if self.planning_context_mode not in {"full", "compact"}:
             raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -86,6 +86,11 @@ class AgentLoopConfig:
     planning_context_mode: str = "compact"
     pr_review_context_mode: str = "full"
     auto_agent_dirs: tuple[AgentName, ...] = ()
+    # Optional plan-first override: use the main coder for planning/revision,
+    # then switch only the approved implementation and PR follow-up coder/model.
+    implementation_coder: AgentName | None = None
+    implementation_coder_model: str = ""
+    implementation_codex_reasoning_effort: str = ""
     # Antigravity (`agy`) backend (#215). Defaulted so existing AgentLoopConfig
     # constructions keep working; real values are set when antigravity is used.
     antigravity_dir: Path = Path("antigravity")
@@ -148,6 +153,12 @@ class AgentLoopConfig:
             raise AgentLoopError("--repair-model must contain at least one nonblank model.")
         if self.repair_timeout_seconds <= 0:
             raise AgentLoopError("--repair-timeout-seconds must be greater than zero.")
+        if self.implementation_coder_model and self.implementation_coder is None:
+            object.__setattr__(self, "implementation_coder", self.coder)
+        if self.implementation_codex_reasoning_effort and self.implementation_coder is None:
+            object.__setattr__(self, "implementation_coder", self.coder)
+        if self.implementation_codex_reasoning_effort and self.implementation_coder != "codex":
+            raise AgentLoopError("--implementation-codex-reasoning-effort requires --implementation-coder codex.")
         ensure_no_model_arg_conflicts(self)
         if self.planning_context_mode not in {"full", "compact"}:
             raise AgentLoopError("--planning-context-mode must be either 'full' or 'compact'.")
@@ -213,6 +224,8 @@ def resolve_base_branch(
 
 def required_agents(config: AgentLoopConfig) -> set[AgentName]:
     required: set[AgentName] = {config.coder, *reviewers(config)}
+    if config.implementation_coder is not None:
+        required.add(config.implementation_coder)
     if config.discuss_analyzer is not None:
         required.add(config.discuss_analyzer)
     return required
@@ -286,6 +299,36 @@ def ensure_no_model_arg_conflicts(config: AgentLoopConfig) -> None:
     if config.claude_model and _args_have_model_flag(config.claude_args):
         raise AgentLoopError(
             "--claude-arg --model conflicts with --claude-model; use --claude-model only."
+        )
+    if config.implementation_coder_model:
+        if config.implementation_coder == "antigravity" and _args_have_model_flag(config.antigravity_args):
+            raise AgentLoopError(
+                "--antigravity-arg --model conflicts with --implementation-coder-model; "
+                "use --implementation-coder-model only."
+            )
+        if config.implementation_coder == "codex" and _args_have_model_flag(config.codex_args):
+            raise AgentLoopError(
+                "--codex-arg --model conflicts with --implementation-coder-model; "
+                "use --implementation-coder-model only."
+            )
+        if config.implementation_coder == "gemini" and _args_have_model_flag(config.gemini_args):
+            raise AgentLoopError(
+                "--gemini-arg --model conflicts with --implementation-coder-model; "
+                "use --implementation-coder-model only."
+            )
+        if config.implementation_coder == "claude" and _args_have_model_flag(config.claude_args):
+            raise AgentLoopError(
+                "--claude-arg --model conflicts with --implementation-coder-model; "
+                "use --implementation-coder-model only."
+            )
+    if (
+        config.implementation_codex_reasoning_effort
+        and config.implementation_coder == "codex"
+        and _args_have_reasoning_effort(config.codex_args)
+    ):
+        raise AgentLoopError(
+            "--codex-arg model_reasoning_effort conflicts with "
+            "--implementation-codex-reasoning-effort; use --implementation-codex-reasoning-effort only."
         )
 
 
@@ -668,9 +711,11 @@ def preflight_agent_commands(
         "antigravity": (args.antigravity_cmd, "--antigravity-cmd"),
     }
     discuss_analyzer = getattr(args, "discuss_analyzer", None)
+    implementation_coder = getattr(args, "implementation_coder", None)
     configured_agents = dict.fromkeys(
         (
             args.coder,
+            *((implementation_coder,) if implementation_coder is not None else ()),
             *configured_reviewers,
             *((discuss_analyzer,) if discuss_analyzer is not None else ()),
             getattr(args, "repair_backend", "antigravity"),
@@ -797,6 +842,9 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         codex_reasoning_effort=getattr(args, "codex_reasoning_effort", ""),
         gemini_model=getattr(args, "gemini_model", ""),
         claude_model=getattr(args, "claude_model", ""),
+        implementation_coder=getattr(args, "implementation_coder", None),
+        implementation_coder_model=getattr(args, "implementation_coder_model", ""),
+        implementation_codex_reasoning_effort=getattr(args, "implementation_codex_reasoning_effort", ""),
         repair_backend=getattr(args, "repair_backend", "antigravity"),
         repair_models=tuple(getattr(args, "repair_model", None) or DEFAULT_REPAIR_MODELS),
         repair_timeout_seconds=getattr(args, "repair_timeout_seconds", 120),

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2622,6 +2622,35 @@ def _round_ledger_may_be_incomplete(
     return same_subject_incomplete or cross_subject_incomplete
 
 
+def _approved_implementation_config(config: AgentLoopConfig) -> tuple[AgentLoopConfig, bool]:
+    """Return the config and session-reuse policy for approved plan implementation."""
+    implementation_coder = config.implementation_coder or config.coder
+    updates: dict[str, object] = {"coder": implementation_coder}
+    reuse_session = implementation_coder == config.coder
+
+    model = config.implementation_coder_model.strip()
+    if model:
+        reuse_session = False
+        if implementation_coder == "claude":
+            updates["claude_model"] = model
+        elif implementation_coder == "codex":
+            updates["codex_model"] = model
+        elif implementation_coder == "gemini":
+            updates["gemini_model"] = model
+        elif implementation_coder == "antigravity":
+            updates["antigravity_model"] = None
+            updates["antigravity_models"] = (model,)
+
+    effort = config.implementation_codex_reasoning_effort.strip()
+    if effort:
+        reuse_session = False
+        updates["codex_reasoning_effort"] = effort
+
+    if updates == {"coder": config.coder}:
+        return config, True
+    return dataclasses_replace(config, **updates), reuse_session
+
+
 def _implement_approved_issue(
     runner: Runner,
     *,
@@ -2636,7 +2665,9 @@ def _implement_approved_issue(
     plan_subject: str | None = None,
     staged_parent_issue: int | None = None,
 ) -> int:
-    coder_name = agent_display_name(config.coder)
+    implementation_config, reuse_planning_session = _approved_implementation_config(config)
+    coder_name = agent_display_name(implementation_config.coder)
+    implementation_session_id = coder_session_id if reuse_planning_session else None
     plan_hash = approved_plan_hash(approved_plan)
 
     # A prior implementation attempt may have created a PR and then aborted
@@ -2655,24 +2686,24 @@ def _implement_approved_issue(
         )
         validate_pr_references_issue(
             runner,
-            config=config,
+            config=implementation_config,
             pr_number=existing_pr_number,
             issue_number=issue_number,
         )
         if staged_parent_issue is not None:
             validate_pr_body_does_not_close_issue(
                 runner,
-                config=config,
+                config=implementation_config,
                 pr_number=existing_pr_number,
                 issue_number=staged_parent_issue,
             )
         if one_shot_parent_issue is not None:
             resumed_pr_context = get_pr_review_context(
-                runner, config=config, pr_number=existing_pr_number
+                runner, config=implementation_config, pr_number=existing_pr_number
             )
             post_one_shot_impl_handoff_comment(
                 runner,
-                config=config,
+                config=implementation_config,
                 parent_issue=one_shot_parent_issue,
                 mode="implement-one-shot",
                 plan_hash=plan_hash,
@@ -2683,35 +2714,35 @@ def _implement_approved_issue(
         return run_pr_loop(
             runner,
             pr_number=existing_pr_number,
-            config=config,
+            config=implementation_config,
             issue_context=issue_context,
             usage_context=usage_context,
         )
 
     salvage_summary = latest_salvage_summary(
-        config.log_dir,
-        repo=config.repo,
+        implementation_config.log_dir,
+        repo=implementation_config.repo,
         issue_number=issue_number,
         scope=APPROVED_PLAN_IMPLEMENTATION_SALVAGE_SCOPE,
         approved_plan_hash=plan_hash,
     )
-    sync_coder_base_before_implementation(config, runner)
+    sync_coder_base_before_implementation(implementation_config, runner)
     log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
-    assigned_head_before = _read_assigned_workdir_head(runner, config)
+    assigned_head_before = _read_assigned_workdir_head(runner, implementation_config)
     coder_response = _run_validated_agent(
         runner,
-        agent=config.coder,
-        config=config,
+        agent=implementation_config.coder,
+        config=implementation_config,
         prompt=build_issue_implementation_prompt(
             issue_number,
             approved_plan,
-            config,
+            implementation_config,
             memory,
             issue_context=issue_context,
             salvage_summary=salvage_summary,
             staged_parent_issue=staged_parent_issue,
         ),
-        session_id=coder_session_id,
+        session_id=implementation_session_id,
         marker_description="<!-- AGENT_PR: <number> --> or PR URL",
         validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
             text,
@@ -2722,43 +2753,43 @@ def _implement_approved_issue(
         ),
         usage_context=usage_context,
         salvage_context=SalvageContext(
-            repo=config.repo,
+            repo=implementation_config.repo,
             issue_number=issue_number,
             scope=APPROVED_PLAN_IMPLEMENTATION_SALVAGE_SCOPE,
-            agent=config.coder,
+            agent=implementation_config.coder,
             run_id=usage_context.run_id,
             approved_plan_hash=plan_hash,
         ),
         operation_description="approved-plan implementation",
     )
     coder_output = coder_response.text
-    validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
+    validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(implementation_config))
     validate_assigned_head_advanced(
         before_head=assigned_head_before,
-        after_head=_read_assigned_workdir_head(runner, config),
-        assigned_workdir=active_workdir(config),
+        after_head=_read_assigned_workdir_head(runner, implementation_config),
+        assigned_workdir=active_workdir(implementation_config),
     )
     pr_number = int(coder_response.marker_value)
     log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
-    validate_open_pr(runner, config=config, pr_number=pr_number)
+    validate_open_pr(runner, config=implementation_config, pr_number=pr_number)
     validate_pr_references_issue(
         runner,
-        config=config,
+        config=implementation_config,
         pr_number=pr_number,
         issue_number=issue_number,
     )
     if staged_parent_issue is not None:
         validate_pr_body_does_not_close_issue(
             runner,
-            config=config,
+            config=implementation_config,
             pr_number=pr_number,
             issue_number=staged_parent_issue,
         )
-    initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
+    initial_pr_context = get_pr_review_context(runner, config=implementation_config, pr_number=pr_number)
     if one_shot_parent_issue is not None:
         post_one_shot_impl_handoff_comment(
             runner,
-            config=config,
+            config=implementation_config,
             parent_issue=one_shot_parent_issue,
             mode="implement-one-shot",
             plan_hash=plan_hash,
@@ -2768,10 +2799,15 @@ def _implement_approved_issue(
         )
     post_pr_comment(
         runner,
-        config=config,
+        config=implementation_config,
         pr_number=pr_number,
         body=_attach_round_metadata(
-            normalize_freeform_signature(coder_output, agent=config.coder, config=config, model_used=coder_response.model_used),
+            normalize_freeform_signature(
+                coder_output,
+                agent=implementation_config.coder,
+                config=implementation_config,
+                model_used=coder_response.model_used,
+            ),
             PostedRoundMetadata(
                 flow="pr",
                 role="coder",
@@ -2786,7 +2822,7 @@ def _implement_approved_issue(
     return run_pr_loop(
         runner,
         pr_number=pr_number,
-        config=config,
+        config=implementation_config,
         coder_session_id=coder_response.session_id,
         issue_context=issue_context,
         workdirs_ready=True,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -17,6 +17,7 @@ from coding_review_agent_loop.cli import (
     config_from_args,
     ensure_log_dir_ignored,
     is_clarification_request,
+    main,
     run_issue_loop,
     run_pr_loop,
     run_task_loop,
@@ -1640,6 +1641,166 @@ def test_plan_first_implementation_coder_cli_is_configurable(tmp_path):
     assert config.implementation_coder == "codex"
     assert config.implementation_coder_model == "gpt-5.5"
     assert config.implementation_codex_reasoning_effort == "xhigh"
+
+
+def test_implementation_coder_options_require_issue_plan_first(capsys):
+    assert main(["pr", "77", "--repo", "OWNER/REPO", "--implementation-coder", "codex"]) == 1
+    assert (
+        "--implementation-coder options are only supported with issue --plan-first"
+        in capsys.readouterr().err
+    )
+
+    assert main(["issue", "56", "--repo", "OWNER/REPO", "--implementation-coder", "codex"]) == 1
+    assert "--implementation-coder options require --plan-first" in capsys.readouterr().err
+
+
+def test_plan_first_post_approval_options_require_plan_first(capsys):
+    assert main(["issue", "56", "--repo", "OWNER/REPO", "--implement-after-approval"]) == 1
+    assert "--implement-after-approval requires --plan-first" in capsys.readouterr().err
+
+    assert (
+        main([
+            "issue",
+            "56",
+            "--repo",
+            "OWNER/REPO",
+            "--plan-execution-mode",
+            "implement-one-shot",
+        ])
+        == 1
+    )
+    assert "--plan-execution-mode requires --plan-first" in capsys.readouterr().err
+
+
+def test_implementation_codex_reasoning_effort_requires_codex_and_model(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "issue",
+        "56",
+        "--repo",
+        "OWNER/REPO",
+        "--plan-first",
+        "--implement-after-approval",
+        "--coder",
+        "claude",
+        "--implementation-codex-reasoning-effort",
+        "high",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+        "--gemini-dir",
+        str(tmp_path / "gemini"),
+    ])
+    with pytest.raises(AgentLoopError, match="requires --implementation-coder codex"):
+        config_from_args(args, FakeRunner())
+
+    args = parser.parse_args([
+        "issue",
+        "56",
+        "--repo",
+        "OWNER/REPO",
+        "--plan-first",
+        "--implement-after-approval",
+        "--coder",
+        "codex",
+        "--implementation-codex-reasoning-effort",
+        "high",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+        "--gemini-dir",
+        str(tmp_path / "gemini"),
+    ])
+    with pytest.raises(AgentLoopError, match="requires --implementation-coder-model or --codex-model"):
+        config_from_args(args, FakeRunner())
+
+
+def test_issue_loop_plan_first_can_switch_implementation_coder_end_to_end(tmp_path):
+    plan_text = "Approved plan.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+    plan_review_text = structured_plan_review(summary="Plan approved.")
+    pr_review_text = structured_pr_review(state="approved", summary="PR approved.")
+    plan_review_marker = parse_plan_review(plan_review_text, reviewer="Google Gemini")
+    pr_review_marker = parse_pr_review(pr_review_text, reviewer="Google Gemini")
+    implementation_text = (
+        "Created PR.\nTests: python -m pytest passed.\n"
+        "<!-- AGENT_PR: 77 -->\n-- OpenAI Codex"
+    )
+    calls = []
+    runner = FakeRunner()
+    config = make_config(
+        tmp_path,
+        coder="claude",
+        reviewer="gemini",
+        implementation_coder="codex",
+        implementation_coder_model="gpt-5.5",
+        implementation_codex_reasoning_effort="high",
+    )
+
+    def fake_run_validated_agent(runner_arg, *, agent, config, session_id=None, **kwargs):
+        calls.append(
+            {
+                "agent": agent,
+                "coder": config.coder,
+                "codex_model": config.codex_model,
+                "codex_reasoning_effort": config.codex_reasoning_effort,
+                "session_id": session_id,
+                "operation": kwargs.get("operation_description"),
+            }
+        )
+        operation = kwargs.get("operation_description")
+        if operation == "planning":
+            return ValidatedAgentResponse(
+                text=plan_text,
+                model_used="claude-fable-5",
+                session_id="planning-session",
+                marker_value=None,
+            )
+        if operation == "plan review":
+            return ValidatedAgentResponse(
+                text=plan_review_text,
+                model_used="gemini-3-pro",
+                session_id=None,
+                marker_value=plan_review_marker,
+            )
+        if operation == "approved-plan implementation":
+            runner_arg.git_head = "def456"
+            return ValidatedAgentResponse(
+                text=implementation_text,
+                model_used="gpt-5.5 (high)",
+                session_id="implementation-session",
+                marker_value="77",
+            )
+        return ValidatedAgentResponse(
+            text=pr_review_text,
+            model_used="gemini-3-pro",
+            session_id=None,
+            marker_value=pr_review_marker,
+        )
+
+    with patch(
+        "coding_review_agent_loop.orchestrator._run_validated_agent",
+        side_effect=fake_run_validated_agent,
+    ):
+        assert (
+            run_issue_loop(
+                runner,
+                issue_number=56,
+                config=config,
+                plan_first=True,
+                implement_after_approval=True,
+            )
+            == 0
+        )
+
+    assert [call["agent"] for call in calls] == ["claude", "gemini", "codex", "gemini"]
+    implementation_call = calls[2]
+    assert implementation_call["coder"] == "codex"
+    assert implementation_call["codex_model"] == "gpt-5.5"
+    assert implementation_call["codex_reasoning_effort"] == "high"
+    assert implementation_call["session_id"] is None
+    assert calls[0]["coder"] == "claude"
 
 
 def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1605,6 +1605,43 @@ def test_plan_execution_mode_cli_is_configurable(tmp_path, mode):
     assert config.plan_execution_mode == mode
 
 
+
+def test_plan_first_implementation_coder_cli_is_configurable(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "issue",
+        "56",
+        "--repo",
+        "OWNER/REPO",
+        "--plan-first",
+        "--implement-after-approval",
+        "--coder",
+        "claude",
+        "--claude-model",
+        "claude-fable-5",
+        "--implementation-coder",
+        "codex",
+        "--implementation-coder-model",
+        "gpt-5.5",
+        "--implementation-codex-reasoning-effort",
+        "xhigh",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+        "--gemini-dir",
+        str(tmp_path / "gemini"),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.coder == "claude"
+    assert config.claude_model == "claude-fable-5"
+    assert config.implementation_coder == "codex"
+    assert config.implementation_coder_model == "gpt-5.5"
+    assert config.implementation_codex_reasoning_effort == "xhigh"
+
+
 def test_explicit_agent_dirs_are_preserved_when_others_default(tmp_path):
     parser = build_parser()
     codex_dir = tmp_path / "codex"

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -1601,6 +1601,48 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     assert runner.comments[4].startswith("Implemented approved plan.")
     assert runner.comments[5].startswith("**Review verdict:** Approved\n\nLGTM.")
 
+
+def test_issue_loop_plan_first_can_override_implementation_model(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            json.dumps(
+                {
+                    "result": "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+                    "session_id": "planning-session",
+                }
+            ),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        claude_model="claude-fable-5",
+        implementation_coder_model="claude-sonnet-5",
+    )
+
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 2
+    assert claude_calls[0][claude_calls[0].index("--model") + 1] == "claude-fable-5"
+    assert claude_calls[1][claude_calls[1].index("--model") + 1] == "claude-sonnet-5"
+    assert "--resume" not in claude_calls[1]
+    assert runner.comments[4].startswith("Implemented approved plan.")
+
+
 def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
     runner = FakeRunner(
         claude_outputs=[


### PR DESCRIPTION
## Summary

- Add plan-first implementation overrides so the planning coder can differ from the implementation coder/model.
- Allow a separate implementation coder model and Codex reasoning effort when approved implementation begins.
- Keep the implementation coder on its own checkout and session lifecycle.

## Tests

```text
/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m pytest /home/wwind123/tools/coding-review-agent-loop/tests/test_orchestrator_issue.py::test_issue_loop_plan_first_can_override_implementation_model /home/wwind123/tools/coding-review-agent-loop/tests/test_orchestrator_issue.py::test_issue_loop_plan_first_can_implement_after_approval /home/wwind123/tools/coding-review-agent-loop/tests/test_agent_loop.py::test_plan_first_implementation_coder_cli_is_configurable
/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile /home/wwind123/tools/coding-review-agent-loop/src/coding_review_agent_loop/config.py /home/wwind123/tools/coding-review-agent-loop/src/coding_review_agent_loop/cli.py /home/wwind123/tools/coding-review-agent-loop/src/coding_review_agent_loop/orchestrator.py /home/wwind123/tools/coding-review-agent-loop/tests/test_agent_loop.py /home/wwind123/tools/coding-review-agent-loop/tests/test_orchestrator_issue.py
/home/wwind123/tools/coding-review-agent-loop/.venv/bin/agent-loop issue --help
```
