### PR TITLE
Fix stale analyzer agendas in final summaries

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -492,8 +492,17 @@ Guardrails — the analyzer is never authoritative:
   votes rule and the divergence stays visible in the summary.
 - The agenda is rendered in the non-final round summary ("Agenda for round
   N+1 (analyzer: ...)"), so it is auditable on the issue.
-- The final summary adds an "Analyzer-extracted consensus (not
-  debater-confirmed)" section kept distinct from the debater vote table.
+- After the final debater responses arrive, the analyzer gets a separate
+  best-effort pass over only those successful final-round responses. A valid
+  result is rendered as "Final analyzer observations (not debater-confirmed)"
+  after the authoritative debater vote table. It is rejected if it names a
+  non-debater or asserts a position, topic, consensus, disagreement, or missing
+  fact unsupported by the final-round text.
+- If an agenda from the preceding non-final round exists, the final summary
+  renders it separately as "Agenda before final round." This is explicitly
+  historical and is never presented as current disagreements. If final analysis
+  fails validation or the final round is partial, the observations are omitted
+  while the answer/vote table and mechanical outcome remain available.
 - If the analyzer invocation fails even after the malformed-response repair
   pass, the orchestrator logs a warning and falls back to the plain mechanical
   agenda for that round (and full prior positions in the next debate prompt)
@@ -502,9 +511,10 @@ Guardrails — the analyzer is never authoritative:
 The raw agenda rides in the round summary's `AGENT_LOOP_META` metadata, so a
 resumed run restores the structured agenda for the next debate round. Legacy
 summaries without an analyzer payload resume in plain mode. With
-`--discuss-max-rounds 0` there is no non-final round, so the analyzer never
-runs (a note is logged). Omitting `--discuss-analyzer` keeps plain #465-style
-direct deliberation unchanged.
+`--discuss-max-rounds 0`, there is no non-final agenda pass, but a configured
+analyzer still receives the final-only pass after the initial final round.
+Omitting `--discuss-analyzer` keeps plain #465-style direct deliberation
+unchanged.
 
 ### Discuss research policy
 

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -941,6 +941,8 @@ def render_discuss_round_summary_comment(
     round_history: Sequence[Sequence[ParsedDiscussResponse]] | None = None,
     split_proposals: Sequence[str] | None = None,
     analyzer_agenda: ParsedDiscussAgenda | None = None,
+    prior_analyzer_agenda: ParsedDiscussAgenda | None = None,
+    final_analyzer_agenda: ParsedDiscussAgenda | None = None,
     analyzer_name: str | None = None,
     research_mode: str | None = None,
     failed_debaters: Sequence[tuple[str, str]] = (),
@@ -964,6 +966,8 @@ def render_discuss_round_summary_comment(
             is_final=is_final, subject=subject, round_number=round_number,
             reviewer_votes=reviewer_votes, consensus_kind=consensus_kind,
             round_history=round_history, analyzer_agenda=analyzer_agenda,
+            prior_analyzer_agenda=prior_analyzer_agenda,
+            final_analyzer_agenda=final_analyzer_agenda,
             analyzer_name=analyzer_name, research_mode=research_mode,
             failed_debaters=failed_debaters, outcome=outcome,
             semantic_comparison=semantic_comparison,
@@ -1043,20 +1047,25 @@ def render_discuss_round_summary_comment(
         lines.append("")
         for proposal in split_proposals:
             lines.append(f"- {proposal}")
-    if analyzer_agenda is not None:
-        heading = "### Analyzer-extracted consensus (not debater-confirmed)"
+    # `analyzer_agenda` is retained as the non-final API for compatibility.
+    # Final callers must pass a final-only analysis and a distinct historical agenda.
+    if final_analyzer_agenda is not None:
+        heading = "### Final analyzer observations (not debater-confirmed)"
         if analyzer_name:
-            heading = f"### Analyzer-extracted consensus (analyzer: {analyzer_name}; not debater-confirmed)"
+            heading = f"### Final analyzer observations (analyzer: {analyzer_name}; not debater-confirmed)"
         lines.append("")
         lines.append(heading)
         lines.append("")
         lines.append(
-            "The debater vote table above is the authoritative consensus. The analyzer's "
-            "last agenda extracted the following; it may misclassify consensus or omit "
-            "minority arguments."
+            "The debater vote table above is authoritative. These advisory observations "
+            "were derived only from final-round responses and are not debater-confirmed."
         )
         lines.append("")
-        agenda_lines = _render_analyzer_agenda_lines(analyzer_agenda)
+        agenda_lines = _render_analyzer_agenda_lines(final_analyzer_agenda)
+        lines.extend(agenda_lines if agenda_lines else ["(the analyzer extracted no points)"])
+    if prior_analyzer_agenda is not None:
+        lines.extend(["", "### Agenda before final round", "", "Historical analyzer agenda only; it is not a statement of current disagreements.", ""])
+        agenda_lines = _render_analyzer_agenda_lines(prior_analyzer_agenda)
         lines.extend(agenda_lines if agenda_lines else ["(the analyzer extracted no points)"])
     if research_mode is not None:
         lines.append("")
@@ -1083,7 +1092,8 @@ def render_discuss_round_summary_comment(
 def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number: int,
     reviewer_votes: Sequence[ParsedDiscussAnswer], consensus_kind: str,
     round_history: Sequence[Sequence[ParsedDiscussAnswer]] | None,
-    analyzer_agenda: ParsedDiscussAgenda | None, analyzer_name: str | None,
+    analyzer_agenda: ParsedDiscussAgenda | None, prior_analyzer_agenda: ParsedDiscussAgenda | None,
+    final_analyzer_agenda: ParsedDiscussAgenda | None, analyzer_name: str | None,
     research_mode: str | None, failed_debaters: Sequence[tuple[str, str]], outcome: str | None,
     semantic_comparison: dict[str, object] | None = None) -> str:
     if not is_final:
@@ -1130,8 +1140,10 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
                     lines.append(f"- {reviewer}: {supports}")
         if semantic_comparison.get("confirmed_answer"):
             lines.extend(["", "The recommendation above was explicitly confirmed by every debater."])
-    if analyzer_agenda is not None:
-        lines.extend(["", "### Analyzer observations (not debater-confirmed)", "", "The analyzer is non-authoritative.", "", *_render_analyzer_agenda_lines(analyzer_agenda)])
+    if final_analyzer_agenda is not None:
+        lines.extend(["", "### Final analyzer observations (not debater-confirmed)", "", "The analyzer is non-authoritative; these observations use only final-round responses.", "", *_render_analyzer_agenda_lines(final_analyzer_agenda)])
+    if prior_analyzer_agenda is not None:
+        lines.extend(["", "### Agenda before final round", "", "Historical analyzer agenda only; it is not current-state analysis.", "", *_render_analyzer_agenda_lines(prior_analyzer_agenda)])
     if research_mode is not None:
         lines.extend(["", *_render_discuss_research_section(research_mode=research_mode, reviewer_votes=reviewer_votes, round_history=round_history)])
     lines.extend(["", "-- Orchestrator", f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->"] if is_final else ["", "-- Orchestrator"])

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -1140,6 +1140,11 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
                     lines.append(f"- {reviewer}: {supports}")
         if semantic_comparison.get("confirmed_answer"):
             lines.extend(["", "The recommendation above was explicitly confirmed by every debater."])
+    if not is_final and analyzer_agenda is not None:
+        heading = f"### Agenda for round {round_number + 1}"
+        if analyzer_name:
+            heading += f" (analyzer: {analyzer_name})"
+        lines.extend(["", heading, "", *_render_analyzer_agenda_lines(analyzer_agenda)])
     if final_analyzer_agenda is not None:
         lines.extend(["", "### Final analyzer observations (not debater-confirmed)", "", "The analyzer is non-authoritative; these observations use only final-round responses.", "", *_render_analyzer_agenda_lines(final_analyzer_agenda)])
     if prior_analyzer_agenda is not None:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -88,6 +88,7 @@ from .prompts import (
     CompactPriorContext,
     CompactPrReviewTailContext,
     build_discuss_agenda_prompt,
+    build_discuss_final_analysis_prompt,
     build_discuss_answer_confirmation_prompt,
     build_discuss_semantic_comparison_prompt,
     build_discuss_review_prompt,
@@ -5377,6 +5378,91 @@ def _run_discuss_analyzer(
     return parsed, response.text
 
 
+def _validate_discuss_final_analyzer_fidelity(
+    agenda: ParsedDiscussAgenda,
+    *,
+    final_votes: Sequence[ParsedDiscussResponse],
+    configured_reviewers: Sequence[AgentName],
+    analyzer: AgentName,
+) -> None:
+    """Validate an advisory final pass against final debater text only (#529)."""
+    if len(final_votes) != len(configured_reviewers) or any(
+        is_failed_discuss_response(vote) for vote in final_votes
+    ):
+        raise AgentLoopError("final analyzer requires a complete successful final round.")
+    if agenda.research_required or agenda.research_questions or agenda.research_question_targets:
+        raise AgentLoopError("final analyzer output must not include next-round research fields.")
+    allowed_names = {agent_display_name(reviewer) for reviewer in configured_reviewers}
+    final_names = {vote.reviewer for vote in final_votes}
+    unknown_names = sorted(
+        {name for disagreement in agenda.disagreements for name, _position in disagreement.positions}
+        - allowed_names.intersection(final_names)
+    )
+    if unknown_names:
+        raise AgentLoopError("final analyzer used unknown or absent debater name(s): " + ", ".join(unknown_names))
+    empty_context = IssueContext(0, "", None, None, None, ())
+    corpus = _build_discuss_agenda_support_corpus(
+        issue_context=empty_context,
+        round_history=(tuple(final_votes),),
+        prior_agenda=None,
+        configured_reviewers=configured_reviewers,
+        analyzer=analyzer,
+    )
+    ignored_names = [agent_display_name(analyzer), *sorted(allowed_names)]
+    fields: list[tuple[str, str]] = [("consensus", point) for point in agenda.consensus]
+    for disagreement in agenda.disagreements:
+        fields.append(("disagreement topic", disagreement.topic))
+        fields.extend(("position", position) for _name, position in disagreement.positions)
+        fields.append(("question_for_next_round", disagreement.question_for_next_round))
+    fields.extend(("missing_fact", fact) for fact in agenda.missing_facts)
+    for field, text in fields:
+        if not _discuss_agenda_text_has_support(text, corpus=corpus, ignored_names=ignored_names):
+            raise AgentLoopError(f"final analyzer {field} lacks final-round support: {text}")
+
+
+def _run_discuss_final_analyzer(
+    runner: Runner,
+    *,
+    issue_number: int,
+    config: AgentLoopConfig,
+    analyzer: AgentName | None,
+    round_number: int,
+    final_votes: Sequence[ParsedDiscussResponse],
+    configured_reviewers: Sequence[AgentName],
+    usage_context: RunUsageContext,
+) -> tuple[ParsedDiscussAgenda | None, str | None]:
+    """Best-effort final-only analyzer pass; failures never affect finalization."""
+    if analyzer is None or len(final_votes) != len(configured_reviewers) or any(
+        is_failed_discuss_response(vote) for vote in final_votes
+    ):
+        return None, None
+    analyzer_name = agent_display_name(analyzer)
+    try:
+        response = _run_validated_agent(
+            runner, agent=analyzer, config=config,
+            prompt=build_discuss_final_analysis_prompt(
+                issue_number, config, analyzer=analyzer, round_number=round_number,
+                final_votes=final_votes,
+            ),
+            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+            validate=validate_structured_discuss_agenda, usage_context=usage_context,
+            use_repair=True, repair_expected_kind="discuss_agenda", role="reviewer",
+            label=f"discuss-final-analyzer-r{round_number}",
+            operation_description="final discuss analyzer",
+        )
+        parsed = response.marker_value
+        assert isinstance(parsed, ParsedDiscussAgenda)
+        _validate_discuss_final_analyzer_fidelity(
+            parsed, final_votes=final_votes, configured_reviewers=configured_reviewers, analyzer=analyzer,
+        )
+        return parsed, response.text
+    except QuotaResetExceededError:
+        raise
+    except Exception as exc:
+        log(config, f"discuss: final analyzer {analyzer_name} unavailable ({exc}); omitting advisory observations")
+        return None, None
+
+
 @dataclass(frozen=True)
 class _DiscussDebaterTurnResult:
     """Outcome of one debater turn: a validated response or a captured failure.
@@ -5699,6 +5785,16 @@ def _run_discuss_loop(
             for vote in final_votes
             if vote.outcome == DISCUSS_FAILED_OUTCOME
         )
+        final_analyzer_agenda, final_analyzer_response_raw = _run_discuss_final_analyzer(
+            runner,
+            issue_number=issue_number,
+            config=config,
+            analyzer=analyzer,
+            round_number=final_round_number,
+            final_votes=final_successful_votes,
+            configured_reviewers=configured_reviewers,
+            usage_context=usage_context,
+        )
         summary_body = render_discuss_round_summary_comment(
             round_number=final_round_number,
             reviewer_votes=final_successful_votes,
@@ -5708,7 +5804,8 @@ def _run_discuss_loop(
             consensus_kind="deadlock",
             round_history=round_history,
             split_proposals=[],
-            analyzer_agenda=prior_analyzer_agenda,
+            prior_analyzer_agenda=prior_analyzer_agenda,
+            final_analyzer_agenda=final_analyzer_agenda,
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
             failed_debaters=final_failed_debaters,
@@ -5729,6 +5826,7 @@ def _run_discuss_loop(
                     is_final=True,
                     consensus_kind="deadlock",
                     agenda=(),
+                    final_analyzer_response=final_analyzer_response_raw,
                     research_mode=config.discuss_research,
                     failed_debaters=final_failed_debaters,
                 ),
@@ -5979,6 +6077,8 @@ def _run_discuss_loop(
                 consensus_kind = ("unanimous" if len(round_history) == 1 else "converged") if is_final else None
         next_analyzer_agenda: ParsedDiscussAgenda | None = None
         analyzer_response_raw: str | None = None
+        final_analyzer_agenda: ParsedDiscussAgenda | None = None
+        final_analyzer_response_raw: str | None = None
         if not is_final and analyzer is not None:
             next_analyzer_agenda, analyzer_response_raw = _run_discuss_analyzer(
                 runner,
@@ -5993,6 +6093,17 @@ def _run_discuss_loop(
                 configured_reviewers=configured_reviewers,
                 usage_context=usage_context,
             )
+        elif is_final:
+            final_analyzer_agenda, final_analyzer_response_raw = _run_discuss_final_analyzer(
+                runner,
+                issue_number=issue_number,
+                config=config,
+                analyzer=analyzer,
+                round_number=round_number,
+                final_votes=successful_votes,
+                configured_reviewers=configured_reviewers,
+                usage_context=usage_context,
+            )
         summary_body = render_discuss_round_summary_comment(
             round_number=round_number,
             # The vote table and agenda draw from real positions only; failed
@@ -6004,10 +6115,9 @@ def _run_discuss_loop(
             consensus_kind=consensus_kind,
             round_history=round_history if is_final else None,
             split_proposals=round_split_proposals,
-            # Final summaries surface the last non-final round's agenda so
-            # analyzer-extracted consensus stays auditable and distinct from
-            # the debater vote table; non-final summaries show the fresh one.
-            analyzer_agenda=prior_analyzer_agenda if is_final else next_analyzer_agenda,
+            analyzer_agenda=next_analyzer_agenda,
+            prior_analyzer_agenda=prior_analyzer_agenda if is_final else None,
+            final_analyzer_agenda=final_analyzer_agenda,
             analyzer_name=analyzer_name,
             research_mode=config.discuss_research,
             failed_debaters=tuple(failed_debaters),
@@ -6031,6 +6141,7 @@ def _run_discuss_loop(
                     consensus_kind=consensus_kind,
                     agenda=agenda,
                     analyzer_response=analyzer_response_raw,
+                    final_analyzer_response=final_analyzer_response_raw,
                     research_mode=config.discuss_research,
                     failed_debaters=tuple(failed_debaters),
                     split_proposals=tuple(round_split_proposals) if is_final else (),

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2445,6 +2445,74 @@ Rules:
 """
 
 
+def build_discuss_final_analysis_prompt(
+    issue_number: int,
+    config: AgentLoopConfig,
+    *,
+    analyzer: AgentName,
+    round_number: int,
+    final_votes: Sequence[ParsedDiscussResponse],
+) -> str:
+    """Ask for advisory observations about *only* the completed final round."""
+    transcript_lines: list[str] = []
+    for vote in final_votes:
+        if isinstance(vote, ParsedDiscussAnswer):
+            transcript_lines.extend(
+                [f"- {vote.reviewer}: `{vote.position}`", f"  Answer: {vote.answer or '(none)'}"]
+            )
+            if vote.open_questions:
+                transcript_lines.extend(f"  Open question: {question}" for question in vote.open_questions)
+        else:
+            transcript_lines.append(f"- {vote.reviewer}: `{vote.outcome}`")
+        transcript_lines.append(f"  Rationale: {vote.rationale}")
+        if vote.rebuttal:
+            transcript_lines.append(f"  Rebuttal: {vote.rebuttal}")
+    transcript = "\n".join(transcript_lines)
+    signature = agent_signature(analyzer, config)
+    return f"""Analyze only these completed final-round debater responses for GitHub issue #{issue_number} in {config.repo}.
+
+You are an advisory analyzer, not a debater. Do not use or infer any earlier
+round, issue context, prior agenda, or external information. Do not edit files.
+
+Final round {round_number} responses:
+
+{transcript}
+
+Report only observations directly supported by the responses above. Every named
+position must belong to a listed debater, and every topic, position, consensus,
+or missing fact must be grounded in their final-round text. This output is not a
+debater-confirmed vote and must not manufacture unresolved disagreements.
+
+Respond using this mandatory structured JSON format:
+
+{{
+  "schema_version": 1,
+  "kind": "discuss_agenda",
+  "consensus": ["A final-round point directly supported by every response."],
+  "disagreements": [
+    {{
+      "topic": "A final-round unresolved topic",
+      "positions": {{"Codex": "A final-round position", "Gemini": "Another final-round position"}},
+      "question_for_next_round": "A question directly raised by the final responses"
+    }}
+  ],
+  "missing_facts": ["A fact the final responses explicitly identify as missing."]
+}}
+<!-- AGENT_PLAN_STATE: approved -->
+-- {signature}
+
+Rules:
+- `consensus`, `disagreements`, and `missing_facts` may be empty arrays.
+- Do not include research fields: there is no next round.
+- The footer must always be `<!-- AGENT_PLAN_STATE: approved -->`.
+- Do not include prose or code fences before the JSON object.
+- Your response must end with, in this exact order:
+
+<!-- AGENT_PLAN_STATE: approved -->
+-- {signature}
+"""
+
+
 def build_discuss_review_prompt(
     issue_number: int,
     config: AgentLoopConfig,

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -54,6 +54,9 @@ class PostedRoundMetadata:
     # Raw structured discuss-agenda response from the optional analyzer (#467).
     # None on final summaries, plain-mode rounds, and legacy comments.
     analyzer_response: str | None = None
+    # Raw structured final-only analyzer response (#529).  Kept separate from
+    # the prior-round agenda so resumes/audit cannot treat history as current.
+    final_analyzer_response: str | None = None
     # Discuss research policy in effect when the comment was posted (#477).
     # None on non-discuss flows and legacy comments.
     research_mode: str | None = None
@@ -163,6 +166,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "is_final": metadata.is_final,
         "agenda": list(metadata.agenda),
         "analyzer_response": metadata.analyzer_response,
+        "final_analyzer_response": metadata.final_analyzer_response,
         "research_mode": metadata.research_mode,
         "failed_debaters": [list(pair) for pair in metadata.failed_debaters],
         "split_proposals": list(metadata.split_proposals),
@@ -211,6 +215,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             analyzer_response=(
                 str(payload["analyzer_response"])
                 if payload.get("analyzer_response") is not None
+                else None
+            ),
+            final_analyzer_response=(
+                str(payload["final_analyzer_response"])
+                if payload.get("final_analyzer_response") is not None
                 else None
             ),
             research_mode=(

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -1084,18 +1084,18 @@ def test_render_discuss_summary_final_distinguishes_analyzer_consensus_from_vote
             _discuss_vote("do-not-implement", reviewer="Gemini"),
         ],
         split_proposals=[],
-        analyzer_agenda=_rendering_agenda(),
+        final_analyzer_agenda=_rendering_agenda(),
         analyzer_name="Anthropic Claude",
     )
     assert (
-        "### Analyzer-extracted consensus (analyzer: Anthropic Claude; not debater-confirmed)"
+        "### Final analyzer observations (analyzer: Anthropic Claude; not debater-confirmed)"
         in rendered
     )
-    assert "The debater vote table above is the authoritative consensus." in rendered
+    assert "The debater vote table above is authoritative." in rendered
     assert "| Codex |" in rendered
     assert "| Gemini |" in rendered
     # The analyzer section comes after the authoritative vote table.
-    assert rendered.index("| Codex |") < rendered.index("Analyzer-extracted consensus")
+    assert rendered.index("| Codex |") < rendered.index("Final analyzer observations")
 
 
 def test_render_discuss_summary_final_without_agenda_has_no_analyzer_section():
@@ -1118,9 +1118,9 @@ def test_render_discuss_summary_final_empty_agenda_renders_placeholder():
         subject="abc123",
         reviewer_votes=[_discuss_vote("implement", reviewer="Codex")],
         split_proposals=[],
-        analyzer_agenda=ParsedDiscussAgenda(consensus=(), disagreements=(), missing_facts=()),
+        final_analyzer_agenda=ParsedDiscussAgenda(consensus=(), disagreements=(), missing_facts=()),
     )
-    assert "### Analyzer-extracted consensus (not debater-confirmed)" in rendered
+    assert "### Final analyzer observations (not debater-confirmed)" in rendered
     assert "(the analyzer extracted no points)" in rendered
 
 

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -1060,6 +1060,32 @@ def test_render_discuss_summary_non_final_uses_analyzer_agenda_with_attribution(
     assert "- Codex held `implement`: Mechanical rationale." not in rendered
 
 
+def test_render_discuss_answer_summary_non_final_uses_analyzer_agenda_with_attribution():
+    answer = ParsedDiscussAnswer(
+        position="answer",
+        rationale="An API has the clearest boundary.",
+        confidence="high",
+        open_questions=(),
+        reviewer="Codex",
+        answer="Use an API.",
+    )
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=[answer],
+        analyzer_agenda=_rendering_agenda(),
+        analyzer_name="Anthropic Claude",
+        result_mode="answer",
+    )
+
+    assert "## Round 1 summary: Answer Pending" in rendered
+    assert "### Agenda for round 2 (analyzer: Anthropic Claude)" in rendered
+    assert "Analyzer-extracted consensus so far (not debater-confirmed):" in rendered
+    assert "**Scope of the change**" in rendered
+    assert "Question for next round: Would splitting resolve the scope objection?" in rendered
+
+
 def test_render_discuss_summary_non_final_without_agenda_keeps_mechanical_lines():
     rendered = render_discuss_round_summary_comment(
         is_final=False,

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -13,6 +13,7 @@ from coding_review_agent_loop.orchestrator import (
     _encode_round_metadata,
     _discuss_subject,
     _validate_discuss_analyzer_agenda_fidelity,
+    _validate_discuss_final_analyzer_fidelity,
     render_public_agent_comment,
     run_discuss_loop,
     _detect_discuss_answer_consensus,
@@ -1437,7 +1438,7 @@ def test_discuss_loop_cli_parser_accepts_discuss_analyzer():
     assert plain.discuss_analyzer is None
 
 
-def test_discuss_loop_unanimous_round1_never_invokes_analyzer(tmp_path):
+def test_discuss_loop_unanimous_round1_attempts_final_only_analyzer(tmp_path):
     implement_text = _discuss_review_text(outcome="implement")
     runner = FakeRunner(
         codex_outputs=[implement_text],
@@ -1451,11 +1452,12 @@ def test_discuss_loop_unanimous_round1_never_invokes_analyzer(tmp_path):
     assert result == 0
     assert len(runner.comments) == 3
     assert "Consensus: Implement" in runner.comments[-1]
-    assert not _claude_commands(runner)
+    assert len(_claude_commands(runner)) == 1
+    assert "Analyze only these completed final-round debater responses" in " ".join(_claude_commands(runner)[0])
     assert "Analyzer" not in runner.comments[-1]
 
 
-def test_discuss_loop_max_rounds_zero_never_invokes_analyzer(tmp_path):
+def test_discuss_loop_max_rounds_zero_runs_final_only_analyzer(tmp_path):
     runner = FakeRunner(
         codex_outputs=[_discuss_review_text(outcome="implement")],
         gemini_outputs=[_discuss_review_text(outcome="needs-human", rationale="Needs input.")],
@@ -1466,7 +1468,8 @@ def test_discuss_loop_max_rounds_zero_never_invokes_analyzer(tmp_path):
     result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
 
     assert result == 0
-    assert not _claude_commands(runner)
+    assert len(_claude_commands(runner)) == 1
+    assert "Analyze only these completed final-round debater responses" in " ".join(_claude_commands(runner)[0])
     assert "Consensus kind: `deadlock` after round 1." in runner.comments[-1]
 
 
@@ -1542,16 +1545,54 @@ def test_discuss_loop_analyzer_agenda_focuses_debate_and_final_summary_distingui
     assert "Gemini round-one rationale." not in codex_prompt
     assert "Gemini round-one rationale." in gemini_prompt
     assert "Codex round-one rationale." not in gemini_prompt
-    # The deadlock final summary keeps analyzer-extracted consensus distinct
-    # from the authoritative debater vote table.
+    # The prior agenda is historical only when the final-only analyzer fails.
     final = runner.comments[-1]
     assert "Consensus kind: `deadlock` after round 2." in final
-    assert (
-        "### Analyzer-extracted consensus (analyzer: Claude; not debater-confirmed)"
-        in final
-    )
-    assert "The debater vote table above is the authoritative consensus." in final
+    assert "### Final analyzer observations" not in final
+    assert "### Agenda before final round" in final
+    assert "Historical analyzer agenda only" in final
     assert "The issue is well-motivated." in final
+
+
+def test_discuss_loop_final_analyzer_uses_only_final_responses_and_preserves_prior_agenda(tmp_path):
+    prior = _discuss_agenda_text()
+    final = _discuss_agenda_text(consensus=["Concession check injection is accepted."], disagreements=[])
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_review_text(outcome="implement", rationale="Prior scope dispute."),
+            _discuss_review_text(outcome="implement", rationale="Concession check injection is accepted.", rebuttal="Resolved."),
+        ],
+        gemini_outputs=[
+            _discuss_review_text(outcome="do-not-implement", rationale="Prior scope dispute."),
+            _discuss_review_text(outcome="implement", rationale="Concession check injection is accepted.", rebuttal="Resolved."),
+        ],
+        claude_outputs=[prior, final], issue_payload=_grounded_agenda_issue_payload(),
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1) == 0
+    final_prompt = next(" ".join(command) for command in _claude_commands(runner) if "Analyze only these completed final-round" in " ".join(command))
+    assert "Concession check injection is accepted." in final_prompt
+    assert "Scope of the change" not in final_prompt
+    summary = runner.comments[-1]
+    assert "### Final analyzer observations (analyzer: Claude; not debater-confirmed)" in summary
+    assert "### Agenda before final round" in summary
+
+
+def test_final_analyzer_fidelity_rejects_unknown_debater_and_unsupported_topic(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+    votes = [
+        ParsedDiscussReview(outcome="implement", rationale="Use concession checks.", split_proposals=(), reviewer="Codex"),
+        ParsedDiscussReview(outcome="implement", rationale="Use concession checks.", split_proposals=(), reviewer="Gemini"),
+    ]
+    bad = ParsedDiscussAgenda(
+        disagreements=(DiscussAgendaDisagreement("Invented synthesis", (("Claude", "Use synthesis."),), "Why?"),),
+        consensus=(), missing_facts=(),
+    )
+    with pytest.raises(AgentLoopError, match="unknown or absent debater"):
+        _validate_discuss_final_analyzer_fidelity(bad, final_votes=votes, configured_reviewers=("codex", "gemini"), analyzer="claude")
+    unsupported = ParsedDiscussAgenda(consensus=("Invented synthesis injection.",), disagreements=(), missing_facts=())
+    with pytest.raises(AgentLoopError, match="lacks final-round support"):
+        _validate_discuss_final_analyzer_fidelity(unsupported, final_votes=votes, configured_reviewers=("codex", "gemini"), analyzer="claude")
 
 
 def test_discuss_loop_debater_misframing_correction_is_rendered(tmp_path):
@@ -1931,7 +1972,8 @@ def test_discuss_loop_agenda_claiming_consensus_is_forwarded_but_votes_rule(tmp_
     # visible next to the vote table.
     assert "Consensus kind: `deadlock` after round 2." in final
     assert "Everyone agrees to implement." in final
-    assert "The debater vote table above is the authoritative consensus." in final
+    assert "### Agenda before final round" in final
+    assert "Historical analyzer agenda only" in final
 
 
 # --- discuss research policy tests (#477) ---

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -585,6 +585,12 @@ def test_discuss_loop_answer_debater_sees_analyzer_agenda_on_rebuttal_round(tmp_
     assert len(round2) == 2, runner.commands
     assert all("Scope of the change" in prompt for prompt in round2)
     assert all("Would splitting resolve the scope objection?" in prompt for prompt in round2)
+    round_one_summary = next(
+        comment for comment in runner.comments
+        if "## Round 1 summary: Answer Pending" in comment
+    )
+    assert "### Agenda for round 2 (analyzer: Claude)" in round_one_summary
+    assert "**Scope of the change**" in round_one_summary
 
 
 def test_discuss_loop_resumes_answer_partial_round_and_is_idempotent(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2015,6 +2015,7 @@ def test_reviewer_prompt_includes_documentation_check(tmp_path):
 
 from coding_review_agent_loop.prompts import (
     build_discuss_agenda_prompt,
+    build_discuss_final_analysis_prompt,
     build_discuss_review_prompt,
 )
 from coding_review_agent_loop.protocol import (
@@ -2352,3 +2353,18 @@ def test_build_discuss_agenda_prompt_research_required_focuses_questions(tmp_pat
     )
     assert "debaters must research" in prompt
     assert "`research_required` / `research_questions`" in prompt
+
+
+def test_build_discuss_final_analysis_prompt_excludes_prior_context(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_analyzer="claude")
+    prompt = build_discuss_final_analysis_prompt(
+        56, config, analyzer="claude", round_number=3,
+        final_votes=[
+            ParsedDiscussReview(outcome="implement", rationale="Accept concession checks.", split_proposals=(), reviewer="Codex"),
+            ParsedDiscussReview(outcome="implement", rationale="Accept concession checks.", split_proposals=(), reviewer="Gemini"),
+        ],
+    )
+    assert "Analyze only these completed final-round debater responses" in prompt
+    assert "Accept concession checks." in prompt
+    assert "Your previous agenda" not in prompt
+    assert "Complete debate transcript so far" not in prompt


### PR DESCRIPTION
Fixes #529

- run a best-effort analyzer pass over only complete final-round debater responses
- reject unsupported or non-debater final analyzer observations and omit them on failure
- render final observations separately from the historical agenda before the final round
- retain separate final-analysis metadata for audit and resume compatibility

Tests: python3 -m pytest