### PR TITLE
Detect semantic convergence in answer-mode discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ implementation vote. Answer-mode transcripts are mode-bound for repair and
 resume, while analyzer observations and sourced research remain clearly
 separate from debater-confirmed conclusions.
 
+When answer-mode final answers differ, semantic convergence is opt-in through
+`--discuss-analyzer`. The explicitly configured analyzer (never an implicit
+reviewer fallback) receives only the final answers and performs no research or
+repository work. Its comparison is advisory: equivalent answers can converge;
+material conflict fails closed to deadlock; and compatible answers get at most
+one extra, budget-exempt confirmation phase. Every debater must then confirm
+the canonical recommendation or refine it, and the effective answers must be
+identical after whitespace/case normalization. The summary preserves the
+analyzer classification separately for audit.
+
 Local command-line orchestration for a coding PR review loop.
 
 Run a local Claude/Codex/Gemini PR review loop using your existing CLI subscriptions.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -358,6 +358,18 @@ Analyzer observations remain non-authoritative and cited research remains a
 separate sourced-facts section. Repair and resume preserve the selected mode;
 transcripts cannot mix answer and triage responses.
 
+To enable semantic comparison for differently worded final answers, configure
+an independent `--discuss-analyzer`. There is no reviewer fallback when it is
+unset. The analyzer receives final-round answers only and is prohibited from
+research or repository work; its output is advisory and recorded separately in
+the summary. Equivalent answers may converge. Compatible answers receive one
+bounded, budget-exempt confirmation phase: each original debater confirms the
+canonical recommendation or supplies a refinement, and only exact normalized
+agreement among those effective answers finalizes. Invalid comparator output,
+comparison failure, failed confirmation, or material conflict safely remains a
+deadlock. This makes resumed finalization idempotent once a final summary is
+recorded.
+
 Discuss mode sends the issue title, body, and comments to all configured
 reviewers and asks each to return a `discuss_review` response with a single
 outcome vote. Instead of collapsing a round into one orchestrator comment,

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -945,6 +945,7 @@ def render_discuss_round_summary_comment(
     research_mode: str | None = None,
     failed_debaters: Sequence[tuple[str, str]] = (),
     result_mode: str = "triage",
+    semantic_comparison: dict[str, object] | None = None,
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -965,6 +966,7 @@ def render_discuss_round_summary_comment(
             round_history=round_history, analyzer_agenda=analyzer_agenda,
             analyzer_name=analyzer_name, research_mode=research_mode,
             failed_debaters=failed_debaters, outcome=outcome,
+            semantic_comparison=semantic_comparison,
         )
     if not is_final:
         lines: list[str] = [
@@ -1082,7 +1084,8 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
     reviewer_votes: Sequence[ParsedDiscussAnswer], consensus_kind: str,
     round_history: Sequence[Sequence[ParsedDiscussAnswer]] | None,
     analyzer_agenda: ParsedDiscussAgenda | None, analyzer_name: str | None,
-    research_mode: str | None, failed_debaters: Sequence[tuple[str, str]], outcome: str | None) -> str:
+    research_mode: str | None, failed_debaters: Sequence[tuple[str, str]], outcome: str | None,
+    semantic_comparison: dict[str, object] | None = None) -> str:
     if not is_final:
         heading = f"## Round {round_number} summary: Answer Pending"
     elif outcome == "needs-human":
@@ -1095,7 +1098,8 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
     if is_final and outcome not in {"needs-human", "deadlock"}:
         answers = [v.answer for v in reviewer_votes if v.answer]
         if answers:
-            lines.extend(["### Answer", "", answers[0], ""])
+            answer = semantic_comparison.get("confirmed_answer") or semantic_comparison.get("shared_recommendation") if semantic_comparison else answers[0]
+            lines.extend(["### Answer", "", str(answer), ""])
     lines.extend(["| Reviewer | Position | Confidence | Answer |", "| --- | --- | --- | --- |"])
     for vote in reviewer_votes:
         answer = (vote.answer or "(no asserted answer)").replace("|", "\\|").replace("\n", " ")
@@ -1107,6 +1111,25 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
         lines.extend(["", "### Open questions", "", *[f"- {q}" for q in dict.fromkeys(questions)]])
     if outcome == "deadlock":
         lines.extend(["", "### Unresolved disagreement", "", "The debaters did not converge on one normalized answer."])
+    if semantic_comparison is not None:
+        lines.extend(["", "### Semantic comparison (advisory; not a debater vote)", "",
+            f"Analyzer: {semantic_comparison.get('analyzer', 'configured analyzer')}",
+            f"Classification: `{semantic_comparison.get('classification', 'failed')}`"])
+        if semantic_comparison.get("shared_recommendation"):
+            lines.extend(["", "Shared recommendation:", str(semantic_comparison["shared_recommendation"])])
+        decisions = semantic_comparison.get("remaining_decisions", ())
+        if decisions:
+            lines.extend(["", "Residual decisions:", *[f"- {item}" for item in decisions]])
+        evidence = semantic_comparison.get("evidence", ())
+        if evidence:
+            lines.extend(["", "Evidence:"])
+            for item in evidence:
+                reviewer = getattr(item, "reviewer", None)
+                supports = getattr(item, "supports", None)
+                if reviewer and supports:
+                    lines.append(f"- {reviewer}: {supports}")
+        if semantic_comparison.get("confirmed_answer"):
+            lines.extend(["", "The recommendation above was explicitly confirmed by every debater."])
     if analyzer_agenda is not None:
         lines.extend(["", "### Analyzer observations (not debater-confirmed)", "", "The analyzer is non-authoritative.", "", *_render_analyzer_agenda_lines(analyzer_agenda)])
     if research_mode is not None:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -88,6 +88,8 @@ from .prompts import (
     CompactPriorContext,
     CompactPrReviewTailContext,
     build_discuss_agenda_prompt,
+    build_discuss_answer_confirmation_prompt,
+    build_discuss_semantic_comparison_prompt,
     build_discuss_review_prompt,
     build_followup_prompt,
     build_issue_implementation_prompt,
@@ -110,6 +112,7 @@ from .protocol import (
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
+    ParsedDiscussSemanticComparison,
     ParsedDiscussResponse,
     ParsedDiscussReview,
     failed_discuss_review_category,
@@ -142,6 +145,8 @@ from .protocol import (
     validate_structured_discuss_agenda,
     validate_structured_discuss_review,
     validate_structured_discuss_answer,
+    validate_structured_discuss_answer_confirmation,
+    validate_structured_discuss_semantic_comparison,
 )
 from .protocol import parse_review
 from .repair import (
@@ -284,7 +289,7 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
     re.I,
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
-    {"plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer"}
+    {"plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 )
 PLAN_REVISION_FOOTER_RE = re.compile(r"(?m)^<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$")
 STRUCTURED_FENCE_RE = re.compile(
@@ -5452,6 +5457,70 @@ def _run_discuss_debater_turn(
     )
 
 
+def _run_discuss_semantic_finalization(
+    runner: Runner, *, issue_number: int, config: AgentLoopConfig, answers: Sequence[ParsedDiscussAnswer],
+    configured_reviewers: Sequence[AgentName], usage_context: RunUsageContext,
+) -> tuple[str, str, dict[str, object] | None]:
+    """Fail-closed semantic answer evaluation. Exact equality is intentionally outside this helper."""
+    analyzer = config.discuss_analyzer
+    if analyzer is None or len(answers) != len(configured_reviewers):
+        return "deadlock", "deadlock", None
+    if any(item.position != "answer" or not item.answer for item in answers):
+        return "deadlock", "deadlock", None
+    names = [item.reviewer for item in answers]
+    try:
+        response = _run_validated_agent(
+            runner, agent=analyzer, config=config,
+            prompt=build_discuss_semantic_comparison_prompt(issue_number, config, answers=answers),
+            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+            validate=lambda text: validate_structured_discuss_semantic_comparison(text, reviewers=names),
+            usage_context=usage_context, use_repair=True,
+            repair_expected_kind="discuss_semantic_comparison", role="analyzer",
+            label="discuss-semantic-comparison", operation_description="semantic answer comparison",
+        )
+        comparison = response.marker_value
+        assert isinstance(comparison, ParsedDiscussSemanticComparison)
+    except (AgentLoopError, AgentInvocationError):
+        return "deadlock", "semantic-comparison-failed", None
+    audit: dict[str, object] = {
+        "classification": comparison.classification,
+        "shared_recommendation": comparison.shared_recommendation,
+        "remaining_decisions": comparison.remaining_decisions,
+        "evidence": comparison.evidence,
+        "analyzer": agent_display_name(analyzer),
+    }
+    if comparison.classification == "equivalent":
+        return "answer", "semantic-equivalent", audit
+    if comparison.classification == "material_conflict":
+        return "deadlock", "material-conflict", audit
+    confirmations = []
+    try:
+        for reviewer in configured_reviewers:
+            reviewer_name = agent_display_name(reviewer)
+            response = _run_validated_agent(
+                runner, agent=reviewer, config=config,
+                prompt=build_discuss_answer_confirmation_prompt(
+                    issue_number, config, reviewer=reviewer,
+                    shared_recommendation=comparison.shared_recommendation,
+                    remaining_decisions=comparison.remaining_decisions),
+                marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+                validate=lambda text, name=reviewer_name: validate_structured_discuss_answer_confirmation(text, reviewer=name),
+                usage_context=usage_context, use_repair=True,
+                repair_expected_kind="discuss_answer_confirmation", role="reviewer",
+                label="discuss-answer-confirmation", timeout_seconds=config.discuss_debater_timeout,
+                operation_description="semantic answer confirmation",
+            )
+            confirmations.append(response.marker_value)
+    except (AgentLoopError, AgentInvocationError):
+        return "deadlock", "confirmation-failed", audit
+    effective = [comparison.shared_recommendation if item.decision == "confirm" else item.answer for item in confirmations]
+    audit["confirmations"] = tuple(confirmations)
+    if all(answer and _normalize_discuss_answer(answer) == _normalize_discuss_answer(effective[0] or "") for answer in effective):
+        audit["confirmed_answer"] = effective[0]
+        return "answer", "debater-confirmed", audit
+    return "deadlock", "confirmation-disagreement", audit
+
+
 def _post_discuss_debater_comment(
     runner: Runner,
     *,
@@ -5872,6 +5941,22 @@ def _run_discuss_loop(
         else:
             consensus = _detect_discuss_consensus(reviewer_votes)  # type: ignore[arg-type]
         is_final = consensus is not None or round_number == max_round_number
+        semantic_comparison: dict[str, object] | None = None
+        # Keep normalized equality as the zero-call fast path.  Only a complete,
+        # final all-answer round is eligible for the configured independent analyzer.
+        if (
+            is_final and consensus is None and config.discuss_result_mode == "answer"
+            and not failed_debaters
+            and len(successful_votes) == len(configured_reviewers)
+            and all(isinstance(vote, ParsedDiscussAnswer) and vote.position == "answer" and vote.answer for vote in successful_votes)
+        ):
+            outcome, semantic_kind, semantic_comparison = _run_discuss_semantic_finalization(
+                runner, issue_number=issue_number, config=config,
+                answers=[vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)],
+                configured_reviewers=configured_reviewers, usage_context=usage_context,
+            )
+            consensus_kind = semantic_kind
+            consensus = (outcome, []) if outcome == "answer" else None
         if consensus is None:
             outcome = "deadlock" if config.discuss_result_mode == "answer" else "needs-human"
             round_split_proposals: list[str] = (
@@ -5880,7 +5965,8 @@ def _run_discuss_loop(
             consensus_kind = "deadlock" if is_final else None
         else:
             outcome, round_split_proposals = consensus
-            consensus_kind = ("unanimous" if len(round_history) == 1 else "converged") if is_final else None
+            if semantic_comparison is None:
+                consensus_kind = ("unanimous" if len(round_history) == 1 else "converged") if is_final else None
         next_analyzer_agenda: ParsedDiscussAgenda | None = None
         analyzer_response_raw: str | None = None
         if not is_final and analyzer is not None:
@@ -5916,6 +6002,7 @@ def _run_discuss_loop(
             research_mode=config.discuss_research,
             failed_debaters=tuple(failed_debaters),
             result_mode=config.discuss_result_mode,
+            semantic_comparison=semantic_comparison,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(successful_votes))
         post_issue_comment(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5481,7 +5481,13 @@ def _run_discuss_semantic_finalization(
         comparison = response.marker_value
         assert isinstance(comparison, ParsedDiscussSemanticComparison)
     except (AgentLoopError, AgentInvocationError):
-        return "deadlock", "semantic-comparison-failed", None
+        # Preserve an explicit audit record even when the comparator itself
+        # fails. This distinguishes its fail-closed deadlock from a purely
+        # textual disagreement in both the public summary and round metadata.
+        return "deadlock", "semantic-comparison-failed", {
+            "classification": "failed",
+            "analyzer": agent_display_name(analyzer),
+        }
     audit: dict[str, object] = {
         "classification": comparison.classification,
         "shared_recommendation": comparison.shared_recommendation,
@@ -5942,6 +5948,7 @@ def _run_discuss_loop(
             consensus = _detect_discuss_consensus(reviewer_votes)  # type: ignore[arg-type]
         is_final = consensus is not None or round_number == max_round_number
         semantic_comparison: dict[str, object] | None = None
+        semantic_finalization_ran = False
         # Keep normalized equality as the zero-call fast path.  Only a complete,
         # final all-answer round is eligible for the configured independent analyzer.
         if (
@@ -5950,6 +5957,7 @@ def _run_discuss_loop(
             and len(successful_votes) == len(configured_reviewers)
             and all(isinstance(vote, ParsedDiscussAnswer) and vote.position == "answer" and vote.answer for vote in successful_votes)
         ):
+            semantic_finalization_ran = True
             outcome, semantic_kind, semantic_comparison = _run_discuss_semantic_finalization(
                 runner, issue_number=issue_number, config=config,
                 answers=[vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)],
@@ -5962,7 +5970,9 @@ def _run_discuss_loop(
             round_split_proposals: list[str] = (
                 [] if config.discuss_result_mode == "answer" else _merge_discuss_split_proposals(successful_votes)  # type: ignore[arg-type]
             )
-            consensus_kind = "deadlock" if is_final else None
+            consensus_kind = None if not is_final else (
+                semantic_kind if semantic_finalization_ran else "deadlock"
+            )
         else:
             outcome, round_split_proposals = consensus
             if semantic_comparison is None:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2673,3 +2673,60 @@ Rules:
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
 """
+
+
+def build_discuss_semantic_comparison_prompt(
+    issue_number: int, config: AgentLoopConfig, *, answers: Sequence[ParsedDiscussAnswer],
+    issue_context: IssueContext | None = None,
+) -> str:
+    """A bounded, advisory final-round comparator prompt (#528)."""
+    answer_lines = "\n".join(f"- {item.reviewer}: {item.answer}" for item in answers)
+    names = [item.reviewer for item in answers]
+    return f"""Compare only these completed final-round answers for GitHub issue #{issue_number} in {config.repo}.
+
+This is advisory only and must not create a debater consensus. Do not use web research, tools, repository inspection, or earlier discussion history. Do not decide unresolved product questions.
+
+Final-round answers:
+{answer_lines}
+
+Return exactly this JSON object followed by the plan-state footer:
+{{
+  "schema_version": 1,
+  "kind": "discuss_semantic_comparison",
+  "classification": "equivalent",
+  "shared_recommendation": "The common recommendation.",
+  "remaining_decisions": [],
+  "evidence": [{", ".join(json.dumps({'reviewer': name, 'supports': 'How this answer supports the classification.'}) for name in names)}]
+}}
+Rules: classification is exactly `equivalent`, `compatible_with_residual_decisions`, or `material_conflict`; equivalent has no remaining decisions; compatible has at least one. Evidence must contain exactly one non-empty entry for every listed reviewer.
+<!-- AGENT_PLAN_STATE: approved -->
+-- {agent_signature(config.discuss_analyzer, config) if config.discuss_analyzer else 'Analyzer'}
+"""
+
+
+def build_discuss_answer_confirmation_prompt(
+    issue_number: int, config: AgentLoopConfig, *, reviewer: AgentName,
+    shared_recommendation: str, remaining_decisions: Sequence[str],
+) -> str:
+    signature = agent_signature(reviewer, config)
+    decisions = "\n".join(f"- {item}" for item in remaining_decisions)
+    return f"""Confirm or refine an advisory semantic comparison for GitHub issue #{issue_number}.
+
+The comparator is not authoritative. Proposed canonical recommendation:
+{shared_recommendation}
+
+Residual decisions:
+{decisions}
+
+Do not research, use tools, or inspect the repository. Reply with exactly:
+{{
+  "schema_version": 1,
+  "kind": "discuss_answer_confirmation",
+  "reviewer": "{agent_display_name(reviewer)}",
+  "decision": "confirm",
+  "rationale": "Why the canonical recommendation is acceptable."
+}}
+For `confirm`, omit `answer`. For `refine`, include a non-empty replacement `answer`. The run converges only if every effective answer is identical after whitespace/case normalization.
+<!-- AGENT_PLAN_STATE: approved -->
+-- {signature}
+"""

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2677,7 +2677,6 @@ Rules:
 
 def build_discuss_semantic_comparison_prompt(
     issue_number: int, config: AgentLoopConfig, *, answers: Sequence[ParsedDiscussAnswer],
-    issue_context: IssueContext | None = None,
 ) -> str:
     """A bounded, advisory final-round comparator prompt (#528)."""
     answer_lines = "\n".join(f"- {item.reviewer}: {item.answer}" for item in answers)

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -275,6 +275,28 @@ class ParsedDiscussAnswer:
 
 
 @dataclass(frozen=True)
+class DiscussSemanticEvidence:
+    reviewer: str
+    supports: str
+
+
+@dataclass(frozen=True)
+class ParsedDiscussSemanticComparison:
+    classification: str
+    shared_recommendation: str
+    remaining_decisions: tuple[str, ...]
+    evidence: tuple[DiscussSemanticEvidence, ...]
+
+
+@dataclass(frozen=True)
+class ParsedDiscussAnswerConfirmation:
+    reviewer: str
+    decision: str
+    rationale: str
+    answer: str | None = None
+
+
+@dataclass(frozen=True)
 class ParsedFailedDiscussResponse:
     reviewer: str
     category: str
@@ -2230,6 +2252,75 @@ def validate_structured_discuss_answer(
     if parsed is None:
         raise AgentLoopError("Discuss answer did not use the required structured format.")
     return parsed
+
+
+DISCUSS_SEMANTIC_CLASSIFICATIONS = frozenset({
+    "equivalent", "compatible_with_residual_decisions", "material_conflict"
+})
+
+
+def validate_structured_discuss_semantic_comparison(
+    text: str, *, reviewers: Sequence[str]
+) -> ParsedDiscussSemanticComparison:
+    payload = _extract_structured_discuss_review_payload(text, context_label="Semantic comparison")
+    if payload is None:
+        raise AgentLoopError("Semantic comparison did not use the required structured format.")
+    _require_supported_schema_version(payload)
+    _expect_exact_keys(payload, context="discuss_semantic_comparison",
+        required={"schema_version", "kind", "classification", "shared_recommendation", "remaining_decisions", "evidence"})
+    if payload.get("kind") != "discuss_semantic_comparison":
+        raise AgentLoopError("Structured response kind mismatch: expected `discuss_semantic_comparison`.")
+    classification = _expect_non_empty_string(payload["classification"], context="discuss_semantic_comparison.classification")
+    if classification not in DISCUSS_SEMANTIC_CLASSIFICATIONS:
+        raise AgentLoopError("Unsupported semantic comparison classification.")
+    shared = _expect_non_empty_string(payload["shared_recommendation"], context="discuss_semantic_comparison.shared_recommendation")
+    decisions = _expect_string_list(payload["remaining_decisions"], context="discuss_semantic_comparison.remaining_decisions", item_context="discuss_semantic_comparison.remaining_decisions")
+    if len(set(item.casefold() for item in decisions)) != len(decisions):
+        raise AgentLoopError("Semantic comparison remaining_decisions must be deduplicated.")
+    if classification == "equivalent" and decisions:
+        raise AgentLoopError("Equivalent semantic comparisons cannot have remaining decisions.")
+    if classification == "compatible_with_residual_decisions" and not decisions:
+        raise AgentLoopError("Compatible semantic comparisons require remaining decisions.")
+    evidence_payload = payload["evidence"]
+    if not isinstance(evidence_payload, list) or not evidence_payload:
+        raise AgentLoopError("Semantic comparison evidence must be a non-empty list.")
+    evidence: list[DiscussSemanticEvidence] = []
+    for index, item in enumerate(evidence_payload):
+        item_payload = _expect_object(item, context=f"discuss_semantic_comparison.evidence[{index}]")
+        _expect_exact_keys(item_payload, context=f"discuss_semantic_comparison.evidence[{index}]", required={"reviewer", "supports"})
+        evidence.append(DiscussSemanticEvidence(
+            reviewer=_expect_non_empty_string(item_payload["reviewer"], context="semantic evidence reviewer"),
+            supports=_expect_non_empty_string(item_payload["supports"], context="semantic evidence supports"),
+        ))
+    expected = set(reviewers)
+    actual = {item.reviewer for item in evidence}
+    if actual != expected or len(evidence) != len(expected):
+        raise AgentLoopError("Semantic comparison evidence must cover exactly every final-round reviewer.")
+    return ParsedDiscussSemanticComparison(classification, shared, decisions, tuple(evidence))
+
+
+def validate_structured_discuss_answer_confirmation(text: str, *, reviewer: str) -> ParsedDiscussAnswerConfirmation:
+    payload = _extract_structured_discuss_review_payload(text, context_label="Answer confirmation")
+    if payload is None:
+        raise AgentLoopError("Answer confirmation did not use the required structured format.")
+    _require_supported_schema_version(payload)
+    _expect_exact_keys(payload, context="discuss_answer_confirmation",
+        required={"schema_version", "kind", "decision", "rationale", "reviewer"}, optional={"answer"})
+    if payload.get("kind") != "discuss_answer_confirmation":
+        raise AgentLoopError("Structured response kind mismatch: expected `discuss_answer_confirmation`.")
+    response_reviewer = _expect_non_empty_string(payload["reviewer"], context="discuss_answer_confirmation.reviewer")
+    if response_reviewer != reviewer:
+        raise AgentLoopError("Answer confirmation reviewer does not match the debater.")
+    decision = _expect_non_empty_string(payload["decision"], context="discuss_answer_confirmation.decision")
+    if decision not in {"confirm", "refine"}:
+        raise AgentLoopError("Answer confirmation decision must be `confirm` or `refine`.")
+    answer = payload.get("answer")
+    if decision == "confirm" and answer is not None:
+        raise AgentLoopError("Confirm responses must not include an answer.")
+    if decision == "refine":
+        answer = _expect_non_empty_string(answer, context="discuss_answer_confirmation.answer")
+    return ParsedDiscussAnswerConfirmation(response_reviewer, decision,
+        _expect_non_empty_string(payload["rationale"], context="discuss_answer_confirmation.rationale"), answer)
 
 
 def _parse_discuss_agenda_disagreement(

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -85,7 +85,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda"}:
+    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}:
         return None
 
     stripped = raw.lstrip()
@@ -100,7 +100,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 
     json_text = stripped[:json_end].rstrip()
     trailing = stripped[json_end:]
-    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda"} else STATE_RE
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"} else STATE_RE
     state_match = state_re.search(trailing)
     if state_match is None:
         return None
@@ -931,7 +931,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda"}
+_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
 ]

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -196,7 +196,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 # Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
-You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, coder follow-up, discuss review, or discuss agenda that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
+You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, coder follow-up, discuss review, discuss agenda, semantic comparison, or answer confirmation that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
 
 {expected_kind_instruction}
 
@@ -343,6 +343,42 @@ When research intent is present, preserve `target` and `questions` together;
 never invent either field or a source while repairing. For `status: "not-needed"`,
 omit both intent fields because they are valid only for active research.
 
+## Valid Format H — Discuss Semantic Comparison:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_semantic_comparison",
+  "classification": "equivalent" | "compatible_with_residual_decisions" | "material_conflict",
+  "shared_recommendation": "<common recommendation or concise conflict summary>",
+  "remaining_decisions": ["<decision required only for compatible answers>"],
+  "evidence": [{"reviewer": "<final-round reviewer>", "supports": "<what its answer supports>"}]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Analyzer Name>
+
+Notes: preserve the supplied final-round reviewers exactly: evidence must contain
+one non-empty entry for every reviewer and no others. `equivalent` requires an
+empty remaining_decisions array; `compatible_with_residual_decisions` requires a
+non-empty one. Never invent repository facts, research, or a recommendation that
+is not recoverable from the compared answers.
+
+## Valid Format I — Discuss Answer Confirmation:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_answer_confirmation",
+  "reviewer": "<the confirming reviewer>",
+  "decision": "confirm" | "refine",
+  "rationale": "<why>",
+  "answer": "<non-empty replacement; required only for refine>"
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Reviewer Name>
+
+Notes: `confirm` must omit answer; `refine` must include a non-empty answer.
+Preserve the reviewer identity supplied by the expected-kind context and do not
+invent a replacement answer.
+
 Notes:
 - consensus, disagreements, and missing_facts may be empty arrays.
 - each disagreement requires non-empty topic, positions, and question_for_next_round.
@@ -440,6 +476,8 @@ the `### Human requirements` section from Format D.
 - If an expected response kind is provided above, use ONLY that format. Do not infer a different kind from keywords in the malformed response.
 - Use Format C if the original contains "coder_followup" or "addressed_items" or "remaining_items".
 - Use Format D if the original contains "plan_revision" or "plan_steps".
+- Use Format H if the original contains "discuss_semantic_comparison" or "remaining_decisions".
+- Use Format I if the original contains "discuss_answer_confirmation" or "decision".
 - Use Format F if the original contains "discuss_agenda" or "question_for_next_round".
 - Use Format B if the original contains AGENT_PLAN_STATE / blocking_plan_issues / same_plan_followups / prior_plan_item_dispositions.
 - Otherwise use Format A.

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -119,6 +119,37 @@ def _discuss_answer_text(
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
 
 
+def _semantic_comparison_text(
+    *, classification: str, shared_recommendation: str,
+    remaining_decisions: list[str] | None = None,
+) -> str:
+    payload = {
+        "schema_version": 1,
+        "kind": "discuss_semantic_comparison",
+        "classification": classification,
+        "shared_recommendation": shared_recommendation,
+        "remaining_decisions": remaining_decisions or [],
+        "evidence": [
+            {"reviewer": "Codex", "supports": "Supports the shared recommendation."},
+            {"reviewer": "Gemini", "supports": "Supports the shared recommendation."},
+        ],
+    }
+    return json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+
+
+def _answer_confirmation_text(*, reviewer: str, decision: str = "confirm", answer: str | None = None) -> str:
+    payload = {
+        "schema_version": 1,
+        "kind": "discuss_answer_confirmation",
+        "reviewer": reviewer,
+        "decision": decision,
+        "rationale": "The recommendation is acceptable.",
+    }
+    if answer is not None:
+        payload["answer"] = answer
+    return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+
+
 def _discuss_agenda_text(
     *,
     consensus: list[str] | None = None,
@@ -350,6 +381,108 @@ def test_discuss_loop_answer_disagreement_is_deadlock_and_unanimous_escalation_i
     assert run_discuss_loop(escalation, issue_number=56, config=config, discuss_max_rounds=0) == 0
     assert "Needs Human Decision" in escalation.comments[-1]
     assert "Who owns the decision?" in escalation.comments[-1]
+
+
+def test_discuss_loop_semantic_equivalent_paraphrases_converge(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_answer_text(answer="Add a bounded verification subphase.")],
+        gemini_outputs=[_discuss_answer_text(answer="Introduce a capped, targeted verification phase.")],
+        claude_outputs=[_semantic_comparison_text(
+            classification="equivalent", shared_recommendation="Add a targeted, budget-capped verification subphase.",
+        )],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer", discuss_analyzer="claude",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    final = runner.comments[-1]
+    assert "Converged Answer" in final
+    assert "Consensus kind: `semantic-equivalent`" in final
+    assert "targeted, budget-capped verification subphase" in final
+    assert "Semantic comparison (advisory; not a debater vote)" in final
+    metadata = ROUND_RESUME_MARKER_RE.search(runner.issue_comments[-1]["body"])
+    assert metadata is not None
+    assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "semantic-equivalent"
+
+
+@pytest.mark.parametrize("refine", [False, True])
+def test_discuss_loop_semantic_compatible_answers_require_debater_confirmation(tmp_path, refine):
+    canonical = "Add a targeted, budget-capped verification subphase."
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_answer_text(answer="Add bounded verification."),
+            _answer_confirmation_text(reviewer="Codex", decision="confirm"),
+        ],
+        gemini_outputs=[
+            _discuss_answer_text(answer="Use targeted verification with a cap."),
+            _answer_confirmation_text(
+                reviewer="Gemini", decision="refine" if refine else "confirm",
+                answer=canonical if refine else None,
+            ),
+        ],
+        claude_outputs=[_semantic_comparison_text(
+            classification="compatible_with_residual_decisions", shared_recommendation=canonical,
+            remaining_decisions=["Choose the cap."],
+        )],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer", discuss_analyzer="claude",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    final = runner.comments[-1]
+    assert "Consensus kind: `debater-confirmed`" in final
+    assert "The recommendation above was explicitly confirmed by every debater." in final
+    assert "Residual decisions:" in final
+    metadata = ROUND_RESUME_MARKER_RE.search(runner.issue_comments[-1]["body"])
+    assert metadata is not None
+    assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "debater-confirmed"
+
+
+@pytest.mark.parametrize("failed_comparison", [("comparator unavailable", 1), "not structured"])
+def test_discuss_loop_semantic_material_conflict_and_failure_are_auditable_deadlocks(tmp_path, failed_comparison):
+    def run_with(comparison):
+        runner = FakeRunner(
+            codex_outputs=[_discuss_answer_text(answer="Use an API.")],
+            gemini_outputs=[_discuss_answer_text(answer="Use a library.")],
+            claude_outputs=[comparison],
+        )
+        config = make_config(
+            tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer", discuss_analyzer="claude",
+        )
+        assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+        return runner
+
+    conflict_runner = run_with(_semantic_comparison_text(
+        classification="material_conflict", shared_recommendation="The alternatives materially differ.",
+    ))
+    conflict = conflict_runner.comments[-1]
+    assert "Deadlock" in conflict
+    assert "Consensus kind: `material-conflict`" in conflict
+    assert "Classification: `material_conflict`" in conflict
+    metadata = ROUND_RESUME_MARKER_RE.search(conflict_runner.issue_comments[-1]["body"])
+    assert metadata is not None
+    assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "material-conflict"
+
+    failure_runner = run_with(failed_comparison)
+    failure = failure_runner.comments[-1]
+    assert "Deadlock" in failure
+    assert "Consensus kind: `semantic-comparison-failed`" in failure
+    assert "Classification: `failed`" in failure
+    metadata = ROUND_RESUME_MARKER_RE.search(failure_runner.issue_comments[-1]["body"])
+    assert metadata is not None
+    assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "semantic-comparison-failed"
+
+
+def test_discuss_loop_triage_mode_does_not_invoke_semantic_comparator(tmp_path):
+    vote = _discuss_review_text(outcome="implement")
+    runner = FakeRunner(codex_outputs=[vote], gemini_outputs=[vote])
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+
+    assert run_discuss_loop(runner, issue_number=56, config=config) == 0
+    assert "Consensus: Implement" in runner.comments[-1]
+    assert not any("discuss_semantic_comparison" in " ".join(command) for command, _ in runner.commands)
 
 
 def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_aware(tmp_path):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -3247,3 +3247,19 @@ def test_build_repair_prompt_accepts_discuss_agenda_expected_kind():
     assert "question_for_next_round" in prompt
     assert "Never invent topics, debater positions, facts, or questions" in prompt
     assert "If no agenda content is recoverable" in prompt
+
+
+@pytest.mark.parametrize(
+    ("kind", "format_name", "field"),
+    [
+        ("discuss_semantic_comparison", "Valid Format H — Discuss Semantic Comparison", "remaining_decisions"),
+        ("discuss_answer_confirmation", "Valid Format I — Discuss Answer Confirmation", "decision"),
+    ],
+)
+def test_build_repair_prompt_includes_new_discuss_expected_kind_schemas(kind, format_name, field):
+    from coding_review_agent_loop.repair import _build_repair_prompt
+
+    prompt = _build_repair_prompt("garbage", expected_kind=kind)
+    assert f"You MUST repair this response as `{kind}`." in prompt
+    assert format_name in prompt
+    assert field in prompt


### PR DESCRIPTION
Fixes #528

Adds opt-in, fail-closed semantic comparison for final answer-mode discuss rounds. Exact normalized agreement remains the no-call fast path; compatible answers receive one bounded debater confirmation phase, and audit details are rendered separately from debater consensus.