### PR TITLE
Include linked issue context in direct PR reviews

### DIFF
--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -98,6 +98,65 @@ PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url,body"
 PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
 ISSUE_REFERENCE_RE_TEMPLATE = r"(?:#%d\b|/issues/%d\b)"
 
+# A direct issue URL is meaningful without an auto-close keyword.  Shorthand
+# references, on the other hand, are only linked here when they are part of a
+# GitHub closing phrase so ordinary discussion of ``#123`` stays untouched.
+_GITHUB_ISSUE_URL_RE = re.compile(
+    r"https?://github\.com/(?P<repo>[^/\s#]+/[^/\s#]+)/issues/(?P<number>[1-9]\d*)\b",
+    re.IGNORECASE,
+)
+_CLOSING_ISSUE_REFERENCE_RE = re.compile(
+    r"\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b"
+    r"\s*:?[ \t]*(?:"
+    r"(?P<unqualified>#[1-9]\d*)|"
+    r"(?P<qualified>[^\s/#]+/[^\s/#]+#[1-9]\d*)|"
+    r"(?P<url>https?://github\.com/[^/\s#]+/[^/\s#]+/issues/[1-9]\d*\b)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def parse_linked_issue_numbers(pr_body: str | None, *, repo: str) -> tuple[int, ...]:
+    """Return same-repository issues linked by a PR body, in first-seen order.
+
+    GitHub closing phrases accept unqualified and ``owner/repo#N`` forms.  A
+    same-repository issue URL is also a link even without a closing phrase.
+    Repository comparison is case-insensitive because GitHub repository names
+    are case-insensitive.
+    """
+    if not pr_body:
+        return ()
+
+    normalized_repo = repo.casefold()
+    matches: list[tuple[int, int]] = []
+    for match in _CLOSING_ISSUE_REFERENCE_RE.finditer(pr_body):
+        reference = match.group("unqualified") or match.group("qualified") or match.group("url")
+        if reference is None:
+            continue
+        if reference.startswith("#"):
+            matches.append((match.start(), int(reference[1:])))
+            continue
+        if reference.lower().startswith(("http://", "https://")):
+            url_match = _GITHUB_ISSUE_URL_RE.fullmatch(reference)
+            if url_match and url_match.group("repo").casefold() == normalized_repo:
+                matches.append((match.start(), int(url_match.group("number"))))
+            continue
+        qualified_repo, number = reference.rsplit("#", 1)
+        if qualified_repo.casefold() == normalized_repo:
+            matches.append((match.start(), int(number)))
+
+    for match in _GITHUB_ISSUE_URL_RE.finditer(pr_body):
+        if match.group("repo").casefold() == normalized_repo:
+            matches.append((match.start(), int(match.group("number"))))
+
+    seen: set[int] = set()
+    numbers: list[int] = []
+    for _, number in sorted(matches, key=lambda item: item[0]):
+        if number not in seen:
+            seen.add(number)
+            numbers.append(number)
+    return tuple(numbers)
+
 
 def detect_repo(runner: Runner, cwd: Path, gh_cmd: str) -> str:
     result = runner.run(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -50,6 +50,7 @@ from .github import (
     PullRequestReviewContext,
     find_open_pr_referencing_issue,
     get_issue_context,
+    parse_linked_issue_numbers,
     get_pr_checks,
     get_pr_review_context,
     get_pr_state,
@@ -4056,6 +4057,30 @@ def run_pr_loop(
             pr_number=pr_number,
             cwd=bootstrap_cwd,
         )
+        if issue_context is None:
+            linked_issue_numbers = parse_linked_issue_numbers(
+                initial_pr_context.metadata.body,
+                repo=config.repo,
+            )
+            if len(linked_issue_numbers) == 1:
+                linked_issue_number = linked_issue_numbers[0]
+                log(
+                    config,
+                    f"PR #{pr_number} references issue #{linked_issue_number}; "
+                    "including linked issue context in review prompts",
+                )
+                issue_context = get_issue_context(
+                    runner, config=config, issue_number=linked_issue_number
+                )
+            elif linked_issue_numbers:
+                candidates = ", ".join(f"#{number}" for number in linked_issue_numbers)
+                log(
+                    config,
+                    f"PR #{pr_number} references multiple issues ({candidates}); "
+                    "linked issue context is ambiguous and will not be included",
+                )
+            else:
+                log(config, f"PR #{pr_number} has no linked issue context to include in review prompts")
         config = resolve_base_branch(
             config,
             runner,

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -257,7 +257,7 @@ class FakeRunner(Runner):
             "state": "OPEN",
             "url": "https://github.com/OWNER/REPO/pull/77",
             "title": "Improve review prompt context",
-            "body": "Fixes #56",
+            "body": "PR description.",
             "headRefName": "feature/review-context",
             "baseRefName": "main",
             "headRefOid": "abc123",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -83,6 +83,7 @@ def test_pre_review_tests_can_be_disabled(tmp_path):
             "Created PR.\nTests: pytest passed.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
         ],
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"body": "Fixes #56"},
     )
     config = make_config(
         tmp_path,
@@ -1728,7 +1729,7 @@ def test_issue_loop_plan_first_can_switch_implementation_coder_end_to_end(tmp_pa
         "<!-- AGENT_PR: 77 -->\n-- OpenAI Codex"
     )
     calls = []
-    runner = FakeRunner()
+    runner = FakeRunner(pr_payload={"body": "Fixes #56"})
     config = make_config(
         tmp_path,
         coder="claude",
@@ -1974,7 +1975,7 @@ def test_issue_and_task_loops_use_repo_default_when_base_is_omitted(tmp_path, mo
             "Implemented.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],
         codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
-        pr_payload={"baseRefName": "develop"},
+        pr_payload={"baseRefName": "develop", "body": "Fixes #56"},
         repo_default_branch="develop",
     )
     config = make_config(

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -28,7 +28,7 @@ from coding_review_agent_loop.salvage import (
     post_salvage_comment,
 )
 from agent_loop_helpers import (
-    FakeRunner,
+    FakeRunner as _FakeRunner,
     command_index,
     make_config,
     prior_item_dispositions,
@@ -38,6 +38,14 @@ from agent_loop_helpers import (
     structured_plan_state,
     structured_pr_review,
 )
+
+
+class FakeRunner(_FakeRunner):
+    """Issue-loop fixtures model the PR created for issue #56 explicitly."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("pr_payload", {"body": "Fixes #56"})
+        super().__init__(**kwargs)
 
 
 def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -72,6 +72,103 @@ def _assert_pending_ci_stop_guidance(text):
     assert "because GitHub check status is unavailable" not in text
 
 
+def _issue_view_commands(runner):
+    return [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "issue", "view"]]
+
+
+def test_direct_pr_resolves_single_linked_issue_context_for_reviewer(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n<!-- HUMAN_REQUIREMENTS_RESOLVED -->\n"
+            "<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+        ],
+        issue_payload={
+            "number": 56,
+            "title": "Original acceptance criteria",
+            "body": "Keep compatibility.\n\n-- Human Reviewer",
+        },
+        issue_comments=[
+            {"author": {"login": "maintainer"}, "createdAt": "2026-06-01T00:00:00Z", "body": "Later clarification."}
+        ],
+        pr_payload={"body": "Fixes #56"},
+    )
+    config = make_config(tmp_path, quiet=False)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(_issue_view_commands(runner)) == 1
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Original acceptance criteria" in prompt
+    assert "Keep compatibility." in prompt
+    assert "Later clarification." in prompt
+    assert "Human requirements" in prompt
+
+
+def test_direct_pr_keeps_linked_issue_context_for_coder_followup(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "Needs a small correction.\n\n### Same-PR follow-ups\n"
+            "- Correct the implementation.\n\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "LGTM."
+            + prior_item_dispositions("[item-1] resolved")
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=["Corrected it.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        issue_payload={"title": "Linked issue title", "body": "Linked issue body"},
+        pr_payload={"body": "Fixes #56"},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    followup_prompt = next(
+        cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]
+    )
+    assert "Linked issue title" in followup_prompt
+    assert "Linked issue body" in followup_prompt
+
+
+@pytest.mark.parametrize(
+    "body, issue_views",
+    [
+        ("https://github.com/owner/repo/issues/56", 1),
+        ("No issue reference.", 0),
+        ("Fixes #56; Resolves #57", 0),
+        ("Fixes #56; https://github.com/OWNER/REPO/issues/56", 1),
+        ("Fixes other/repo#56 https://github.com/other/repo/issues/57", 0),
+    ],
+)
+def test_direct_pr_linked_issue_resolution_handles_urls_absence_and_ambiguity(
+    tmp_path, body, issue_views
+):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"body": body},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(_issue_view_commands(runner)) == issue_views
+
+
+def test_issue_mode_context_is_not_replaced_by_pr_link(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"body": "Fixes #99"},
+    )
+    config = make_config(tmp_path)
+    supplied_context = IssueContext(
+        number=56, repo="OWNER/REPO", title="Caller issue", body="Caller body", url=None, comments=()
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config, issue_context=supplied_context) == 0
+
+    assert not _issue_view_commands(runner)
+    prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"])
+    assert "Caller issue" in prompt
+
+
 def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
     runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
     config = make_config(
@@ -3654,7 +3751,7 @@ def test_pr_initial_coder_post_includes_model(tmp_path):
             marker_value=pr_review_marker,
         )
 
-    runner = FakeRunner()
+    runner = FakeRunner(pr_payload={"body": "Fixes #56"})
     config = make_config(tmp_path, coder="claude", reviewer="codex")
     with patch(
         "coding_review_agent_loop.orchestrator._run_validated_agent",

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -947,6 +947,7 @@ def test_issue_loop_includes_issue_comments_in_coder_and_review_prompts(tmp_path
         codex_outputs=[
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
+        pr_payload={"body": "Fixes #56"},
     )
     config = make_config(tmp_path)
 

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -4,6 +4,7 @@ from coding_review_agent_loop.cli import AgentLoopError
 from coding_review_agent_loop.github import (
     IssueComment,
     find_open_pr_referencing_issue,
+    parse_linked_issue_numbers,
     validate_pr_body_does_not_close_issue,
 )
 from coding_review_agent_loop.split_materialization import (
@@ -26,6 +27,25 @@ from agent_loop_helpers import FakeRunner, make_config
 
 def _comment(body: str) -> IssueComment:
     return IssueComment(author="bot", created_at="2026-05-23T00:00:00Z", body=body)
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        ("Close #1 closes: #2 CLOSED #3", (1, 2, 3)),
+        ("fix #4 fixes #5 fixed #6", (4, 5, 6)),
+        ("resolve #7 resolves #8 resolved #9", (7, 8, 9)),
+        ("FIXES Owner/Repo#10", (10,)),
+        ("https://github.com/OWNER/repo/issues/11", (11,)),
+        ("Fixes #12 and https://github.com/owner/repo/issues/12", (12,)),
+        ("Fixes #13; Resolves owner/repo#14", (13, 14)),
+        ("", ()),
+        ("Fixes #0; refs #15; Fixes github.com/owner/repo/pull/16", ()),
+        ("Fixes other/repo#17 https://github.com/other/repo/issues/18", ()),
+    ],
+)
+def test_parse_linked_issue_numbers_recognizes_only_same_repo_issues(body, expected):
+    assert parse_linked_issue_numbers(body, repo="OWNER/REPO") == expected
 
 
 def test_split_stage_proposal_from_text_uses_first_line_as_title():

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -60,6 +60,7 @@ def _existing_split_children_comment() -> dict:
 
 def test_plan_first_no_prior_split_materializes_deferred_stages_before_implementation(tmp_path):
     runner = FakeRunner(
+        pr_payload={"body": "Fixes #56"},
         claude_outputs=[
             structured_plan_state(
                 state="blocking",
@@ -103,6 +104,7 @@ def test_plan_first_deferred_stage_title_with_colon_round_trips_through_canonica
     round-trip exactly through materialization instead of being corrupted by
     a naive split-on-first-colon parse (#492 review)."""
     runner = FakeRunner(
+        pr_payload={"body": "Fixes #56"},
         claude_outputs=[
             "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
             structured_plan_revision(
@@ -144,6 +146,7 @@ def test_plan_first_deferred_stage_title_with_colon_round_trips_through_canonica
 
 def test_plan_first_no_prior_split_warns_when_materialization_disabled(tmp_path):
     runner = FakeRunner(
+        pr_payload={"body": "Fixes #56"},
         claude_outputs=[
             structured_plan_state(
                 state="blocking",
@@ -287,6 +290,7 @@ def test_plan_first_deferred_stage_rerun_resumes_parent_one_shot_handoff(tmp_pat
         pr_head_sha="abc123",
     )
     runner = FakeRunner(
+        pr_payload={"body": "Fixes #56"},
         issue_comments=[
             {
                 "author": {"login": "bot"},

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -74,6 +74,7 @@ def test_usage_summary_keeps_retry_attempts_and_marks_only_validated_call_succes
 
 def test_plan_first_issue_run_writes_one_summary_for_planning_implementation_and_review(tmp_path):
     runner = FakeRunner(
+        pr_payload={"body": "Fixes #56"},
         claude_outputs=[
             "Plan:\n- Implement usage logging.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude",
             "Opened PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",


### PR DESCRIPTION
## Summary
- resolve one same-repository issue linked from a direct PR body
- include the resolved context in review and coder follow-up prompts
- cover parser and direct PR resolution behavior

Fixes #513