### PR TITLE
Focus discuss research on decision-relevant tradeoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,13 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-research auto
 ```
 
+For design or implementation issues, round-one research defaults to the
+decision-relevant tradeoff: solution design and prior art, cost/latency,
+implementation feasibility, and guardrails. Validate a motivating example only
+when its truth is disputed or outcome-critical. Active research records a target
+and concrete questions; targets are `example-validation`, `solution-design`,
+`cost-latency`, `implementation-feasibility`, and `policy/legal/current-facts`.
+
 Pass `--discuss-parallel` to run same-round debaters concurrently instead of
 sequentially. Prompts are built from shared pre-round state before any debater
 launches and comments are posted only after every debater in the round

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -506,6 +506,17 @@ agent-loop discuss 123 --repo OWNER/REPO \
   --discuss-research auto
 ```
 
+For design issues, round-one research focuses on the decision under debate
+(solution design, prior art, cost/latency, feasibility, or guardrails), not just
+verification of an illustrative incident. Example validation is appropriate
+when the example is disputed or outcome-critical. Active research records a
+target and concrete questions. Allowed targets are `example-validation`,
+`solution-design`, `cost-latency`, `implementation-feasibility`, and
+`policy/legal/current-facts`.
+New active responses and research-required agendas should include these fields;
+older transcripts may omit them and remain resumable as legacy, unclassified
+research.
+
 - `none`: prompts explicitly forbid online research; plain discuss mode and
   analyzer mode remain usable without network-dependent behavior. Best for
   internal design questions.
@@ -527,11 +538,12 @@ add a shared research brief:
 ```json
 {
   "research_required": true,
-  "research_questions": ["Is Gemini CLI still available for enterprise users?"]
+  "research_questions": ["Is Gemini CLI still available for enterprise users?"],
+  "research_question_targets": ["policy/legal/current-facts"]
 }
 ```
 
-The orchestrator forwards those questions to the next round's debater prompts
+The orchestrator forwards those questions and their aligned classifications to the next round's debater prompts
 ("Shared research brief") so parallel or repeated debater turns do not
 duplicate work, and carries unresolved questions forward between rounds. In
 `auto` mode the analyzer is told to set `research_required: true` only when a

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -747,6 +747,12 @@ def _render_public_discuss_review_comment(
     if parsed.research_status is not None:
         label = _DISCUSS_RESEARCH_STATUS_LABELS.get(parsed.research_status, parsed.research_status)
         sections.append(f"**Research:** {label} (`{parsed.research_status}`)")
+    if parsed.research_target:
+        sections.append(
+            "### Research intent\n\n"
+            f"- Target: `{parsed.research_target}`\n"
+            + "\n".join(f"- Question: {question}" for question in parsed.research_questions)
+        )
     if parsed.sourced_facts:
         facts = "\n".join(
             f"- {fact.fact} — source: {fact.source}" for fact in parsed.sourced_facts
@@ -771,6 +777,12 @@ def _render_public_discuss_answer_comment(
         sections.append("### Rebuttal\n\n" + parsed.rebuttal.strip())
     if parsed.research_status is not None:
         sections.append(f"**Research:** `{parsed.research_status}`")
+    if parsed.research_target:
+        sections.append(
+            "### Research intent\n\n"
+            f"- Target: `{parsed.research_target}`\n"
+            + "\n".join(f"- Question: {question}" for question in parsed.research_questions)
+        )
     if parsed.sourced_facts:
         sections.append("### Sourced facts\n\n" + "\n".join(f"- {f.fact} — source: {f.source}" for f in parsed.sourced_facts))
     sections.append(f"-- {_comment_signature(reviewer, config, model_used)}")
@@ -815,7 +827,11 @@ def _render_analyzer_agenda_lines(agenda: ParsedDiscussAgenda) -> list[str]:
         if lines:
             lines.append("")
         lines.append("Research brief for the next round (answer with cited sources):")
-        lines.extend(f"- {question}" for question in agenda.research_questions)
+        for index, question in enumerate(agenda.research_questions):
+            target = (agenda.research_question_targets[index]
+                      if index < len(agenda.research_question_targets) else "legacy/unclassified")
+            suffix = f" (target: `{target}`)" if target != "legacy/unclassified" else ""
+            lines.append(f"- {question}{suffix}")
     return lines
 
 
@@ -846,6 +862,9 @@ def _render_discuss_research_section(
                 vote.research_status, vote.research_status
             )
             lines.append(f"- {vote.reviewer}: {label} (`{vote.research_status}`)")
+        if getattr(vote, "research_target", None):
+            lines.append(f"  Target: `{vote.research_target}`")
+            lines.extend(f"  Question: {question}" for question in vote.research_questions)
     fact_rounds = round_history if round_history else [reviewer_votes]
     sourced: list[str] = []
     seen: set[tuple[str, str, str]] = set()

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -104,6 +104,7 @@ from .prompts import (
 )
 from .protocol import (
     DISCUSS_FAILED_OUTCOME,
+    DISCUSS_RESEARCH_TARGET_VALUES,
     DeferredStage,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
@@ -5150,6 +5151,9 @@ def _build_discuss_agenda_support_corpus(
             add(getattr(vote, "analyzer_framing", None))
             add(getattr(vote, "framing_note", None), phrase_support=True)
             add(getattr(vote, "research_status", None))
+            add(getattr(vote, "research_target", None))
+            for question in getattr(vote, "research_questions", ()):
+                add(question, phrase_support=True)
             for fact in getattr(vote, "sourced_facts", ()):
                 add(fact.fact, phrase_support=True)
                 add(fact.source, phrase_support=True)
@@ -5166,6 +5170,8 @@ def _build_discuss_agenda_support_corpus(
             add(fact, phrase_support=True)
         for question in prior_agenda.research_questions:
             add(question, phrase_support=True)
+        for target in prior_agenda.research_question_targets:
+            add(target)
 
     ignored_names = [
         agent_display_name(analyzer),
@@ -5217,6 +5223,16 @@ def _validate_discuss_analyzer_agenda_fidelity(
     analyzer: AgentName,
 ) -> None:
     allowed_names = {agent_display_name(reviewer) for reviewer in configured_reviewers}
+    targets = agenda.research_question_targets
+    if targets and len(targets) != len(agenda.research_questions):
+        raise AgentLoopError(
+            "analyzer agenda research_question_targets must align one-to-one with research_questions."
+        )
+    invalid_targets = sorted(set(targets) - DISCUSS_RESEARCH_TARGET_VALUES)
+    if invalid_targets:
+        raise AgentLoopError(
+            "analyzer agenda used invalid research target(s): " + ", ".join(invalid_targets)
+        )
     unknown_names = sorted(
         {name for disagreement in agenda.disagreements for name, _position in disagreement.positions}
         - allowed_names

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2493,7 +2493,7 @@ def build_discuss_review_prompt(
                 + "  }"
             )
             research_rules = (
-                " Research is required by the selected policy; when active, include "
+                " When research is active under the selected policy, include "
                 "research.target and non-empty research.questions before sourced_facts. "
                 "Use only the targets example-validation, solution-design, cost-latency, "
                 "implementation-feasibility, or policy/legal/current-facts."

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2252,7 +2252,11 @@ def _render_discuss_agenda_prompt_block(agenda: ParsedDiscussAgenda) -> list[str
             "Shared research brief — answer these with cited sources before "
             "restating positions, so parallel debater turns do not duplicate work:"
         )
-        lines.extend(f"- {question}" for question in agenda.research_questions)
+        for index, question in enumerate(agenda.research_questions):
+            target = (agenda.research_question_targets[index]
+                      if index < len(agenda.research_question_targets) else "legacy/unclassified")
+            suffix = f" (target: `{target}`)" if target != "legacy/unclassified" else ""
+            lines.append(f"- {question}{suffix}")
         lines.append("")
     return lines
 
@@ -2269,8 +2273,11 @@ DISCUSS_RESEARCH_AUTO_TRIGGERS = (
 def _discuss_research_policy_block(research_mode: str) -> str:
     if research_mode == "required":
         return (
-            "Research policy: `required`. Before answering, do online research on the\n"
-            "external facts this question depends on. Cite a source (URL or equivalent\n"
+            "Research policy: `required`. Before answering, research the decision-relevant\n"
+            "implementation/design tradeoff: prior art, cost/latency, feasibility, and\n"
+            "guardrails. Do not spend the budget merely validating an illustrative incident\n"
+            "unless its truth is disputed or outcome-critical. State the target and concrete\n"
+            "question(s) you researched before listing sourced facts. Cite a source (URL or equivalent\n"
             "reference) for every external fact via `research.sourced_facts`, and keep\n"
             "sourced facts separate from your own judgment. If research is unavailable\n"
             "or inconclusive, say so via `research.status` instead of presenting stale\n"
@@ -2280,6 +2287,10 @@ def _discuss_research_policy_block(research_mode: str) -> str:
         return (
             "Research policy: `auto`. Do online research only if the question materially\n"
             f"depends on current external facts — conservative triggers: {DISCUSS_RESEARCH_AUTO_TRIGGERS}.\n"
+            "When research is needed, prioritize the decision-relevant design, prior art,\n"
+            "cost/latency, feasibility, and guardrails over validating an illustrative incident\n"
+            "unless its truth is disputed or outcome-critical. State the target and concrete\n"
+            "question(s) before listing sourced facts.\n"
             "If no trigger applies, set `research.status` to `not-needed` and use only\n"
             "repo/issue context. If you do research, cite a source (URL or equivalent\n"
             "reference) for every external fact via `research.sourced_facts`, and keep\n"
@@ -2368,9 +2379,13 @@ def build_discuss_agenda_prompt(
             )
         research_example = (
             ',\n  "research_required": true,\n'
-            '  "research_questions": ["Is Gemini CLI still available for enterprise users?"]'
+            '  "research_questions": ["Is Gemini CLI still available for enterprise users?"],\n'
+            '  "research_question_targets": ["policy/legal/current-facts"]'
         )
         research_rules = (
+            "\n- `research_question_targets` must align one-to-one with `research_questions` "
+            "when supplied; each target is one of `example-validation`, `solution-design`, "
+            "`cost-latency`, `implementation-feasibility`, or `policy/legal/current-facts`."
             "\n- `research_questions` must be non-empty when `research_required` is "
             "true, and empty or omitted when it is false."
         )
@@ -2461,6 +2476,28 @@ def build_discuss_review_prompt(
             )
         rebuttal = "omit `rebuttal` in round 1" if round_number == 1 else "include a non-empty `rebuttal` directly addressing the prior round"
         research = _discuss_research_policy_block(research_mode)
+        research_example = ""
+        research_rules = ""
+        if research_mode in {"required", "auto"}:
+            status = "sourced" if research_mode == "required" else "not-needed"
+            research_example = (
+                ',\n  "research": {\n'
+                f'    "status": "{status}"'
+                + (
+                    ',\n    "target": "solution-design",\n'
+                    '    "questions": ["What implementation strategy and guardrails best resolve this tradeoff?"],\n'
+                    '    "sourced_facts": [{"fact": "A sourced design fact.", "source": "https://example.com/source"}]\n'
+                    if status == "sourced"
+                    else ',\n    "sourced_facts": []\n'
+                )
+                + "  }"
+            )
+            research_rules = (
+                " Research is required by the selected policy; when active, include "
+                "research.target and non-empty research.questions before sourced_facts. "
+                "Use only the targets example-validation, solution-design, cost-latency, "
+                "implementation-feasibility, or policy/legal/current-facts."
+            )
         return f"""Evaluate GitHub issue #{issue_number} in {config.repo} as an open-ended system/design question.
 
 Use this local checkout only to inspect context. Do not edit files, create a branch, commit, push, or open a pull request.
@@ -2479,9 +2516,9 @@ Respond with exactly this JSON object followed by the approved plan footer:
   "rationale": "Why this answer follows from the evidence.",
   "confidence": "medium",
   "open_questions": [],
-  "rebuttal": "..."
+  "rebuttal": "..."{research_example}
 }}
-Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.
+Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.{research_rules}
 Do not include triage fields such as outcome or split_proposals. The analyzer is not authoritative and is context only; sourced research facts must remain distinct from judgment.
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
@@ -2574,9 +2611,12 @@ Do not include triage fields such as outcome or split_proposals. The analyzer is
         )
         research_example = (
             ',\n  "research": {\n'
-            f'    "status": "{example_status}",\n'
-            f'    "sourced_facts": {example_facts}\n'
-            "  }"
+            + f'    "status": "{example_status}",\n'
+            + ('    "target": "solution-design",\n'
+             '    "questions": ["What implementation strategy and guardrails best resolve this tradeoff?"],\n'
+             if example_status == "sourced" else '')
+            + f'    "sourced_facts": {example_facts}\n'
+            + "  }"
         )
         research_rules = (
             "\n- The `research` object is required. `research.status` must be one of: "
@@ -2584,6 +2624,9 @@ Do not include triage fields such as outcome or split_proposals. The analyzer is
             "\n- `research.sourced_facts` must be non-empty when `research.status` is "
             "`sourced`; each entry needs a non-empty `fact` and `source`. Omit or use "
             "`[]` for other statuses."
+            "\n- When research is active, include `research.target` and non-empty `research.questions` "
+            "before the facts. Target must be one of `example-validation`, `solution-design`, "
+            "`cost-latency`, `implementation-feasibility`, or `policy/legal/current-facts`."
         )
         if research_mode == "required":
             research_rules += (

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -270,6 +270,8 @@ class ParsedDiscussAnswer:
     framing_note: str | None = None
     research_status: str | None = None
     sourced_facts: tuple[DiscussSourcedFact, ...] = ()
+    research_target: str | None = None
+    research_questions: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -298,6 +300,8 @@ class ParsedDiscussReview:
     # `research` object (legacy transcripts and `none`-mode responses).
     research_status: str | None = None
     sourced_facts: tuple[DiscussSourcedFact, ...] = ()
+    research_target: str | None = None
+    research_questions: tuple[str, ...] = ()
 
 
 ParsedDiscussResponse = ParsedDiscussReview | ParsedDiscussAnswer | ParsedFailedDiscussResponse
@@ -320,6 +324,15 @@ def discuss_response_position(response: ParsedDiscussResponse) -> str | None:
 DISCUSS_OUTCOME_VALUES = frozenset({"implement", "do-not-implement", "needs-human", "split"})
 DISCUSS_ANALYZER_FRAMING_VALUES = frozenset({"accurate", "misframed"})
 DISCUSS_RESEARCH_STATUS_VALUES = frozenset({"sourced", "not-needed", "unavailable", "inconclusive"})
+DISCUSS_RESEARCH_TARGET_VALUES = frozenset(
+    {
+        "example-validation",
+        "solution-design",
+        "cost-latency",
+        "implementation-feasibility",
+        "policy/legal/current-facts",
+    }
+)
 
 # Internal-only outcome for debaters that failed or timed out in a partial
 # round (#475). Deliberately NOT in DISCUSS_OUTCOME_VALUES: real agent
@@ -364,6 +377,7 @@ class ParsedDiscussAgenda:
     # turns do not duplicate work.
     research_required: bool = False
     research_questions: tuple[str, ...] = ()
+    research_question_targets: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1971,13 +1985,15 @@ def parse_non_blocking_followups(text: str, *, reviewer: str) -> list[ApprovedFo
     return list(parse_approved_followups(text, reviewer=reviewer).future)
 
 
-def _parse_discuss_research(value: object) -> tuple[str, tuple[DiscussSourcedFact, ...]]:
+def _parse_discuss_research(
+    value: object,
+) -> tuple[str, tuple[DiscussSourcedFact, ...], str | None, tuple[str, ...]]:
     payload = _expect_object(value, context="discuss_review.research")
     _expect_exact_keys(
         payload,
         context="discuss_review.research",
         required={"status"},
-        optional={"sourced_facts"},
+        optional={"sourced_facts", "target", "questions"},
     )
     status = _expect_non_empty_string(payload["status"], context="discuss_review.research.status")
     if status not in DISCUSS_RESEARCH_STATUS_VALUES:
@@ -2007,7 +2023,29 @@ def _parse_discuss_research(value: object) -> tuple[str, tuple[DiscussSourcedFac
         raise AgentLoopError(
             "discuss_review.research.sourced_facts requires status `sourced`."
         )
-    return status, tuple(sourced_facts)
+    has_target = "target" in payload
+    has_questions = "questions" in payload
+    if has_target != has_questions:
+        raise AgentLoopError(
+            "discuss_review.research.target and research.questions must be supplied together."
+        )
+    target: str | None = None
+    questions: tuple[str, ...] = ()
+    if has_target:
+        target = _expect_non_empty_string(payload["target"], context="discuss_review.research.target")
+        if target not in DISCUSS_RESEARCH_TARGET_VALUES:
+            rendered = ", ".join(sorted(DISCUSS_RESEARCH_TARGET_VALUES))
+            raise AgentLoopError(f"discuss_review.research.target must be one of: {rendered}")
+        questions = _expect_string_list(
+            payload["questions"],
+            context="discuss_review.research.questions",
+            item_context="discuss_review.research.questions",
+        )
+        if not questions:
+            raise AgentLoopError("discuss_review.research.questions must be non-empty when research intent is supplied.")
+        if status == "not-needed":
+            raise AgentLoopError("discuss_review.research intent requires an active research status.")
+    return status, tuple(sourced_facts), target, questions
 
 
 def parse_structured_discuss_review(
@@ -2071,8 +2109,10 @@ def parse_structured_discuss_review(
         )
     research_status: str | None = None
     sourced_facts: tuple[DiscussSourcedFact, ...] = ()
+    research_target: str | None = None
+    research_questions: tuple[str, ...] = ()
     if "research" in payload:
-        research_status, sourced_facts = _parse_discuss_research(payload["research"])
+        research_status, sourced_facts, research_target, research_questions = _parse_discuss_research(payload["research"])
     if research_mode == "required":
         if research_status is None:
             raise AgentLoopError(
@@ -2094,6 +2134,8 @@ def parse_structured_discuss_review(
         framing_note=framing_note,
         research_status=research_status,
         sourced_facts=sourced_facts,
+        research_target=research_target,
+        research_questions=research_questions,
     )
 
 
@@ -2166,8 +2208,10 @@ def parse_structured_discuss_answer(
     if framing_note is not None and analyzer_framing is None:
         raise AgentLoopError("discuss_answer.framing_note requires analyzer_framing to be set.")
     research_status, sourced_facts = (None, ())
+    research_target: str | None = None
+    research_questions: tuple[str, ...] = ()
     if "research" in payload:
-        research_status, sourced_facts = _parse_discuss_research(payload["research"])
+        research_status, sourced_facts, research_target, research_questions = _parse_discuss_research(payload["research"])
     if research_mode == "required" and (research_status is None or research_status == "not-needed"):
         raise AgentLoopError("discuss_answer.research with sourced, unavailable, or inconclusive status is required.")
     return ParsedDiscussAnswer(
@@ -2175,6 +2219,7 @@ def parse_structured_discuss_answer(
         open_questions=open_questions, reviewer=reviewer, answer=answer,
         rebuttal=rebuttal, analyzer_framing=analyzer_framing, framing_note=framing_note,
         research_status=research_status, sourced_facts=sourced_facts,
+        research_target=research_target, research_questions=research_questions,
     )
 
 
@@ -2228,7 +2273,7 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         payload,
         context="discuss_agenda",
         required={"schema_version", "kind", "consensus", "disagreements"},
-        optional={"missing_facts", "research_required", "research_questions"},
+        optional={"missing_facts", "research_required", "research_questions", "research_question_targets"},
     )
     consensus = _expect_string_list(
         payload["consensus"],
@@ -2261,6 +2306,20 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         context="discuss_agenda.research_questions",
         item_context="discuss_agenda.research_questions",
     )
+    research_question_targets = _expect_optional_string_list(
+        payload,
+        "research_question_targets",
+        context="discuss_agenda.research_question_targets",
+        item_context="discuss_agenda.research_question_targets",
+    )
+    for target in research_question_targets:
+        if target not in DISCUSS_RESEARCH_TARGET_VALUES:
+            rendered = ", ".join(sorted(DISCUSS_RESEARCH_TARGET_VALUES))
+            raise AgentLoopError(f"discuss_agenda.research_question_targets must use only: {rendered}")
+    if research_question_targets and len(research_question_targets) != len(research_questions):
+        raise AgentLoopError(
+            "discuss_agenda.research_question_targets must align one-to-one with research_questions."
+        )
     if research_required and not research_questions:
         raise AgentLoopError(
             "discuss_agenda.research_questions must be non-empty when "
@@ -2276,6 +2335,7 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         missing_facts=missing_facts,
         research_required=research_required,
         research_questions=research_questions,
+        research_question_targets=research_question_targets,
     )
 
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -289,6 +289,7 @@ Notes:
 - analyzer_framing (optional) must be "accurate" or "misframed"; framing_note is required when analyzer_framing is "misframed".
 - research (optional): keep it only when the original reported research; never invent statuses, facts, or sources, and never drop ones the original stated.
 - research.sourced_facts must be non-empty when research.status is "sourced" (each entry needs non-empty fact and source) and empty or omitted for other statuses.
+- In the research examples above, `target` and `questions` are conditional intent fields: include them together only when research is active (any status other than `not-needed`); omit both for `status: "not-needed"`. Never add them just to match the example shape.
 - Preserve recoverable research.target and research.questions together; use only the allowed targets (example-validation, solution-design, cost-latency, implementation-feasibility, policy/legal/current-facts). Never infer missing intent.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
@@ -339,7 +340,8 @@ Notes: preserve answer-mode fields, never convert this payload to `outcome` or
 deadlock caused by disagreement.
 
 When research intent is present, preserve `target` and `questions` together;
-never invent either field or a source while repairing.
+never invent either field or a source while repairing. For `status: "not-needed"`,
+omit both intent fields because they are valid only for active research.
 
 Notes:
 - consensus, disagreements, and missing_facts may be empty arrays.

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -273,6 +273,8 @@ You are a format-repair assistant. An AI agent produced a code review, plan revi
   "rebuttal": "<required in debate rounds; omit in initial round>",
   "research": {
     "status": "sourced" | "not-needed" | "unavailable" | "inconclusive",
+    "target": "solution-design",
+    "questions": ["<concrete research question>"],
     "sourced_facts": [{"fact": "<external fact>", "source": "<URL or reference>"}]
   }
 }
@@ -287,6 +289,7 @@ Notes:
 - analyzer_framing (optional) must be "accurate" or "misframed"; framing_note is required when analyzer_framing is "misframed".
 - research (optional): keep it only when the original reported research; never invent statuses, facts, or sources, and never drop ones the original stated.
 - research.sourced_facts must be non-empty when research.status is "sourced" (each entry needs non-empty fact and source) and empty or omitted for other statuses.
+- Preserve recoverable research.target and research.questions together; use only the allowed targets (example-validation, solution-design, cost-latency, implementation-feasibility, policy/legal/current-facts). Never infer missing intent.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
 ## Valid Format F — Discuss Agenda:
@@ -304,7 +307,8 @@ Notes:
   ],
   "missing_facts": ["<missing fact or assumption>"],
   "research_required": false,
-  "research_questions": []
+  "research_questions": [],
+  "research_question_targets": []
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- <Analyzer Name>
@@ -320,7 +324,12 @@ Notes:
   "confidence": "low" | "medium" | "high",
   "open_questions": ["<question; required for needs-human>"],
   "rebuttal": "<required after round one>",
-  "research": {"status": "sourced" | "not-needed" | "unavailable" | "inconclusive", "sourced_facts": []}
+  "research": {
+    "status": "sourced" | "not-needed" | "unavailable" | "inconclusive",
+    "target": "solution-design",
+    "questions": ["<concrete research question>"],
+    "sourced_facts": []
+  }
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- <Reviewer Name>
@@ -329,12 +338,16 @@ Notes: preserve answer-mode fields, never convert this payload to `outcome` or
 `split_proposals`; `needs-human` is explicit escalation and is distinct from
 deadlock caused by disagreement.
 
+When research intent is present, preserve `target` and `questions` together;
+never invent either field or a source while repairing.
+
 Notes:
 - consensus, disagreements, and missing_facts may be empty arrays.
 - each disagreement requires non-empty topic, positions, and question_for_next_round.
 - positions maps debater display names to short position statements and must not be empty.
 - research_required/research_questions (optional): keep them only when present in the original; never invent research questions or drop ones the original stated.
 - research_questions must be non-empty when research_required is true, and empty or omitted when it is false or absent.
+- research_question_targets, when present, must preserve the original one-to-one alignment with research_questions; never invent classifications.
 - Repair only agenda content that is recoverable from the malformed response and supplied context.
 - Never invent topics, debater positions, facts, or questions to make the agenda schema-valid.
 - If no agenda content is recoverable, return the closest faithful output even if it remains invalid; the orchestrator will fall back mechanically.

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -1175,6 +1175,8 @@ def _discuss_research_vote(
     outcome: str = "implement",
     research_status: str | None = None,
     sourced_facts: tuple[DiscussSourcedFact, ...] = (),
+    research_target: str | None = None,
+    research_questions: tuple[str, ...] = (),
 ) -> ParsedDiscussReview:
     return ParsedDiscussReview(
         outcome=outcome,
@@ -1183,6 +1185,8 @@ def _discuss_research_vote(
         reviewer=reviewer,
         research_status=research_status,
         sourced_facts=sourced_facts,
+        research_target=research_target,
+        research_questions=research_questions,
     )
 
 
@@ -1196,10 +1200,15 @@ def test_render_public_discuss_comment_renders_sourced_facts():
                 source="https://example.com/gemini-cli-notice",
             ),
         ),
+        research_target="solution-design",
+        research_questions=("What prior art and guardrails apply?",),
     )
     rendered = _render_public_discuss_review_comment(parsed, reviewer="Codex", round_number=1)
     assert "**Research:** done, sourced facts cited below (`sourced`)" in rendered
     assert "### Sourced facts" in rendered
+    assert "### Research intent" in rendered
+    assert "Target: `solution-design`" in rendered
+    assert "What prior art and guardrails apply?" in rendered
     assert (
         "- Gemini CLI remains available for enterprise users. — source: "
         "https://example.com/gemini-cli-notice" in rendered

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -676,6 +676,7 @@ def _agenda_for_fidelity(
     question: str = "Supported title?",
     missing_facts: tuple[str, ...] = (),
     research_questions: tuple[str, ...] = (),
+    research_question_targets: tuple[str, ...] = (),
 ) -> ParsedDiscussAgenda:
     return ParsedDiscussAgenda(
         consensus=consensus,
@@ -689,7 +690,21 @@ def _agenda_for_fidelity(
         missing_facts=missing_facts,
         research_required=bool(research_questions),
         research_questions=research_questions,
+        research_question_targets=research_question_targets,
     )
+
+
+def test_discuss_analyzer_fidelity_accepts_classified_supported_research_question():
+    vote = ParsedDiscussReview(
+        outcome="implement", rationale="Research the design.", split_proposals=(), reviewer="Codex",
+        research_status="sourced", research_target="solution-design",
+        research_questions=("What prior art supports this design?",),
+    )
+    agenda = _agenda_for_fidelity(
+        research_questions=("What prior art supports this design?",),
+        research_question_targets=("solution-design",),
+    )
+    _validate_agenda_for_test(agenda, round_history=[[vote]])
 
 
 def test_discuss_analyzer_fidelity_rejects_unknown_position_key():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2262,6 +2262,15 @@ def test_build_discuss_review_prompt_research_auto_documents_triggers(tmp_path):
     assert "must not be `not-needed`" not in prompt
     assert "illustrative incident" in prompt
 
+    answer_config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer"
+    )
+    answer_prompt = build_discuss_review_prompt(
+        56, answer_config, reviewer="codex", round_number=1, research_mode="auto"
+    )
+    assert "Research is required by the selected policy" not in answer_prompt
+    assert "When research is active under the selected policy" in answer_prompt
+
 
 def test_build_discuss_review_prompt_renders_shared_research_brief(tmp_path):
     config = make_config(tmp_path, reviewer=("codex", "gemini"))

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2181,8 +2181,10 @@ def test_build_discuss_answer_prompt_keeps_analyzer_and_research_non_authoritati
     assert '"kind": "discuss_answer"' in prompt
     assert '"position": "answer"' in prompt
     assert "The analyzer is not authoritative" in prompt
-    assert "Research policy: `required`" in prompt
+    assert "Research policy:" in prompt
     assert "sourced_facts" in prompt
+    assert '"target": "solution-design"' in prompt
+    assert '"questions":' in prompt
     assert '"outcome":' not in prompt
     assert '"split_proposals":' not in prompt
 
@@ -2241,6 +2243,8 @@ def test_build_discuss_review_prompt_research_required_enforces_sources(tmp_path
     assert '"research"' in prompt
     assert '"status": "sourced"' in prompt
     assert "sourced_facts" in prompt
+    assert "decision-relevant" in prompt
+    assert "solution-design" in prompt
     assert "must not be `not-needed`" in prompt
     assert "instead of presenting stale\nassumptions as fact" in prompt
 
@@ -2256,6 +2260,7 @@ def test_build_discuss_review_prompt_research_auto_documents_triggers(tmp_path):
     assert "`not-needed`" in prompt
     assert '"status": "not-needed"' in prompt
     assert "must not be `not-needed`" not in prompt
+    assert "illustrative incident" in prompt
 
 
 def test_build_discuss_review_prompt_renders_shared_research_brief(tmp_path):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -127,6 +127,12 @@ def test_discuss_answer_parser_enforces_escalation_rebuttal_research_and_analyze
         _discuss_answer_text(base), reviewer="Reviewer", round_number=2, research_mode="required"
     )
     assert parsed.research_status == "sourced"
+    intent = {**base, "research": {**base["research"], "target": "cost-latency", "questions": ["What latency cost applies?"]}}
+    parsed_intent = validate_structured_discuss_answer(
+        _discuss_answer_text(intent), reviewer="Reviewer", round_number=2, research_mode="required"
+    )
+    assert parsed_intent.research_target == "cost-latency"
+    assert parsed_intent.research_questions == ("What latency cost applies?",)
     with pytest.raises(AgentLoopError, match="framing_note requires"):
         validate_structured_discuss_answer(
             _discuss_answer_text({**base, "analyzer_framing": None, "framing_note": "note"}),
@@ -3263,6 +3269,35 @@ def test_parse_structured_discuss_review_research_rejects_empty_source():
         parse_structured_discuss_review(text, reviewer="Gemini")
 
 
+def test_discuss_research_intent_round_trips_and_rejects_inconsistent_metadata():
+    text = _discuss_review_with_research(research={
+        "status": "sourced",
+        "target": "solution-design",
+        "questions": ["What prior art and guardrails apply?"],
+        "sourced_facts": [{"fact": "Prior art exists.", "source": "https://example.test/prior-art"}],
+    })
+    result = parse_structured_discuss_review(text, reviewer="Gemini")
+    assert result is not None
+    assert result.research_target == "solution-design"
+    assert result.research_questions == ("What prior art and guardrails apply?",)
+    with pytest.raises(AgentLoopError, match="target must be one of"):
+        parse_structured_discuss_review(
+            _discuss_review_with_research(research={
+                "status": "sourced", "target": "incident", "questions": ["Why?"],
+                "sourced_facts": [{"fact": "Fact", "source": "https://example.test"}],
+            }),
+            reviewer="Gemini",
+        )
+    with pytest.raises(AgentLoopError, match="supplied together"):
+        parse_structured_discuss_review(
+            _discuss_review_with_research(research={
+                "status": "sourced", "target": "solution-design",
+                "sourced_facts": [{"fact": "Fact", "source": "https://example.test"}],
+            }),
+            reviewer="Gemini",
+        )
+
+
 def test_parse_structured_discuss_review_research_rejects_facts_without_sourced_status():
     text = _discuss_review_with_research(
         research={
@@ -3347,6 +3382,24 @@ def test_parse_structured_discuss_agenda_research_round_trip():
     assert result.research_questions == (
         "Is Gemini CLI still available for enterprise users?",
     )
+
+
+def test_parse_structured_discuss_agenda_classified_questions_align():
+    payload = json.loads(_discuss_agenda_with_research(
+        research_required=True,
+        research_questions=["What implementation strategy is safest?", "What is the latency cost?"],
+    ).split("\n", 1)[0])
+    payload["research_question_targets"] = ["solution-design", "cost-latency"]
+    result = parse_structured_discuss_agenda(
+        json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Claude"
+    )
+    assert result is not None
+    assert result.research_question_targets == ("solution-design", "cost-latency")
+    payload["research_question_targets"] = ["solution-design"]
+    with pytest.raises(AgentLoopError, match="align one-to-one"):
+        parse_structured_discuss_agenda(
+            json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Claude"
+        )
 
 
 def test_parse_structured_discuss_agenda_accepts_explicit_no_research():

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -399,6 +399,12 @@ def test_attempt_repair_format_d_marks_human_requirements_optional():
     assert "omit the `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` marker" in _REPAIR_PROMPT
     assert "the `### Human requirements` section from Format D" in _REPAIR_PROMPT
 
+
+def test_repair_prompt_makes_research_intent_conditional_on_active_status():
+    assert '`target` and `questions` are conditional intent fields' in _REPAIR_PROMPT
+    assert 'omit both for `status: "not-needed"`' in _REPAIR_PROMPT
+    assert 'For `status: "not-needed"`,' in _REPAIR_PROMPT
+
 def test_attempt_repair_includes_prior_item_disposition_repair_context():
     repaired = structured_plan_revision(prior_plan_item_dispositions=[])
     mock_result = MagicMock()


### PR DESCRIPTION
Fixes #515

## Summary
- Add backward-compatible research target/question metadata for debaters and analyzer agendas.
- Steer required/auto research toward decision-relevant design tradeoffs and classify agenda questions.
- Preserve and render intent through orchestration, repairs, comments, docs, and tests.

## Tests
- `python3 -m pytest tests/test_protocol.py tests/test_prompts.py tests/test_discuss_loop.py tests/test_comment_rendering.py tests/test_repair.py`
- `python3 -m pytest`

Both pass.