### PR TITLE
Reconcile final discuss evidence ledgers

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,29 @@ python -m pytest
 
 Tests use fake subprocess runners. They do not call real `claude`, `codex`, `gemini`, or `gh`.
 
+### Discuss evidence reconciliation
+
+Final discuss summaries reconcile structured debater evidence instead of
+rendering an append-only research ledger. Claims are `verified`,
+`reported-but-unverified`, or `missing`; an explicit update records the
+historical `retracted` or `superseded` state. `verified` means the debater
+attests it directly inspected the cited source or checkout location and that it
+supports the exact claim (`external-source-inspected` with a reference, or
+`checkout-inspected` with a repository-relative `path:line`). Legacy
+`research.sourced_facts` remain reported, never automatically verified.
+
+Debaters provide `evidence.claims` and `evidence.updates`; an update names a
+stable prior observation ID and has `action: retract|supersede` plus a reason.
+Exact fact/source duplicates combine contributor attribution without an
+analyzer. The optional evidence reconciler may group paraphrases, but cannot
+create claims, change statuses, or decide retractions. Final-analyzer
+observations remain final-round-text-only.
+
+The optional reconciler sees at most 64 clipped observations / 24,000 UTF-8
+bytes. The rendered ledger is capped at 50 entries / 16,000 bytes, prioritizing
+updates and targets, final-round claims, verified, reported, missing, then old
+history. Round comments and replay metadata retain the full raw audit trail.
+
 ### Test file layout
 
 The test suite is split across focused modules for faster, targeted runs:

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -587,6 +587,34 @@ Rendering keeps sourced facts distinct from judgment:
   research policy never fails on old comments; enforcement applies only to
   newly invoked debaters.
 
+### Reconciled final evidence
+
+New discuss responses include an `evidence` object with `claims` and `updates`
+(both arrays may be empty). Claims use `verified`, `reported-but-unverified`,
+or `missing`. A verified claim requires an agent attestation that it inspected
+the exact supporting source: `external-source-inspected` with a non-empty
+reference, or `checkout-inspected` with repository-relative `path:line`.
+`missing` cannot carry a citation. Legacy `research.sourced_facts` are retained
+as reported-but-unverified; citations alone never promote a claim.
+
+For later rounds, prompts show stable observation IDs. Debaters retract or
+replace an earlier claim only through `updates`, for example
+`{"action":"supersede","target_observation_id":"issue-123-r1-Codex-c0","reason":"direct inspection disproved it","replacement_claim_index":0}`.
+This works without `--discuss-analyzer`; exact normalized fact/source matches
+combine attribution deterministically. Paraphrase grouping is optional
+evidence-reconciler behavior and never changes a status, invents an unknown, or
+revives an agenda. The existing #529 rule still applies: the final analyzer
+gets final-round debater text only.
+
+Final comments render separate Verified evidence, Reported but unverified,
+Missing facts, and Retracted or superseded history sections. Reconciliation
+input is bounded to 64 observations / 24,000 UTF-8 bytes (fact/reason fields
+clip to 512 bytes and sources to 256); the final ledger is bounded to 50
+entries / 16,000 bytes. Selection is newest-first within updates/targets,
+final-round claims, verified, reported, missing, and old history. Omitted
+counts and a digest point to the complete per-round comments and replay
+metadata, which remain the audit trail.
+
 ### Parallel debater execution
 
 `--discuss-parallel` runs same-round debaters concurrently instead of one

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -840,6 +840,7 @@ def _render_discuss_research_section(
     research_mode: str,
     reviewer_votes: Sequence[ParsedDiscussResponse],
     round_history: Sequence[Sequence[ParsedDiscussResponse]] | None,
+    evidence_reconciliation: dict[str, object] | None = None,
 ) -> list[str]:
     """Render the final-summary research section (#477).
 
@@ -865,24 +866,51 @@ def _render_discuss_research_section(
         if getattr(vote, "research_target", None):
             lines.append(f"  Target: `{vote.research_target}`")
             lines.extend(f"  Question: {question}" for question in vote.research_questions)
-    fact_rounds = round_history if round_history else [reviewer_votes]
-    sourced: list[str] = []
-    seen: set[tuple[str, str, str]] = set()
-    for votes in fact_rounds:
-        for vote in votes:
-            if isinstance(vote, ParsedFailedDiscussResponse):
-                continue
-            for fact in vote.sourced_facts:
-                key = (vote.reviewer, fact.fact, fact.source)
-                if key not in seen:
-                    seen.add(key)
-                    sourced.append(f"- {vote.reviewer}: {fact.fact} — source: {fact.source}")
-    if sourced:
-        lines.append("")
-        lines.append(
-            "Sourced facts cited by debaters (everything else above is agent judgment):"
-        )
-        lines.extend(sourced)
+    # Final summaries use the reconciled ledger.  Individual debater comments
+    # remain the complete append-only audit trail.
+    if evidence_reconciliation is not None:
+        rendered = evidence_reconciliation.get("rendered", [])
+        lines.append("Sourced facts cited by debaters are reported evidence unless directly verified below.")
+        current = [item for item in rendered if "status" in item]
+        history = [item for item in rendered if "action" in item]
+        for status, heading in (
+            ("verified", "Verified evidence"),
+            ("reported-but-unverified", "Reported but unverified"),
+            ("missing", "Missing facts"),
+        ):
+            entries = [item for item in current if item.get("status") == status]
+            if entries:
+                lines.extend(["", f"### {heading}", ""])
+                for item in entries:
+                    sources = "; ".join(item.get("sources", [])) or "no source supplied"
+                    contributors = ", ".join(item.get("contributors", []))
+                    refs = ", ".join(item.get("ids", []))
+                    lines.append(f"- {item.get('fact')} — contributors: {contributors}; source: {sources} (`{refs}`)")
+        if history:
+            lines.extend(["", "### Retracted or superseded history", ""])
+            for item in history:
+                lines.append(f"- {item.get('action')}: {item.get('fact')} (`{item.get('id')}`); reason: {item.get('reason')}")
+        omitted = evidence_reconciliation.get("omitted_entries", 0)
+        lines.extend(["", f"Audit: {evidence_reconciliation.get('observation_count', 0)} observations, {evidence_reconciliation.get('update_count', 0)} updates; ledger digest `{evidence_reconciliation.get('digest')}`."])
+        if omitted:
+            lines.append(f"{omitted} lower-priority ledger entries were omitted from this bounded summary; round comments and replay metadata retain the raw audit trail.")
+    else:
+        # Compatibility for callers rendering an old transcript without the
+        # persisted reconciliation artifact.
+        fact_rounds = round_history if round_history else [reviewer_votes]
+        sourced: list[str] = []
+        seen: set[tuple[str, str, str]] = set()
+        for votes in fact_rounds:
+            for vote in votes:
+                if isinstance(vote, ParsedFailedDiscussResponse):
+                    continue
+                for fact in vote.sourced_facts:
+                    key = (vote.reviewer, fact.fact, fact.source)
+                    if key not in seen:
+                        seen.add(key)
+                        sourced.append(f"- {vote.reviewer}: {fact.fact} — source: {fact.source}")
+        if sourced:
+            lines.extend(["", "Sourced facts cited by debaters (everything else above is agent judgment):", *sourced])
     statuses = [vote.research_status for vote in successful_votes]
     if statuses and all(status == "not-needed" for status in statuses):
         lines.append("")
@@ -948,6 +976,7 @@ def render_discuss_round_summary_comment(
     failed_debaters: Sequence[tuple[str, str]] = (),
     result_mode: str = "triage",
     semantic_comparison: dict[str, object] | None = None,
+    evidence_reconciliation: dict[str, object] | None = None,
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -970,7 +999,7 @@ def render_discuss_round_summary_comment(
             final_analyzer_agenda=final_analyzer_agenda,
             analyzer_name=analyzer_name, research_mode=research_mode,
             failed_debaters=failed_debaters, outcome=outcome,
-            semantic_comparison=semantic_comparison,
+            semantic_comparison=semantic_comparison, evidence_reconciliation=evidence_reconciliation,
         )
     if not is_final:
         lines: list[str] = [
@@ -1074,6 +1103,7 @@ def render_discuss_round_summary_comment(
                 research_mode=research_mode,
                 reviewer_votes=reviewer_votes,
                 round_history=round_history,
+                evidence_reconciliation=evidence_reconciliation,
             )
         )
     if round_history:
@@ -1095,7 +1125,8 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
     analyzer_agenda: ParsedDiscussAgenda | None, prior_analyzer_agenda: ParsedDiscussAgenda | None,
     final_analyzer_agenda: ParsedDiscussAgenda | None, analyzer_name: str | None,
     research_mode: str | None, failed_debaters: Sequence[tuple[str, str]], outcome: str | None,
-    semantic_comparison: dict[str, object] | None = None) -> str:
+    semantic_comparison: dict[str, object] | None = None,
+    evidence_reconciliation: dict[str, object] | None = None) -> str:
     if not is_final:
         heading = f"## Round {round_number} summary: Answer Pending"
     elif outcome == "needs-human":
@@ -1150,6 +1181,6 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
     if prior_analyzer_agenda is not None:
         lines.extend(["", "### Agenda before final round", "", "Historical analyzer agenda only; it is not current-state analysis.", "", *_render_analyzer_agenda_lines(prior_analyzer_agenda)])
     if research_mode is not None:
-        lines.extend(["", *_render_discuss_research_section(research_mode=research_mode, reviewer_votes=reviewer_votes, round_history=round_history)])
+        lines.extend(["", *_render_discuss_research_section(research_mode=research_mode, reviewer_votes=reviewer_votes, round_history=round_history, evidence_reconciliation=evidence_reconciliation)])
     lines.extend(["", "-- Orchestrator", f"<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->"] if is_final else ["", "-- Orchestrator"])
     return "\n".join(lines)

--- a/src/coding_review_agent_loop/evidence_reconciliation.py
+++ b/src/coding_review_agent_loop/evidence_reconciliation.py
@@ -123,11 +123,15 @@ def reconcile_evidence(
             warnings.append(f"dangling update target: {target}")
             continue
         inactive[target] = update
-    aliases = {item: item for item in by_id}
+    # Keep semantic-group membership separate from the canonical ID mapping.
+    # An identity alias cannot tell a group leader from an observation that was
+    # never grouped, so using it as the condition would leave the leader in an
+    # exact-match bucket while its peers use the semantic bucket.
+    semantic_aliases: dict[str, str] = {}
     for group in semantic_groups:
         if group:
             for item in group:
-                aliases[item] = group[0]
+                semantic_aliases[item] = group[0]
     grouped: dict[tuple[str, str, str], dict[str, object]] = {}
     history: list[dict[str, object]] = []
     for item in observations:
@@ -140,8 +144,8 @@ def reconcile_evidence(
             continue
         # Analyzer grouping may merge paraphrases, but only after strict ID and
         # status validation in the protocol parser.
-        key = (("semantic", aliases[item.observation_id], item.status)
-               if aliases[item.observation_id] != item.observation_id
+        key = (("semantic", semantic_aliases[item.observation_id], item.status)
+               if item.observation_id in semantic_aliases
                else (_normalize(item.fact), _normalize(item.source), item.status))
         entry = grouped.setdefault(key, {"ids": [], "fact": _clip(item.fact, MAX_FACT_BYTES), "status": item.status,
                                          "sources": [], "contributors": [], "rounds": []})

--- a/src/coding_review_agent_loop/evidence_reconciliation.py
+++ b/src/coding_review_agent_loop/evidence_reconciliation.py
@@ -1,0 +1,177 @@
+"""Deterministic reconciliation for final discuss evidence ledgers (#535)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Sequence
+
+from .protocol import ParsedDiscussResponse
+
+MAX_RECONCILIATION_CANDIDATES = 64
+MAX_RECONCILIATION_BYTES = 24_000
+MAX_RENDERED_EVIDENCE_ENTRIES = 50
+MAX_RENDERED_EVIDENCE_BYTES = 16_000
+MAX_FACT_BYTES = 512
+MAX_SOURCE_BYTES = 256
+MAX_REASON_BYTES = 512
+
+
+def _clip(value: str | None, limit: int) -> str | None:
+    if value is None:
+        return None
+    raw = value.encode("utf-8")
+    if len(raw) <= limit:
+        return value
+    return raw[: max(0, limit - 3)].decode("utf-8", "ignore") + "..."
+
+
+def _normalize(value: str | None) -> str:
+    return re.sub(r"\s+", " ", (value or "").strip()).casefold()
+
+
+@dataclass(frozen=True)
+class EvidenceObservation:
+    observation_id: str
+    round_number: int
+    reviewer: str
+    fact: str
+    status: str
+    source: str | None = None
+    verification_basis: str | None = None
+
+
+def observation_id(subject: str, round_number: int, reviewer: str, index: int) -> str:
+    return f"{subject}-r{round_number}-{reviewer}-c{index}"
+
+
+def collect_evidence_observations(
+    subject: str, round_history: Sequence[Sequence[ParsedDiscussResponse]],
+) -> tuple[list[EvidenceObservation], list[dict[str, object]]]:
+    """Collect claims and ordered updates while preserving legacy citations."""
+    observations: list[EvidenceObservation] = []
+    updates: list[dict[str, object]] = []
+    for round_number, votes in enumerate(round_history, start=1):
+        for vote in votes:
+            if not hasattr(vote, "evidence_claims"):
+                continue
+            claims = list(vote.evidence_claims)
+            # Legacy citations are intentionally never promoted to verified.
+            claims.extend(type("Legacy", (), {
+                "fact": fact.fact, "status": "reported-but-unverified", "source": fact.source,
+                "verification_basis": None,
+            })() for fact in vote.sourced_facts)
+            for index, claim in enumerate(claims):
+                observations.append(EvidenceObservation(
+                    observation_id=observation_id(subject, round_number, vote.reviewer, index),
+                    round_number=round_number, reviewer=vote.reviewer, fact=claim.fact,
+                    status=claim.status, source=getattr(claim, "source", None),
+                    verification_basis=getattr(claim, "verification_basis", None),
+                ))
+            for update in vote.evidence_updates:
+                updates.append({
+                    "round_number": round_number, "reviewer": vote.reviewer, "action": update.action,
+                    "target_observation_id": update.target_observation_id, "reason": update.reason,
+                    "replacement_claim_index": update.replacement_claim_index,
+                })
+    return observations, updates
+
+
+def bounded_reconciliation_candidates(observations: Sequence[EvidenceObservation], updates: Sequence[dict[str, object]]) -> list[dict[str, object]]:
+    """Newest-first bounded input; relation targets are included atomically."""
+    by_id = {item.observation_id: item for item in observations}
+    selected: list[EvidenceObservation] = []
+    selected_ids: set[str] = set()
+    # Updates/targets first, then all claims newest-first.  Invalid old targets
+    # are audit-only and never suppress a current item.
+    priority_ids = [str(item["target_observation_id"]) for item in reversed(updates)]
+    priority_ids += [item.observation_id for item in reversed(observations)]
+    for candidate_id in priority_ids:
+        item = by_id.get(candidate_id)
+        if item is None or candidate_id in selected_ids:
+            continue
+        candidate = {
+            "id": item.observation_id, "fact": _clip(item.fact, MAX_FACT_BYTES),
+            "status": item.status, "source": _clip(item.source, MAX_SOURCE_BYTES),
+            "contributors": [item.reviewer],
+        }
+        trial = selected + [item]
+        payload = [{"id": x.observation_id, "fact": _clip(x.fact, MAX_FACT_BYTES), "status": x.status,
+                    "source": _clip(x.source, MAX_SOURCE_BYTES)} for x in trial]
+        if len(trial) > MAX_RECONCILIATION_CANDIDATES or len(json.dumps(payload, ensure_ascii=False).encode()) > MAX_RECONCILIATION_BYTES:
+            continue
+        selected.append(item)
+        selected_ids.add(candidate_id)
+    return [{"id": item.observation_id, "fact": _clip(item.fact, MAX_FACT_BYTES), "status": item.status,
+             "source": _clip(item.source, MAX_SOURCE_BYTES), "contributors": [item.reviewer]} for item in selected]
+
+
+def reconcile_evidence(
+    subject: str, round_history: Sequence[Sequence[ParsedDiscussResponse]],
+    semantic_groups: Sequence[Sequence[str]] = (),
+) -> dict[str, object]:
+    """Apply explicit updates and exact-match grouping without analyzer inference."""
+    observations, updates = collect_evidence_observations(subject, round_history)
+    by_id = {item.observation_id: item for item in observations}
+    inactive: dict[str, dict[str, object]] = {}
+    warnings: list[str] = []
+    for update in updates:
+        target = str(update["target_observation_id"])
+        if target not in by_id:
+            warnings.append(f"dangling update target: {target}")
+            continue
+        inactive[target] = update
+    aliases = {item: item for item in by_id}
+    for group in semantic_groups:
+        if group:
+            for item in group:
+                aliases[item] = group[0]
+    grouped: dict[tuple[str, str, str], dict[str, object]] = {}
+    history: list[dict[str, object]] = []
+    for item in observations:
+        if item.observation_id in inactive:
+            update = inactive[item.observation_id]
+            history.append({"id": item.observation_id, "fact": _clip(item.fact, MAX_FACT_BYTES),
+                            "action": update["action"], "reason": _clip(str(update["reason"]), MAX_REASON_BYTES),
+                            "target_round": item.round_number, "reviewer": item.reviewer,
+                            "replacement_claim_index": update["replacement_claim_index"]})
+            continue
+        # Analyzer grouping may merge paraphrases, but only after strict ID and
+        # status validation in the protocol parser.
+        key = (("semantic", aliases[item.observation_id], item.status)
+               if aliases[item.observation_id] != item.observation_id
+               else (_normalize(item.fact), _normalize(item.source), item.status))
+        entry = grouped.setdefault(key, {"ids": [], "fact": _clip(item.fact, MAX_FACT_BYTES), "status": item.status,
+                                         "sources": [], "contributors": [], "rounds": []})
+        entry["ids"].append(item.observation_id)
+        if item.source and item.source not in entry["sources"]:
+            entry["sources"].append(_clip(item.source, MAX_SOURCE_BYTES))
+        if item.reviewer not in entry["contributors"]:
+            entry["contributors"].append(item.reviewer)
+        if item.round_number not in entry["rounds"]:
+            entry["rounds"].append(item.round_number)
+    entries = list(grouped.values())
+    # Current evidence gets stable status order; later observations win ties.
+    order = {"verified": 0, "reported-but-unverified": 1, "missing": 2}
+    entries.sort(key=lambda entry: (order[str(entry["status"])], -max(entry["rounds"]), str(entry["fact"])))
+    history.sort(key=lambda item: (-int(item["target_round"]), str(item["id"])))
+    candidates = bounded_reconciliation_candidates(observations, updates)
+    material = {"entries": entries, "history": history, "warnings": warnings}
+    digest = hashlib.sha256(json.dumps(material, sort_keys=True, ensure_ascii=False).encode()).hexdigest()[:16]
+    rendered: list[dict[str, object]] = []
+    used = 0
+    for item in entries + history:
+        encoded = len(json.dumps(item, ensure_ascii=False).encode())
+        if len(rendered) >= MAX_RENDERED_EVIDENCE_ENTRIES or used + encoded > MAX_RENDERED_EVIDENCE_BYTES:
+            continue
+        rendered.append(item)
+        used += encoded
+    return {
+        "entries": entries, "history": history, "rendered": rendered,
+        "omitted_entries": len(entries) + len(history) - len(rendered),
+        "candidate_omitted": len(observations) - len(candidates), "digest": digest,
+        "warnings": warnings, "candidate_observations": candidates,
+        "observation_count": len(observations), "update_count": len(updates),
+    }

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -81,6 +81,11 @@ from .split_materialization import (
     split_stage_proposal_from_text,
 )
 from .logging import log, new_run_id, run_usage_summary_path
+from .evidence_reconciliation import (
+    bounded_reconciliation_candidates,
+    collect_evidence_observations,
+    reconcile_evidence,
+)
 from .memory import AgentMemoryContext, prepare_agent_memory
 from .migrations import validate_pr_migration_topology
 from .prompts import (
@@ -89,6 +94,7 @@ from .prompts import (
     CompactPrReviewTailContext,
     build_discuss_agenda_prompt,
     build_discuss_final_analysis_prompt,
+    build_discuss_evidence_reconciliation_prompt,
     build_discuss_answer_confirmation_prompt,
     build_discuss_semantic_comparison_prompt,
     build_discuss_review_prompt,
@@ -112,6 +118,7 @@ from .protocol import (
     DeferredStage,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
+    ParsedDiscussEvidenceReconciliation,
     ParsedDiscussAnswer,
     ParsedDiscussSemanticComparison,
     ParsedDiscussResponse,
@@ -147,6 +154,7 @@ from .protocol import (
     validate_structured_discuss_review,
     validate_structured_discuss_answer,
     validate_structured_discuss_answer_confirmation,
+    validate_structured_discuss_evidence_reconciliation,
     validate_structured_discuss_semantic_comparison,
 )
 from .protocol import parse_review
@@ -5436,6 +5444,8 @@ def _run_discuss_final_analyzer(
         is_failed_discuss_response(vote) for vote in final_votes
     ):
         return None, None
+
+
     analyzer_name = agent_display_name(analyzer)
     try:
         response = _run_validated_agent(
@@ -5461,6 +5471,39 @@ def _run_discuss_final_analyzer(
     except Exception as exc:
         log(config, f"discuss: final analyzer {analyzer_name} unavailable ({exc}); omitting advisory observations")
         return None, None
+
+
+def _run_discuss_evidence_reconciler(
+    runner: Runner, *, issue_number: int, config: AgentLoopConfig, analyzer: AgentName | None,
+    subject: str, round_history: Sequence[Sequence[ParsedDiscussResponse]], usage_context: RunUsageContext,
+) -> tuple[tuple[tuple[str, ...], ...], str | None]:
+    """Best-effort semantic grouping, isolated from the final agenda analyzer."""
+    if analyzer is None:
+        return (), None
+    observations, updates = collect_evidence_observations(subject, round_history)
+    candidates = bounded_reconciliation_candidates(observations, updates)
+    candidate_ids = {str(candidate["id"]) for candidate in candidates}
+    statuses = {item.observation_id: item.status for item in observations if item.observation_id in candidate_ids}
+    if len(candidates) < 2:
+        return (), None
+    try:
+        response = _run_validated_agent(
+            runner, agent=analyzer, config=config,
+            prompt=build_discuss_evidence_reconciliation_prompt(issue_number, config, analyzer=analyzer, candidates=candidates),
+            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+            validate=lambda text: validate_structured_discuss_evidence_reconciliation(text, observation_ids=tuple(statuses), observation_statuses=statuses),
+            usage_context=usage_context, use_repair=True,
+            repair_expected_kind="discuss_evidence_reconciliation", role="analyzer",
+            label="discuss-evidence-reconciliation", operation_description="evidence reconciliation",
+        )
+        parsed = response.marker_value
+        assert isinstance(parsed, ParsedDiscussEvidenceReconciliation)
+        return parsed.groups, response.text
+    except QuotaResetExceededError:
+        raise
+    except Exception as exc:
+        log(config, f"discuss: evidence reconciler unavailable ({exc}); using exact-match ledger")
+        return (), None
 
 
 @dataclass(frozen=True)
@@ -5652,6 +5695,19 @@ def _post_discuss_debater_comment(
     )
 
 
+def _validate_discuss_evidence_update_targets(
+    parsed: ParsedDiscussResponse, *, subject: str, round_history: Sequence[Sequence[ParsedDiscussResponse]],
+) -> None:
+    """Reject active malformed updates; legacy replay merely audits them."""
+    if not isinstance(parsed, (ParsedDiscussReview, ParsedDiscussAnswer)):
+        return
+    observations, _updates = collect_evidence_observations(subject, round_history)
+    allowed = {item.observation_id for item in observations}
+    for update in parsed.evidence_updates:
+        if not update.target_observation_id.startswith(f"{subject}-") or update.target_observation_id not in allowed:
+            raise AgentLoopError(f"evidence update targets unknown or cross-subject observation: {update.target_observation_id}")
+
+
 def _run_discuss_loop(
     runner: Runner,
     *,
@@ -5795,6 +5851,12 @@ def _run_discuss_loop(
             configured_reviewers=configured_reviewers,
             usage_context=usage_context,
         )
+        evidence_groups, evidence_reconciler_raw = _run_discuss_evidence_reconciler(
+            runner, issue_number=issue_number, config=config, analyzer=analyzer, subject=f"issue-{issue_number}",
+            round_history=round_history, usage_context=usage_context,
+        )
+        evidence_reconciliation = reconcile_evidence(f"issue-{issue_number}", round_history, evidence_groups)
+        evidence_reconciliation["raw_evidence_reconciler_response"] = evidence_reconciler_raw
         summary_body = render_discuss_round_summary_comment(
             round_number=final_round_number,
             reviewer_votes=final_successful_votes,
@@ -5810,6 +5872,7 @@ def _run_discuss_loop(
             research_mode=config.discuss_research,
             failed_debaters=final_failed_debaters,
             result_mode=config.discuss_result_mode,
+            evidence_reconciliation=evidence_reconciliation,
         )
         post_issue_comment(
             runner,
@@ -5829,6 +5892,7 @@ def _run_discuss_loop(
                     final_analyzer_response=final_analyzer_response_raw,
                     research_mode=config.discuss_research,
                     failed_debaters=final_failed_debaters,
+                    evidence_reconciliation=evidence_reconciliation,
                 ),
             ),
         )
@@ -5899,6 +5963,11 @@ def _run_discuss_loop(
                         prompt=prompts[reviewer_name],
                         round_number=round_number,
                         usage_context=usage_context,
+                    )
+                    parsed = response.marker_value
+                    assert isinstance(parsed, (ParsedDiscussReview, ParsedDiscussAnswer))
+                    _validate_discuss_evidence_update_targets(
+                        parsed, subject=f"issue-{issue_number}", round_history=round_history
                     )
                 except AgentLoopError as exc:
                     # Includes QuotaResetExceededError: captured here and
@@ -5987,6 +6056,9 @@ def _run_discuss_loop(
                     continue
                 parsed = response.marker_value
                 assert isinstance(parsed, (ParsedDiscussReview, ParsedDiscussAnswer))
+                _validate_discuss_evidence_update_targets(
+                    parsed, subject=f"issue-{issue_number}", round_history=round_history
+                )
                 _post_discuss_debater_comment(
                     runner,
                     config=config,
@@ -6104,6 +6176,14 @@ def _run_discuss_loop(
                 configured_reviewers=configured_reviewers,
                 usage_context=usage_context,
             )
+        evidence_reconciliation = None
+        if is_final:
+            evidence_groups, evidence_reconciler_raw = _run_discuss_evidence_reconciler(
+                runner, issue_number=issue_number, config=config, analyzer=analyzer, subject=f"issue-{issue_number}",
+                round_history=round_history, usage_context=usage_context,
+            )
+            evidence_reconciliation = reconcile_evidence(f"issue-{issue_number}", round_history, evidence_groups)
+            evidence_reconciliation["raw_evidence_reconciler_response"] = evidence_reconciler_raw
         summary_body = render_discuss_round_summary_comment(
             round_number=round_number,
             # The vote table and agenda draw from real positions only; failed
@@ -6123,6 +6203,7 @@ def _run_discuss_loop(
             failed_debaters=tuple(failed_debaters),
             result_mode=config.discuss_result_mode,
             semantic_comparison=semantic_comparison,
+            evidence_reconciliation=evidence_reconciliation,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(successful_votes))
         post_issue_comment(
@@ -6146,6 +6227,7 @@ def _run_discuss_loop(
                     failed_debaters=tuple(failed_debaters),
                     split_proposals=tuple(round_split_proposals) if is_final else (),
                     result_mode=config.discuss_result_mode,
+                    evidence_reconciliation=evidence_reconciliation,
                 ),
             ),
         )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2304,6 +2304,26 @@ def _discuss_research_policy_block(research_mode: str) -> str:
     )
 
 
+def _render_prior_evidence_index(issue_number: int, prior_round_votes: Sequence[ParsedDiscussResponse], round_number: int) -> str:
+    """A compact, analyzer-independent target index for explicit updates."""
+    if round_number <= 1 or not prior_round_votes:
+        return ""
+    lines = ["Prior evidence index (use these stable IDs in `evidence.updates`; this is not analyzer agenda text):"]
+    for vote in prior_round_votes:
+        claims = list(getattr(vote, "evidence_claims", ()))
+        claims.extend(
+            # Legacy sourced facts are still addressable and always reported.
+            type("Legacy", (), {"fact": item.fact, "status": "reported-but-unverified"})()
+            for item in getattr(vote, "sourced_facts", ())
+        )
+        for index, claim in enumerate(claims):
+            lines.append(f"- issue-{issue_number}-r{round_number - 1}-{vote.reviewer}-c{index}: [{claim.status}] {claim.fact}")
+    return "\n".join(lines) + "\n"
+
+
+DISCUSS_EVIDENCE_PROMPT_RULES = """Record evidence separately from your recommendation in a required `evidence` object. `claims` may be empty and each claim is `{fact, status, source?, verification_basis?}`. Status is exactly `verified`, `reported-but-unverified`, or `missing`. A source is only reported until you attest that you directly inspected it and it supports the exact claim: then use `verified` with `verification_basis` `external-source-inspected` (URL/reference) or `checkout-inspected` (repository-relative `path:line`). `missing` has no source or verification. To withdraw or replace prior evidence, add `updates` entries with `action` `retract` or `supersede`, target ID, non-empty reason, and optional `replacement_claim_index` into this response's claims. Do not infer retractions from prose."""
+
+
 def build_discuss_agenda_prompt(
     issue_number: int,
     config: AgentLoopConfig,
@@ -2513,6 +2533,35 @@ Rules:
 """
 
 
+def build_discuss_evidence_reconciliation_prompt(
+    issue_number: int, config: AgentLoopConfig, *, analyzer: AgentName,
+    candidates: Sequence[dict[str, object]],
+) -> str:
+    """Optional, evidence-only paraphrase grouper; it cannot adjudicate facts."""
+    signature = agent_signature(analyzer, config)
+    rendered = json.dumps(list(candidates), ensure_ascii=False, indent=2)
+    return f"""Group only semantically equivalent active evidence observations for GitHub issue #{issue_number} in {config.repo}.
+
+You are an evidence-only reconciler. Do not use issue context, debate prose,
+earlier agendas, sources, or external information. Do not create, remove,
+verify, retract, supersede, rank, or change the status of any claim. Return
+only disjoint groups of supplied IDs with the same status; omit IDs that should
+remain separate.
+
+Bounded observations:
+{rendered}
+
+Return exactly:
+{{
+  "schema_version": 1,
+  "kind": "discuss_evidence_reconciliation",
+  "groups": [["observation-id-a", "observation-id-b"]]
+}}
+<!-- AGENT_PLAN_STATE: approved -->
+-- {signature}
+"""
+
+
 def build_discuss_review_prompt(
     issue_number: int,
     config: AgentLoopConfig,
@@ -2529,6 +2578,11 @@ def build_discuss_review_prompt(
     reviewer_signature = agent_signature(reviewer, config)
     prior_round_votes = tuple(prior_round_votes or ())
     prior_round_agenda = tuple(prior_round_agenda or ())
+    prior_evidence_index = _render_prior_evidence_index(issue_number, prior_round_votes, round_number)
+    evidence_example = (',\n  "evidence": {\n'
+                        '    "claims": [{"fact": "A reported implementation fact.", "status": "reported-but-unverified"}],\n'
+                        '    "updates": []\n'
+                        '  }')
     if config.discuss_result_mode == "answer":
         history = "\n".join(
             f"- {getattr(v, 'reviewer', 'unknown')}: position={getattr(v, 'position', 'failed')}; "
@@ -2572,6 +2626,7 @@ Use this local checkout only to inspect context. Do not edit files, create a bra
 {_issue_context_block(issue_context)}{_memory_block(memory)}
 Prior round positions (the analyzer is non-authoritative; do not treat it as a vote):
 {history}{analyzer_context}
+{prior_evidence_index}
 
 Produce the best consensus answer or tradeoff recommendation, not an implementation vote.
 {research}
@@ -2584,9 +2639,9 @@ Respond with exactly this JSON object followed by the approved plan footer:
   "rationale": "Why this answer follows from the evidence.",
   "confidence": "medium",
   "open_questions": [],
-  "rebuttal": "..."{research_example}
+  "rebuttal": "..."{research_example}{evidence_example}
 }}
-Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.{research_rules}
+Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.{research_rules} {DISCUSS_EVIDENCE_PROMPT_RULES}
 Do not include triage fields such as outcome or split_proposals. The analyzer is not authoritative and is context only; sourced research facts must remain distinct from judgment.
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
@@ -2708,6 +2763,8 @@ branch, commit, push, or open a pull request during this evaluation.
 {_issue_context_block(issue_context)}{_memory_block(memory)}
 {round_context}
 
+{prior_evidence_index}
+
 {_discuss_research_policy_block(research_mode)}
 
 Vote on one of these outcomes:
@@ -2723,7 +2780,7 @@ Respond using this mandatory structured JSON format:
   "kind": "discuss_review",
   "outcome": "implement",
   "rationale": "The feature is clearly scoped and fills a documented user need.",
-  "split_proposals": []{rebuttal_example}{research_example}
+  "split_proposals": []{rebuttal_example}{research_example}{evidence_example}
 }}
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}
@@ -2733,6 +2790,7 @@ Rules:
 - `rationale` is required and must be non-empty.
 - `split_proposals` is required and must be non-empty when `outcome` is `split`; omit or use `[]` for other outcomes.
 {rebuttal_rule}{analyzer_rules}{research_rules}
+- {DISCUSS_EVIDENCE_PROMPT_RULES}
 - The footer must always be `<!-- AGENT_PLAN_STATE: approved -->` regardless of your outcome.
 - Do not include prose or code fences before the JSON object.
 - Do not place your signature before the `AGENT_PLAN_STATE` footer.

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -257,6 +257,29 @@ class StructuredDiscussAnswer:
     framing_note: str | None = None
 
 
+DISCUSS_EVIDENCE_STATUS_VALUES = frozenset({"verified", "reported-but-unverified", "missing"})
+DISCUSS_EVIDENCE_UPDATE_ACTIONS = frozenset({"retract", "supersede"})
+DISCUSS_VERIFICATION_BASES = frozenset({"external-source-inspected", "checkout-inspected"})
+
+
+@dataclass(frozen=True)
+class DiscussEvidenceClaim:
+    """A debater-authored observation.  IDs are assigned by the orchestrator."""
+
+    fact: str
+    status: str
+    source: str | None = None
+    verification_basis: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscussEvidenceUpdate:
+    action: str
+    target_observation_id: str
+    reason: str
+    replacement_claim_index: int | None = None
+
+
 @dataclass(frozen=True)
 class ParsedDiscussAnswer:
     position: str
@@ -272,6 +295,8 @@ class ParsedDiscussAnswer:
     sourced_facts: tuple[DiscussSourcedFact, ...] = ()
     research_target: str | None = None
     research_questions: tuple[str, ...] = ()
+    evidence_claims: tuple[DiscussEvidenceClaim, ...] = ()
+    evidence_updates: tuple[DiscussEvidenceUpdate, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -294,6 +319,11 @@ class ParsedDiscussAnswerConfirmation:
     decision: str
     rationale: str
     answer: str | None = None
+
+
+@dataclass(frozen=True)
+class ParsedDiscussEvidenceReconciliation:
+    groups: tuple[tuple[str, ...], ...]
 
 
 @dataclass(frozen=True)
@@ -324,6 +354,8 @@ class ParsedDiscussReview:
     sourced_facts: tuple[DiscussSourcedFact, ...] = ()
     research_target: str | None = None
     research_questions: tuple[str, ...] = ()
+    evidence_claims: tuple[DiscussEvidenceClaim, ...] = ()
+    evidence_updates: tuple[DiscussEvidenceUpdate, ...] = ()
 
 
 ParsedDiscussResponse = ParsedDiscussReview | ParsedDiscussAnswer | ParsedFailedDiscussResponse
@@ -2070,6 +2102,70 @@ def _parse_discuss_research(
     return status, tuple(sourced_facts), target, questions
 
 
+def _parse_discuss_evidence(
+    value: object,
+) -> tuple[tuple[DiscussEvidenceClaim, ...], tuple[DiscussEvidenceUpdate, ...]]:
+    """Parse explicit evidence without trying to infer meaning from prose.
+
+    This deliberately stays optional so persisted pre-#535 transcript responses
+    can still be replayed.  Legacy ``research.sourced_facts`` are projected by
+    the reconciliation layer as reported observations.
+    """
+    payload = _expect_object(value, context="discuss evidence")
+    _expect_exact_keys(payload, context="discuss evidence", required={"claims", "updates"})
+    claims_value = payload["claims"]
+    updates_value = payload["updates"]
+    if not isinstance(claims_value, list) or not isinstance(updates_value, list):
+        raise AgentLoopError("discuss evidence.claims and evidence.updates must be JSON arrays.")
+    claims: list[DiscussEvidenceClaim] = []
+    for index, item in enumerate(claims_value):
+        context = f"discuss evidence.claims at index {index}"
+        claim = _expect_object(item, context=context)
+        _expect_exact_keys(
+            claim, context=context, required={"fact", "status"},
+            optional={"source", "verification_basis"},
+        )
+        fact = _expect_non_empty_string(claim["fact"], context=f"{context}.fact")
+        status = _expect_non_empty_string(claim["status"], context=f"{context}.status")
+        if status not in DISCUSS_EVIDENCE_STATUS_VALUES:
+            raise AgentLoopError("discuss evidence claim status must be verified, reported-but-unverified, or missing.")
+        source = (_expect_non_empty_string(claim["source"], context=f"{context}.source")
+                  if "source" in claim else None)
+        basis = (_expect_non_empty_string(claim["verification_basis"], context=f"{context}.verification_basis")
+                 if "verification_basis" in claim else None)
+        if status == "missing" and (source is not None or basis is not None):
+            raise AgentLoopError("missing evidence claims cannot carry a source or verification basis.")
+        if status == "verified":
+            if basis not in DISCUSS_VERIFICATION_BASES or source is None:
+                raise AgentLoopError("verified evidence requires source and verification_basis external-source-inspected or checkout-inspected.")
+            if basis == "checkout-inspected" and not re.fullmatch(r"[^\s:][^:]*:\d+", source):
+                raise AgentLoopError("checkout-inspected verified evidence requires a repository-relative path:line source.")
+        elif basis is not None:
+            raise AgentLoopError("only verified evidence may carry verification_basis.")
+        claims.append(DiscussEvidenceClaim(fact=fact, status=status, source=source, verification_basis=basis))
+    updates: list[DiscussEvidenceUpdate] = []
+    for index, item in enumerate(updates_value):
+        context = f"discuss evidence.updates at index {index}"
+        update = _expect_object(item, context=context)
+        _expect_exact_keys(
+            update, context=context, required={"action", "target_observation_id", "reason"},
+            optional={"replacement_claim_index"},
+        )
+        action = _expect_non_empty_string(update["action"], context=f"{context}.action")
+        if action not in DISCUSS_EVIDENCE_UPDATE_ACTIONS:
+            raise AgentLoopError("discuss evidence update action must be retract or supersede.")
+        replacement = update.get("replacement_claim_index")
+        if replacement is not None and (not isinstance(replacement, int) or isinstance(replacement, bool) or replacement < 0 or replacement >= len(claims)):
+            raise AgentLoopError("evidence replacement_claim_index must reference a claim in the same response.")
+        updates.append(DiscussEvidenceUpdate(
+            action=action,
+            target_observation_id=_expect_non_empty_string(update["target_observation_id"], context=f"{context}.target_observation_id"),
+            reason=_expect_non_empty_string(update["reason"], context=f"{context}.reason"),
+            replacement_claim_index=replacement,
+        ))
+    return tuple(claims), tuple(updates)
+
+
 def parse_structured_discuss_review(
     text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
 ) -> ParsedDiscussReview | None:
@@ -2086,7 +2182,7 @@ def parse_structured_discuss_review(
         payload,
         context="discuss_review",
         required={"schema_version", "kind", "outcome", "rationale"},
-        optional={"split_proposals", "rebuttal", "analyzer_framing", "framing_note", "research"},
+        optional={"split_proposals", "rebuttal", "analyzer_framing", "framing_note", "research", "evidence"},
     )
     outcome = _expect_non_empty_string(payload["outcome"], context="discuss_review.outcome")
     if outcome not in DISCUSS_OUTCOME_VALUES:
@@ -2135,6 +2231,9 @@ def parse_structured_discuss_review(
     research_questions: tuple[str, ...] = ()
     if "research" in payload:
         research_status, sourced_facts, research_target, research_questions = _parse_discuss_research(payload["research"])
+    evidence_claims, evidence_updates = ((), ())
+    if "evidence" in payload:
+        evidence_claims, evidence_updates = _parse_discuss_evidence(payload["evidence"])
     if research_mode == "required":
         if research_status is None:
             raise AgentLoopError(
@@ -2158,6 +2257,8 @@ def parse_structured_discuss_review(
         sourced_facts=sourced_facts,
         research_target=research_target,
         research_questions=research_questions,
+        evidence_claims=evidence_claims,
+        evidence_updates=evidence_updates,
     )
 
 
@@ -2191,7 +2292,7 @@ def parse_structured_discuss_answer(
         payload,
         context="discuss_answer",
         required={"schema_version", "kind", "position", "rationale", "confidence", "open_questions"},
-        optional={"answer", "rebuttal", "analyzer_framing", "framing_note", "research"},
+        optional={"answer", "rebuttal", "analyzer_framing", "framing_note", "research", "evidence"},
     )
     position = _expect_non_empty_string(payload["position"], context="discuss_answer.position")
     if position not in DISCUSS_ANSWER_POSITION_VALUES:
@@ -2234,6 +2335,9 @@ def parse_structured_discuss_answer(
     research_questions: tuple[str, ...] = ()
     if "research" in payload:
         research_status, sourced_facts, research_target, research_questions = _parse_discuss_research(payload["research"])
+    evidence_claims, evidence_updates = ((), ())
+    if "evidence" in payload:
+        evidence_claims, evidence_updates = _parse_discuss_evidence(payload["evidence"])
     if research_mode == "required" and (research_status is None or research_status == "not-needed"):
         raise AgentLoopError("discuss_answer.research with sourced, unavailable, or inconclusive status is required.")
     return ParsedDiscussAnswer(
@@ -2242,6 +2346,7 @@ def parse_structured_discuss_answer(
         rebuttal=rebuttal, analyzer_framing=analyzer_framing, framing_note=framing_note,
         research_status=research_status, sourced_facts=sourced_facts,
         research_target=research_target, research_questions=research_questions,
+        evidence_claims=evidence_claims, evidence_updates=evidence_updates,
     )
 
 
@@ -2252,6 +2357,32 @@ def validate_structured_discuss_answer(
     if parsed is None:
         raise AgentLoopError("Discuss answer did not use the required structured format.")
     return parsed
+
+
+def validate_structured_discuss_evidence_reconciliation(
+    text: str, *, observation_ids: Sequence[str], observation_statuses: dict[str, str],
+) -> ParsedDiscussEvidenceReconciliation:
+    payload = _extract_structured_discuss_review_payload(text, context_label="Evidence reconciliation")
+    if payload is None:
+        raise AgentLoopError("Evidence reconciliation did not use the required structured format.")
+    _require_supported_schema_version(payload)
+    _expect_exact_keys(payload, context="discuss_evidence_reconciliation", required={"schema_version", "kind", "groups"})
+    if payload.get("kind") != "discuss_evidence_reconciliation" or not isinstance(payload["groups"], list):
+        raise AgentLoopError("Expected discuss_evidence_reconciliation groups.")
+    known = set(observation_ids)
+    used: set[str] = set()
+    groups: list[tuple[str, ...]] = []
+    for index, value in enumerate(payload["groups"]):
+        if not isinstance(value, list) or len(value) < 2 or not all(isinstance(item, str) and item for item in value):
+            raise AgentLoopError(f"evidence reconciliation group {index} must contain at least two observation IDs.")
+        group = tuple(value)
+        if any(item not in known for item in group) or any(item in used for item in group):
+            raise AgentLoopError("evidence reconciliation groups must use each supplied ID at most once.")
+        if len({observation_statuses[item] for item in group}) != 1:
+            raise AgentLoopError("evidence reconciliation can group only compatible active statuses.")
+        used.update(group)
+        groups.append(group)
+    return ParsedDiscussEvidenceReconciliation(groups=tuple(groups))
 
 
 DISCUSS_SEMANTIC_CLASSIFICATIONS = frozenset({

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -85,7 +85,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}:
+    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
         return None
 
     stripped = raw.lstrip()

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -71,6 +71,9 @@ class PostedRoundMetadata:
     split_proposals: tuple[str, ...] = ()
     # Missing metadata decodes as triage for legacy transcripts.
     result_mode: str = "triage"
+    # Canonical bounded #535 evidence artifact on final summaries.  Keeping it
+    # here makes resume idempotent without feeding evidence into analyzer agenda.
+    evidence_reconciliation: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -171,6 +174,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "failed_debaters": [list(pair) for pair in metadata.failed_debaters],
         "split_proposals": list(metadata.split_proposals),
         "result_mode": metadata.result_mode,
+        "evidence_reconciliation": metadata.evidence_reconciliation,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -234,6 +238,11 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             ),
             split_proposals=tuple(str(item) for item in payload.get("split_proposals", [])),
             result_mode=str(payload.get("result_mode", "triage")),
+            evidence_reconciliation=(
+                payload.get("evidence_reconciliation")
+                if isinstance(payload.get("evidence_reconciliation"), dict)
+                else None
+            ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc

--- a/tests/test_evidence_reconciliation.py
+++ b/tests/test_evidence_reconciliation.py
@@ -1,0 +1,52 @@
+from coding_review_agent_loop.evidence_reconciliation import (
+    MAX_RENDERED_EVIDENCE_ENTRIES,
+    reconcile_evidence,
+)
+from coding_review_agent_loop.protocol import (
+    DiscussEvidenceClaim,
+    DiscussEvidenceUpdate,
+    ParsedDiscussReview,
+    parse_structured_discuss_review,
+)
+
+
+def _vote(reviewer, claims=(), updates=()):
+    return ParsedDiscussReview(
+        outcome="implement", rationale="test", split_proposals=(), reviewer=reviewer,
+        evidence_claims=tuple(claims), evidence_updates=tuple(updates),
+    )
+
+
+def test_reconciliation_retracts_old_claim_and_combines_exact_contributors():
+    subject = "issue-535"
+    first = _vote("Codex", [DiscussEvidenceClaim("Same fact", "reported-but-unverified", "https://x")])
+    duplicate = _vote("Gemini", [DiscussEvidenceClaim(" same   fact ", "reported-but-unverified", "https://x")])
+    retraction = _vote("Codex", [], [DiscussEvidenceUpdate("retract", "issue-535-r1-Codex-c0", "later inspection disproved it")])
+    ledger = reconcile_evidence(subject, [[first, duplicate], [retraction]])
+    assert len(ledger["entries"]) == 1
+    assert ledger["entries"][0]["contributors"] == ["Gemini"]
+    assert ledger["history"][0]["action"] == "retract"
+
+
+def test_reconciliation_keeps_reported_separate_from_missing_and_bounds_output():
+    claims = [DiscussEvidenceClaim(f"fact {index}", "reported-but-unverified") for index in range(60)]
+    claims.append(DiscussEvidenceClaim("implementation assertion", "missing"))
+    ledger = reconcile_evidence("issue-535", [[_vote("Codex", claims)]])
+    assert any(item["status"] == "missing" for item in ledger["entries"])
+    assert len(ledger["rendered"]) <= MAX_RENDERED_EVIDENCE_ENTRIES
+    assert ledger["omitted_entries"] > 0
+
+
+def test_protocol_accepts_verified_attestation_and_rejects_missing_citation():
+    good = '''{"schema_version":1,"kind":"discuss_review","outcome":"implement","rationale":"r","evidence":{"claims":[{"fact":"checked","status":"verified","source":"src/x.py:4","verification_basis":"checkout-inspected"}],"updates":[]}}
+<!-- AGENT_PLAN_STATE: approved -->
+-- Codex'''
+    parsed = parse_structured_discuss_review(good, reviewer="Codex")
+    assert parsed and parsed.evidence_claims[0].status == "verified"
+    bad = good.replace('"status":"verified","source":"src/x.py:4","verification_basis":"checkout-inspected"', '"status":"missing","source":"src/x.py:4"')
+    try:
+        parse_structured_discuss_review(bad, reviewer="Codex")
+    except Exception as exc:
+        assert "missing evidence claims" in str(exc)
+    else:
+        raise AssertionError("missing evidence with a citation was accepted")

--- a/tests/test_evidence_reconciliation.py
+++ b/tests/test_evidence_reconciliation.py
@@ -28,6 +28,30 @@ def test_reconciliation_retracts_old_claim_and_combines_exact_contributors():
     assert ledger["history"][0]["action"] == "retract"
 
 
+def test_reconciliation_combines_semantic_paraphrases_and_contributors():
+    subject = "issue-535"
+    first = _vote("Codex", [DiscussEvidenceClaim(
+        "The renderer adds each sourced fact as a separate ledger entry.",
+        "reported-but-unverified", "src/comment_rendering.py:130",
+    )])
+    paraphrase = _vote("Antigravity", [DiscussEvidenceClaim(
+        "Every sourced fact is shown in its own final evidence ledger item.",
+        "reported-but-unverified", "src/comment_rendering.py:131",
+    )])
+    ledger = reconcile_evidence(
+        subject,
+        [[first, paraphrase]],
+        semantic_groups=[
+            ("issue-535-r1-Codex-c0", "issue-535-r1-Antigravity-c0"),
+        ],
+    )
+
+    assert len(ledger["entries"]) == 1
+    entry = ledger["entries"][0]
+    assert entry["contributors"] == ["Codex", "Antigravity"]
+    assert entry["ids"] == ["issue-535-r1-Codex-c0", "issue-535-r1-Antigravity-c0"]
+
+
 def test_reconciliation_keeps_reported_separate_from_missing_and_bounds_output():
     claims = [DiscussEvidenceClaim(f"fact {index}", "reported-but-unverified") for index in range(60)]
     claims.append(DiscussEvidenceClaim("implementation assertion", "missing"))


### PR DESCRIPTION
## Summary
- add explicit discuss evidence claims, updates, and verification attestations
- reconcile bounded final ledgers with retraction history and combined attribution
- isolate optional evidence-only paraphrase grouping from the final analyzer

## Tests
- python3 -m pytest tests/test_evidence_reconciliation.py -q
- python3 -m pytest tests/test_protocol.py tests/test_prompts.py -q
- python3 -m pytest tests/test_comment_rendering.py tests/test_discuss_loop.py -q
- python3 -m pytest tests/test_agent_loop.py tests/test_backends.py tests/test_decomposition.py tests/test_migrations.py tests/test_orchestrator_issue.py tests/test_orchestrator_pr.py -q

Fixes #535