### PR TITLE
Reject unsupported repaired discuss agendas

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -4986,6 +4986,235 @@ def _recover_final_discuss_split_proposals(
     return consensus[1], final_votes
 
 
+_DISCUSS_AGENDA_SUPPORT_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "but",
+        "by",
+        "can",
+        "could",
+        "do",
+        "does",
+        "for",
+        "from",
+        "has",
+        "have",
+        "if",
+        "in",
+        "is",
+        "it",
+        "its",
+        "of",
+        "on",
+        "or",
+        "our",
+        "so",
+        "than",
+        "that",
+        "the",
+        "their",
+        "this",
+        "to",
+        "use",
+        "was",
+        "we",
+        "what",
+        "when",
+        "whether",
+        "which",
+        "while",
+        "with",
+        "would",
+        # Low-signal discuss/analyzer boilerplate. These terms are common in
+        # agenda summaries and should not validate invented content alone.
+        "approach",
+        "change",
+        "custom",
+        "existing",
+        "implementation",
+        "issue",
+        "next",
+        "objection",
+        "question",
+        "round",
+        "scope",
+        "strategy",
+    }
+)
+
+
+def _normalize_discuss_agenda_phrase(text: str) -> str:
+    return " ".join(re.findall(r"[A-Za-z0-9_]+", text.lower()))
+
+
+def _tokenize_discuss_agenda_support(
+    text: str,
+    *,
+    ignored_names: Sequence[str] = (),
+) -> tuple[str, ...]:
+    ignored_tokens = {
+        token
+        for name in ignored_names
+        for token in re.findall(r"[A-Za-z0-9_]+", name.lower())
+    }
+    tokens: list[str] = []
+    for token in re.findall(r"[A-Za-z0-9_]+", text.lower()):
+        if len(token) <= 2 and not token.isdigit():
+            continue
+        if token in ignored_tokens or token in _DISCUSS_AGENDA_SUPPORT_STOP_WORDS:
+            continue
+        tokens.append(token)
+    return tuple(tokens)
+
+
+@dataclass(frozen=True)
+class _DiscussAgendaSupportCorpus:
+    phrase_segments: tuple[str, ...]
+    tokens: frozenset[str]
+
+
+def _build_discuss_agenda_support_corpus(
+    *,
+    issue_context: IssueContext,
+    round_history: Sequence[Sequence[ParsedDiscussReview]],
+    prior_agenda: ParsedDiscussAgenda | None,
+    configured_reviewers: Sequence[AgentName],
+    analyzer: AgentName,
+) -> _DiscussAgendaSupportCorpus:
+    segments: list[str] = []
+    phrase_segments: list[str] = []
+
+    def add(value: object, *, phrase_support: bool = False) -> None:
+        if isinstance(value, str) and value.strip():
+            segments.append(value)
+            if phrase_support:
+                phrase_segments.append(value)
+
+    add(issue_context.title, phrase_support=True)
+    add(issue_context.body, phrase_support=True)
+    for comment in issue_context.comments:
+        add(comment.author)
+        add(comment.created_at)
+        add(comment.body, phrase_support=True)
+    for reviewer in configured_reviewers:
+        add(agent_display_name(reviewer))
+    for round_index, votes in enumerate(round_history, start=1):
+        add(f"Round {round_index}")
+        for vote in votes:
+            add(vote.reviewer)
+            add(vote.outcome)
+            add(vote.rationale, phrase_support=True)
+            add(vote.rebuttal, phrase_support=True)
+            add(vote.analyzer_framing)
+            add(vote.framing_note, phrase_support=True)
+            for proposal in vote.split_proposals:
+                add(proposal, phrase_support=True)
+            add(vote.research_status)
+            for fact in vote.sourced_facts:
+                add(fact.fact, phrase_support=True)
+                add(fact.source, phrase_support=True)
+    if prior_agenda is not None:
+        for point in prior_agenda.consensus:
+            add(point, phrase_support=True)
+        for disagreement in prior_agenda.disagreements:
+            add(disagreement.topic, phrase_support=True)
+            for name, position in disagreement.positions:
+                add(name)
+                add(position, phrase_support=True)
+            add(disagreement.question_for_next_round, phrase_support=True)
+        for fact in prior_agenda.missing_facts:
+            add(fact, phrase_support=True)
+        for question in prior_agenda.research_questions:
+            add(question, phrase_support=True)
+
+    ignored_names = [
+        agent_display_name(analyzer),
+        *(agent_display_name(r) for r in configured_reviewers),
+    ]
+    tokens = frozenset(
+        token
+        for segment in segments
+        for token in _tokenize_discuss_agenda_support(segment, ignored_names=ignored_names)
+    )
+    return _DiscussAgendaSupportCorpus(
+        phrase_segments=tuple(
+            normalized
+            for segment in phrase_segments
+            if (normalized := _normalize_discuss_agenda_phrase(segment))
+        ),
+        tokens=tokens,
+    )
+
+
+def _discuss_agenda_text_has_support(
+    text: str,
+    *,
+    corpus: _DiscussAgendaSupportCorpus,
+    ignored_names: Sequence[str],
+) -> bool:
+    tokens = _tokenize_discuss_agenda_support(text, ignored_names=ignored_names)
+    if tokens:
+        supported = sum(1 for token in set(tokens) if token in corpus.tokens)
+        required = 1 if len(set(tokens)) <= 4 else 2
+        return supported >= required
+    normalized = _normalize_discuss_agenda_phrase(text)
+    return bool(
+        normalized
+        and any(
+            normalized == segment or normalized in segment
+            for segment in corpus.phrase_segments
+        )
+    )
+
+
+def _validate_discuss_analyzer_agenda_fidelity(
+    agenda: ParsedDiscussAgenda,
+    *,
+    issue_context: IssueContext,
+    round_history: Sequence[Sequence[ParsedDiscussReview]],
+    prior_agenda: ParsedDiscussAgenda | None,
+    configured_reviewers: Sequence[AgentName],
+    analyzer: AgentName,
+) -> None:
+    allowed_names = {agent_display_name(reviewer) for reviewer in configured_reviewers}
+    unknown_names = sorted(
+        {name for disagreement in agenda.disagreements for name, _position in disagreement.positions}
+        - allowed_names
+    )
+    if unknown_names:
+        raise AgentLoopError(
+            "analyzer agenda used unknown debater name(s): " + ", ".join(unknown_names)
+        )
+
+    ignored_names = [agent_display_name(analyzer), *sorted(allowed_names)]
+    corpus = _build_discuss_agenda_support_corpus(
+        issue_context=issue_context,
+        round_history=round_history,
+        prior_agenda=prior_agenda,
+        configured_reviewers=configured_reviewers,
+        analyzer=analyzer,
+    )
+
+    fields: list[tuple[str, str]] = []
+    fields.extend(("consensus", point) for point in agenda.consensus)
+    for disagreement in agenda.disagreements:
+        fields.append(("disagreement topic", disagreement.topic))
+        fields.extend(("position", position) for _name, position in disagreement.positions)
+        fields.append(("question_for_next_round", disagreement.question_for_next_round))
+    fields.extend(("missing_fact", fact) for fact in agenda.missing_facts)
+    fields.extend(("research_question", question) for question in agenda.research_questions)
+
+    for field, text in fields:
+        if not _discuss_agenda_text_has_support(text, corpus=corpus, ignored_names=ignored_names):
+            raise AgentLoopError(f"analyzer agenda {field} lacks transcript support: {text}")
+
+
 def _run_discuss_analyzer(
     runner: Runner,
     *,
@@ -5049,19 +5278,22 @@ def _run_discuss_analyzer(
         return None, None
     parsed = response.marker_value
     assert isinstance(parsed, ParsedDiscussAgenda)
-    known_names = {agent_display_name(reviewer) for reviewer in configured_reviewers}
-    unknown_names = sorted(
-        {name for disagreement in parsed.disagreements for name, _position in disagreement.positions}
-        - known_names
-    )
-    if unknown_names:
-        # Non-authoritative analyzer output is forwarded as-is; debaters and the
-        # public summary can audit and correct it.
+    try:
+        _validate_discuss_analyzer_agenda_fidelity(
+            parsed,
+            issue_context=issue_context,
+            round_history=round_history,
+            prior_agenda=prior_agenda,
+            configured_reviewers=configured_reviewers,
+            analyzer=analyzer,
+        )
+    except AgentLoopError as exc:
         log(
             config,
-            f"discuss: analyzer agenda names unknown debater(s): {', '.join(unknown_names)}; "
-            "forwarding as-is",
+            f"discuss: analyzer {analyzer_name} agenda rejected ({exc}); falling back to the "
+            f"mechanical agenda for round {round_number + 1}",
         )
+        return None, None
     return parsed, response.text
 
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -315,6 +315,9 @@ Notes:
 - positions maps debater display names to short position statements and must not be empty.
 - research_required/research_questions (optional): keep them only when present in the original; never invent research questions or drop ones the original stated.
 - research_questions must be non-empty when research_required is true, and empty or omitted when it is false or absent.
+- Repair only agenda content that is recoverable from the malformed response and supplied context.
+- Never invent topics, debater positions, facts, or questions to make the agenda schema-valid.
+- If no agenda content is recoverable, return the closest faithful output even if it remains invalid; the orchestrator will fall back mechanically.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format D — Plan Revision:

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -1747,6 +1747,7 @@ def test_discuss_loop_auto_mode_analyzer_can_decide_no_research(tmp_path):
             ),
         ],
         claude_outputs=[agenda_text],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(
         tmp_path,
@@ -2015,6 +2016,7 @@ def test_discuss_parallel_analyzer_waits_for_debater_synchronization_point(tmp_p
             ),
         ],
         claude_outputs=[_discuss_agenda_text()],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(
         tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude", discuss_parallel=True
@@ -2293,6 +2295,7 @@ def test_discuss_parallel_artifacts_are_isolated_by_round_and_agent(tmp_path):
             _discuss_review_text(outcome="implement", rationale="Now yes.", rebuttal="Conceding.", analyzer_framing="accurate"),
         ],
         claude_outputs=[_discuss_agenda_text()],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(
         tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude", discuss_parallel=True

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -11,13 +11,19 @@ from coding_review_agent_loop.orchestrator import (
     _attach_round_metadata,
     _decode_round_metadata,
     _discuss_subject,
+    _validate_discuss_analyzer_agenda_fidelity,
     render_public_agent_comment,
     run_discuss_loop,
 )
 from coding_review_agent_loop.comment_rendering import render_discuss_round_summary_comment
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import IssueComment, IssueContext
-from coding_review_agent_loop.protocol import ParsedDiscussReview
+from coding_review_agent_loop.protocol import (
+    DiscussAgendaDisagreement,
+    DiscussSourcedFact,
+    ParsedDiscussAgenda,
+    ParsedDiscussReview,
+)
 
 from agent_loop_helpers import FakeRunner, make_config
 
@@ -86,6 +92,18 @@ def _discuss_agenda_text(
 def _issue_subject(title: str = "Fix issue-mode context", body: str = "Original issue body.") -> str:
     text = title + "\n\n" + body
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def _grounded_agenda_issue_payload() -> dict[str, str]:
+    return {
+        "body": (
+            "Original issue body. The issue is well-motivated. Scope of the change. "
+            "Would splitting resolve the scope objection? Whether the API boundary is specified. "
+            "Narrow enough. Too broad. "
+            "Round-one agenda marker. Round-two agenda marker. "
+            "Everyone agrees to implement. Is Gemini CLI still available for enterprise users?"
+        )
+    }
 
 
 def _seed_debater_comment(
@@ -365,6 +383,170 @@ def test_discuss_subject_excludes_debater_and_summary_comments_from_hash():
         ),
     )
     assert _discuss_subject(ctx_with_rounds) == subject
+
+
+def _validate_agenda_for_test(
+    agenda: ParsedDiscussAgenda,
+    *,
+    issue_context: IssueContext | None = None,
+    round_history: list[list[ParsedDiscussReview]] | None = None,
+    prior_agenda: ParsedDiscussAgenda | None = None,
+) -> None:
+    _validate_discuss_analyzer_agenda_fidelity(
+        agenda,
+        issue_context=issue_context
+        or IssueContext(
+            number=1,
+            repo="OWNER/REPO",
+            title="Supported title",
+            body="Supported body",
+            url=None,
+            comments=(),
+        ),
+        round_history=round_history or [],
+        prior_agenda=prior_agenda,
+        configured_reviewers=("codex", "gemini"),
+        analyzer="claude",
+    )
+
+
+def _agenda_for_fidelity(
+    *,
+    consensus: tuple[str, ...] = (),
+    topic: str = "Supported title",
+    positions: tuple[tuple[str, str], ...] = (("Codex", "Supported body"),),
+    question: str = "Supported title?",
+    missing_facts: tuple[str, ...] = (),
+    research_questions: tuple[str, ...] = (),
+) -> ParsedDiscussAgenda:
+    return ParsedDiscussAgenda(
+        consensus=consensus,
+        disagreements=(
+            DiscussAgendaDisagreement(
+                topic=topic,
+                positions=positions,
+                question_for_next_round=question,
+            ),
+        ),
+        missing_facts=missing_facts,
+        research_required=bool(research_questions),
+        research_questions=research_questions,
+    )
+
+
+def test_discuss_analyzer_fidelity_rejects_unknown_position_key():
+    agenda = _agenda_for_fidelity(positions=(("Developer", "Supported body"),))
+
+    with pytest.raises(AgentLoopError, match="unknown debater"):
+        _validate_agenda_for_test(agenda)
+
+
+@pytest.mark.parametrize(
+    ("field", "agenda"),
+    [
+        ("topic", _agenda_for_fidelity(topic="Levitation library strategy")),
+        ("position", _agenda_for_fidelity(positions=(("Codex", "Use levitation libraries"),))),
+        ("question", _agenda_for_fidelity(question="Should custom field manipulation win?")),
+        ("missing_fact", _agenda_for_fidelity(missing_facts=("Levitation benchmark data",))),
+        ("consensus", _agenda_for_fidelity(consensus=("Levitation is agreed",))),
+        (
+            "research_question",
+            _agenda_for_fidelity(research_questions=("Which levitation library is fastest?",)),
+        ),
+    ],
+)
+def test_discuss_analyzer_fidelity_rejects_unsupported_agenda_text(field, agenda):
+    with pytest.raises(AgentLoopError, match=field):
+        _validate_agenda_for_test(agenda)
+
+
+def test_discuss_analyzer_fidelity_accepts_issue_comment_and_body_support():
+    ctx = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="API boundary",
+        body="The scoped change is the implementation approach.",
+        url=None,
+        comments=(
+            IssueComment(author="user", created_at="2026-01-01", body="Missing migration facts."),
+        ),
+    )
+    agenda = _agenda_for_fidelity(
+        consensus=("API boundary",),
+        topic="scoped change",
+        positions=(("Codex", "implementation approach"),),
+        question="API boundary?",
+        missing_facts=("Missing migration facts",),
+    )
+
+    _validate_agenda_for_test(agenda, issue_context=ctx)
+
+
+def test_discuss_analyzer_fidelity_accepts_vote_research_and_prior_agenda_support():
+    round_history = [
+        [
+            ParsedDiscussReview(
+                outcome="split",
+                rationale="Codex wants adapter cleanup.",
+                split_proposals=("Extract parser stage",),
+                reviewer="Codex",
+                rebuttal="Keep adapter cleanup small.",
+                analyzer_framing="misframed",
+                framing_note="The API migration risk was overstated.",
+                research_status="sourced",
+                sourced_facts=(
+                    DiscussSourcedFact(
+                        fact="Gemini CLI remains available.",
+                        source="https://example.com/gemini",
+                    ),
+                ),
+            ),
+            ParsedDiscussReview(
+                outcome="implement",
+                rationale="Gemini accepts parser stage.",
+                split_proposals=(),
+                reviewer="Gemini",
+            ),
+        ]
+    ]
+    prior_agenda = ParsedDiscussAgenda(
+        consensus=("Prior analyzer agenda",),
+        disagreements=(),
+        missing_facts=("Prior missing fact",),
+    )
+    agenda = _agenda_for_fidelity(
+        consensus=("Prior analyzer agenda",),
+        topic="adapter cleanup",
+        positions=(("Codex", "Extract parser stage"), ("Gemini", "accepts parser stage")),
+        question="API migration risk?",
+        missing_facts=("Prior missing fact",),
+        research_questions=("Gemini CLI remains available?",),
+    )
+
+    _validate_agenda_for_test(agenda, round_history=round_history, prior_agenda=prior_agenda)
+
+
+def test_discuss_analyzer_fidelity_accepts_empty_agenda_collections():
+    agenda = ParsedDiscussAgenda(consensus=(), disagreements=(), missing_facts=())
+
+    _validate_agenda_for_test(agenda)
+
+
+def test_discuss_analyzer_fidelity_requires_exact_support_for_generic_only_text():
+    agenda = _agenda_for_fidelity(topic="Scope of the change")
+
+    with pytest.raises(AgentLoopError, match="topic"):
+        _validate_agenda_for_test(agenda)
+
+    ctx = IssueContext(
+        number=1,
+        repo="OWNER/REPO",
+        title="My issue",
+        body="Scope of the change. Supported body. Supported title.",
+        url=None,
+        comments=(),
+    )
+    _validate_agenda_for_test(agenda, issue_context=ctx)
 
 
 def test_discuss_loop_reruns_when_human_comment_added(tmp_path):
@@ -908,6 +1090,7 @@ def test_discuss_loop_analyzer_agenda_focuses_debate_and_final_summary_distingui
             ),
         ],
         claude_outputs=[agenda_text],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
 
@@ -987,6 +1170,7 @@ def test_discuss_loop_debater_misframing_correction_is_rendered(tmp_path):
             ),
         ],
         claude_outputs=[_discuss_agenda_text()],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
 
@@ -1047,6 +1231,83 @@ def test_discuss_loop_analyzer_failure_falls_back_to_mechanical_agenda(tmp_path)
     assert "Analyzer-extracted consensus" not in final
 
 
+def test_discuss_loop_rejects_repaired_hallucinated_analyzer_agenda(tmp_path):
+    from unittest.mock import patch
+
+    repaired = _discuss_agenda_text(
+        disagreements=[
+            {
+                "topic": "Antigravity implementation strategy",
+                "positions": {
+                    "Developer": "Use existing levitation libraries.",
+                    "Reviewer": "Implement custom field manipulation for performance.",
+                },
+                "question_for_next_round": (
+                    "Does custom field manipulation provide significant enough performance "
+                    "gains to justify the maintenance overhead?"
+                ),
+            }
+        ],
+        missing_facts=["Performance benchmarks for existing levitation libraries."],
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Codex round-one rationale."),
+            _discuss_review_text(
+                outcome="implement", rationale="Still scoped.", rebuttal="Scope holds."
+            ),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(
+                outcome="split",
+                rationale="Gemini round-one rationale.",
+                split_proposals=["Extract setup work"],
+            ),
+            _discuss_review_text(
+                outcome="split",
+                rationale="Still split.",
+                split_proposals=["Extract setup work"],
+                rebuttal="Split still fits.",
+            ),
+        ],
+        claude_outputs=[
+            "I've drafted the round-1 agenda but the write to the required response file needs your permission."
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired):
+        result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    rendered = "\n".join(runner.comments)
+    assert "Antigravity implementation strategy" not in rendered
+    assert "levitation libraries" not in rendered
+    assert "custom field manipulation" not in rendered
+    round1_summary = runner.comments[2]
+    assert "### Agenda for round 2" in round1_summary
+    assert "(analyzer:" not in round1_summary
+    assert "- Codex held `implement`: Codex round-one rationale." in round1_summary
+    assert "- Gemini held `split`: Gemini round-one rationale." in round1_summary
+    assert "### Analyzer-extracted consensus" not in round1_summary
+    match = ROUND_RESUME_MARKER_RE.search(runner.issue_comments[2]["body"])
+    assert match is not None
+    metadata = _decode_round_metadata(match.group("payload"))
+    assert metadata is not None
+    assert metadata.analyzer_response is None
+    debate_commands = [cmd for cmd, _cwd in runner.commands if "debate round 2" in " ".join(cmd)]
+    assert len(debate_commands) == 2
+    for command in debate_commands:
+        prompt = " ".join(command)
+        assert "Prior round reviewer positions:" in prompt
+        assert "Codex round-one rationale." in prompt
+        assert "Gemini round-one rationale." in prompt
+        assert "Antigravity implementation strategy" not in prompt
+        assert "levitation libraries" not in prompt
+    final = runner.comments[-1]
+    assert "Analyzer-extracted consensus" not in final
+
+
 def test_discuss_loop_three_rounds_second_analyzer_prompt_includes_full_history(tmp_path):
     agenda_round1 = _discuss_agenda_text(consensus=["Round-one agenda marker."])
     agenda_round2 = _discuss_agenda_text(consensus=["Round-two agenda marker."])
@@ -1084,6 +1345,7 @@ def test_discuss_loop_three_rounds_second_analyzer_prompt_includes_full_history(
             ),
         ],
         claude_outputs=[agenda_round1, agenda_round2],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
 
@@ -1249,6 +1511,7 @@ def test_discuss_loop_agenda_claiming_consensus_is_forwarded_but_votes_rule(tmp_
             ),
         ],
         claude_outputs=[agenda_text],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
 
@@ -1419,6 +1682,7 @@ def test_discuss_loop_auto_mode_analyzer_brief_propagates_to_next_round(tmp_path
             ),
         ],
         claude_outputs=[agenda_text],
+        issue_payload=_grounded_agenda_issue_payload(),
     )
     config = make_config(
         tmp_path,

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -3209,3 +3209,5 @@ def test_build_repair_prompt_accepts_discuss_agenda_expected_kind():
     assert "You MUST repair this response as `discuss_agenda`." in prompt
     assert "Valid Format F — Discuss Agenda" in prompt
     assert "question_for_next_round" in prompt
+    assert "Never invent topics, debater positions, facts, or questions" in prompt
+    assert "If no agenda content is recoverable" in prompt


### PR DESCRIPTION
## Summary
- add a deterministic fidelity gate for discuss analyzer agendas before accepting repaired analyzer output
- reject unknown debater names and analyzer agenda text without issue/transcript support, falling back to the mechanical agenda
- tighten discuss agenda repair instructions and add regression/helper coverage

Fixes #514

## Tests
- python3 -m pytest tests/test_discuss_loop.py -k "analyzer"
- python3 -m pytest tests/test_repair.py -k "discuss_agenda"
- python3 -m pytest tests/test_discuss_loop.py
- python3 -m pytest