### PR TITLE
Add open-ended discuss answer mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # coding-review-agent-loop
 
+Discuss mode defaults to the backward-compatible implementation-triage result
+contract. For open-ended design or system questions, pass
+`--discuss-result-mode answer`; it produces a consensus recommendation,
+explicit `needs-human` escalation, or a deadlock summary without forcing an
+implementation vote. Answer-mode transcripts are mode-bound for repair and
+resume, while analyzer observations and sourced research remain clearly
+separate from debater-confirmed conclusions.
+
 Local command-line orchestration for a coding PR review loop.
 
 Run a local Claude/Codex/Gemini PR review loop using your existing CLI subscriptions.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -349,9 +349,11 @@ agent-loop discuss 123 --repo OWNER/REPO \
 Debaters return `kind: "discuss_answer"` with `position: "answer"` or
 `"needs-human"`, plus `answer`, `rationale`, `confidence`, and
 `open_questions`. A unanimous normalized answer is rendered as **Consensus
-Answer** in round one; later convergence is **Converged Answer**. An explicit
-`needs-human` position is **Needs Human Decision**. Otherwise disagreement or
-partial failure is **Deadlock**—disagreement alone never becomes escalation.
+Answer** in round one; later convergence is **Converged Answer**. When every
+successful debater has an explicit `needs-human` position, the
+result is **Needs Human Decision**. Otherwise disagreement or partial failure
+is **Deadlock**—a lone `needs-human` position and disagreement alone never
+become escalation.
 Analyzer observations remain non-authoritative and cited research remains a
 separate sourced-facts section. Repair and resume preserve the selected mode;
 transcripts cannot mix answer and triage responses.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -333,6 +333,27 @@ Evaluate a GitHub issue without writing any code:
 
 ```bash
 agent-loop discuss 123 --repo OWNER/REPO
+
+### Open-ended answer results
+
+The legacy implementation-triage contract remains the default. For system and
+design questions, use `--discuss-result-mode answer`:
+
+```bash
+agent-loop discuss 123 --repo OWNER/REPO \
+  --reviewer codex --reviewer claude \
+  --discuss-result-mode answer
+```
+
+Debaters return `kind: "discuss_answer"` with `position: "answer"` or
+`"needs-human"`, plus `answer`, `rationale`, `confidence`, and
+`open_questions`. A unanimous normalized answer is rendered as **Consensus
+Answer** in round one; later convergence is **Converged Answer**. An explicit
+`needs-human` position is **Needs Human Decision**. Otherwise disagreement or
+partial failure is **Deadlock**—disagreement alone never becomes escalation.
+Analyzer observations remain non-authoritative and cited research remains a
+separate sourced-facts section. Repair and resume preserve the selected mode;
+transcripts cannot mix answer and triage responses.
 ```
 
 Discuss mode sends the issue title, body, and comments to all configured

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -333,6 +333,7 @@ Evaluate a GitHub issue without writing any code:
 
 ```bash
 agent-loop discuss 123 --repo OWNER/REPO
+```
 
 ### Open-ended answer results
 
@@ -354,7 +355,6 @@ partial failure is **Deadlock**—disagreement alone never becomes escalation.
 Analyzer observations remain non-authoritative and cited research remains a
 separate sourced-facts section. Repair and resume preserve the selected mode;
 transcripts cannot mix answer and triage responses.
-```
 
 Discuss mode sends the issue title, body, and comments to all configured
 reviewers and asks each to return a `discuss_review` response with a single

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -542,6 +542,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     discuss.add_argument(
+        "--discuss-result-mode",
+        choices=("triage", "answer"),
+        default="triage",
+        help=(
+            "Discuss result contract (default: triage). `answer` produces an "
+            "open-ended consensus answer or explicit human escalation; omitting "
+            "this flag preserves the legacy implementation-triage votes."
+        ),
+    )
+    discuss.add_argument(
         "--discuss-parallel",
         action="store_true",
         help=(

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -777,8 +777,17 @@ def _render_public_discuss_answer_comment(
     return "\n\n".join(sections)
 
 
-def _render_discuss_agenda_lines(votes: Sequence[ParsedDiscussReview]) -> list[str]:
-    return [f"- {vote.reviewer} held `{vote.outcome}`: {vote.rationale}" for vote in votes]
+def _render_discuss_agenda_lines(votes: Sequence[ParsedDiscussResponse]) -> list[str]:
+    lines: list[str] = []
+    for vote in votes:
+        if isinstance(vote, ParsedDiscussAnswer):
+            position = vote.position
+            detail = vote.answer or vote.rationale
+        else:
+            position = vote.outcome
+            detail = vote.rationale
+        lines.append(f"- {vote.reviewer} held `{position}`: {detail}")
+    return lines
 
 
 def _render_analyzer_agenda_lines(agenda: ParsedDiscussAgenda) -> list[str]:
@@ -907,10 +916,10 @@ def render_discuss_round_summary_comment(
     is_final: bool,
     subject: str,
     round_number: int = 1,
-    reviewer_votes: Sequence[ParsedDiscussReview],
+    reviewer_votes: Sequence[ParsedDiscussResponse],
     outcome: str | None = None,
     consensus_kind: str = "unanimous",
-    round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
+    round_history: Sequence[Sequence[ParsedDiscussResponse]] | None = None,
     split_proposals: Sequence[str] | None = None,
     analyzer_agenda: ParsedDiscussAgenda | None = None,
     analyzer_name: str | None = None,

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -19,6 +19,8 @@ from .protocol import (
     SIGNATURE_RE,
     DeferredStage,
     ParsedDiscussAgenda,
+    ParsedDiscussAnswer,
+    ParsedDiscussResponse,
     ParsedDiscussReview,
     ParsedPlanReview,
     ParsedReview,
@@ -690,6 +692,12 @@ def render_public_agent_comment(
             config=config,
             model_used=model_used,
         )
+    if kind == "discuss_answer":
+        if not isinstance(parsed, ParsedDiscussAnswer):
+            raise AgentLoopError("render_public_agent_comment expected ParsedDiscussAnswer.")
+        return _render_public_discuss_answer_comment(
+            parsed, reviewer=agent, round_number=round_number, config=config, model_used=model_used
+        )
     raise AgentLoopError(f"Unknown render kind: {kind}")
 
 
@@ -745,6 +753,27 @@ def _render_public_discuss_review_comment(
         sections.append("### Sourced facts\n\n" + facts)
     sections.append(f"-- {_comment_signature(reviewer, config, model_used)}")
     return "\n\n".join(section for section in sections if section)
+
+
+def _render_public_discuss_answer_comment(
+    parsed: ParsedDiscussAnswer, *, reviewer: str, round_number: int = 1,
+    config: AgentLoopConfig | None = None, model_used: str | None = None,
+) -> str:
+    sections = [f"## Round {round_number}: {reviewer} answer", f"**Position:** `{parsed.position}`"]
+    if parsed.answer:
+        sections.append("### Answer\n\n" + parsed.answer.strip())
+    sections.append("### Rationale\n\n" + parsed.rationale.strip())
+    sections.append(f"**Confidence:** `{parsed.confidence}`")
+    if parsed.open_questions:
+        sections.append("### Open questions\n\n" + "\n".join(f"- {q}" for q in parsed.open_questions))
+    if parsed.rebuttal:
+        sections.append("### Rebuttal\n\n" + parsed.rebuttal.strip())
+    if parsed.research_status is not None:
+        sections.append(f"**Research:** `{parsed.research_status}`")
+    if parsed.sourced_facts:
+        sections.append("### Sourced facts\n\n" + "\n".join(f"- {f.fact} — source: {f.source}" for f in parsed.sourced_facts))
+    sections.append(f"-- {_comment_signature(reviewer, config, model_used)}")
+    return "\n\n".join(sections)
 
 
 def _render_discuss_agenda_lines(votes: Sequence[ParsedDiscussReview]) -> list[str]:
@@ -883,6 +912,7 @@ def render_discuss_round_summary_comment(
     analyzer_name: str | None = None,
     research_mode: str | None = None,
     failed_debaters: Sequence[tuple[str, str]] = (),
+    result_mode: str = "triage",
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -896,6 +926,14 @@ def render_discuss_round_summary_comment(
     consensus section kept distinct from the debater vote table.
     """
     split_proposals = list(split_proposals or ())
+    if result_mode == "answer":
+        return _render_discuss_answer_summary(
+            is_final=is_final, subject=subject, round_number=round_number,
+            reviewer_votes=reviewer_votes, consensus_kind=consensus_kind,
+            round_history=round_history, analyzer_agenda=analyzer_agenda,
+            analyzer_name=analyzer_name, research_mode=research_mode,
+            failed_debaters=failed_debaters, outcome=outcome,
+        )
     if not is_final:
         lines: list[str] = [
             f"## Round {round_number} summary: Consensus Pending",
@@ -1005,4 +1043,41 @@ def render_discuss_round_summary_comment(
     lines.append("")
     lines.append("-- Orchestrator")
     lines.append(f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->")
+    return "\n".join(lines)
+
+
+def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number: int,
+    reviewer_votes: Sequence[ParsedDiscussAnswer], consensus_kind: str,
+    round_history: Sequence[Sequence[ParsedDiscussAnswer]] | None,
+    analyzer_agenda: ParsedDiscussAgenda | None, analyzer_name: str | None,
+    research_mode: str | None, failed_debaters: Sequence[tuple[str, str]], outcome: str | None) -> str:
+    if not is_final:
+        heading = f"## Round {round_number} summary: Answer Pending"
+    elif outcome == "needs-human":
+        heading = "## Needs Human Decision"
+    elif outcome == "deadlock":
+        heading = "## Deadlock"
+    else:
+        heading = "## " + ("Consensus Answer" if consensus_kind == "unanimous" else "Converged Answer")
+    lines = [heading, "", f"Consensus kind: `{consensus_kind}` after round {round_number}.", ""]
+    if is_final and outcome not in {"needs-human", "deadlock"}:
+        answers = [v.answer for v in reviewer_votes if v.answer]
+        if answers:
+            lines.extend(["### Answer", "", answers[0], ""])
+    lines.extend(["| Reviewer | Position | Confidence | Answer |", "| --- | --- | --- | --- |"])
+    for vote in reviewer_votes:
+        answer = (vote.answer or "(no asserted answer)").replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| {vote.reviewer} | {vote.position} | {vote.confidence} | {answer} |")
+    if failed_debaters:
+        lines.extend(_render_discuss_failed_debater_lines(failed_debaters, is_final=is_final))
+    questions = [q for v in reviewer_votes for q in v.open_questions]
+    if questions:
+        lines.extend(["", "### Open questions", "", *[f"- {q}" for q in dict.fromkeys(questions)]])
+    if outcome == "deadlock":
+        lines.extend(["", "### Unresolved disagreement", "", "The debaters did not converge on one normalized answer."])
+    if analyzer_agenda is not None:
+        lines.extend(["", "### Analyzer observations (not debater-confirmed)", "", "The analyzer is non-authoritative.", "", *_render_analyzer_agenda_lines(analyzer_agenda)])
+    if research_mode is not None:
+        lines.extend(["", *_render_discuss_research_section(research_mode=research_mode, reviewer_votes=reviewer_votes, round_history=round_history)])
+    lines.extend(["", "-- Orchestrator", f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->"] if is_final else ["", "-- Orchestrator"])
     return "\n".join(lines)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -20,6 +20,7 @@ from .protocol import (
     DeferredStage,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
+    ParsedFailedDiscussResponse,
     ParsedDiscussResponse,
     ParsedDiscussReview,
     ParsedPlanReview,
@@ -812,8 +813,8 @@ def _render_analyzer_agenda_lines(agenda: ParsedDiscussAgenda) -> list[str]:
 def _render_discuss_research_section(
     *,
     research_mode: str,
-    reviewer_votes: Sequence[ParsedDiscussReview],
-    round_history: Sequence[Sequence[ParsedDiscussReview]] | None,
+    reviewer_votes: Sequence[ParsedDiscussResponse],
+    round_history: Sequence[Sequence[ParsedDiscussResponse]] | None,
 ) -> list[str]:
     """Render the final-summary research section (#477).
 
@@ -827,7 +828,8 @@ def _render_discuss_research_section(
         lines.append("Online research was disabled; all positions are agent judgment.")
         return lines
     lines.append("")
-    for vote in reviewer_votes:
+    successful_votes = [v for v in reviewer_votes if not isinstance(v, ParsedFailedDiscussResponse)]
+    for vote in successful_votes:
         if vote.research_status is None:
             lines.append(f"- {vote.reviewer}: no research status reported")
         else:
@@ -840,6 +842,8 @@ def _render_discuss_research_section(
     seen: set[tuple[str, str, str]] = set()
     for votes in fact_rounds:
         for vote in votes:
+            if isinstance(vote, ParsedFailedDiscussResponse):
+                continue
             for fact in vote.sourced_facts:
                 key = (vote.reviewer, fact.fact, fact.source)
                 if key not in seen:
@@ -851,7 +855,7 @@ def _render_discuss_research_section(
             "Sourced facts cited by debaters (everything else above is agent judgment):"
         )
         lines.extend(sourced)
-    statuses = [vote.research_status for vote in reviewer_votes]
+    statuses = [vote.research_status for vote in successful_votes]
     if statuses and all(status == "not-needed" for status in statuses):
         lines.append("")
         lines.append(
@@ -859,7 +863,7 @@ def _render_discuss_research_section(
         )
     gap_reviewers = [
         vote.reviewer
-        for vote in reviewer_votes
+        for vote in successful_votes
         if vote.research_status in {"unavailable", "inconclusive"}
     ]
     if gap_reviewers:
@@ -868,7 +872,7 @@ def _render_discuss_research_section(
             f"Research was unavailable or inconclusive for {', '.join(gap_reviewers)}; "
             "treat their related claims as judgment, not sourced fact."
         )
-    unreported = [vote.reviewer for vote in reviewer_votes if vote.research_status is None]
+    unreported = [vote.reviewer for vote in successful_votes if vote.research_status is None]
     if unreported:
         lines.append("")
         lines.append(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -45,6 +45,7 @@ DISCUSS_RESEARCH_MODES: frozenset[str] = frozenset({"none", "required", "auto"})
 
 # Discuss-mode debater failure policy values (#475).
 DISCUSS_DEBATER_FAILURE_MODES: frozenset[str] = frozenset({"fail", "partial"})
+DISCUSS_RESULT_MODES: frozenset[str] = frozenset({"triage", "answer"})
 
 
 @dataclass(frozen=True)
@@ -116,6 +117,9 @@ class AgentLoopConfig:
     # "required" enforces sourced external facts from every debater, "auto"
     # lets debaters/analyzer decide using conservative triggers.
     discuss_research: str = "none"
+    # Result contract for discuss.  Triage is deliberately the default for
+    # backwards compatibility with existing transcripts and callers.
+    discuss_result_mode: str = "triage"
     # Parallel debater execution for discuss mode (#475). Opt-in; sequential
     # stays the default to avoid surprise quota pressure.
     discuss_parallel: bool = False
@@ -184,6 +188,9 @@ class AgentLoopConfig:
         if self.discuss_research not in DISCUSS_RESEARCH_MODES:
             rendered = ", ".join(f"'{mode}'" for mode in sorted(DISCUSS_RESEARCH_MODES))
             raise AgentLoopError(f"--discuss-research must be one of: {rendered}.")
+        if self.discuss_result_mode not in DISCUSS_RESULT_MODES:
+            rendered = ", ".join(f"'{mode}'" for mode in sorted(DISCUSS_RESULT_MODES))
+            raise AgentLoopError(f"--discuss-result-mode must be one of: {rendered}.")
         if self.discuss_on_debater_failure not in DISCUSS_DEBATER_FAILURE_MODES:
             rendered = ", ".join(f"'{mode}'" for mode in sorted(DISCUSS_DEBATER_FAILURE_MODES))
             raise AgentLoopError(f"--discuss-on-debater-failure must be one of: {rendered}.")
@@ -869,6 +876,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         repair_timeout_seconds=getattr(args, "repair_timeout_seconds", 120),
         discuss_analyzer=getattr(args, "discuss_analyzer", None),
         discuss_research=getattr(args, "discuss_research", "none") or "none",
+        discuss_result_mode=getattr(args, "discuss_result_mode", "triage") or "triage",
         discuss_parallel=getattr(args, "discuss_parallel", False),
         discuss_debater_timeout=getattr(args, "discuss_debater_timeout", None),
         discuss_on_debater_failure=getattr(args, "discuss_on_debater_failure", "fail") or "fail",

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -113,6 +113,7 @@ from .protocol import (
     failed_discuss_review_category,
     failed_discuss_review_placeholder,
     failed_discuss_answer_placeholder,
+    is_failed_discuss_response,
     ParsedPlanReview,
     ParsedReview,
     PUBLIC_RESPONSE_MARKER,
@@ -4906,7 +4907,7 @@ def _detect_discuss_answer_consensus(
 ) -> tuple[str, list[str]] | None:
     if partial or not responses:
         return None
-    if any(response.position == "needs-human" for response in responses):
+    if all(response.position == "needs-human" for response in responses):
         return "needs-human", []
     answers = [response.answer for response in responses]
     if all(answer is not None for answer in answers):
@@ -5105,7 +5106,7 @@ class _DiscussAgendaSupportCorpus:
 def _build_discuss_agenda_support_corpus(
     *,
     issue_context: IssueContext,
-    round_history: Sequence[Sequence[ParsedDiscussReview]],
+    round_history: Sequence[Sequence[ParsedDiscussResponse]],
     prior_agenda: ParsedDiscussAgenda | None,
     configured_reviewers: Sequence[AgentName],
     analyzer: AgentName,
@@ -5131,15 +5132,25 @@ def _build_discuss_agenda_support_corpus(
         add(f"Round {round_index}")
         for vote in votes:
             add(vote.reviewer)
-            add(vote.outcome)
-            add(vote.rationale, phrase_support=True)
-            add(vote.rebuttal, phrase_support=True)
-            add(vote.analyzer_framing)
-            add(vote.framing_note, phrase_support=True)
-            for proposal in vote.split_proposals:
-                add(proposal, phrase_support=True)
-            add(vote.research_status)
-            for fact in vote.sourced_facts:
+            if isinstance(vote, ParsedDiscussAnswer):
+                add(vote.position)
+                add(vote.answer, phrase_support=True)
+                add(vote.rationale, phrase_support=True)
+                for question in vote.open_questions:
+                    add(question, phrase_support=True)
+            elif isinstance(vote, ParsedDiscussReview):
+                add(vote.outcome)
+                add(vote.rationale, phrase_support=True)
+                for proposal in vote.split_proposals:
+                    add(proposal, phrase_support=True)
+            else:
+                add("failed")
+                add(vote.category, phrase_support=True)
+            add(getattr(vote, "rebuttal", None), phrase_support=True)
+            add(getattr(vote, "analyzer_framing", None))
+            add(getattr(vote, "framing_note", None), phrase_support=True)
+            add(getattr(vote, "research_status", None))
+            for fact in getattr(vote, "sourced_facts", ()):
                 add(fact.fact, phrase_support=True)
                 add(fact.source, phrase_support=True)
     if prior_agenda is not None:
@@ -5200,7 +5211,7 @@ def _validate_discuss_analyzer_agenda_fidelity(
     agenda: ParsedDiscussAgenda,
     *,
     issue_context: IssueContext,
-    round_history: Sequence[Sequence[ParsedDiscussReview]],
+    round_history: Sequence[Sequence[ParsedDiscussResponse]],
     prior_agenda: ParsedDiscussAgenda | None,
     configured_reviewers: Sequence[AgentName],
     analyzer: AgentName,
@@ -5247,7 +5258,7 @@ def _run_discuss_analyzer(
     memory: AgentMemoryContext | None,
     issue_context: IssueContext,
     round_number: int,
-    round_history: Sequence[Sequence[ParsedDiscussReview]],
+    round_history: Sequence[Sequence[ParsedDiscussResponse]],
     prior_agenda: ParsedDiscussAgenda | None,
     configured_reviewers: Sequence[AgentName],
     usage_context: RunUsageContext,
@@ -5809,8 +5820,7 @@ def _run_discuss_loop(
             )
         successful_votes = [
             vote for vote in reviewer_votes
-            if not (isinstance(vote, ParsedDiscussReview) and vote.outcome == DISCUSS_FAILED_OUTCOME)
-            and not isinstance(vote, type(failed_discuss_answer_placeholder("", "")))
+            if not is_failed_discuss_response(vote)
         ]
         round_history.append(reviewer_votes)
         if config.discuss_result_mode == "answer":

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5896,6 +5896,7 @@ def _run_discuss_loop(
                     research_mode=config.discuss_research,
                     failed_debaters=tuple(failed_debaters),
                     split_proposals=tuple(round_split_proposals) if is_final else (),
+                    result_mode=config.discuss_result_mode,
                 ),
             ),
         )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -107,9 +107,12 @@ from .protocol import (
     DeferredStage,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
+    ParsedDiscussAnswer,
+    ParsedDiscussResponse,
     ParsedDiscussReview,
     failed_discuss_review_category,
     failed_discuss_review_placeholder,
+    failed_discuss_answer_placeholder,
     ParsedPlanReview,
     ParsedReview,
     PUBLIC_RESPONSE_MARKER,
@@ -135,6 +138,7 @@ from .protocol import (
     validate_structured_plan_revision,
     validate_structured_discuss_agenda,
     validate_structured_discuss_review,
+    validate_structured_discuss_answer,
 )
 from .protocol import parse_review
 from .repair import (
@@ -277,7 +281,7 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
     re.I,
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
-    {"plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review"}
+    {"plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer"}
 )
 PLAN_REVISION_FOOTER_RE = re.compile(r"(?m)^<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$")
 STRUCTURED_FENCE_RE = re.compile(
@@ -4893,6 +4897,25 @@ def _detect_discuss_consensus(
     return outcome, split_proposals
 
 
+def _normalize_discuss_answer(answer: str) -> str:
+    return " ".join(answer.strip().split()).casefold()
+
+
+def _detect_discuss_answer_consensus(
+    responses: Sequence[ParsedDiscussAnswer], *, partial: bool = False
+) -> tuple[str, list[str]] | None:
+    if partial or not responses:
+        return None
+    if any(response.position == "needs-human" for response in responses):
+        return "needs-human", []
+    answers = [response.answer for response in responses]
+    if all(answer is not None for answer in answers):
+        normalized = {_normalize_discuss_answer(answer or "") for answer in answers}
+        if len(normalized) == 1:
+            return "answer", []
+    return None
+
+
 def _handle_discuss_split_outcome(
     runner: Runner,
     *,
@@ -5362,12 +5385,14 @@ def _run_discuss_debater_turn(
         config=config,
         prompt=prompt,
         marker_description="<!-- AGENT_PLAN_STATE: approved -->",
-        validate=lambda text, r=reviewer_name, rn=round_number: validate_structured_discuss_review(
-            text, reviewer=r, round_number=rn, research_mode=config.discuss_research
+        validate=lambda text, r=reviewer_name, rn=round_number: (
+            validate_structured_discuss_answer(text, reviewer=r, round_number=rn, research_mode=config.discuss_research)
+            if config.discuss_result_mode == "answer"
+            else validate_structured_discuss_review(text, reviewer=r, round_number=rn, research_mode=config.discuss_research)
         ),
         usage_context=usage_context,
         use_repair=True,
-        repair_expected_kind="discuss_review",
+        repair_expected_kind="discuss_answer" if config.discuss_result_mode == "answer" else "discuss_review",
         role="reviewer",
         label=f"discuss-r{round_number}",
         timeout_seconds=config.discuss_debater_timeout,
@@ -5381,7 +5406,7 @@ def _post_discuss_debater_comment(
     config: AgentLoopConfig,
     issue_number: int,
     reviewer_name: str,
-    parsed: ParsedDiscussReview,
+    parsed: ParsedDiscussResponse,
     response: ValidatedAgentResponse,
     round_number: int,
     subject: str,
@@ -5392,7 +5417,7 @@ def _post_discuss_debater_comment(
         issue_number=issue_number,
         body=_attach_round_metadata(
             render_public_agent_comment(
-                kind="discuss_review",
+                kind="discuss_answer" if config.discuss_result_mode == "answer" else "discuss_review",
                 parsed=parsed,
                 agent=reviewer_name,
                 config=config,
@@ -5408,6 +5433,7 @@ def _post_discuss_debater_comment(
                 raw_structured_coder_response=response.text,
                 model_used=response.model_used,
                 research_mode=config.discuss_research,
+                result_mode=config.discuss_result_mode,
             ),
         ),
     )
@@ -5428,10 +5454,13 @@ def _run_discuss_loop(
     subject = _discuss_subject(issue_context)
     configured_reviewers = list(_reviewers(config))
     resume_state = _resume_discuss_round(
-        issue_context.comments, subject=subject, configured_reviewers=configured_reviewers
+        issue_context.comments, subject=subject, configured_reviewers=configured_reviewers,
+        result_mode=config.discuss_result_mode,
     )
 
     def _resolve_final_split_proposals() -> tuple[list[str], Sequence[ParsedDiscussReview]] | None:
+        if config.discuss_result_mode == "answer":
+            return None
         # Resuming (or already-final) reruns must materialize a split consensus
         # instead of silently skipping (#476): prefer the split proposals
         # recorded directly on the final summary metadata, and fall back to
@@ -5556,6 +5585,7 @@ def _run_discuss_loop(
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
             failed_debaters=final_failed_debaters,
+            result_mode=config.discuss_result_mode,
         )
         post_issue_comment(
             runner,
@@ -5675,7 +5705,7 @@ def _run_discuss_loop(
                 turn = turn_results[name]
                 if turn.error is None:
                     parsed = turn.response.marker_value
-                    assert isinstance(parsed, ParsedDiscussReview)
+                    assert isinstance(parsed, (ParsedDiscussReview, ParsedDiscussAnswer))
                     _post_discuss_debater_comment(
                         runner,
                         config=config,
@@ -5731,7 +5761,7 @@ def _run_discuss_loop(
                     )
                     continue
                 parsed = response.marker_value
-                assert isinstance(parsed, ParsedDiscussReview)
+                assert isinstance(parsed, (ParsedDiscussReview, ParsedDiscussAnswer))
                 _post_discuss_debater_comment(
                     runner,
                     config=config,
@@ -5745,7 +5775,7 @@ def _run_discuss_loop(
                 votes_by_name[reviewer_name] = parsed
 
         failed_debaters: list[tuple[str, str]] = []
-        reviewer_votes: list[ParsedDiscussReview] = []
+        reviewer_votes: list[ParsedDiscussResponse] = []
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             vote = votes_by_name.get(reviewer_name)
@@ -5755,7 +5785,11 @@ def _run_discuss_loop(
             failure = failures_by_name[reviewer_name]
             category = failure.failure_category
             failed_debaters.append((reviewer_name, category))
-            reviewer_votes.append(failed_discuss_review_placeholder(reviewer_name, category))
+            reviewer_votes.append(
+                failed_discuss_answer_placeholder(reviewer_name, category)
+                if config.discuss_result_mode == "answer"
+                else failed_discuss_review_placeholder(reviewer_name, category)
+            )
         if failed_debaters:
             # Reached only under the "partial" policy: continue when at least
             # two debaters produced votes; a partial round can never declare
@@ -5774,14 +5808,24 @@ def _run_discuss_loop(
                 + ", ".join(f"{name} ({category})" for name, category in failed_debaters),
             )
         successful_votes = [
-            vote for vote in reviewer_votes if vote.outcome != DISCUSS_FAILED_OUTCOME
+            vote for vote in reviewer_votes
+            if not (isinstance(vote, ParsedDiscussReview) and vote.outcome == DISCUSS_FAILED_OUTCOME)
+            and not isinstance(vote, type(failed_discuss_answer_placeholder("", "")))
         ]
         round_history.append(reviewer_votes)
-        consensus = _detect_discuss_consensus(reviewer_votes)
+        if config.discuss_result_mode == "answer":
+            consensus = _detect_discuss_answer_consensus(
+                [vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)],
+                partial=bool(failed_debaters),
+            )
+        else:
+            consensus = _detect_discuss_consensus(reviewer_votes)  # type: ignore[arg-type]
         is_final = consensus is not None or round_number == max_round_number
         if consensus is None:
-            outcome = "needs-human"
-            round_split_proposals: list[str] = _merge_discuss_split_proposals(successful_votes)
+            outcome = "deadlock" if config.discuss_result_mode == "answer" else "needs-human"
+            round_split_proposals: list[str] = (
+                [] if config.discuss_result_mode == "answer" else _merge_discuss_split_proposals(successful_votes)  # type: ignore[arg-type]
+            )
             consensus_kind = "deadlock" if is_final else None
         else:
             outcome, round_split_proposals = consensus
@@ -5820,6 +5864,7 @@ def _run_discuss_loop(
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
             failed_debaters=tuple(failed_debaters),
+            result_mode=config.discuss_result_mode,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(successful_votes))
         post_issue_comment(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2458,7 +2458,7 @@ def build_discuss_review_prompt(
 
 Use this local checkout only to inspect context. Do not edit files, create a branch, commit, push, or open a pull request.
 {_issue_context_block(issue_context)}{_memory_block(memory)}
-Prior round positions (the analyzer is non-authoritative):
+Prior round positions (the analyzer is non-authoritative; do not treat it as a vote):
 {history}
 
 Produce the best consensus answer or tradeoff recommendation, not an implementation vote.
@@ -2475,7 +2475,7 @@ Respond with exactly this JSON object followed by the approved plan footer:
   "rebuttal": "..."
 }}
 Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.
-Do not include triage fields such as outcome or split_proposals. The analyzer is context only, and sourced research facts must remain distinct from judgment.
+Do not include triage fields such as outcome or split_proposals. The analyzer is not authoritative and is context only; sourced research facts must remain distinct from judgment.
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
 """

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2301,7 +2301,7 @@ def build_discuss_agenda_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     round_number: int = 1,
-    round_history: Sequence[Sequence[ParsedDiscussReview]] | None = None,
+    round_history: Sequence[Sequence[ParsedDiscussResponse]] | None = None,
     prior_agenda: ParsedDiscussAgenda | None = None,
     research_mode: str = "none",
 ) -> str:
@@ -2314,13 +2314,21 @@ def build_discuss_agenda_prompt(
             label = f"{label} (latest round)"
         history_lines.append(f"{label}:")
         for vote in votes:
-            history_lines.append(f"- {vote.reviewer}: `{vote.outcome}`")
-            history_lines.append(f"  Rationale: {vote.rationale}")
-            if vote.rebuttal:
+            if hasattr(vote, "position"):
+                history_lines.append(f"- {vote.reviewer}: `{vote.position}`")
+                if getattr(vote, "answer", None):
+                    history_lines.append(f"  Answer: {vote.answer}")
+            elif hasattr(vote, "outcome"):
+                history_lines.append(f"- {vote.reviewer}: `{vote.outcome}`")
+            else:
+                history_lines.append(f"- {vote.reviewer}: `failed`")
+            rationale = getattr(vote, "rationale", f"did not respond this round ({getattr(vote, 'category', 'failure')})")
+            history_lines.append(f"  Rationale: {rationale}")
+            if getattr(vote, "rebuttal", None):
                 history_lines.append(f"  Rebuttal: {vote.rebuttal}")
-            if vote.analyzer_framing == "misframed" and vote.framing_note:
+            if getattr(vote, "analyzer_framing", None) == "misframed" and getattr(vote, "framing_note", None):
                 history_lines.append(f"  Framing correction: {vote.framing_note}")
-            if vote.split_proposals:
+            if getattr(vote, "split_proposals", ()):
                 history_lines.append("  Split proposals:")
                 for proposal in vote.split_proposals:
                     history_lines.append(f"  - {proposal}")

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -20,6 +20,8 @@ from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
     ParsedDiscussAgenda,
+    ParsedDiscussAnswer,
+    ParsedDiscussResponse,
     ParsedDiscussReview,
     UnresolvedReviewItem,
 )
@@ -2428,7 +2430,7 @@ def build_discuss_review_prompt(
     memory: AgentMemoryContext | None = None,
     issue_context: IssueContext | None = None,
     round_number: int = 1,
-    prior_round_votes: Sequence[ParsedDiscussReview] | None = None,
+    prior_round_votes: Sequence[ParsedDiscussResponse] | None = None,
     prior_round_agenda: Sequence[str] | None = None,
     analyzer_agenda: ParsedDiscussAgenda | None = None,
     research_mode: str = "none",
@@ -2436,6 +2438,39 @@ def build_discuss_review_prompt(
     reviewer_signature = agent_signature(reviewer, config)
     prior_round_votes = tuple(prior_round_votes or ())
     prior_round_agenda = tuple(prior_round_agenda or ())
+    if config.discuss_result_mode == "answer":
+        history = "\n".join(
+            f"- {getattr(v, 'reviewer', 'unknown')}: position={getattr(v, 'position', 'failed')}; "
+            f"answer={getattr(v, 'answer', None) or '(none)'}; rationale={getattr(v, 'rationale', getattr(v, 'category', ''))}"
+            for v in prior_round_votes
+        ) or "(no prior round)"
+        rebuttal = "omit `rebuttal` in round 1" if round_number == 1 else "include a non-empty `rebuttal` directly addressing the prior round"
+        research = _discuss_research_policy_block(research_mode)
+        return f"""Evaluate GitHub issue #{issue_number} in {config.repo} as an open-ended system/design question.
+
+Use this local checkout only to inspect context. Do not edit files, create a branch, commit, push, or open a pull request.
+{_issue_context_block(issue_context)}{_memory_block(memory)}
+Prior round positions (the analyzer is non-authoritative):
+{history}
+
+Produce the best consensus answer or tradeoff recommendation, not an implementation vote.
+{research}
+Respond with exactly this JSON object followed by the approved plan footer:
+{{
+  "schema_version": 1,
+  "kind": "discuss_answer",
+  "position": "answer",
+  "answer": "A concise answer or recommendation.",
+  "rationale": "Why this answer follows from the evidence.",
+  "confidence": "medium",
+  "open_questions": [],
+  "rebuttal": "..."
+}}
+Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.
+Do not include triage fields such as outcome or split_proposals. The analyzer is context only, and sourced research facts must remain distinct from judgment.
+<!-- AGENT_PLAN_STATE: approved -->
+-- {reviewer_signature}
+"""
     analyzer_rules = ""
     if round_number <= 1:
         round_context = (

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2452,6 +2452,13 @@ def build_discuss_review_prompt(
             f"answer={getattr(v, 'answer', None) or '(none)'}; rationale={getattr(v, 'rationale', getattr(v, 'category', ''))}"
             for v in prior_round_votes
         ) or "(no prior round)"
+        analyzer_context = ""
+        if analyzer_agenda is not None:
+            analyzer_context = (
+                "\n\nAnalyzer agenda for the prior round (non-authoritative; verify it "
+                "against the issue and your own reasoning):\n"
+                + "\n".join(_render_discuss_agenda_prompt_block(analyzer_agenda))
+            )
         rebuttal = "omit `rebuttal` in round 1" if round_number == 1 else "include a non-empty `rebuttal` directly addressing the prior round"
         research = _discuss_research_policy_block(research_mode)
         return f"""Evaluate GitHub issue #{issue_number} in {config.repo} as an open-ended system/design question.
@@ -2459,7 +2466,7 @@ def build_discuss_review_prompt(
 Use this local checkout only to inspect context. Do not edit files, create a branch, commit, push, or open a pull request.
 {_issue_context_block(issue_context)}{_memory_block(memory)}
 Prior round positions (the analyzer is non-authoritative; do not treat it as a vote):
-{history}
+{history}{analyzer_context}
 
 Produce the best consensus answer or tradeoff recommendation, not an implementation vote.
 {research}

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -244,6 +244,42 @@ class StructuredDiscussReview:
 
 
 @dataclass(frozen=True)
+class StructuredDiscussAnswer:
+    schema_version: int
+    kind: str
+    position: str
+    rationale: str
+    confidence: str
+    open_questions: tuple[str, ...]
+    answer: str | None = None
+    rebuttal: str | None = None
+    analyzer_framing: str | None = None
+    framing_note: str | None = None
+
+
+@dataclass(frozen=True)
+class ParsedDiscussAnswer:
+    position: str
+    rationale: str
+    confidence: str
+    open_questions: tuple[str, ...]
+    reviewer: str
+    answer: str | None = None
+    rebuttal: str | None = None
+    analyzer_framing: str | None = None
+    framing_note: str | None = None
+    research_status: str | None = None
+    sourced_facts: tuple[DiscussSourcedFact, ...] = ()
+
+
+@dataclass(frozen=True)
+class ParsedFailedDiscussResponse:
+    reviewer: str
+    category: str
+    result_mode: str = "triage"
+
+
+@dataclass(frozen=True)
 class DiscussSourcedFact:
     fact: str
     source: str
@@ -262,6 +298,23 @@ class ParsedDiscussReview:
     # `research` object (legacy transcripts and `none`-mode responses).
     research_status: str | None = None
     sourced_facts: tuple[DiscussSourcedFact, ...] = ()
+
+
+ParsedDiscussResponse = ParsedDiscussReview | ParsedDiscussAnswer | ParsedFailedDiscussResponse
+
+
+def is_failed_discuss_response(response: ParsedDiscussResponse) -> bool:
+    return isinstance(response, ParsedFailedDiscussResponse) or (
+        isinstance(response, ParsedDiscussReview) and response.outcome == DISCUSS_FAILED_OUTCOME
+    )
+
+
+def discuss_response_position(response: ParsedDiscussResponse) -> str | None:
+    if isinstance(response, ParsedDiscussAnswer):
+        return response.position
+    if isinstance(response, ParsedDiscussReview):
+        return response.outcome
+    return None
 
 
 DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-human", "split"})
@@ -288,6 +341,10 @@ def failed_discuss_review_category(vote: ParsedDiscussReview) -> str:
     """Recover the failure category from a placeholder vote's rationale."""
     match = re.fullmatch(r"did not respond this round \((.+)\)", vote.rationale)
     return match.group(1) if match else vote.rationale
+
+
+def failed_discuss_answer_placeholder(reviewer: str, category: str) -> ParsedFailedDiscussResponse:
+    return ParsedFailedDiscussResponse(reviewer=reviewer, category=category, result_mode="answer")
 
 
 @dataclass(frozen=True)
@@ -2045,6 +2102,81 @@ def validate_structured_discuss_review(
     if parsed is not None:
         return parsed
     raise AgentLoopError("Discuss review did not use the required structured format.")
+
+
+DISCUSS_ANSWER_POSITION_VALUES = frozenset({"answer", "needs-human"})
+DISCUSS_ANSWER_CONFIDENCE_VALUES = frozenset({"low", "medium", "high"})
+
+
+def parse_structured_discuss_answer(
+    text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
+) -> ParsedDiscussAnswer | None:
+    payload = _extract_structured_discuss_review_payload(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    if payload.get("kind") != "discuss_answer":
+        raise AgentLoopError("Structured response kind mismatch: expected `discuss_answer`.")
+    _expect_exact_keys(
+        payload,
+        context="discuss_answer",
+        required={"schema_version", "kind", "position", "rationale", "confidence", "open_questions"},
+        optional={"answer", "rebuttal", "analyzer_framing", "framing_note", "research"},
+    )
+    position = _expect_non_empty_string(payload["position"], context="discuss_answer.position")
+    if position not in DISCUSS_ANSWER_POSITION_VALUES:
+        raise AgentLoopError("discuss_answer.position must be `answer` or `needs-human`.")
+    rationale = _expect_non_empty_string(payload["rationale"], context="discuss_answer.rationale")
+    confidence = _expect_non_empty_string(payload["confidence"], context="discuss_answer.confidence")
+    if confidence not in DISCUSS_ANSWER_CONFIDENCE_VALUES:
+        raise AgentLoopError("discuss_answer.confidence must be one of: low, medium, high.")
+    open_questions = _expect_string_list(
+        payload.get("open_questions", []),
+        context="discuss_answer.open_questions",
+        item_context="discuss_answer.open_questions",
+    )
+    answer = None
+    if "answer" in payload:
+        answer = _expect_non_empty_string(payload["answer"], context="discuss_answer.answer")
+    if position == "answer" and answer is None:
+        raise AgentLoopError("discuss_answer.answer is required when position is `answer`.")
+    if position == "needs-human" and not open_questions:
+        raise AgentLoopError("discuss_answer.open_questions must be non-empty for `needs-human`.")
+    rebuttal = None
+    if "rebuttal" in payload:
+        rebuttal = _expect_non_empty_string(payload["rebuttal"], context="discuss_answer.rebuttal")
+    if round_number > 1 and rebuttal is None:
+        raise AgentLoopError("discuss_answer.rebuttal is required for debate rounds.")
+    analyzer_framing = payload.get("analyzer_framing")
+    if analyzer_framing is not None:
+        analyzer_framing = _expect_non_empty_string(analyzer_framing, context="discuss_answer.analyzer_framing")
+        if analyzer_framing not in DISCUSS_ANALYZER_FRAMING_VALUES:
+            raise AgentLoopError("discuss_answer.analyzer_framing must be `accurate` or `misframed`.")
+    framing_note = payload.get("framing_note")
+    if framing_note is not None:
+        framing_note = _expect_non_empty_string(framing_note, context="discuss_answer.framing_note")
+    if analyzer_framing == "misframed" and framing_note is None:
+        raise AgentLoopError("discuss_answer.framing_note is required when analyzer_framing is `misframed`.")
+    research_status, sourced_facts = (None, ())
+    if "research" in payload:
+        research_status, sourced_facts = _parse_discuss_research(payload["research"])
+    if research_mode == "required" and (research_status is None or research_status == "not-needed"):
+        raise AgentLoopError("discuss_answer.research with sourced, unavailable, or inconclusive status is required.")
+    return ParsedDiscussAnswer(
+        position=position, rationale=rationale, confidence=confidence,
+        open_questions=open_questions, reviewer=reviewer, answer=answer,
+        rebuttal=rebuttal, analyzer_framing=analyzer_framing, framing_note=framing_note,
+        research_status=research_status, sourced_facts=sourced_facts,
+    )
+
+
+def validate_structured_discuss_answer(
+    text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
+) -> ParsedDiscussAnswer:
+    parsed = parse_structured_discuss_answer(text, reviewer=reviewer, round_number=round_number, research_mode=research_mode)
+    if parsed is None:
+        raise AgentLoopError("Discuss answer did not use the required structured format.")
+    return parsed
 
 
 def _parse_discuss_agenda_disagreement(

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -2163,6 +2163,8 @@ def parse_structured_discuss_answer(
         framing_note = _expect_non_empty_string(framing_note, context="discuss_answer.framing_note")
     if analyzer_framing == "misframed" and framing_note is None:
         raise AgentLoopError("discuss_answer.framing_note is required when analyzer_framing is `misframed`.")
+    if framing_note is not None and analyzer_framing is None:
+        raise AgentLoopError("discuss_answer.framing_note requires analyzer_framing to be set.")
     research_status, sourced_facts = (None, ())
     if "research" in payload:
         research_status, sourced_facts = _parse_discuss_research(payload["research"])

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -979,7 +979,9 @@ def _extract_structured_plan_state_payload(text: str) -> dict[str, object] | Non
     )
 
 
-def _extract_structured_discuss_review_payload(text: str) -> dict[str, object] | None:
+def _extract_structured_discuss_review_payload(
+    text: str, *, context_label: str = "Structured discuss review"
+) -> dict[str, object] | None:
     text, _status = normalize_response_file_structured_text(text)
     extracted = _extract_json_object_prefix(text)
     if extracted is None:
@@ -990,7 +992,7 @@ def _extract_structured_discuss_review_payload(text: str) -> dict[str, object] |
         trailing=trailing,
         state_re=PLAN_STATE_RE,
         state_marker_name="AGENT_PLAN_STATE",
-        context_label="Structured discuss review",
+        context_label=context_label,
     )
     if result is None:
         return None
@@ -999,7 +1001,7 @@ def _extract_structured_discuss_review_payload(text: str) -> dict[str, object] |
         footer_state = footer_match.group(1).lower()
         if footer_state != "approved":
             raise AgentLoopError(
-                f"Structured discuss review footer AGENT_PLAN_STATE must be `approved`; got `{footer_state}`."
+                f"{context_label} footer AGENT_PLAN_STATE must be `approved`; got `{footer_state}`."
             )
     return result
 
@@ -2011,7 +2013,9 @@ def _parse_discuss_research(value: object) -> tuple[str, tuple[DiscussSourcedFac
 def parse_structured_discuss_review(
     text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
 ) -> ParsedDiscussReview | None:
-    payload = _extract_structured_discuss_review_payload(text)
+    payload = _extract_structured_discuss_review_payload(
+        text, context_label="Structured discuss review"
+    )
     if payload is None:
         return None
     _require_supported_schema_version(payload)
@@ -2111,7 +2115,9 @@ DISCUSS_ANSWER_CONFIDENCE_VALUES = frozenset({"low", "medium", "high"})
 def parse_structured_discuss_answer(
     text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
 ) -> ParsedDiscussAnswer | None:
-    payload = _extract_structured_discuss_review_payload(text)
+    payload = _extract_structured_discuss_review_payload(
+        text, context_label="Structured discuss answer"
+    )
     if payload is None:
         return None
     _require_supported_schema_version(payload)

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -85,7 +85,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_agenda"}:
+    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda"}:
         return None
 
     stripped = raw.lstrip()
@@ -100,7 +100,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 
     json_text = stripped[:json_end].rstrip()
     trailing = stripped[json_end:]
-    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review", "discuss_agenda"} else STATE_RE
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda"} else STATE_RE
     state_match = state_re.search(trailing)
     if state_match is None:
         return None
@@ -308,6 +308,26 @@ Notes:
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- <Analyzer Name>
+
+## Valid Format G — Discuss Answer:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_answer",
+  "position": "answer" | "needs-human",
+  "answer": "<answer or recommendation; required for answer>",
+  "rationale": "<why>",
+  "confidence": "low" | "medium" | "high",
+  "open_questions": ["<question; required for needs-human>"],
+  "rebuttal": "<required after round one>",
+  "research": {"status": "sourced" | "not-needed" | "unavailable" | "inconclusive", "sourced_facts": []}
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Reviewer Name>
+
+Notes: preserve answer-mode fields, never convert this payload to `outcome` or
+`split_proposals`; `needs-human` is explicit escalation and is distinct from
+deadlock caused by disagreement.
 
 Notes:
 - consensus, disagreements, and missing_facts may be empty arrays.
@@ -859,7 +879,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_agenda"}
+_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
 ]

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -864,6 +864,43 @@ Notes:
 - Preserve research.status, every sourced fact, and every source verbatim; never invent or drop them.
 - If the original reported no research, do not add a research object.
 
+## WORKED EXAMPLE 17 — discuss_answer with answer and needs-human positions:
+
+Original (malformed): answer-mode output uses a triage `outcome` field and omits
+the required answer-mode fields.
+
+CORRECT repair — use only the answer schema, preserve the conclusion, and keep
+the AGENT_PLAN_STATE footer:
+{
+  "schema_version": 1,
+  "kind": "discuss_answer",
+  "position": "answer",
+  "answer": "Use an API boundary with an explicit adapter.",
+  "rationale": "This keeps the integration replaceable without duplicating policy.",
+  "confidence": "medium",
+  "open_questions": []
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Reviewer
+
+For an escalation, use `position: "needs-human"`, omit `answer` when there is
+no asserted answer, and include at least one concrete `open_questions` entry:
+{
+  "schema_version": 1,
+  "kind": "discuss_answer",
+  "position": "needs-human",
+  "rationale": "The requirements conflict and cannot be resolved from the issue.",
+  "confidence": "low",
+  "open_questions": ["Which latency target should control the design?"]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Reviewer
+
+For debate rounds, preserve a non-empty `rebuttal`. Preserve `analyzer_framing`
+and its required `framing_note`, and preserve the `research` object and every
+sourced fact. Do not repair answer mode into `discuss_review`, and do not add
+`outcome` or `split_proposals` fields.
+
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -16,12 +16,15 @@ from .protocol import (
     HTML_COMMENT_RE,
     SIGNATURE_RE,
     ParsedDiscussAgenda,
+    ParsedDiscussAnswer,
+    ParsedDiscussResponse,
     ParsedDiscussReview,
     ReviewItemDisposition,
     UnresolvedReviewItem,
     failed_discuss_review_placeholder,
     parse_structured_discuss_agenda,
     parse_structured_discuss_review,
+    parse_structured_discuss_answer,
 )
 from .unresolved_items import _apply_unresolved_item_dispositions
 
@@ -62,6 +65,8 @@ class PostedRoundMetadata:
     # having to reconstruct them from debater comment metadata. Empty on
     # non-final, non-split, and legacy comments.
     split_proposals: tuple[str, ...] = ()
+    # Missing metadata decodes as triage for legacy transcripts.
+    result_mode: str = "triage"
 
 
 @dataclass(frozen=True)
@@ -160,6 +165,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "research_mode": metadata.research_mode,
         "failed_debaters": [list(pair) for pair in metadata.failed_debaters],
         "split_proposals": list(metadata.split_proposals),
+        "result_mode": metadata.result_mode,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -217,6 +223,7 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
                 if isinstance(pair, (list, tuple)) and len(pair) == 2
             ),
             split_proposals=tuple(str(item) for item in payload.get("split_proposals", [])),
+            result_mode=str(payload.get("result_mode", "triage")),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc
@@ -593,11 +600,11 @@ def _resume_plan_round(
 @dataclass(frozen=True)
 class ResumedDiscussState:
     done: bool
-    round_history: tuple[tuple[ParsedDiscussReview, ...], ...]
+    round_history: tuple[tuple[ParsedDiscussResponse, ...], ...]
     next_round_number: int
     prior_round_agenda: tuple[str, ...] = ()
     prior_analyzer_agenda: ParsedDiscussAgenda | None = None
-    in_progress_votes: dict[str, ParsedDiscussReview] = None  # type: ignore[assignment]
+    in_progress_votes: dict[str, ParsedDiscussResponse] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         if self.in_progress_votes is None:
@@ -614,12 +621,15 @@ def _decode_analyzer_agenda(raw: str | None) -> ParsedDiscussAgenda | None:
         return None
 
 
-def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> ParsedDiscussReview:
+def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> ParsedDiscussResponse:
     text = record.metadata.raw_structured_coder_response or record.body
-    vote = parse_structured_discuss_review(text, reviewer=record.metadata.agent, round_number=round_number)
+    if record.metadata.result_mode == "answer":
+        vote = parse_structured_discuss_answer(text, reviewer=record.metadata.agent, round_number=round_number)
+    else:
+        vote = parse_structured_discuss_review(text, reviewer=record.metadata.agent, round_number=round_number)
     if vote is None:
         raise AgentLoopError(
-            f"Could not decode discuss_review metadata for {record.metadata.agent} "
+            f"Could not decode discuss response metadata for {record.metadata.agent} "
             f"(round {round_number}); the posted comment's structured payload is missing "
             "or invalid."
         )
@@ -631,21 +641,28 @@ def _resume_discuss_round(
     *,
     subject: str,
     configured_reviewers: Sequence[AgentName],
+    result_mode: str = "triage",
 ) -> ResumedDiscussState | None:
     records = _extract_round_metadata_records(comments, flow="discuss")
     subject_records = [record for record in records if record.metadata.subject == subject]
     if not subject_records:
         return None
+    stored_modes = {record.metadata.result_mode for record in subject_records}
+    if stored_modes != {result_mode}:
+        raise AgentLoopError(
+            "Discuss transcript result mode conflicts with the requested mode; "
+            "use the same --discuss-result-mode used to create the transcript."
+        )
     configured_reviewer_names = [agent_display_name(agent) for agent in configured_reviewers]
     rounds: dict[int, list[PostedRoundRecord]] = {}
     for record in subject_records:
         rounds.setdefault(record.metadata.round_number, []).append(record)
 
-    round_history: list[tuple[ParsedDiscussReview, ...]] = []
+    round_history: list[tuple[ParsedDiscussResponse, ...]] = []
     prior_round_agenda: tuple[str, ...] = ()
     prior_analyzer_agenda: ParsedDiscussAgenda | None = None
     next_round_number = 1
-    in_progress_votes: dict[str, ParsedDiscussReview] = {}
+    in_progress_votes: dict[str, ParsedDiscussResponse] = {}
     for round_number in sorted(rounds):
         round_records = rounds[round_number]
         summary_record = next(

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -22,6 +22,7 @@ from .protocol import (
     ReviewItemDisposition,
     UnresolvedReviewItem,
     failed_discuss_review_placeholder,
+    failed_discuss_answer_placeholder,
     parse_structured_discuss_agenda,
     parse_structured_discuss_review,
     parse_structured_discuss_answer,
@@ -690,7 +691,11 @@ def _resume_discuss_round(
             votes = tuple(
                 _decode_discuss_vote(debater_records[name], round_number=round_number)
                 if name in debater_records
-                else failed_discuss_review_placeholder(name, failed_by_name[name])
+                else (
+                    failed_discuss_answer_placeholder(name, failed_by_name[name])
+                    if result_mode == "answer"
+                    else failed_discuss_review_placeholder(name, failed_by_name[name])
+                )
                 for name in configured_reviewer_names
             )
             round_history.append(votes)

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -19,7 +19,7 @@ from coding_review_agent_loop.comment_rendering import (
     render_deferred_stages_section,
     render_discuss_round_summary_comment,
 )
-from coding_review_agent_loop.protocol import ParsedDiscussReview
+from coding_review_agent_loop.protocol import ParsedDiscussAnswer, ParsedFailedDiscussResponse, ParsedDiscussReview
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     ITEM_SUMMARY_LIMIT,
@@ -54,6 +54,21 @@ from agent_loop_helpers import (
     structured_plan_state,
     structured_pr_review,
 )
+
+
+def test_answer_research_rendering_ignores_failed_resume_placeholder():
+    answer = ParsedDiscussAnswer(
+        position="answer", rationale="Supported.", confidence="medium", open_questions=(),
+        reviewer="Codex", answer="Use an API.", research_status="not-needed",
+    )
+    failed = ParsedFailedDiscussResponse("Claude", "timeout", "answer")
+    rendered = render_discuss_round_summary_comment(
+        is_final=True, subject="subject", round_number=1, reviewer_votes=[answer],
+        round_history=[[answer, failed]], outcome="answer", consensus_kind="unanimous",
+        research_mode="auto", result_mode="answer",
+    )
+    assert "Use an API." in rendered
+    assert "Claude" not in rendered
 
 def test_render_canonical_plan_steps_numbers_items():
     assert render_canonical_plan_steps(("Update protocol.py.", "Add tests.")) == (

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -10,6 +10,7 @@ from coding_review_agent_loop.orchestrator import (
     ROUND_RESUME_MARKER_RE,
     _attach_round_metadata,
     _decode_round_metadata,
+    _encode_round_metadata,
     _discuss_subject,
     _validate_discuss_analyzer_agenda_fidelity,
     render_public_agent_comment,
@@ -46,6 +47,20 @@ def test_answer_consensus_escalates_when_all_debaters_request_human_decision():
     assert _detect_discuss_answer_consensus(responses) == ("needs-human", [])
 
 
+def test_answer_round_metadata_round_trips_mode_and_legacy_defaults_to_triage():
+    metadata = PostedRoundMetadata(
+        flow="discuss", role="debater", agent="Codex", round_number=1,
+        subject="subject", result_mode="answer", research_mode="auto",
+    )
+    decoded = _decode_round_metadata(_encode_round_metadata(metadata))
+    assert decoded.result_mode == "answer"
+    assert decoded.research_mode == "auto"
+    legacy = _decode_round_metadata(_encode_round_metadata(
+        PostedRoundMetadata(flow="discuss", role="debater", agent="Codex", round_number=1, subject="subject")
+    ))
+    assert legacy.result_mode == "triage"
+
+
 def _discuss_review_text(
     *,
     outcome: str = "implement",
@@ -71,6 +86,34 @@ def _discuss_review_text(
         payload["analyzer_framing"] = analyzer_framing
     if framing_note is not None:
         payload["framing_note"] = framing_note
+    if research is not None:
+        payload["research"] = research
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+
+
+def _discuss_answer_text(
+    *,
+    answer: str | None = "Use an API boundary.",
+    position: str = "answer",
+    rationale: str = "It keeps the integration replaceable.",
+    confidence: str = "medium",
+    open_questions: list[str] | None = None,
+    rebuttal: str | None = None,
+    research: dict | None = None,
+    reviewer: str = "OpenAI Codex",
+) -> str:
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_answer",
+        "position": position,
+        "rationale": rationale,
+        "confidence": confidence,
+        "open_questions": open_questions or [],
+    }
+    if answer is not None:
+        payload["answer"] = answer
+    if rebuttal is not None:
+        payload["rebuttal"] = rebuttal
     if research is not None:
         payload["research"] = research
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
@@ -230,6 +273,69 @@ def test_discuss_loop_happy_path_two_implement_votes(tmp_path):
     assert "Round 1: Codex position" in runner.comments[0]
     assert "Round 1: Gemini position" in runner.comments[1]
     assert "Consensus: Implement" in runner.comments[2]
+
+
+def test_discuss_loop_unanimous_answer_is_not_triage(tmp_path):
+    answer_text = _discuss_answer_text()
+    runner = FakeRunner(codex_outputs=[answer_text], gemini_outputs=[answer_text])
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+
+    assert run_discuss_loop(runner, issue_number=56, config=config) == 0
+    assert "Consensus Answer" in runner.comments[-1]
+    assert "Use an API boundary." in runner.comments[-1]
+    assert "Consensus: Implement" not in runner.comments[-1]
+
+
+def test_discuss_loop_answer_converges_after_rebuttal(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_answer_text(answer="Use an API boundary.", reviewer="OpenAI Codex"),
+            _discuss_answer_text(answer="Use an API boundary.", rebuttal="The concern is addressed.", reviewer="OpenAI Codex"),
+        ],
+        gemini_outputs=[
+            _discuss_answer_text(answer="Use a shared library.", reviewer="Google Gemini"),
+            _discuss_answer_text(answer="Use an API boundary.", rebuttal="The boundary avoids coupling.", reviewer="Google Gemini"),
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1) == 0
+    final = runner.comments[-1]
+    assert "Converged Answer" in final
+    assert "Use an API boundary." in final
+    assert "Consensus kind: `converged`" in final
+
+
+def test_discuss_loop_answer_disagreement_is_deadlock_and_unanimous_escalation_is_human(tmp_path):
+    disagreement = FakeRunner(
+        codex_outputs=[_discuss_answer_text(answer="Use an API.", reviewer="OpenAI Codex")],
+        gemini_outputs=[_discuss_answer_text(answer="Use a library.", reviewer="Google Gemini")],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    assert run_discuss_loop(disagreement, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Deadlock" in disagreement.comments[-1]
+    assert "Needs Human Decision" not in disagreement.comments[-1]
+
+    escalation = FakeRunner(
+        codex_outputs=[_discuss_answer_text(answer=None, position="needs-human", open_questions=["Who owns the decision?"], reviewer="OpenAI Codex")],
+        gemini_outputs=[_discuss_answer_text(answer=None, position="needs-human", open_questions=["What is the target latency?"], reviewer="Google Gemini")],
+    )
+    assert run_discuss_loop(escalation, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Needs Human Decision" in escalation.comments[-1]
+    assert "Who owns the decision?" in escalation.comments[-1]
+
+
+def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_aware(tmp_path):
+    sourced = {"status": "sourced", "sourced_facts": [{"fact": "Fact", "source": "https://example.test"}]}
+    answer = _discuss_answer_text(research=sourced)
+    runner = FakeRunner(codex_outputs=[answer], gemini_outputs=[answer])
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer",
+        discuss_research="required", discuss_analyzer="claude",
+    )
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Use an API boundary." in runner.comments[-1]
+    assert all('"kind": "discuss_answer"' in " ".join(cmd) for cmd, _ in runner.commands if cmd[:1] in (["codex"], ["gemini"]))
 
 
 def test_discuss_loop_debates_then_deadlocks_instead_of_veto(tmp_path):

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -14,6 +14,7 @@ from coding_review_agent_loop.orchestrator import (
     _validate_discuss_analyzer_agenda_fidelity,
     render_public_agent_comment,
     run_discuss_loop,
+    _detect_discuss_answer_consensus,
 )
 from coding_review_agent_loop.comment_rendering import render_discuss_round_summary_comment
 from coding_review_agent_loop.errors import AgentLoopError
@@ -23,9 +24,26 @@ from coding_review_agent_loop.protocol import (
     DiscussSourcedFact,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
+    ParsedDiscussAnswer,
 )
 
 from agent_loop_helpers import FakeRunner, make_config
+
+
+def test_answer_consensus_does_not_escalate_for_one_early_needs_human():
+    responses = [
+        ParsedDiscussAnswer("needs-human", "unclear", "low", ("scope",), "Codex"),
+        ParsedDiscussAnswer("answer", "clear", "medium", (), "Claude", answer="Use an API."),
+    ]
+    assert _detect_discuss_answer_consensus(responses) is None
+
+
+def test_answer_consensus_escalates_when_all_debaters_request_human_decision():
+    responses = [
+        ParsedDiscussAnswer("needs-human", "unclear", "low", ("scope",), "Codex"),
+        ParsedDiscussAnswer("needs-human", "unclear", "low", ("security",), "Claude"),
+    ]
+    assert _detect_discuss_answer_consensus(responses) == ("needs-human", [])
 
 
 def _discuss_review_text(

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -214,6 +214,33 @@ def _seed_debater_comment(
     return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
 
 
+def _seed_answer_debater_comment(
+    *, reviewer: str, round_number: int, subject: str, answer: str,
+    rationale: str = "The evidence supports this recommendation.",
+    rebuttal: str | None = None, config=None,
+) -> dict:
+    vote = ParsedDiscussAnswer(
+        position="answer", rationale=rationale, confidence="medium",
+        open_questions=(), reviewer=reviewer, answer=answer, rebuttal=rebuttal,
+    )
+    raw_text = _discuss_answer_text(
+        answer=answer, rationale=rationale, rebuttal=rebuttal, reviewer=reviewer,
+    )
+    body = render_public_agent_comment(
+        kind="discuss_answer", parsed=vote, agent=reviewer, config=config,
+        round_number=round_number,
+    )
+    body = _attach_round_metadata(
+        body,
+        PostedRoundMetadata(
+            flow="discuss", role="debater", agent=reviewer,
+            round_number=round_number, subject=subject, result_mode="answer",
+            raw_structured_coder_response=raw_text,
+        ),
+    )
+    return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
+
+
 def _seed_summary_comment(
     *,
     round_number: int,
@@ -336,6 +363,55 @@ def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_awar
     assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
     assert "Use an API boundary." in runner.comments[-1]
     assert all('"kind": "discuss_answer"' in " ".join(cmd) for cmd, _ in runner.commands if cmd[:1] in (["codex"], ["gemini"]))
+
+
+def test_discuss_loop_answer_debater_sees_analyzer_agenda_on_rebuttal_round(tmp_path):
+    agenda = _discuss_agenda_text()
+    answer1 = _discuss_answer_text(answer="Use an API.", reviewer="OpenAI Codex")
+    answer2 = _discuss_answer_text(
+        answer="Use an API.", rebuttal="The analyzer's ownership question is resolved by the API boundary.",
+        reviewer="OpenAI Codex",
+    )
+    gemini1 = _discuss_answer_text(answer="Use a library.", reviewer="Google Gemini")
+    gemini2 = _discuss_answer_text(
+        answer="Use an API.", rebuttal="The ownership concern favors an API.", reviewer="Google Gemini",
+    )
+    runner = FakeRunner(
+        codex_outputs=[answer1, answer2], gemini_outputs=[gemini1, gemini2],
+        claude_outputs=[agenda], issue_payload=_grounded_agenda_issue_payload(),
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer",
+        discuss_analyzer="claude",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1) == 0
+    round2 = [
+        " ".join(cmd) for cmd, _ in runner.commands
+        if "Analyzer agenda for the prior round" in " ".join(cmd)
+    ]
+    assert len(round2) == 2, runner.commands
+    assert all("Scope of the change" in prompt for prompt in round2)
+    assert all("Would splitting resolve the scope objection?" in prompt for prompt in round2)
+
+
+def test_discuss_loop_resumes_answer_partial_round_and_is_idempotent(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    seeded = _seed_answer_debater_comment(
+        reviewer="Codex", round_number=1, subject=subject,
+        answer="Use an API.", config=config,
+    )
+    answer = _discuss_answer_text(answer="Use an API.", reviewer="Google Gemini")
+    runner = FakeRunner(issue_comments=[seeded], gemini_outputs=[answer])
+
+    assert run_discuss_loop(runner, issue_number=56, config=config) == 0
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert "Consensus Answer" in runner.comments[-1]
+    comment_count = len(runner.comments)
+
+    assert run_discuss_loop(runner, issue_number=56, config=config) == 0
+    assert len(runner.comments) == comment_count
 
 
 def test_discuss_loop_debates_then_deadlocks_instead_of_veto(tmp_path):

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -365,6 +365,64 @@ def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_awar
     assert all('"kind": "discuss_answer"' in " ".join(cmd) for cmd, _ in runner.commands if cmd[:1] in (["codex"], ["gemini"]))
 
 
+def test_discuss_loop_answer_partial_live_round_records_failure_and_deadlocks(tmp_path):
+    answer = _discuss_answer_text(answer="Use an API boundary.")
+    runner = FakeRunner(
+        codex_outputs=[answer],
+        gemini_outputs=[answer],
+        claude_outputs=[("provider unavailable", 1)],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini", "claude"),
+        discuss_result_mode="answer",
+        discuss_on_debater_failure="partial",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    final = runner.comments[-1]
+    assert "Deadlock" in final
+    assert "Claude" in final
+    assert "Debater failures" in final
+    assert "Consensus Answer" not in final
+
+
+def test_discuss_loop_answer_mode_never_materializes_split_issues(tmp_path):
+    answer = _discuss_answer_text(answer="Use an API boundary.")
+    runner = FakeRunner(
+        codex_outputs=[answer],
+        gemini_outputs=[answer],
+        issue_urls=["https://github.com/OWNER/REPO/issues/101"],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        discuss_result_mode="answer",
+        materialize_split_issues=True,
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert runner.issues == []
+    assert "Consensus Answer" in runner.comments[-1]
+    assert "Consensus: Split" not in "\n".join(runner.comments)
+
+
+def test_discuss_loop_rejects_resume_with_conflicting_result_mode(tmp_path):
+    subject = _issue_subject()
+    seeded = _seed_answer_debater_comment(
+        reviewer="Codex", round_number=1, subject=subject,
+        answer="Use an API boundary.",
+    )
+    runner = FakeRunner(issue_comments=[seeded])
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="triage")
+
+    with pytest.raises(
+        AgentLoopError,
+        match="Discuss transcript result mode conflicts with the requested mode",
+    ):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+
 def test_discuss_loop_answer_debater_sees_analyzer_agenda_on_rebuttal_round(tmp_path):
     agenda = _discuss_agenda_text()
     answer1 = _discuss_answer_text(answer="Use an API.", reviewer="OpenAI Codex")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2166,6 +2166,27 @@ def test_build_discuss_review_prompt_analyzer_mode_omits_other_debaters_text(tmp
     assert "The analyzer is not authoritative" in prompt
 
 
+def test_build_discuss_answer_prompt_keeps_analyzer_and_research_non_authoritative(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    prior = ParsedDiscussAnswer(
+        position="answer", rationale="Prior rationale.", confidence="medium",
+        open_questions=("Which latency target applies?",), reviewer="Codex",
+        answer="Use an API.", rebuttal="The boundary reduces coupling.",
+    )
+    prompt = build_discuss_review_prompt(
+        56, config, reviewer="codex", round_number=2, prior_round_votes=[prior],
+        prior_round_agenda=("- Codex held `answer`: Use an API.",),
+        analyzer_agenda=_sample_agenda(), research_mode="required",
+    )
+    assert '"kind": "discuss_answer"' in prompt
+    assert '"position": "answer"' in prompt
+    assert "The analyzer is not authoritative" in prompt
+    assert "Research policy: `required`" in prompt
+    assert "sourced_facts" in prompt
+    assert '"outcome":' not in prompt
+    assert '"split_proposals":' not in prompt
+
+
 def test_build_discuss_review_prompt_plain_mode_unchanged_without_agenda(tmp_path):
     config = make_config(tmp_path, reviewer=("codex", "gemini"))
     prior_votes = [

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2018,6 +2018,7 @@ from coding_review_agent_loop.prompts import (
 )
 from coding_review_agent_loop.protocol import (
     DiscussAgendaDisagreement,
+    ParsedDiscussAnswer,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
 )
@@ -2097,6 +2098,20 @@ def test_build_discuss_agenda_prompt_includes_every_round_of_history(tmp_path):
     assert "never invent positions" in prompt
     assert "Carry forward unresolved `missing_facts`" in prompt
     assert '"kind": "discuss_agenda"' in prompt
+
+
+def test_build_discuss_agenda_prompt_supports_answer_history(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    answer = ParsedDiscussAnswer(
+        position="answer", rationale="The evidence favors the API.", confidence="high",
+        open_questions=(), reviewer="Codex", answer="Use an API.", rebuttal="Addressed the concern.",
+    )
+    prompt = build_discuss_agenda_prompt(
+        56, config, analyzer="claude", round_number=2, round_history=[[answer]]
+    )
+    assert "`answer`" in prompt
+    assert "Use an API." in prompt
+    assert "Split proposals:" not in prompt
 
 
 def test_build_discuss_agenda_prompt_without_prior_agenda(tmp_path):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -43,6 +43,7 @@ from coding_review_agent_loop.protocol import (
     parse_plan_review_items,
     parse_plan_state,
     parse_structured_discuss_agenda,
+    parse_structured_discuss_answer,
     parse_structured_discuss_review,
     parse_structured_plan_review,
     parse_structured_pr_review,
@@ -55,11 +56,87 @@ from coding_review_agent_loop.protocol import (
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
     validate_structured_discuss_agenda,
+    validate_structured_discuss_answer,
     validate_structured_discuss_review,
     validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_state,
     validate_structured_plan_revision,
 )
+
+
+def _discuss_answer_text(payload: dict) -> str:
+    return json.dumps({"schema_version": 1, "kind": "discuss_answer", **payload}) + (
+        "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Reviewer"
+    )
+
+
+def test_discuss_answer_parser_requires_answer_fields_and_is_mode_isolated():
+    parsed = validate_structured_discuss_answer(
+        _discuss_answer_text({
+            "position": "answer",
+            "answer": "Use an adapter.",
+            "rationale": "It preserves a replaceable boundary.",
+            "confidence": "high",
+            "open_questions": [],
+        }),
+        reviewer="Reviewer",
+    )
+    assert parsed.answer == "Use an adapter."
+    with pytest.raises(AgentLoopError, match="answer is required"):
+        validate_structured_discuss_answer(
+            _discuss_answer_text({
+                "position": "answer", "rationale": "Reason", "confidence": "medium",
+                "open_questions": [],
+            }),
+            reviewer="Reviewer",
+        )
+    with pytest.raises(AgentLoopError, match="kind mismatch"):
+        parse_structured_discuss_answer(
+            json.dumps({
+                "schema_version": 1, "kind": "discuss_review", "outcome": "implement",
+                "rationale": "Reason",
+            }) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Reviewer",
+            reviewer="Reviewer",
+        )
+
+
+def test_discuss_answer_parser_enforces_escalation_rebuttal_research_and_analyzer_rules():
+    with pytest.raises(AgentLoopError, match="open_questions must be non-empty"):
+        validate_structured_discuss_answer(
+            _discuss_answer_text({
+                "position": "needs-human", "rationale": "Blocked", "confidence": "low",
+                "open_questions": [],
+            }),
+            reviewer="Reviewer",
+        )
+    with pytest.raises(AgentLoopError, match="rebuttal is required"):
+        validate_structured_discuss_answer(
+            _discuss_answer_text({
+                "position": "answer", "answer": "Use an adapter.", "rationale": "Reason",
+                "confidence": "medium", "open_questions": [],
+            }),
+            reviewer="Reviewer", round_number=2,
+        )
+    base = {
+        "position": "answer", "answer": "Use an adapter.", "rationale": "Reason",
+        "confidence": "medium", "open_questions": [], "analyzer_framing": "accurate",
+        "rebuttal": "Addressed the objection.",
+        "research": {"status": "sourced", "sourced_facts": [{"fact": "Fact", "source": "https://example.test"}]},
+    }
+    parsed = validate_structured_discuss_answer(
+        _discuss_answer_text(base), reviewer="Reviewer", round_number=2, research_mode="required"
+    )
+    assert parsed.research_status == "sourced"
+    with pytest.raises(AgentLoopError, match="framing_note requires"):
+        validate_structured_discuss_answer(
+            _discuss_answer_text({**base, "analyzer_framing": None, "framing_note": "note"}),
+            reviewer="Reviewer",
+        )
+    with pytest.raises(AgentLoopError, match="research.*required"):
+        validate_structured_discuss_answer(
+            _discuss_answer_text({k: v for k, v in base.items() if k != "research"}),
+            reviewer="Reviewer", research_mode="required",
+        )
 from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER
 from coding_review_agent_loop.errors import UnknownPriorItemDispositionError
 from coding_review_agent_loop.orchestrator import (

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -3,10 +3,40 @@ from agent_loop_helpers import *  # noqa: F403
 
 from coding_review_agent_loop.repair import (
     _REPAIR_PROMPT,
+    _build_repair_prompt,
     attempt_envelope_normalization,
     attempt_repair,
     execute_repair,
 )
+from coding_review_agent_loop.protocol import validate_structured_discuss_answer
+
+
+def test_answer_repair_prompt_has_mode_specific_schema_and_examples():
+    prompt = _build_repair_prompt(
+        '{"kind":"discuss_review","outcome":"implement","rationale":"Use an adapter."}',
+        expected_kind="discuss_answer",
+    )
+    assert '"kind": "discuss_answer"' in prompt
+    assert '"position": "needs-human"' in prompt
+    assert '"open_questions"' in prompt
+    assert "Do not repair answer mode into `discuss_review`" in prompt
+    assert "split_proposals" in prompt
+
+
+def test_answer_repair_shape_preserves_answer_and_rejects_triage_fields():
+    valid = json.dumps({
+        "schema_version": 1, "kind": "discuss_answer", "position": "answer",
+        "answer": "Use an adapter.", "rationale": "It isolates policy.",
+        "confidence": "medium", "open_questions": [],
+    }) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Reviewer"
+    assert validate_structured_discuss_answer(valid, reviewer="Reviewer").position == "answer"
+    malformed = json.dumps({
+        "schema_version": 1, "kind": "discuss_answer", "position": "answer",
+        "answer": "Use an adapter.", "rationale": "Reason", "confidence": "medium",
+        "open_questions": [], "outcome": "implement",
+    }) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Reviewer"
+    with pytest.raises(AgentLoopError, match="unknown field.*outcome"):
+        validate_structured_discuss_answer(malformed, reviewer="Reviewer")
 
 def test_envelope_normalization_duplicate_pr_state_footer_preserves_dispositions():
     raw = (


### PR DESCRIPTION
## Summary

Adds the approved open-ended `discuss` result mode for issue #512 while preserving legacy triage as the default. Answer mode has strict answer/escalation schemas, mode-aware prompts and repair, consensus/deadlock rendering, research/analyzer separation, and mode-bound resume metadata.

Fixes #512

## Tests

- `python3 -m pytest -q` (1414 passed)
- `python3 -m pytest -q tests/test_protocol.py tests/test_prompts.py tests/test_comment_rendering.py tests/test_discuss_loop.py tests/test_repair.py` (588 passed)
- Answer parser/rendering smoke test (passed)