### PR TITLE
Persist implementation salvage summaries to GitHub for cross-workdir reruns

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1200,7 +1200,11 @@ when it is under `--salvage-comment-patch-max-bytes` (default 20000), has no
 `GIT binary patch` section, and does not match a conservative secret scan
 (private keys, AWS key ids, `ghp_`/`github_pat_` tokens, bearer/authorization
 headers, `password=`/`secret=`-style assignments); otherwise the comment notes
-the patch is local-only. Posting failures are logged and never mask the
+the patch is local-only. `AGENT_SALVAGE` breadcrumb comments are excluded from
+the raw issue-comment context sent to the coder (they are consumed only
+through the parsed salvage summary above) so they cannot bloat or displace
+real discussion when the issue-context prompt is truncated. Posting failures
+are logged and never mask the
 original agent failure. Use `--no-salvage-comments` to keep salvage entirely
 local (matching prior behavior).
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1186,6 +1186,24 @@ later rerun injects only the latest matching salvage summary into the coder
 prompt so the next attempt can cherry-pick or ignore it selectively. The
 orchestrator never auto-applies the patch.
 
+For `issue-implementation` and `approved-plan-implementation` scopes (the two
+whose rerun prompts consume a salvage summary), the orchestrator also posts a
+best-effort GitHub issue comment with a hidden `<!-- AGENT_SALVAGE: ... -->`
+marker alongside the local artifacts. This makes salvage durable across a
+different coder, workdir, or machine: a rerun with an empty local `--log-dir`
+can still discover the latest matching comment (filtered by repo, issue,
+scope, and approved-plan hash) and inject it into the coder prompt, noting
+that the referenced local artifact paths may not exist on this machine. Local
+and remote salvage are merged deterministically by timestamp, with ties
+preferring the local copy. The partial patch is embedded in the comment only
+when it is under `--salvage-comment-patch-max-bytes` (default 20000), has no
+`GIT binary patch` section, and does not match a conservative secret scan
+(private keys, AWS key ids, `ghp_`/`github_pat_` tokens, bearer/authorization
+headers, `password=`/`secret=`-style assignments); otherwise the comment notes
+the patch is local-only. Posting failures are logged and never mask the
+original agent failure. Use `--no-salvage-comments` to keep salvage entirely
+local (matching prior behavior).
+
 If strict structured-response validation fails, the log may show a repair pass:
 `schema validation failed ... attempting repair pass`, followed by either
 `repair pass recovered malformed response` or `repair pass produced invalid

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -369,6 +369,33 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="Regenerate the cached execution/test profile before invoking agents.",
         )
+        salvage_comments_group = subparser.add_mutually_exclusive_group()
+        salvage_comments_group.add_argument(
+            "--salvage-comments",
+            dest="salvage_comments",
+            action="store_true",
+            default=True,
+            help=(
+                "Post a hidden AGENT_SALVAGE marker comment to the issue when a mutating "
+                "implementation attempt fails, so a rerun with a different coder/workdir/"
+                "machine can still discover the latest salvage context (default)."
+            ),
+        )
+        salvage_comments_group.add_argument(
+            "--no-salvage-comments",
+            dest="salvage_comments",
+            action="store_false",
+            help="Do not post GitHub salvage breadcrumb comments for failed implementation attempts.",
+        )
+        subparser.add_argument(
+            "--salvage-comment-patch-max-bytes",
+            type=int,
+            default=20000,
+            help=(
+                "Maximum size of a partial patch embedded in a GitHub salvage comment; "
+                "larger (or unsafe) patches are omitted with a local-only note (default: 20000)."
+            ),
+        )
         subparser.add_argument(
             "--approved-followups",
             choices=("ignore", "summarize", "issue", "fix-and-summarize", "fix-and-issue"),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -135,6 +135,13 @@ class AgentLoopConfig:
     # materialized into child issues (#476). None means resolve by unique
     # title match instead.
     split_stage: int | None = None
+    # GitHub-backed salvage breadcrumbs (#507): post a hidden AGENT_SALVAGE marker
+    # comment for failed mutating implementation attempts so a rerun with a
+    # different coder/workdir/machine can still discover the latest salvage
+    # context. Defaulted on so existing AgentLoopConfig constructions keep
+    # working with the new behavior enabled.
+    salvage_comments: bool = True
+    salvage_comment_patch_max_bytes: int = 20000
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -182,6 +189,8 @@ class AgentLoopConfig:
             raise AgentLoopError(f"--discuss-on-debater-failure must be one of: {rendered}.")
         if self.discuss_debater_timeout is not None and self.discuss_debater_timeout <= 0:
             raise AgentLoopError("--discuss-debater-timeout must be greater than zero seconds.")
+        if self.salvage_comment_patch_max_bytes <= 0:
+            raise AgentLoopError("--salvage-comment-patch-max-bytes must be greater than zero.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -865,6 +874,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         discuss_on_debater_failure=getattr(args, "discuss_on_debater_failure", "fail") or "fail",
         materialize_split_issues=getattr(args, "materialize_split_issues", False),
         split_stage=getattr(args, "split_stage", None),
+        salvage_comments=getattr(args, "salvage_comments", True),
+        salvage_comment_patch_max_bytes=getattr(args, "salvage_comment_patch_max_bytes", 20000),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -149,7 +149,8 @@ from .salvage import (
     SalvageArtifacts,
     SalvageContext,
     capture_salvage_artifacts,
-    latest_salvage_summary,
+    latest_salvage_context,
+    post_salvage_comment,
 )
 from .transient import (
     NON_RETRYABLE_AGENT_OUTPUT_RE,
@@ -1368,6 +1369,7 @@ def _capture_failed_run_salvage_diagnostic(
                 f"{operation_description}, not a mutating implementation attempt."
             ),
         )
+    compacted_failure_reason = _compact_failure_reason(failure_reason, classification_text)
     try:
         artifacts = capture_salvage_artifacts(
             runner,
@@ -1375,7 +1377,7 @@ def _capture_failed_run_salvage_diagnostic(
             log_dir=config.log_dir,
             context=salvage_context,
             failure_category=failure_category,
-            failure_reason=_compact_failure_reason(failure_reason, classification_text),
+            failure_reason=compacted_failure_reason,
             required_marker=marker_description,
             result=result,
         )
@@ -1394,11 +1396,24 @@ def _capture_failed_run_salvage_diagnostic(
         )
     if artifacts is not None:
         log(config, f"{agent_name}: salvage artifacts written to {artifacts.directory}")
+        comment_posted = post_salvage_comment(
+            runner,
+            config=config,
+            artifacts=artifacts,
+            context=salvage_context,
+            failure_category=failure_category,
+            failure_reason=compacted_failure_reason,
+        )
+        comment_note = (
+            f" A GitHub salvage comment was posted to issue #{salvage_context.issue_number}."
+            if comment_posted
+            else " No GitHub salvage comment was posted."
+        )
         return _PatchSalvageDiagnostic(
             artifacts=artifacts,
             line=(
                 "Implementation salvage artifacts were written to "
-                f"{artifacts.summary_path}; patch: {artifacts.patch_path}."
+                f"{artifacts.summary_path}; patch: {artifacts.patch_path}.{comment_note}"
             ),
         )
 
@@ -2719,8 +2734,9 @@ def _implement_approved_issue(
             usage_context=usage_context,
         )
 
-    salvage_summary = latest_salvage_summary(
+    salvage_summary = latest_salvage_context(
         implementation_config.log_dir,
+        issue_context.comments,
         repo=implementation_config.repo,
         issue_number=issue_number,
         scope=APPROVED_PLAN_IMPLEMENTATION_SALVAGE_SCOPE,
@@ -3726,8 +3742,9 @@ def run_issue_loop(
 
         sync_coder_base_before_implementation(config, runner)
         assigned_head_before = _read_assigned_workdir_head(runner, config)
-        salvage_summary = latest_salvage_summary(
+        salvage_summary = latest_salvage_context(
             config.log_dir,
+            issue_context.comments,
             repo=config.repo,
             issue_number=issue_number,
             scope=ISSUE_IMPLEMENTATION_SALVAGE_SCOPE,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -15,6 +15,7 @@ from .config import AgentLoopConfig, reviewers
 from .decomposition import MAX_DECOMPOSITION_PHASES
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
+from .salvage import AGENT_SALVAGE_MARKER_RE
 from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
@@ -178,6 +179,10 @@ def _truncate_issue_text(text: str, *, max_chars: int, label: str) -> str:
     return text[: max(0, max_chars - len(suffix))].rstrip() + suffix
 
 
+def _is_salvage_breadcrumb_comment(comment) -> bool:
+    return bool(comment.body) and bool(AGENT_SALVAGE_MARKER_RE.search(comment.body))
+
+
 def format_issue_context(issue_context: IssueContext, *, max_chars: int = 24_000) -> str:
     raw_body = issue_context.body if issue_context.body else "(none)"
     body = _truncate_issue_text(raw_body, max_chars=max_chars // 3, label="Issue body")
@@ -193,7 +198,14 @@ def format_issue_context(issue_context: IssueContext, *, max_chars: int = 24_000
         "",
         "Comments, oldest to newest:",
     ]
-    if issue_context.comments:
+    # AGENT_SALVAGE breadcrumb comments carry a bounded but potentially large
+    # embedded patch/metadata payload for cross-workdir salvage discovery
+    # (#507); they are consumed separately via latest_salvage_context and
+    # would otherwise bloat/displace real discussion in this raw rendering.
+    visible_comments = tuple(
+        comment for comment in issue_context.comments if not _is_salvage_breadcrumb_comment(comment)
+    )
+    if visible_comments:
         comments = [
             "\n".join(
                 [
@@ -205,7 +217,7 @@ def format_issue_context(issue_context: IssueContext, *, max_chars: int = 24_000
                     comment.body if comment.body else "(none)",
                 ]
             )
-            for comment in issue_context.comments
+            for comment in visible_comments
         ]
         issue_header = "\n".join(lines)
         full_text = issue_header + "\n".join(comments)

--- a/src/coding_review_agent_loop/salvage.py
+++ b/src/coding_review_agent_loop/salvage.py
@@ -1,21 +1,56 @@
-"""Local salvage artifacts for failed mutating agent runs."""
+"""Local salvage artifacts for failed mutating agent runs.
+
+Also implements durable GitHub-backed salvage breadcrumbs (#507): when a
+mutating implementation attempt fails, a hidden ``AGENT_SALVAGE`` marker
+comment is posted alongside the local artifacts so a rerun with a different
+coder, workdir, or machine can still discover the latest matching salvage
+context.
+"""
 
 from __future__ import annotations
 
+import base64
 import datetime
 import json
 import re
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .agents.base import AgentName, AgentResult
 from .errors import AgentLoopError
+from .github import IssueComment, post_issue_comment
+from .logging import log
 from .runner import ensure_log_dir_ignored
 
 if TYPE_CHECKING:
+    from .config import AgentLoopConfig
     from .runner import Runner
+
+# Scopes whose rerun prompts actually consume a salvage summary today (#507).
+# Posting is narrowed to these so pr-followup/task-implementation salvage
+# stays local-only until their rerun prompts are wired to inject one.
+SALVAGE_COMMENT_SCOPES = frozenset({"issue-implementation", "approved-plan-implementation"})
+
+AGENT_SALVAGE_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_SALVAGE:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+
+_SALVAGE_SCHEMA_VERSION = 1
+_MAX_COMMENT_CHARS = 60_000
+_GIT_BINARY_PATCH_MARKER = "GIT binary patch"
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"gh[opsu]_[A-Za-z0-9]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"(?i)authorization:\s*bearer\s+\S+"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._-]{10,}"),
+    re.compile(r"(?i)\b(password|secret|api[_-]?key)\s*[:=]\s*\S+"),
+)
 
 
 @dataclass(frozen=True)
@@ -331,14 +366,14 @@ def _metadata_matches(
     return metadata_hash in (None, "")
 
 
-def latest_salvage_summary(
+def _latest_local_salvage_record(
     log_dir: Path,
     *,
     repo: str,
     issue_number: int,
     scope: str,
     approved_plan_hash: str | None = None,
-) -> str | None:
+) -> tuple[int, str] | None:
     root = log_dir / "salvage"
     if not root.is_dir():
         return None
@@ -384,4 +419,400 @@ def latest_salvage_summary(
         if newest is None or candidate[:2] > newest[:2]:
             newest = candidate
 
-    return None if newest is None else newest[2]
+    return None if newest is None else (newest[0], newest[2])
+
+
+def latest_salvage_summary(
+    log_dir: Path,
+    *,
+    repo: str,
+    issue_number: int,
+    scope: str,
+    approved_plan_hash: str | None = None,
+) -> str | None:
+    record = _latest_local_salvage_record(
+        log_dir,
+        repo=repo,
+        issue_number=issue_number,
+        scope=scope,
+        approved_plan_hash=approved_plan_hash,
+    )
+    return None if record is None else record[1]
+
+
+def _truncate_field(text: str, *, max_lines: int = 20, max_chars: int = 4000) -> str:
+    """Bound a text field before encoding, mirroring `_compact_failure_reason`'s tail-keeping rule."""
+    if not text:
+        return text
+    lines = text.splitlines()
+    if len(lines) > max_lines:
+        text = "\n".join(lines[-max_lines:])
+    if len(text) > max_chars:
+        text = text[-max_chars:]
+    return text
+
+
+def _patch_secret_scan_flagged(patch_text: str) -> bool:
+    return any(pattern.search(patch_text) for pattern in _SECRET_PATTERNS)
+
+
+def _evaluate_patch_policy(patch_text: str, *, max_bytes: int) -> str | None:
+    """Return the patch text to embed, or None if policy excludes it."""
+    if not patch_text.strip():
+        return None
+    if len(patch_text.encode("utf-8")) > max_bytes:
+        return None
+    if _GIT_BINARY_PATCH_MARKER in patch_text:
+        return None
+    if _patch_secret_scan_flagged(patch_text):
+        return None
+    return patch_text
+
+
+def _encode_json_payload(payload: dict[str, object]) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_json_payload(encoded: str) -> dict[str, object] | None:
+    """Decode a marker payload, returning None instead of raising.
+
+    Issue comments can come from third parties or a future incompatible
+    schema, so discovery must skip malformed/unknown payloads silently
+    rather than aborting a rerun.
+    """
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _build_salvage_payload(
+    *,
+    artifacts: SalvageArtifacts,
+    context: SalvageContext,
+    failure_category: str,
+    failure_reason: str,
+    patch_max_bytes: int,
+) -> dict[str, object]:
+    try:
+        changed_files_text = artifacts.changed_files_path.read_text(encoding="utf-8")
+    except OSError:
+        changed_files_text = ""
+    try:
+        diff_stat_text = artifacts.diff_stat_path.read_text(encoding="utf-8")
+    except OSError:
+        diff_stat_text = ""
+    try:
+        patch_text = artifacts.patch_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        patch_text = ""
+
+    included_patch_text = _evaluate_patch_policy(patch_text, max_bytes=patch_max_bytes)
+
+    payload: dict[str, object] = {
+        "schema_version": _SALVAGE_SCHEMA_VERSION,
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "created_at_ns": time.time_ns(),
+        "repo": context.repo,
+        "issue_number": context.issue_number,
+        "scope": context.scope,
+        "agent": context.agent,
+        "run_id": context.run_id,
+        "approved_plan_hash": context.approved_plan_hash,
+        "failure_category": failure_category,
+        "failure_reason": _truncate_field(failure_reason),
+        "changed_files": _truncate_field(changed_files_text),
+        "diff_stat": _truncate_field(diff_stat_text),
+        "local_directory": str(artifacts.directory),
+        "patch_exists": bool(patch_text.strip()),
+        "patch_included": included_patch_text is not None,
+    }
+    if included_patch_text is not None:
+        payload["patch_text"] = included_patch_text
+    return payload
+
+
+def _render_salvage_comment_body(payload: dict[str, object]) -> str:
+    approved_hash_line = (
+        f"\n- Approved plan hash: `{payload['approved_plan_hash']}`"
+        if payload.get("approved_plan_hash")
+        else ""
+    )
+    patch_note = (
+        "Patch content is embedded in the machine-readable marker below, within the "
+        "configured size and safety limits."
+        if payload.get("patch_included")
+        else (
+            "Patch content is local-only at "
+            f"`{payload['local_directory']}/partial.patch` on the machine that produced "
+            "this attempt; it was omitted from this comment (over the size limit, "
+            "binary, or flagged by a secret scan) and was not included below."
+        )
+    )
+    issue_number = payload.get("issue_number")
+    return f"""### Implementation salvage breadcrumb
+
+The {payload['agent']} agent failed before producing a valid public response. No
+successful response, review result, or pull request should be inferred from this
+comment. It exists only so a later rerun (possibly with a different coder, workdir,
+or machine) can recover partial context; do not auto-apply anything from it.
+
+- Repository: `{payload['repo']}`
+- Issue: `{issue_number if issue_number is not None else "unknown"}`
+- Scope: `{payload['scope']}`
+- Agent: `{payload['agent']}`{approved_hash_line}
+- Failure category: `{payload['failure_category']}`
+- Failure reason: {payload['failure_reason']}
+- Local artifact directory (on the original run's machine): `{payload['local_directory']}`
+- {patch_note}
+
+<!-- AGENT_SALVAGE: {_encode_json_payload(payload)} -->
+"""
+
+
+def _render_clamped_salvage_comment(payload: dict[str, object]) -> str:
+    body = _render_salvage_comment_body(payload)
+    if len(body) > _MAX_COMMENT_CHARS and payload.get("patch_included"):
+        payload = dict(payload)
+        payload.pop("patch_text", None)
+        payload["patch_included"] = False
+        body = _render_salvage_comment_body(payload)
+    return body
+
+
+def post_salvage_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    artifacts: SalvageArtifacts,
+    context: SalvageContext,
+    failure_category: str,
+    failure_reason: str,
+) -> bool:
+    """Best-effort post of a GitHub salvage breadcrumb comment.
+
+    Returns whether a comment was posted. Never raises: posting is a
+    durability nice-to-have and must never mask the original agent failure
+    that triggered local salvage capture.
+    """
+    if context.issue_number is None or context.scope not in SALVAGE_COMMENT_SCOPES:
+        return False
+    if config.dry_run or not config.salvage_comments:
+        return False
+    try:
+        payload = _build_salvage_payload(
+            artifacts=artifacts,
+            context=context,
+            failure_category=failure_category,
+            failure_reason=failure_reason,
+            patch_max_bytes=config.salvage_comment_patch_max_bytes,
+        )
+        body = _render_clamped_salvage_comment(payload)
+        post_issue_comment(runner, config=config, issue_number=context.issue_number, body=body)
+    except (AgentLoopError, OSError, UnicodeDecodeError) as exc:
+        log(config, f"salvage comment posting failed ({exc}); preserving original agent failure")
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class RemoteSalvageRecord:
+    created_at_ns: int
+    repo: str
+    issue_number: int | None
+    scope: str
+    agent: str
+    run_id: str | None
+    approved_plan_hash: str | None
+    failure_category: str
+    failure_reason: str
+    changed_files: str
+    diff_stat: str
+    local_directory: str
+    patch_exists: bool
+    patch_included: bool
+    patch_text: str | None
+
+
+def _remote_payload_matches(
+    payload: dict[str, Any],
+    *,
+    repo: str,
+    issue_number: int,
+    scope: str,
+    approved_plan_hash: str | None,
+) -> bool:
+    if payload.get("repo") != repo:
+        return False
+    try:
+        payload_issue = int(payload.get("issue_number"))
+    except (TypeError, ValueError):
+        return False
+    if payload_issue != issue_number:
+        return False
+    if payload.get("scope") != scope:
+        return False
+    payload_hash = payload.get("approved_plan_hash")
+    if approved_plan_hash is not None:
+        return payload_hash == approved_plan_hash
+    return payload_hash in (None, "")
+
+
+def _record_from_payload(payload: dict[str, Any]) -> RemoteSalvageRecord | None:
+    if payload.get("schema_version") != _SALVAGE_SCHEMA_VERSION:
+        return None
+    try:
+        created_at_ns = int(payload["created_at_ns"])
+        repo = str(payload["repo"])
+        scope = str(payload["scope"])
+        agent = str(payload["agent"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    issue_number_raw = payload.get("issue_number")
+    issue_number = issue_number_raw if isinstance(issue_number_raw, int) else None
+    run_id = payload.get("run_id")
+    run_id = run_id if isinstance(run_id, str) else None
+    approved_plan_hash = payload.get("approved_plan_hash")
+    approved_plan_hash = approved_plan_hash if isinstance(approved_plan_hash, str) else None
+    patch_included = bool(payload.get("patch_included", False))
+    patch_text = payload.get("patch_text")
+    patch_text = patch_text if patch_included and isinstance(patch_text, str) else None
+    return RemoteSalvageRecord(
+        created_at_ns=created_at_ns,
+        repo=repo,
+        issue_number=issue_number,
+        scope=scope,
+        agent=agent,
+        run_id=run_id,
+        approved_plan_hash=approved_plan_hash,
+        failure_category=str(payload.get("failure_category", "")),
+        failure_reason=str(payload.get("failure_reason", "")),
+        changed_files=str(payload.get("changed_files", "")),
+        diff_stat=str(payload.get("diff_stat", "")),
+        local_directory=str(payload.get("local_directory", "")),
+        patch_exists=bool(payload.get("patch_exists", False)),
+        patch_included=patch_included,
+        patch_text=patch_text,
+    )
+
+
+def find_latest_remote_salvage(
+    comments: Sequence[IssueComment],
+    *,
+    repo: str,
+    issue_number: int,
+    scope: str,
+    approved_plan_hash: str | None = None,
+) -> RemoteSalvageRecord | None:
+    best: RemoteSalvageRecord | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in AGENT_SALVAGE_MARKER_RE.finditer(body):
+            payload = _decode_json_payload(match.group("payload"))
+            if payload is None:
+                continue
+            if not _remote_payload_matches(
+                payload,
+                repo=repo,
+                issue_number=issue_number,
+                scope=scope,
+                approved_plan_hash=approved_plan_hash,
+            ):
+                continue
+            record = _record_from_payload(payload)
+            if record is None:
+                continue
+            if best is None or record.created_at_ns >= best.created_at_ns:
+                best = record
+    return best
+
+
+def render_remote_salvage_summary(record: RemoteSalvageRecord) -> str:
+    approved_hash_line = (
+        f"\n- Approved plan hash: `{record.approved_plan_hash}`" if record.approved_plan_hash else ""
+    )
+    if record.patch_text is not None:
+        patch_section = (
+            "\n## Patch (embedded in the GitHub salvage comment)\n\n"
+            "```diff\n"
+            f"{record.patch_text}\n"
+            "```\n"
+        )
+    elif record.patch_exists:
+        patch_section = (
+            "\n## Patch\n\n"
+            f"The partial patch is local-only at `{record.local_directory}/partial.patch` "
+            "on the machine that produced this attempt and was not included in the "
+            "GitHub comment.\n"
+        )
+    else:
+        patch_section = ""
+    return f"""# Salvage Summary (recovered from a GitHub issue comment)
+
+The {record.agent} agent failed before producing a valid public response on a
+prior run. No successful response, review result, or pull request should be
+inferred from this artifact. Local artifact paths below were written on that
+run's machine/workdir and may not exist here.
+
+This is incomplete context only. A later attempt may cherry-pick or ignore it
+selectively, but must not treat it as validated, complete, or automatically
+applicable.
+
+- Repository: `{record.repo}`
+- Issue: `{record.issue_number if record.issue_number is not None else "unknown"}`
+- Scope: `{record.scope}`
+- Agent: `{record.agent}`{approved_hash_line}
+- Failure category: `{record.failure_category}`
+- Failure reason: {record.failure_reason}
+
+## Local Artifacts (from the original run; may not exist here)
+
+- Salvage directory: `{record.local_directory}`
+- Changed files/status:
+
+{record.changed_files}
+
+- Diff stat:
+
+{record.diff_stat}
+{patch_section}"""
+
+
+def latest_salvage_context(
+    log_dir: Path,
+    comments: Sequence[IssueComment],
+    *,
+    repo: str,
+    issue_number: int,
+    scope: str,
+    approved_plan_hash: str | None = None,
+) -> str | None:
+    """Merge local and GitHub-backed salvage discovery, newest wins (ties prefer local)."""
+    local_record = _latest_local_salvage_record(
+        log_dir,
+        repo=repo,
+        issue_number=issue_number,
+        scope=scope,
+        approved_plan_hash=approved_plan_hash,
+    )
+    remote_record = find_latest_remote_salvage(
+        comments,
+        repo=repo,
+        issue_number=issue_number,
+        scope=scope,
+        approved_plan_hash=approved_plan_hash,
+    )
+    if remote_record is None:
+        return None if local_record is None else local_record[1]
+    if local_record is None:
+        return render_remote_salvage_summary(remote_record)
+    local_created_at_ns, local_summary = local_record
+    if remote_record.created_at_ns > local_created_at_ns:
+        return render_remote_salvage_summary(remote_record)
+    return local_summary

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -2650,6 +2650,11 @@ def test_issue_implementation_rerun_discovers_remote_salvage_when_local_log_dir_
     assert "remote-only failure summary" in coder_prompt
     assert "```diff" in coder_prompt
     assert "-old" in coder_prompt and "+new" in coder_prompt
+    # The raw AGENT_SALVAGE breadcrumb comment must not also be rendered
+    # verbatim via the ordinary issue-context comment block (#507 follow-up):
+    # it is consumed only through the parsed salvage_summary injection above.
+    assert "AGENT_SALVAGE" not in coder_prompt
+    assert "Implementation salvage breadcrumb" not in coder_prompt
 
 
 def test_issue_implementation_rerun_remote_salvage_with_omitted_patch_renders_local_only_note(tmp_path):

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -21,7 +21,12 @@ from coding_review_agent_loop.prompts import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
 )
 from coding_review_agent_loop.protocol import UnresolvedReviewItem
-from coding_review_agent_loop.salvage import latest_salvage_summary
+from coding_review_agent_loop.salvage import (
+    SalvageContext,
+    capture_salvage_artifacts,
+    latest_salvage_summary,
+    post_salvage_comment,
+)
 from agent_loop_helpers import (
     FakeRunner,
     command_index,
@@ -2519,3 +2524,302 @@ def test_latest_salvage_summary_filters_approved_plan_hash(tmp_path):
     )
 
     assert summary == "current approved-plan summary"
+
+
+def test_failed_issue_implementation_posts_github_salvage_comment(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[("quota exceeded; reset in 10m", 1)],
+        post_agent_git_status=" M src/coding_review_agent_loop/cli.py\n",
+        post_agent_git_diff=(
+            "diff --git a/src/coding_review_agent_loop/cli.py b/src/coding_review_agent_loop/cli.py\n"
+            "--- a/src/coding_review_agent_loop/cli.py\n"
+            "+++ b/src/coding_review_agent_loop/cli.py\n"
+            "@@ -1 +1 @@\n-old\n+new\n"
+        ),
+        post_agent_git_diff_stat=" src/coding_review_agent_loop/cli.py | 2 +-\n",
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(QuotaResetExceededError) as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    message = str(excinfo.value)
+    assert "A GitHub salvage comment was posted to issue #56." in message
+    assert len(runner.issue_comments) == 1
+    posted_body = runner.issue_comments[0]["body"]
+    assert "<!-- AGENT_SALVAGE:" in posted_body
+    assert "Implementation salvage breadcrumb" in posted_body
+
+
+def test_failed_issue_implementation_salvage_comment_disabled_posts_nothing(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[("quota exceeded; reset in 10m", 1)],
+        post_agent_git_status=" M src/coding_review_agent_loop/cli.py\n",
+        post_agent_git_diff=(
+            "diff --git a/src/coding_review_agent_loop/cli.py b/src/coding_review_agent_loop/cli.py\n"
+            "--- a/src/coding_review_agent_loop/cli.py\n"
+            "+++ b/src/coding_review_agent_loop/cli.py\n"
+            "@@ -1 +1 @@\n-old\n+new\n"
+        ),
+    )
+    config = make_config(tmp_path, salvage_comments=False)
+
+    with pytest.raises(QuotaResetExceededError) as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    message = str(excinfo.value)
+    assert "No GitHub salvage comment was posted." in message
+    assert runner.issue_comments == []
+
+
+def _build_remote_salvage_comment(
+    tmp_path,
+    *,
+    issue_number=56,
+    scope="issue-implementation",
+    approved_plan_hash_value=None,
+    patch_text=None,
+    failure_reason="remote-only failure summary",
+    patch_max_bytes=20000,
+):
+    patch_text = patch_text or (
+        "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n"
+    )
+    checkout = tmp_path / "remote-source-checkout"
+    checkout.mkdir(parents=True, exist_ok=True)
+    seed_runner = FakeRunner(
+        git_diff=patch_text,
+        git_status=" M file.txt\n",
+        git_diff_stat=" file.txt | 2 +-\n",
+    )
+    context = SalvageContext(
+        repo="OWNER/REPO",
+        issue_number=issue_number,
+        scope=scope,
+        agent="claude",
+        approved_plan_hash=approved_plan_hash_value,
+    )
+    artifacts = capture_salvage_artifacts(
+        seed_runner,
+        checkout=checkout,
+        log_dir=tmp_path / "remote-source-logs",
+        context=context,
+        failure_category="transient",
+        failure_reason=failure_reason,
+        required_marker="<!-- AGENT_PR: <number> -->",
+        result=None,
+    )
+    post_config = make_config(tmp_path, salvage_comment_patch_max_bytes=patch_max_bytes)
+    posted = post_salvage_comment(
+        seed_runner,
+        config=post_config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason=failure_reason,
+    )
+    assert posted
+    return seed_runner.issue_comments[-1]
+
+
+def test_issue_implementation_rerun_discovers_remote_salvage_when_local_log_dir_is_empty(tmp_path):
+    remote_comment = _build_remote_salvage_comment(
+        tmp_path,
+        issue_number=56,
+        scope="issue-implementation",
+        failure_reason="remote-only failure summary",
+    )
+    runner = FakeRunner(
+        issue_comments=[remote_comment],
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    coder_prompt = next(
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "Fix GitHub issue #56" in cmd[-1]
+    )
+    assert "Previous failed implementation attempt salvage:" in coder_prompt
+    assert "recovered from a GitHub issue comment" in coder_prompt
+    assert "remote-only failure summary" in coder_prompt
+    assert "```diff" in coder_prompt
+    assert "-old" in coder_prompt and "+new" in coder_prompt
+
+
+def test_issue_implementation_rerun_remote_salvage_with_omitted_patch_renders_local_only_note(tmp_path):
+    oversized_patch = (
+        "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n"
+    ) + ("+padding\n" * 5000)
+    remote_comment = _build_remote_salvage_comment(
+        tmp_path,
+        issue_number=56,
+        scope="issue-implementation",
+        patch_text=oversized_patch,
+        patch_max_bytes=100,
+        failure_reason="remote failure with an oversized patch",
+    )
+    runner = FakeRunner(
+        issue_comments=[remote_comment],
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    coder_prompt = next(
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "Fix GitHub issue #56" in cmd[-1]
+    )
+    assert "recovered from a GitHub issue comment" in coder_prompt
+    assert "local-only" in coder_prompt
+    assert "```diff" not in coder_prompt
+
+
+def test_issue_implementation_rerun_ignores_remote_salvage_for_a_different_issue(tmp_path):
+    remote_comment = _build_remote_salvage_comment(
+        tmp_path,
+        issue_number=999,
+        scope="issue-implementation",
+        failure_reason="unrelated issue failure",
+    )
+    runner = FakeRunner(
+        issue_comments=[remote_comment],
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    coder_prompt = next(
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "Fix GitHub issue #56" in cmd[-1]
+    )
+    assert "Previous failed implementation attempt salvage:" not in coder_prompt
+
+
+def test_approved_plan_implementation_rerun_discovers_remote_salvage_with_matching_plan_hash(tmp_path):
+    approved_plan = "Plan:\n- Do the thing."
+    plan_hash = approved_plan_hash(approved_plan)
+    remote_comment = _build_remote_salvage_comment(
+        tmp_path,
+        issue_number=56,
+        scope="approved-plan-implementation",
+        approved_plan_hash_value=plan_hash,
+        failure_reason="remote approved-plan failure",
+    )
+    runner = FakeRunner(
+        issue_comments=[remote_comment],
+        claude_outputs=[
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+    issue_context = get_issue_context(runner, config=config, issue_number=56)
+    usage_context = orchestrator_module._new_usage_context(config)
+
+    result = orchestrator_module._implement_approved_issue(
+        runner,
+        issue_number=56,
+        approved_plan=approved_plan,
+        config=config,
+        memory=None,
+        issue_context=issue_context,
+        coder_session_id=None,
+        usage_context=usage_context,
+    )
+
+    assert result == 0
+    coder_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "Previous failed implementation attempt salvage:" in coder_prompt
+    assert "recovered from a GitHub issue comment" in coder_prompt
+    assert "remote approved-plan failure" in coder_prompt
+
+
+def test_approved_plan_implementation_rerun_ignores_remote_salvage_on_plan_hash_mismatch(tmp_path):
+    approved_plan = "Plan:\n- Do the current thing."
+    stale_plan_hash = approved_plan_hash("Plan:\n- Do the old thing.")
+    remote_comment = _build_remote_salvage_comment(
+        tmp_path,
+        issue_number=56,
+        scope="approved-plan-implementation",
+        approved_plan_hash_value=stale_plan_hash,
+        failure_reason="stale plan failure",
+    )
+    runner = FakeRunner(
+        issue_comments=[remote_comment],
+        claude_outputs=[
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+    issue_context = get_issue_context(runner, config=config, issue_number=56)
+    usage_context = orchestrator_module._new_usage_context(config)
+
+    result = orchestrator_module._implement_approved_issue(
+        runner,
+        issue_number=56,
+        approved_plan=approved_plan,
+        config=config,
+        memory=None,
+        issue_context=issue_context,
+        coder_session_id=None,
+        usage_context=usage_context,
+    )
+
+    assert result == 0
+    coder_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "Previous failed implementation attempt salvage:" not in coder_prompt
+
+
+def test_task_and_pr_followup_salvage_scopes_post_no_github_comment(tmp_path):
+    config = make_config(tmp_path)
+    runner = FakeRunner(
+        post_agent_git_status=" M file.txt\n",
+        post_agent_git_diff=(
+            "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n"
+        ),
+    )
+    runner._mark_agent_command_seen()
+
+    for scope in (
+        orchestrator_module.TASK_IMPLEMENTATION_SALVAGE_SCOPE,
+        orchestrator_module.PR_FOLLOWUP_SALVAGE_SCOPE,
+    ):
+        diagnostic = orchestrator_module._capture_failed_run_salvage_diagnostic(
+            runner=runner,
+            config=config,
+            agent_name="claude",
+            salvage_context=SalvageContext(
+                repo=config.repo,
+                issue_number=56,
+                scope=scope,
+                agent="claude",
+            ),
+            operation_description="task implementation",
+            failure_category="transient",
+            failure_reason="agent failed",
+            classification_text="",
+            marker_description="<!-- AGENT_PR: <number> -->",
+            result=None,
+        )
+        assert diagnostic.artifacts is not None
+        assert "No GitHub salvage comment was posted." in diagnostic.line
+
+    assert runner.comments == []
+    assert runner.issue_comments == []

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -143,6 +143,40 @@ def test_issue_prompts_include_salvage_guardrail_block(tmp_path):
         assert "partial.patch" in prompt
 
 
+def test_issue_prompts_render_remote_salvage_summary_shape(tmp_path):
+    from coding_review_agent_loop.salvage import RemoteSalvageRecord, render_remote_salvage_summary
+
+    config = make_config(tmp_path)
+    record = RemoteSalvageRecord(
+        created_at_ns=1,
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        agent="claude",
+        run_id="run-1",
+        approved_plan_hash=None,
+        failure_category="transient",
+        failure_reason="agent failed on a different machine",
+        changed_files=" M file.txt",
+        diff_stat=" file.txt | 2 +-",
+        local_directory="/tmp/other-workdir/.agent-loop-logs/salvage/run-1-claude-issue-implementation",
+        patch_exists=True,
+        patch_included=True,
+        patch_text="diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    salvage_summary = render_remote_salvage_summary(record)
+
+    prompt = build_issue_prompt(56, config, salvage_summary=salvage_summary)
+
+    assert "Previous failed implementation attempt salvage:" in prompt
+    assert "recovered from a GitHub issue comment" in prompt
+    assert "agent failed on a different machine" in prompt
+    assert "```diff" in prompt
+    assert "-old" in prompt and "+new" in prompt
+    assert "Do not auto-apply the patch" in prompt
+    assert "may not exist here" in prompt
+
+
 def test_reviewer_prompts_use_reviewer_assigned_workdir_rule(tmp_path):
     config = make_config(
         tmp_path,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -998,6 +998,38 @@ def test_format_issue_context_truncates_oversized_newest_comment():
     assert "[Newest comment truncated to keep this prompt bounded.]" in text
     assert "Older detail should not be kept instead of the newest comment." not in text
 
+
+def test_format_issue_context_filters_out_agent_salvage_breadcrumb_comments():
+    salvage_comment_body = (
+        "### Implementation salvage breadcrumb\n\n"
+        "<!-- AGENT_SALVAGE: eyJzY2hlbWFfdmVyc2lvbiI6IDF9 -->\n"
+    )
+    issue_context = IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Support issue comments",
+        body="Original request.",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(
+            IssueComment(
+                author="human-user",
+                created_at="2026-05-17T09:00:00Z",
+                body="A real discussion comment that must stay visible.",
+            ),
+            IssueComment(
+                author="coding-review-agent-loop",
+                created_at="2026-05-17T10:00:00Z",
+                body=salvage_comment_body,
+            ),
+        ),
+    )
+
+    text = format_issue_context(issue_context)
+
+    assert "A real discussion comment that must stay visible." in text
+    assert "AGENT_SALVAGE" not in text
+    assert "Implementation salvage breadcrumb" not in text
+
 def test_format_human_requirements_uses_distinct_high_priority_section():
     text = format_human_requirements(
         (

--- a/tests/test_salvage.py
+++ b/tests/test_salvage.py
@@ -1,0 +1,399 @@
+import coding_review_agent_loop.salvage as salvage_module
+from coding_review_agent_loop.github import IssueComment
+from coding_review_agent_loop.salvage import (
+    RemoteSalvageRecord,
+    SalvageContext,
+    capture_salvage_artifacts,
+    find_latest_remote_salvage,
+    latest_salvage_context,
+    post_salvage_comment,
+    render_remote_salvage_summary,
+)
+from agent_loop_helpers import FakeRunner, make_config
+
+CLEAN_PATCH = (
+    "diff --git a/file.txt b/file.txt\n"
+    "--- a/file.txt\n"
+    "+++ b/file.txt\n"
+    "@@ -1 +1 @@\n"
+    "-old\n"
+    "+new\n"
+)
+
+
+def _capture(tmp_path, *, patch_text=CLEAN_PATCH, context=None, subdir="checkout"):
+    checkout = tmp_path / subdir
+    checkout.mkdir(parents=True, exist_ok=True)
+    runner = FakeRunner(
+        git_diff=patch_text,
+        git_status=" M file.txt\n",
+        git_diff_stat=" file.txt | 2 +-\n",
+        git_diff_check="",
+    )
+    context = context or SalvageContext(
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        agent="claude",
+        run_id="run-1",
+        approved_plan_hash="hash-1",
+    )
+    artifacts = capture_salvage_artifacts(
+        runner,
+        checkout=checkout,
+        log_dir=tmp_path / "logs",
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+        required_marker="<!-- AGENT_PR: <number> -->",
+        result=None,
+    )
+    assert artifacts is not None
+    return runner, artifacts, context
+
+
+def _comments_from_runner(runner):
+    return [
+        IssueComment(author="bot", created_at=raw["createdAt"], body=raw["body"])
+        for raw in runner.issue_comments
+    ]
+
+
+def test_post_salvage_comment_round_trips_metadata_fields(tmp_path):
+    runner, artifacts, context = _capture(tmp_path)
+    config = make_config(tmp_path)
+
+    posted = post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+
+    assert posted is True
+    assert len(runner.issue_comments) == 1
+    body = runner.issue_comments[0]["body"]
+    assert "<!-- AGENT_SALVAGE:" in body
+
+    record = find_latest_remote_salvage(
+        _comments_from_runner(runner),
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        approved_plan_hash="hash-1",
+    )
+    assert record is not None
+    assert record.repo == "OWNER/REPO"
+    assert record.issue_number == 56
+    assert record.scope == "issue-implementation"
+    assert record.agent == "claude"
+    assert record.run_id == "run-1"
+    assert record.approved_plan_hash == "hash-1"
+    assert record.failure_category == "transient"
+    assert record.failure_reason == "agent failed"
+    assert record.patch_included is True
+    assert record.patch_text == CLEAN_PATCH
+
+
+def test_patch_omitted_when_over_size_limit(tmp_path):
+    oversized_patch = CLEAN_PATCH + ("+padding line\n" * 5000)
+    runner, artifacts, context = _capture(tmp_path, patch_text=oversized_patch)
+    config = make_config(tmp_path, salvage_comment_patch_max_bytes=100)
+
+    post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+
+    record = find_latest_remote_salvage(
+        _comments_from_runner(runner),
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        approved_plan_hash="hash-1",
+    )
+    assert record.patch_exists is True
+    assert record.patch_included is False
+    assert record.patch_text is None
+    assert "local-only" in runner.issue_comments[0]["body"]
+
+
+def test_patch_omitted_when_binary(tmp_path):
+    binary_patch = CLEAN_PATCH + "GIT binary patch\n1234 bytes of nonsense\n"
+    runner, artifacts, context = _capture(tmp_path, patch_text=binary_patch)
+    config = make_config(tmp_path)
+
+    post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+
+    record = find_latest_remote_salvage(
+        _comments_from_runner(runner),
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        approved_plan_hash="hash-1",
+    )
+    assert record.patch_included is False
+    assert record.patch_text is None
+
+
+def test_patch_omitted_when_secret_pattern_detected(tmp_path):
+    secret_patch = CLEAN_PATCH + "+aws_key = AKIAABCDEFGHIJKLMNOP\n"
+    runner, artifacts, context = _capture(tmp_path, patch_text=secret_patch)
+    config = make_config(tmp_path)
+
+    post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+
+    record = find_latest_remote_salvage(
+        _comments_from_runner(runner),
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        approved_plan_hash="hash-1",
+    )
+    assert record.patch_included is False
+    assert record.patch_text is None
+
+
+def test_post_salvage_comment_skips_ineligible_scopes(tmp_path):
+    runner, artifacts, context = _capture(
+        tmp_path,
+        context=SalvageContext(
+            repo="OWNER/REPO",
+            issue_number=56,
+            scope="pr-followup",
+            agent="claude",
+        ),
+    )
+    config = make_config(tmp_path)
+
+    posted = post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+
+    assert posted is False
+    assert runner.issue_comments == []
+
+
+def test_post_salvage_comment_skips_when_disabled_or_dry_run(tmp_path):
+    runner, artifacts, context = _capture(tmp_path)
+
+    disabled_config = make_config(tmp_path, salvage_comments=False)
+    assert (
+        post_salvage_comment(
+            runner,
+            config=disabled_config,
+            artifacts=artifacts,
+            context=context,
+            failure_category="transient",
+            failure_reason="agent failed",
+        )
+        is False
+    )
+
+    dry_run_config = make_config(tmp_path, dry_run=True)
+    assert (
+        post_salvage_comment(
+            runner,
+            config=dry_run_config,
+            artifacts=artifacts,
+            context=context,
+            failure_category="transient",
+            failure_reason="agent failed",
+        )
+        is False
+    )
+    assert runner.issue_comments == []
+
+
+def test_post_salvage_comment_swallows_posting_failure(tmp_path, monkeypatch, capsys):
+    runner, artifacts, context = _capture(tmp_path)
+    config = make_config(tmp_path, quiet=False)
+
+    def boom(*args, **kwargs):
+        raise salvage_module.AgentLoopError("gh unavailable")
+
+    monkeypatch.setattr(salvage_module, "post_issue_comment", boom)
+
+    posted = post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+
+    assert posted is False
+    assert "salvage comment posting failed" in capsys.readouterr().err
+
+
+def test_render_remote_salvage_summary_includes_patch_verbatim_when_included():
+    record = RemoteSalvageRecord(
+        created_at_ns=1,
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        agent="claude",
+        run_id="run-1",
+        approved_plan_hash="hash-1",
+        failure_category="transient",
+        failure_reason="agent failed",
+        changed_files=" M file.txt",
+        diff_stat=" file.txt | 2 +-",
+        local_directory="/tmp/some/old/workdir/salvage/run-1-claude-issue-implementation",
+        patch_exists=True,
+        patch_included=True,
+        patch_text=CLEAN_PATCH,
+    )
+
+    summary = render_remote_salvage_summary(record)
+
+    assert "recovered from a GitHub issue comment" in summary
+    assert CLEAN_PATCH in summary
+    assert "local-only" not in summary
+
+
+def test_render_remote_salvage_summary_omits_patch_block_when_not_included():
+    record = RemoteSalvageRecord(
+        created_at_ns=1,
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        agent="claude",
+        run_id="run-1",
+        approved_plan_hash=None,
+        failure_category="transient",
+        failure_reason="agent failed",
+        changed_files=" M file.txt",
+        diff_stat=" file.txt | 2 +-",
+        local_directory="/tmp/some/old/workdir/salvage/run-1-claude-issue-implementation",
+        patch_exists=True,
+        patch_included=False,
+        patch_text=None,
+    )
+
+    summary = render_remote_salvage_summary(record)
+
+    assert "local-only" in summary
+    assert "```diff" not in summary
+
+
+def test_latest_salvage_context_merge_prefers_newer_remote(tmp_path, monkeypatch):
+    counter = iter([100, 200])
+    monkeypatch.setattr(salvage_module.time, "time_ns", lambda: next(counter))
+
+    runner, artifacts, context = _capture(tmp_path)
+    config = make_config(tmp_path)
+    post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="remote is newer",
+    )
+
+    summary = latest_salvage_context(
+        tmp_path / "logs",
+        _comments_from_runner(runner),
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        approved_plan_hash="hash-1",
+    )
+    assert summary is not None
+    assert "recovered from a GitHub issue comment" in summary
+    assert "remote is newer" in summary
+
+
+def test_latest_salvage_context_merge_ties_prefer_local(tmp_path, monkeypatch):
+    monkeypatch.setattr(salvage_module.time, "time_ns", lambda: 100)
+
+    runner, artifacts, context = _capture(tmp_path)
+    config = make_config(tmp_path)
+    post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="remote failure reason",
+    )
+
+    summary = latest_salvage_context(
+        tmp_path / "logs",
+        _comments_from_runner(runner),
+        repo="OWNER/REPO",
+        issue_number=56,
+        scope="issue-implementation",
+        approved_plan_hash="hash-1",
+    )
+    assert summary is not None
+    assert "recovered from a GitHub issue comment" not in summary
+    assert "The claude agent failed before producing a valid public response" in summary
+
+
+def test_find_latest_remote_salvage_filters_plan_hash_scope_repo_issue(tmp_path):
+    runner, artifacts, context = _capture(tmp_path)
+    config = make_config(tmp_path)
+    post_salvage_comment(
+        runner,
+        config=config,
+        artifacts=artifacts,
+        context=context,
+        failure_category="transient",
+        failure_reason="agent failed",
+    )
+    comments = _comments_from_runner(runner)
+
+    assert find_latest_remote_salvage(
+        comments, repo="OWNER/OTHER", issue_number=56, scope="issue-implementation", approved_plan_hash="hash-1"
+    ) is None
+    assert find_latest_remote_salvage(
+        comments, repo="OWNER/REPO", issue_number=99, scope="issue-implementation", approved_plan_hash="hash-1"
+    ) is None
+    assert find_latest_remote_salvage(
+        comments, repo="OWNER/REPO", issue_number=56, scope="approved-plan-implementation", approved_plan_hash="hash-1"
+    ) is None
+    assert find_latest_remote_salvage(
+        comments, repo="OWNER/REPO", issue_number=56, scope="issue-implementation", approved_plan_hash="different-hash"
+    ) is None
+    assert find_latest_remote_salvage(
+        comments, repo="OWNER/REPO", issue_number=56, scope="issue-implementation", approved_plan_hash="hash-1"
+    ) is not None
+
+
+def test_find_latest_remote_salvage_skips_malformed_markers():
+    comments = [
+        IssueComment(author="bot", created_at="2026-01-01T00:00:00Z", body="<!-- AGENT_SALVAGE: not-valid-base64!! -->"),
+        IssueComment(author="bot", created_at="2026-01-01T00:00:01Z", body="<!-- AGENT_SALVAGE: aGVsbG8= -->"),
+    ]
+
+    assert find_latest_remote_salvage(
+        comments, repo="OWNER/REPO", issue_number=56, scope="issue-implementation", approved_plan_hash=None
+    ) is None


### PR DESCRIPTION
## Summary

Fixes #507

- Adds a durable GitHub-backed salvage breadcrumb: a hidden `<!-- AGENT_SALVAGE: ... -->` marker comment is posted to the issue (alongside the existing local artifacts) whenever a mutating `issue-implementation` or `approved-plan-implementation` attempt fails. `pr-followup`/`task-implementation` stay local-only since their rerun prompts don't consume a salvage summary today.
- The payload embeds repo/issue/scope/agent/run-id/approved-plan-hash/failure fields plus truncated changed-files/diff-stat, and the partial patch text itself when it is under `--salvage-comment-patch-max-bytes` (default 20000), has no `GIT binary patch` section, and clears a conservative secret scan (private keys, AWS key ids, `ghp_`/`github_pat_` tokens, bearer/authorization headers, `password=`/`secret=`-style assignments). Otherwise the comment states the patch is local-only.
- On rerun, `find_latest_remote_salvage` scans issue comments for matching markers (filtered by repo/issue/scope/approved-plan-hash, same semantics as local lookup) and `latest_salvage_context` merges local and remote discovery deterministically — newest by timestamp wins, ties prefer local.
- New `--no-salvage-comments` / `--salvage-comments` and `--salvage-comment-patch-max-bytes` flags; posting is skipped for `--dry-run` too. Posting failures are logged and never mask the original agent failure.
- `latest_salvage_summary`'s existing signature/behavior is unchanged (now a thin wrapper over an internal record helper).

## Test plan
- [x] `python3 -m pytest tests/ -q` (1395 passed)
- [x] New unit tests in `tests/test_salvage.py`: payload round-trip, patch policy (clean/oversized/binary/secret-pattern), scope restriction, dry-run/disabled skip, posting-failure swallowed, remote-summary rendering, local/remote merge determinism, malformed-marker skip.
- [x] Orchestrator-level tests in `tests/test_orchestrator_issue.py`: comment posted on failure, comment posting disabled, rerun discovers remote salvage with empty local log dir (including embedded patch), oversized-patch remote summary renders local-only note, repo/issue/plan-hash mismatches are ignored, task/pr-followup scopes post nothing.
- [x] Prompt-shape test in `tests/test_prompts.py` for a remote-rendered salvage summary.
- [x] `docs/local_agent_loop.md` updated to describe the new behavior and flag.