### PR TITLE
Make test-location validation ignore environment prose

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -764,12 +764,20 @@ and to avoid sibling, home, deployment, or duplicate clones such as `~/REPO` or
 `~/claude-code/REPO`.
 
 The orchestrator validates coder-reported test commands before posting normal
-coder progress. If a `Tests:` report or structured `tests_run` entry references
-an absolute, `$HOME`, or `~/` path outside the assigned checkout, the loop fails
-with an `AgentLoopError` naming the offending command and assigned checkout.
-For initial issue, task, and approved-plan implementations, the loop also
-checks that the assigned checkout `HEAD` advanced when the coder reports a PR;
-unchanged `HEAD` is rejected before the coder PR comment is posted.
+coder progress. For `Tests:` reports and structured `tests_run` entries, it
+checks shell tokens that explicitly carry location information, such as `cd
+<path>`, `-C <path>`, `--directory <path>`, `--directory=<path>`, or a command
+token that begins with `/`, `$HOME/`, or `~/`. Prose-only environment details,
+including virtualenv notes or URL-like text, are not treated as test working
+directories. If an explicit test location is outside the assigned checkout, the
+loop fails with an `AgentLoopError` naming the offending command and assigned
+checkout. When that failure happens after a PR was already created or detected,
+the error also confirms the PR state and tells the user to continue with
+`agent-loop pr <number>` instead of rerunning implementation and creating a
+duplicate PR. For initial issue, task, and approved-plan implementations, the
+loop also checks that the assigned checkout `HEAD` advanced when the coder
+reports a PR; unchanged `HEAD` is rejected before the coder PR comment is
+posted.
 
 These temporary checkouts may disappear after reboot or `/tmp` cleanup. Large
 projects and long-lived agent setups should use explicit persistent workdirs to

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2613,6 +2613,34 @@ def _read_assigned_workdir_head(runner: Runner, config: AgentLoopConfig) -> str 
     return result.stdout.strip() or None
 
 
+def _validate_response_tests_with_post_pr_context(
+    text: str,
+    *,
+    runner: Runner,
+    config: AgentLoopConfig,
+    pr_number: int,
+) -> None:
+    try:
+        validate_response_tests_within_workdir(text, assigned_workdir=active_workdir(config))
+    except AgentLoopError as exc:
+        try:
+            validate_open_pr(runner, config=config, pr_number=pr_number)
+        except Exception as pr_exc:
+            raise AgentLoopError(
+                f"{exc}\n\n"
+                f"The coder reported PR #{pr_number}, but the orchestrator could not confirm it is open. "
+                "The handoff/reviewer comments were not posted because the test report was invalid. "
+                "Inspect the PR state on GitHub before deciding whether to resume the existing PR or rerun "
+                "implementation."
+            ) from pr_exc
+        raise AgentLoopError(
+            f"{exc}\n\n"
+            f"PR #{pr_number} was confirmed open, but the handoff/reviewer comments were not posted because "
+            "the test report was invalid. Correct the PR/comment if needed, then continue safely with "
+            f"`agent-loop pr {pr_number}` instead of rerunning implementation and creating a duplicate PR."
+        ) from exc
+
+
 def _round_ledger_may_be_incomplete(
     *,
     current_resume: ResumedReviewRound | None,
@@ -2779,13 +2807,18 @@ def _implement_approved_issue(
         operation_description="approved-plan implementation",
     )
     coder_output = coder_response.text
-    validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(implementation_config))
+    pr_number = int(coder_response.marker_value)
+    _validate_response_tests_with_post_pr_context(
+        coder_output,
+        runner=runner,
+        config=implementation_config,
+        pr_number=pr_number,
+    )
     validate_assigned_head_advanced(
         before_head=assigned_head_before,
         after_head=_read_assigned_workdir_head(runner, implementation_config),
         assigned_workdir=active_workdir(implementation_config),
     )
-    pr_number = int(coder_response.marker_value)
     log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
     validate_open_pr(runner, config=implementation_config, pr_number=pr_number)
     validate_pr_references_issue(
@@ -3780,13 +3813,18 @@ def run_issue_loop(
         )
         coder_output = coder_response.text
         coder_session_id = coder_response.session_id
-        validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
+        pr_number = int(coder_response.marker_value)
+        _validate_response_tests_with_post_pr_context(
+            coder_output,
+            runner=runner,
+            config=config,
+            pr_number=pr_number,
+        )
         validate_assigned_head_advanced(
             before_head=assigned_head_before,
             after_head=_read_assigned_workdir_head(runner, config),
             assigned_workdir=active_workdir(config),
         )
-        pr_number = int(coder_response.marker_value)
         log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
         validate_open_pr(runner, config=config, pr_number=pr_number)
         validate_pr_references_issue(
@@ -3900,13 +3938,18 @@ def run_task_loop(
             session_id = coder_response.session_id
 
             if isinstance(coder_response.marker_value, int):
-                validate_response_tests_within_workdir(coder_output, assigned_workdir=active_workdir(config))
+                pr_number = coder_response.marker_value
+                _validate_response_tests_with_post_pr_context(
+                    coder_output,
+                    runner=runner,
+                    config=config,
+                    pr_number=pr_number,
+                )
                 validate_assigned_head_advanced(
                     before_head=assigned_head_before,
                     after_head=_read_assigned_workdir_head(runner, config),
                     assigned_workdir=active_workdir(config),
                 )
-                pr_number = coder_response.marker_value
                 log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
                 validate_open_pr(runner, config=config, pr_number=pr_number)
                 initial_pr_metadata = get_pr_review_context(runner, config=config, pr_number=pr_number).metadata

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -42,8 +42,6 @@ def _normalize_reported_path(raw_path: str) -> Path | None:
 
 
 def _reported_paths(command: str) -> Iterable[str]:
-    yield from HOME_PATH_RE.findall(command)
-    yield from ABSOLUTE_PATH_RE.findall(command)
     yield from WINDOWS_PATH_RE.findall(command)
 
     try:

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -11,8 +11,6 @@ from .errors import AgentLoopError
 
 
 TEST_SECTION_RE = re.compile(r"(?im)^\s*tests(?:\s+run)?\s*:\s*(?P<body>.*)$")
-ABSOLUTE_PATH_RE = re.compile(r"(?<![\w.\\<>-])/(?:[^\s`'\"|;&)<>]+)")
-HOME_PATH_RE = re.compile(r"(?<![\w.-])(?:~|\$HOME)/(?:[^\s`'\"|;&)<>]+)")
 WINDOWS_PATH_RE = re.compile(r"(?<![\w.-])[A-Za-z]:\\[^\s`'\"|;&)<>]+")
 
 

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -2123,6 +2123,60 @@ def test_issue_loop_rejects_outside_workdir_tests_before_posting_pr_comment(tmp_
     assert runner.comments == []
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
+def test_issue_loop_outside_workdir_after_reported_pr_mentions_confirmed_resume(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Fixed issue.\n"
+            "Tests: cd /outside && python -m pytest\n"
+            "<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n"
+            "-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError) as exc_info:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    message = str(exc_info.value)
+    assert "outside the assigned checkout" in message
+    assert "PR #77 was confirmed open" in message
+    assert "handoff/reviewer comments were not posted" in message
+    assert "agent-loop pr 77" in message
+    assert runner.comments == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+def test_issue_loop_outside_workdir_after_reported_pr_hedges_unconfirmed_pr(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Fixed issue.\n"
+            "Tests: cd /outside && python -m pytest\n"
+            "<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n"
+            "-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Looks good.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude",
+        ],
+        pr_payload={"state": "CLOSED"},
+    )
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError) as exc_info:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    message = str(exc_info.value)
+    assert "outside the assigned checkout" in message
+    assert "reported PR #77" in message
+    assert "could not confirm it is open" in message
+    assert "handoff/reviewer comments were not posted" in message
+    assert "agent-loop pr 77" not in message
+    assert runner.comments == []
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
 def test_issue_loop_rejects_reported_pr_when_assigned_head_unchanged(tmp_path):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -11,6 +11,16 @@ def test_workdir_guard_rejects_outside_home_path(tmp_path):
             assigned_workdir=assigned,
         )
 
+def test_workdir_guard_rejects_outside_absolute_cwd(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        validate_test_commands_within_workdir(
+            ("cd /outside && python -m pytest",),
+            assigned_workdir=assigned,
+        )
+
 def test_workdir_guard_rejects_windows_path_with_clear_message(tmp_path):
     assigned = tmp_path / "claude" / "repo"
     assigned.mkdir(parents=True)
@@ -33,6 +43,43 @@ def test_workdir_guard_accepts_assigned_absolute_path(tmp_path):
         (f"cd {assigned} && python -m pytest {tests_dir}",),
         assigned_workdir=assigned,
     )
+
+def test_workdir_guard_accepts_absolute_test_path_inside_checkout(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    test_file = assigned / "tests" / "test_agent_loop.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_placeholder():\n    assert True\n", encoding="utf-8")
+
+    validate_test_commands_within_workdir(
+        (f"python -m pytest {test_file}",),
+        assigned_workdir=assigned,
+    )
+
+def test_workdir_guard_ignores_environment_prose_in_tests_line(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+    text = (
+        "Tests: `python -m pytest` run from a fresh `pip install -e '.[dev]'` venv "
+        "(matching CI exactly) — 1332 passed, 0 failed."
+    )
+
+    validate_response_tests_within_workdir(text, assigned_workdir=assigned)
+
+def test_workdir_guard_ignores_url_like_prose_in_tests_line(tmp_path):
+    assigned = tmp_path / "claude" / "repo"
+    assigned.mkdir(parents=True)
+    text = (
+        "Tests: `.venv/bin/python -m pytest tests/test_server.py tests/test_security.py "
+        "tests/test_pricing.py tests/test_summarizer.py tests/test_language.py "
+        "tests/test_providers.py tests/test_attachments.py -q` (the mandated CI command) - "
+        "435 passed. Also ran `tests/test_database.py`, `tests/test_sitemap.py`, and the new "
+        "`tests/test_routes.py` - all passed. Did not run the Playwright E2E suite "
+        "(`test_debate_e2e.js`, `test_csrf_redirect_e2e.js`); those target a live "
+        "`https://dev.aispar.app` session cookie and are not runnable from this sandboxed "
+        "checkout - recommend running them before any prod deploy, per project policy."
+    )
+
+    validate_response_tests_within_workdir(text, assigned_workdir=assigned)
 
 def test_workdir_guard_accepts_javascript_regex_closing_script_tag(tmp_path):
     assigned = tmp_path / "codex" / "repo"


### PR DESCRIPTION
## Summary
- narrow test-location path validation to command-aware POSIX/home path evidence while preserving raw Windows path rejection
- add post-PR test-location failure diagnostics that confirm open PRs before recommending resume commands
- add regressions for environment prose, URL-like prose, outside cwd reports, and post-PR diagnostics

Fixes #493

## Tests
- python3 -m pytest tests/test_workdir_guard.py tests/test_orchestrator_issue.py -k 'workdir_guard or outside_workdir or test_location or reported_pr'
- python3 -m pytest