### PR TITLE
Classify unresolved items in discuss answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ implementation vote. Answer-mode transcripts are mode-bound for repair and
 resume, while analyzer observations and sourced research remain clearly
 separate from debater-confirmed conclusions.
 
+Answer-mode uses classified `unresolved_items`, not generic questions. Each item
+is exactly `{"status": "blocker" | "human-decision" | "follow-up", "text":
+"..."}`. `position` describes the debater's asserted response shape; it does
+not override the final outcome. An asserted answer can still carry a blocker
+or human decision. On the final complete round, `human-decision` takes
+precedence over `blocker`, which takes precedence over answer convergence;
+follow-ups alone are non-blocking. Each completed round replaces the prior
+round's active classifications, so concerns may be cleared or reclassified.
+Existing persisted answer-mode transcripts using `open_questions` remain
+resumable: old `needs-human` questions map to `human-decision` and old answer
+questions map conservatively to `blocker`.
+
 When answer-mode final answers differ, semantic convergence is opt-in through
 `--discuss-analyzer`. The explicitly configured analyzer (never an implicit
 reviewer fallback) receives only the final answers and performs no research or

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -348,12 +348,21 @@ agent-loop discuss 123 --repo OWNER/REPO \
 
 Debaters return `kind: "discuss_answer"` with `position: "answer"` or
 `"needs-human"`, plus `answer`, `rationale`, `confidence`, and
-`open_questions`. A unanimous normalized answer is rendered as **Consensus
-Answer** in round one; later convergence is **Converged Answer**. When every
-successful debater has an explicit `needs-human` position, the
-result is **Needs Human Decision**. Otherwise disagreement or partial failure
-is **Deadlock**—a lone `needs-human` position and disagreement alone never
-become escalation.
+`unresolved_items`. Each item has exactly a non-empty `text` and a `status` of
+`blocker`, `human-decision`, or `follow-up`. `position: "answer"` requires an
+answer and may include any classification; for example, an otherwise useful
+answer with a pricing `blocker` is valid but cannot conclude successfully.
+`position: "needs-human"` omits `answer` and requires at least one
+`human-decision` item.
+
+The final complete round is authoritative: later rounds can clear or
+reclassify earlier concerns. Final precedence is `human-decision` (Needs Human
+Decision), then `blocker` (Deadlock), then answer convergence; follow-ups alone
+remain non-blocking. Summaries list Blockers, Human decisions, and Non-blocking
+follow-ups separately. Legacy persisted transcripts that use `open_questions`
+are accepted only while resuming: old `needs-human` questions map to
+`human-decision`, while old asserted-answer questions map conservatively to
+`blocker`. New live responses must use `unresolved_items`.
 Analyzer observations remain non-authoritative and cited research remains a
 separate sourced-facts section. Repair and resume preserve the selected mode;
 transcripts cannot mix answer and triage responses.

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -771,8 +771,7 @@ def _render_public_discuss_answer_comment(
         sections.append("### Answer\n\n" + parsed.answer.strip())
     sections.append("### Rationale\n\n" + parsed.rationale.strip())
     sections.append(f"**Confidence:** `{parsed.confidence}`")
-    if parsed.open_questions:
-        sections.append("### Open questions\n\n" + "\n".join(f"- {q}" for q in parsed.open_questions))
+    sections.extend(_render_discuss_unresolved_item_sections([parsed]))
     if parsed.rebuttal:
         sections.append("### Rebuttal\n\n" + parsed.rebuttal.strip())
     if parsed.research_status is not None:
@@ -787,6 +786,28 @@ def _render_public_discuss_answer_comment(
         sections.append("### Sourced facts\n\n" + "\n".join(f"- {f.fact} — source: {f.source}" for f in parsed.sourced_facts))
     sections.append(f"-- {_comment_signature(reviewer, config, model_used)}")
     return "\n\n".join(sections)
+
+
+def _render_discuss_unresolved_item_sections(
+    votes: Sequence[ParsedDiscussAnswer],
+) -> list[str]:
+    headings = (
+        ("blocker", "Blockers"),
+        ("human-decision", "Human decisions"),
+        ("follow-up", "Non-blocking follow-ups"),
+    )
+    sections: list[str] = []
+    for status, heading in headings:
+        seen: set[str] = set()
+        texts: list[str] = []
+        for vote in votes:
+            for item in vote.unresolved_items:
+                if item.status == status and item.text not in seen:
+                    seen.add(item.text)
+                    texts.append(item.text)
+        if texts:
+            sections.append(f"### {heading}\n\n" + "\n".join(f"- {text}" for text in texts))
+    return sections
 
 
 def _render_discuss_agenda_lines(votes: Sequence[ParsedDiscussResponse]) -> list[str]:
@@ -1147,11 +1168,20 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
         lines.append(f"| {vote.reviewer} | {vote.position} | {vote.confidence} | {answer} |")
     if failed_debaters:
         lines.extend(_render_discuss_failed_debater_lines(failed_debaters, is_final=is_final))
-    questions = [q for v in reviewer_votes for q in v.open_questions]
-    if questions:
-        lines.extend(["", "### Open questions", "", *[f"- {q}" for q in dict.fromkeys(questions)]])
+    item_sections = _render_discuss_unresolved_item_sections(reviewer_votes)
+    for section in item_sections:
+        lines.extend(["", section])
+    if is_final:
+        statuses = {item.status for vote in reviewer_votes for item in vote.unresolved_items}
+        if outcome == "needs-human":
+            lines.extend(["", "The run needs human input because the listed human decisions remain."])
+        elif outcome == "deadlock" and "blocker" in statuses:
+            lines.extend(["", "The run is deadlocked because the listed blockers remain."])
+        elif outcome not in {"deadlock", "needs-human"}:
+            lines.extend(["", "The answer can proceed because no material items remain; non-blocking follow-ups do not block it."])
     if outcome == "deadlock":
-        lines.extend(["", "### Unresolved disagreement", "", "The debaters did not converge on one normalized answer."])
+        if not any(item.status == "blocker" for vote in reviewer_votes for item in vote.unresolved_items):
+            lines.extend(["", "### Unresolved disagreement", "", "The debaters did not converge on one normalized answer, or a required semantic check or debater failed."])
     if semantic_comparison is not None:
         lines.extend(["", "### Semantic comparison (advisory; not a debater vote)", "",
             f"Analyzer: {semantic_comparison.get('analyzer', 'configured analyzer')}",

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -120,6 +120,7 @@ from .protocol import (
     ParsedDiscussAgenda,
     ParsedDiscussEvidenceReconciliation,
     ParsedDiscussAnswer,
+    DiscussUnresolvedItem,
     ParsedDiscussSemanticComparison,
     ParsedDiscussResponse,
     ParsedDiscussReview,
@@ -4947,6 +4948,11 @@ def _detect_discuss_answer_consensus(
 ) -> tuple[str, list[str]] | None:
     if partial or not responses:
         return None
+    if _discuss_has_material_items(responses):
+        # A final round applies explicit outcome precedence. Before then,
+        # classified material prevents normalized-text convergence.
+        if not all(response.position == "needs-human" for response in responses):
+            return None
     if all(response.position == "needs-human" for response in responses):
         return "needs-human", []
     answers = [response.answer for response in responses]
@@ -4954,6 +4960,43 @@ def _detect_discuss_answer_consensus(
         normalized = {_normalize_discuss_answer(answer or "") for answer in answers}
         if len(normalized) == 1:
             return "answer", []
+    return None
+
+
+def _aggregate_discuss_unresolved_items(
+    responses: Sequence[ParsedDiscussAnswer],
+) -> tuple[DiscussUnresolvedItem, ...]:
+    """Return current-round classified items, deduplicated within a status.
+
+    We deliberately retain identical text under different statuses: a blocker
+    must not disappear merely because another debater calls it a follow-up.
+    """
+    seen: set[tuple[str, str]] = set()
+    merged: list[DiscussUnresolvedItem] = []
+    for response in responses:
+        for item in response.unresolved_items:
+            key = (item.status, item.text)
+            if key not in seen:
+                seen.add(key)
+                merged.append(item)
+    return tuple(merged)
+
+
+def _discuss_has_material_items(responses: Sequence[ParsedDiscussAnswer]) -> bool:
+    return any(
+        item.status in {"blocker", "human-decision"}
+        for item in _aggregate_discuss_unresolved_items(responses)
+    )
+
+
+def _final_discuss_answer_item_outcome(
+    responses: Sequence[ParsedDiscussAnswer],
+) -> str | None:
+    statuses = {item.status for item in _aggregate_discuss_unresolved_items(responses)}
+    if "human-decision" in statuses:
+        return "needs-human"
+    if "blocker" in statuses:
+        return "deadlock"
     return None
 
 
@@ -5176,8 +5219,9 @@ def _build_discuss_agenda_support_corpus(
                 add(vote.position)
                 add(vote.answer, phrase_support=True)
                 add(vote.rationale, phrase_support=True)
-                for question in vote.open_questions:
-                    add(question, phrase_support=True)
+                for item in vote.unresolved_items:
+                    add(item.status)
+                    add(item.text, phrase_support=True)
             elif isinstance(vote, ParsedDiscussReview):
                 add(vote.outcome)
                 add(vote.rationale, phrase_support=True)
@@ -5594,7 +5638,7 @@ def _run_discuss_semantic_finalization(
     analyzer = config.discuss_analyzer
     if analyzer is None or len(answers) != len(configured_reviewers):
         return "deadlock", "deadlock", None
-    if any(item.position != "answer" or not item.answer for item in answers):
+    if any(item.position != "answer" or not item.answer for item in answers) or _discuss_has_material_items(answers):
         return "deadlock", "deadlock", None
     names = [item.reviewer for item in answers]
     try:
@@ -6110,13 +6154,21 @@ def _run_discuss_loop(
         ]
         round_history.append(reviewer_votes)
         if config.discuss_result_mode == "answer":
-            consensus = _detect_discuss_answer_consensus(
-                [vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)],
-                partial=bool(failed_debaters),
-            )
+            answer_votes = [vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)]
+            consensus = _detect_discuss_answer_consensus(answer_votes, partial=bool(failed_debaters))
         else:
             consensus = _detect_discuss_consensus(reviewer_votes)  # type: ignore[arg-type]
         is_final = consensus is not None or round_number == max_round_number
+        # The completed current round is authoritative: a later round can
+        # clear/reclassify earlier items. At the final round, classified
+        # material selects a fail-closed outcome before text comparison.
+        if (
+            is_final and config.discuss_result_mode == "answer" and not failed_debaters
+            and len(answer_votes) == len(configured_reviewers)
+        ):
+            material_outcome = _final_discuss_answer_item_outcome(answer_votes)
+            if material_outcome is not None:
+                consensus = (material_outcome, [])
         semantic_comparison: dict[str, object] | None = None
         semantic_finalization_ran = False
         # Keep normalized equality as the zero-call fast path.  Only a complete,
@@ -6126,6 +6178,9 @@ def _run_discuss_loop(
             and not failed_debaters
             and len(successful_votes) == len(configured_reviewers)
             and all(isinstance(vote, ParsedDiscussAnswer) and vote.position == "answer" and vote.answer for vote in successful_votes)
+            and not _discuss_has_material_items(
+                [vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)]
+            )
         ):
             semantic_finalization_ran = True
             outcome, semantic_kind, semantic_comparison = _run_discuss_semantic_finalization(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2480,8 +2480,11 @@ def build_discuss_final_analysis_prompt(
             transcript_lines.extend(
                 [f"- {vote.reviewer}: `{vote.position}`", f"  Answer: {vote.answer or '(none)'}"]
             )
-            if vote.open_questions:
-                transcript_lines.extend(f"  Open question: {question}" for question in vote.open_questions)
+            if vote.unresolved_items:
+                transcript_lines.extend(
+                    f"  Unresolved item ({item.status}): {item.text}"
+                    for item in vote.unresolved_items
+                )
         else:
             transcript_lines.append(f"- {vote.reviewer}: `{vote.outcome}`")
         transcript_lines.append(f"  Rationale: {vote.rationale}")
@@ -2584,11 +2587,16 @@ def build_discuss_review_prompt(
                         '    "updates": []\n'
                         '  }')
     if config.discuss_result_mode == "answer":
-        history = "\n".join(
-            f"- {getattr(v, 'reviewer', 'unknown')}: position={getattr(v, 'position', 'failed')}; "
-            f"answer={getattr(v, 'answer', None) or '(none)'}; rationale={getattr(v, 'rationale', getattr(v, 'category', ''))}"
-            for v in prior_round_votes
-        ) or "(no prior round)"
+        history_lines: list[str] = []
+        for vote in prior_round_votes:
+            history_lines.append(
+                f"- {getattr(vote, 'reviewer', 'unknown')}: position={getattr(vote, 'position', 'failed')}; "
+                f"answer={getattr(vote, 'answer', None) or '(none)'}; "
+                f"rationale={getattr(vote, 'rationale', getattr(vote, 'category', ''))}"
+            )
+            for item in getattr(vote, "unresolved_items", ()):
+                history_lines.append(f"  Unresolved item ({item.status}): {item.text}")
+        history = "\n".join(history_lines) or "(no prior round)"
         analyzer_context = ""
         if analyzer_agenda is not None:
             analyzer_context = (
@@ -2638,10 +2646,10 @@ Respond with exactly this JSON object followed by the approved plan footer:
   "answer": "A concise answer or recommendation.",
   "rationale": "Why this answer follows from the evidence.",
   "confidence": "medium",
-  "open_questions": [],
+  "unresolved_items": [],
   "rebuttal": "..."{research_example}{evidence_example}
 }}
-Rules: position is exactly `answer` or `needs-human`; `answer` requires non-empty answer; `needs-human` requires non-empty open_questions and may omit answer; {rebuttal}.{research_rules} {DISCUSS_EVIDENCE_PROMPT_RULES}
+Rules: position is exactly `answer` or `needs-human`; `answer` requires a non-empty answer; `needs-human` omits `answer` and requires at least one unresolved item with status `human-decision`. Every unresolved item is exactly `{{"status": "blocker" | "human-decision" | "follow-up", "text": "..."}}`. `blocker` prevents implementation, `human-decision` requires a human choice, and `follow-up` is non-blocking. An answer may include any status, but a material status changes the final outcome. {rebuttal}.{research_rules} {DISCUSS_EVIDENCE_PROMPT_RULES}
 Do not include triage fields such as outcome or split_proposals. The analyzer is not authoritative and is context only; sourced research facts must remain distinct from judgment.
 <!-- AGENT_PLAN_STATE: approved -->
 -- {reviewer_signature}

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -244,13 +244,30 @@ class StructuredDiscussReview:
 
 
 @dataclass(frozen=True)
+class DiscussUnresolvedItem:
+    """A classified unresolved concern from an answer-mode discuss vote.
+
+    This is intentionally distinct from ``UnresolvedReviewItem``, which is the
+    PR/plan-review ledger type and has unrelated lifecycle semantics.
+    """
+
+    status: str
+    text: str
+
+
+DISCUSS_UNRESOLVED_ITEM_STATUS_VALUES = frozenset(
+    {"blocker", "human-decision", "follow-up"}
+)
+
+
+@dataclass(frozen=True)
 class StructuredDiscussAnswer:
     schema_version: int
     kind: str
     position: str
     rationale: str
     confidence: str
-    open_questions: tuple[str, ...]
+    unresolved_items: tuple[DiscussUnresolvedItem, ...]
     answer: str | None = None
     rebuttal: str | None = None
     analyzer_framing: str | None = None
@@ -285,7 +302,7 @@ class ParsedDiscussAnswer:
     position: str
     rationale: str
     confidence: str
-    open_questions: tuple[str, ...]
+    unresolved_items: tuple[DiscussUnresolvedItem, ...]
     reviewer: str
     answer: str | None = None
     rebuttal: str | None = None
@@ -2280,6 +2297,52 @@ DISCUSS_ANSWER_CONFIDENCE_VALUES = frozenset({"low", "medium", "high"})
 def parse_structured_discuss_answer(
     text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
 ) -> ParsedDiscussAnswer | None:
+    return _parse_structured_discuss_answer(
+        text, reviewer=reviewer, round_number=round_number, research_mode=research_mode,
+        allow_legacy_open_questions=False,
+    )
+
+
+def parse_legacy_structured_discuss_answer(
+    text: str, *, reviewer: str, round_number: int = 1, research_mode: str | None = None
+) -> ParsedDiscussAnswer | None:
+    """Decode only persisted pre-#536 answer votes.
+
+    New agent output must use ``unresolved_items``.  Legacy untyped questions
+    are conservatively mapped to blockers for asserted answers, and to human
+    decisions for escalations, so a resumed run cannot silently proceed.
+    """
+    return _parse_structured_discuss_answer(
+        text, reviewer=reviewer, round_number=round_number, research_mode=research_mode,
+        allow_legacy_open_questions=True,
+    )
+
+
+def _parse_discuss_unresolved_items(value: object, *, context: str) -> tuple[DiscussUnresolvedItem, ...]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    items: list[DiscussUnresolvedItem] = []
+    for index, item in enumerate(value):
+        item_context = f"{context}[{index}]"
+        if not isinstance(item, dict):
+            raise AgentLoopError(f"{item_context} must be an object.")
+        _expect_exact_keys(item, context=item_context, required={"status", "text"})
+        status = _expect_non_empty_string(item["status"], context=f"{item_context}.status")
+        if status not in DISCUSS_UNRESOLVED_ITEM_STATUS_VALUES:
+            raise AgentLoopError(
+                f"{item_context}.status must be one of: blocker, human-decision, follow-up."
+            )
+        items.append(DiscussUnresolvedItem(
+            status=status,
+            text=_expect_non_empty_string(item["text"], context=f"{item_context}.text"),
+        ))
+    return tuple(items)
+
+
+def _parse_structured_discuss_answer(
+    text: str, *, reviewer: str, round_number: int, research_mode: str | None,
+    allow_legacy_open_questions: bool,
+) -> ParsedDiscussAnswer | None:
     payload = _extract_structured_discuss_review_payload(
         text, context_label="Structured discuss answer"
     )
@@ -2288,10 +2351,11 @@ def parse_structured_discuss_answer(
     _require_supported_schema_version(payload)
     if payload.get("kind") != "discuss_answer":
         raise AgentLoopError("Structured response kind mismatch: expected `discuss_answer`.")
+    item_key = "open_questions" if allow_legacy_open_questions else "unresolved_items"
     _expect_exact_keys(
         payload,
         context="discuss_answer",
-        required={"schema_version", "kind", "position", "rationale", "confidence", "open_questions"},
+        required={"schema_version", "kind", "position", "rationale", "confidence", item_key},
         optional={"answer", "rebuttal", "analyzer_framing", "framing_note", "research", "evidence"},
     )
     position = _expect_non_empty_string(payload["position"], context="discuss_answer.position")
@@ -2301,18 +2365,32 @@ def parse_structured_discuss_answer(
     confidence = _expect_non_empty_string(payload["confidence"], context="discuss_answer.confidence")
     if confidence not in DISCUSS_ANSWER_CONFIDENCE_VALUES:
         raise AgentLoopError("discuss_answer.confidence must be one of: low, medium, high.")
-    open_questions = _expect_string_list(
-        payload.get("open_questions", []),
-        context="discuss_answer.open_questions",
-        item_context="discuss_answer.open_questions",
-    )
+    if allow_legacy_open_questions:
+        legacy_questions = _expect_string_list(
+            payload["open_questions"], context="discuss_answer.open_questions",
+            item_context="discuss_answer.open_questions",
+        )
+        legacy_status = "human-decision" if position == "needs-human" else "blocker"
+        unresolved_items = tuple(
+            DiscussUnresolvedItem(status=legacy_status, text=question)
+            for question in legacy_questions
+        )
+    else:
+        unresolved_items = _parse_discuss_unresolved_items(
+            payload["unresolved_items"], context="discuss_answer.unresolved_items"
+        )
     answer = None
     if "answer" in payload:
         answer = _expect_non_empty_string(payload["answer"], context="discuss_answer.answer")
     if position == "answer" and answer is None:
         raise AgentLoopError("discuss_answer.answer is required when position is `answer`.")
-    if position == "needs-human" and not open_questions:
-        raise AgentLoopError("discuss_answer.open_questions must be non-empty for `needs-human`.")
+    if position == "needs-human":
+        if answer is not None:
+            raise AgentLoopError("discuss_answer.answer must be omitted when position is `needs-human`.")
+        if not any(item.status == "human-decision" for item in unresolved_items):
+            raise AgentLoopError(
+                "discuss_answer.unresolved_items must include a human-decision for `needs-human`."
+            )
     rebuttal = None
     if "rebuttal" in payload:
         rebuttal = _expect_non_empty_string(payload["rebuttal"], context="discuss_answer.rebuttal")
@@ -2342,7 +2420,7 @@ def parse_structured_discuss_answer(
         raise AgentLoopError("discuss_answer.research with sourced, unavailable, or inconclusive status is required.")
     return ParsedDiscussAnswer(
         position=position, rationale=rationale, confidence=confidence,
-        open_questions=open_questions, reviewer=reviewer, answer=answer,
+        unresolved_items=unresolved_items, reviewer=reviewer, answer=answer,
         rebuttal=rebuttal, analyzer_framing=analyzer_framing, framing_note=framing_note,
         research_status=research_status, sourced_facts=sourced_facts,
         research_target=research_target, research_questions=research_questions,

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -323,7 +323,9 @@ Notes:
   "answer": "<answer or recommendation; required for answer>",
   "rationale": "<why>",
   "confidence": "low" | "medium" | "high",
-  "open_questions": ["<question; required for needs-human>"],
+  "unresolved_items": [
+    {"status": "blocker" | "human-decision" | "follow-up", "text": "<non-empty concern>"}
+  ],
   "rebuttal": "<required after round one>",
   "research": {
     "status": "sourced" | "not-needed" | "unavailable" | "inconclusive",
@@ -337,7 +339,8 @@ Notes:
 
 Notes: preserve answer-mode fields, never convert this payload to `outcome` or
 `split_proposals`; `needs-human` is explicit escalation and is distinct from
-deadlock caused by disagreement.
+deadlock caused by disagreement. Preserve every valid unresolved-item status
+and text verbatim; do not downgrade, discard, or invent a classification.
 
 When research intent is present, preserve `target` and `questions` together;
 never invent either field or a source while repairing. For `status: "not-needed"`,
@@ -931,20 +934,22 @@ the AGENT_PLAN_STATE footer:
   "answer": "Use an API boundary with an explicit adapter.",
   "rationale": "This keeps the integration replaceable without duplicating policy.",
   "confidence": "medium",
-  "open_questions": []
+  "unresolved_items": []
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- Reviewer
 
 For an escalation, use `position: "needs-human"`, omit `answer` when there is
-no asserted answer, and include at least one concrete `open_questions` entry:
+no asserted answer, and include at least one concrete `human-decision` item:
 {
   "schema_version": 1,
   "kind": "discuss_answer",
   "position": "needs-human",
   "rationale": "The requirements conflict and cannot be resolved from the issue.",
   "confidence": "low",
-  "open_questions": ["Which latency target should control the design?"]
+  "unresolved_items": [
+    {"status": "human-decision", "text": "Which latency target should control the design?"}
+  ]
 }
 <!-- AGENT_PLAN_STATE: approved -->
 -- Reviewer

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -26,6 +26,7 @@ from .protocol import (
     parse_structured_discuss_agenda,
     parse_structured_discuss_review,
     parse_structured_discuss_answer,
+    parse_legacy_structured_discuss_answer,
 )
 from .unresolved_items import _apply_unresolved_item_dispositions
 
@@ -643,7 +644,17 @@ def _decode_analyzer_agenda(raw: str | None) -> ParsedDiscussAgenda | None:
 def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> ParsedDiscussResponse:
     text = record.metadata.raw_structured_coder_response or record.body
     if record.metadata.result_mode == "answer":
-        vote = parse_structured_discuss_answer(text, reviewer=record.metadata.agent, round_number=round_number)
+        try:
+            vote = parse_structured_discuss_answer(
+                text, reviewer=record.metadata.agent, round_number=round_number
+            )
+        except AgentLoopError:
+            # Only persisted round metadata gets the explicitly opt-in legacy
+            # decoder. Its exact-key validation still rejects malformed/mixed
+            # payloads rather than hiding a corrupt transcript.
+            vote = parse_legacy_structured_discuss_answer(
+                text, reviewer=record.metadata.agent, round_number=round_number
+            )
     else:
         vote = parse_structured_discuss_review(text, reviewer=record.metadata.agent, round_number=round_number)
     if vote is None:

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -19,7 +19,7 @@ from coding_review_agent_loop.comment_rendering import (
     render_deferred_stages_section,
     render_discuss_round_summary_comment,
 )
-from coding_review_agent_loop.protocol import ParsedDiscussAnswer, ParsedFailedDiscussResponse, ParsedDiscussReview
+from coding_review_agent_loop.protocol import DiscussUnresolvedItem, ParsedDiscussAnswer, ParsedFailedDiscussResponse, ParsedDiscussReview
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     ITEM_SUMMARY_LIMIT,
@@ -58,7 +58,7 @@ from agent_loop_helpers import (
 
 def test_answer_research_rendering_ignores_failed_resume_placeholder():
     answer = ParsedDiscussAnswer(
-        position="answer", rationale="Supported.", confidence="medium", open_questions=(),
+        position="answer", rationale="Supported.", confidence="medium", unresolved_items=(),
         reviewer="Codex", answer="Use an API.", research_status="not-needed",
     )
     failed = ParsedFailedDiscussResponse("Claude", "timeout", "answer")
@@ -68,6 +68,28 @@ def test_answer_research_rendering_ignores_failed_resume_placeholder():
         research_mode="auto", result_mode="answer",
     )
     assert "Use an API." in rendered
+
+
+def test_answer_summary_groups_classified_items_without_cross_status_deduplication():
+    answer = ParsedDiscussAnswer(
+        position="answer", rationale="Supported.", confidence="medium", reviewer="Codex",
+        answer="Use an API.", unresolved_items=(
+            DiscussUnresolvedItem("blocker", "Verify capability."),
+            DiscussUnresolvedItem("human-decision", "Choose tier."),
+            DiscussUnresolvedItem("follow-up", "Refresh pricing."),
+            DiscussUnresolvedItem("follow-up", "Verify capability."),
+        ),
+    )
+    rendered = render_discuss_round_summary_comment(
+        is_final=True, subject="subject", round_number=1, reviewer_votes=[answer],
+        round_history=[[answer]], outcome="needs-human", consensus_kind="unanimous",
+        result_mode="answer",
+    )
+    assert "### Blockers" in rendered
+    assert "### Human decisions" in rendered
+    assert "### Non-blocking follow-ups" in rendered
+    assert rendered.count("Verify capability.") == 2
+    assert "because the listed human decisions remain" in rendered
     assert "Claude" not in rendered
 
 def test_render_canonical_plan_steps_numbers_items():
@@ -1065,7 +1087,7 @@ def test_render_discuss_answer_summary_non_final_uses_analyzer_agenda_with_attri
         position="answer",
         rationale="An API has the clearest boundary.",
         confidence="high",
-        open_questions=(),
+        unresolved_items=(),
         reviewer="Codex",
         answer="Use an API.",
     )

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -27,6 +27,7 @@ from coding_review_agent_loop.protocol import (
     ParsedDiscussAgenda,
     ParsedDiscussReview,
     ParsedDiscussAnswer,
+    DiscussUnresolvedItem,
 )
 
 from agent_loop_helpers import FakeRunner, make_config
@@ -34,7 +35,7 @@ from agent_loop_helpers import FakeRunner, make_config
 
 def test_answer_consensus_does_not_escalate_for_one_early_needs_human():
     responses = [
-        ParsedDiscussAnswer("needs-human", "unclear", "low", ("scope",), "Codex"),
+        ParsedDiscussAnswer("needs-human", "unclear", "low", (DiscussUnresolvedItem("human-decision", "scope"),), "Codex"),
         ParsedDiscussAnswer("answer", "clear", "medium", (), "Claude", answer="Use an API."),
     ]
     assert _detect_discuss_answer_consensus(responses) is None
@@ -42,8 +43,8 @@ def test_answer_consensus_does_not_escalate_for_one_early_needs_human():
 
 def test_answer_consensus_escalates_when_all_debaters_request_human_decision():
     responses = [
-        ParsedDiscussAnswer("needs-human", "unclear", "low", ("scope",), "Codex"),
-        ParsedDiscussAnswer("needs-human", "unclear", "low", ("security",), "Claude"),
+        ParsedDiscussAnswer("needs-human", "unclear", "low", (DiscussUnresolvedItem("human-decision", "scope"),), "Codex"),
+        ParsedDiscussAnswer("needs-human", "unclear", "low", (DiscussUnresolvedItem("human-decision", "security"),), "Claude"),
     ]
     assert _detect_discuss_answer_consensus(responses) == ("needs-human", [])
 
@@ -99,6 +100,7 @@ def _discuss_answer_text(
     rationale: str = "It keeps the integration replaceable.",
     confidence: str = "medium",
     open_questions: list[str] | None = None,
+    unresolved_items: list[dict[str, str]] | None = None,
     rebuttal: str | None = None,
     research: dict | None = None,
     reviewer: str = "OpenAI Codex",
@@ -109,7 +111,10 @@ def _discuss_answer_text(
         "position": position,
         "rationale": rationale,
         "confidence": confidence,
-        "open_questions": open_questions or [],
+        "unresolved_items": unresolved_items if unresolved_items is not None else [
+            {"status": "human-decision" if position == "needs-human" else "blocker", "text": question}
+            for question in (open_questions or [])
+        ],
     }
     if answer is not None:
         payload["answer"] = answer
@@ -249,15 +254,22 @@ def _seed_debater_comment(
 def _seed_answer_debater_comment(
     *, reviewer: str, round_number: int, subject: str, answer: str,
     rationale: str = "The evidence supports this recommendation.",
-    rebuttal: str | None = None, config=None,
+    rebuttal: str | None = None, config=None, legacy: bool = False,
 ) -> dict:
     vote = ParsedDiscussAnswer(
         position="answer", rationale=rationale, confidence="medium",
-        open_questions=(), reviewer=reviewer, answer=answer, rebuttal=rebuttal,
+        unresolved_items=(), reviewer=reviewer, answer=answer, rebuttal=rebuttal,
     )
-    raw_text = _discuss_answer_text(
-        answer=answer, rationale=rationale, rebuttal=rebuttal, reviewer=reviewer,
-    )
+    if legacy:
+        raw_text = json.dumps({
+            "schema_version": 1, "kind": "discuss_answer", "position": "answer",
+            "answer": answer, "rationale": rationale, "confidence": "medium",
+            "open_questions": ["Verify availability."],
+        }) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+    else:
+        raw_text = _discuss_answer_text(
+            answer=answer, rationale=rationale, rebuttal=rebuttal, reviewer=reviewer,
+        )
     body = render_public_agent_comment(
         kind="discuss_answer", parsed=vote, agent=reviewer, config=config,
         round_number=round_number,
@@ -343,6 +355,37 @@ def test_discuss_loop_unanimous_answer_is_not_triage(tmp_path):
     assert "Consensus Answer" in runner.comments[-1]
     assert "Use an API boundary." in runner.comments[-1]
     assert "Consensus: Implement" not in runner.comments[-1]
+
+
+def test_answer_mode_followups_succeed_but_material_items_select_final_outcome(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    followups = FakeRunner(
+        codex_outputs=[_discuss_answer_text(unresolved_items=[{"status": "follow-up", "text": "Refresh pricing."}])],
+        gemini_outputs=[_discuss_answer_text(unresolved_items=[{"status": "follow-up", "text": "Refresh pricing."}])],
+    )
+    assert run_discuss_loop(followups, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Consensus Answer" in followups.comments[-1]
+    assert "Non-blocking follow-ups" in followups.comments[-1]
+
+    material = FakeRunner(
+        codex_outputs=[_discuss_answer_text(unresolved_items=[{"status": "blocker", "text": "Verify capability."}])],
+        gemini_outputs=[_discuss_answer_text(unresolved_items=[{"status": "human-decision", "text": "Choose a product tier."}])],
+    )
+    assert run_discuss_loop(material, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    final = material.comments[-1]
+    assert "Needs Human Decision" in final
+    assert "Blockers" in final and "Human decisions" in final
+
+
+def test_answer_mode_blocker_suppresses_exact_and_semantic_convergence(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[_discuss_answer_text(unresolved_items=[{"status": "blocker", "text": "Verify capability."}])],
+        gemini_outputs=[_discuss_answer_text(unresolved_items=[{"status": "blocker", "text": "Verify capability."}])],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Deadlock" in runner.comments[-1]
+    assert "Verify capability." in runner.comments[-1]
 
 
 def test_discuss_loop_answer_converges_after_rebuttal(tmp_path):
@@ -610,6 +653,22 @@ def test_discuss_loop_resumes_answer_partial_round_and_is_idempotent(tmp_path):
 
     assert run_discuss_loop(runner, issue_number=56, config=config) == 0
     assert len(runner.comments) == comment_count
+
+
+def test_discuss_loop_resumes_legacy_answer_metadata_conservatively(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    seeded = _seed_answer_debater_comment(
+        reviewer="Codex", round_number=1, subject=subject, answer="Use an API.",
+        config=config, legacy=True,
+    )
+    runner = FakeRunner(
+        issue_comments=[seeded],
+        gemini_outputs=[_discuss_answer_text(answer="Use an API.", reviewer="Google Gemini")],
+    )
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Deadlock" in runner.comments[-1]
+    assert "Verify availability." in runner.comments[-1]
 
 
 def test_discuss_loop_debates_then_deadlocks_instead_of_veto(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2020,6 +2020,7 @@ from coding_review_agent_loop.prompts import (
 )
 from coding_review_agent_loop.protocol import (
     DiscussAgendaDisagreement,
+    DiscussUnresolvedItem,
     ParsedDiscussAnswer,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
@@ -2106,7 +2107,7 @@ def test_build_discuss_agenda_prompt_supports_answer_history(tmp_path):
     config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
     answer = ParsedDiscussAnswer(
         position="answer", rationale="The evidence favors the API.", confidence="high",
-        open_questions=(), reviewer="Codex", answer="Use an API.", rebuttal="Addressed the concern.",
+        unresolved_items=(), reviewer="Codex", answer="Use an API.", rebuttal="Addressed the concern.",
     )
     prompt = build_discuss_agenda_prompt(
         56, config, analyzer="claude", round_number=2, round_history=[[answer]]
@@ -2172,7 +2173,7 @@ def test_build_discuss_answer_prompt_keeps_analyzer_and_research_non_authoritati
     config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
     prior = ParsedDiscussAnswer(
         position="answer", rationale="Prior rationale.", confidence="medium",
-        open_questions=("Which latency target applies?",), reviewer="Codex",
+        unresolved_items=(DiscussUnresolvedItem("follow-up", "Which latency target applies?"),), reviewer="Codex",
         answer="Use an API.", rebuttal="The boundary reduces coupling.",
     )
     prompt = build_discuss_review_prompt(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -26,6 +26,7 @@ from coding_review_agent_loop.protocol import (
     DISCUSS_OUTCOME_VALUES,
     DISCUSS_RESEARCH_STATUS_VALUES,
     DiscussAgendaDisagreement,
+    DiscussUnresolvedItem,
     DiscussSourcedFact,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
@@ -44,6 +45,7 @@ from coding_review_agent_loop.protocol import (
     parse_plan_state,
     parse_structured_discuss_agenda,
     parse_structured_discuss_answer,
+    parse_legacy_structured_discuss_answer,
     parse_structured_discuss_review,
     parse_structured_plan_review,
     parse_structured_pr_review,
@@ -77,7 +79,7 @@ def test_discuss_answer_parser_requires_answer_fields_and_is_mode_isolated():
             "answer": "Use an adapter.",
             "rationale": "It preserves a replaceable boundary.",
             "confidence": "high",
-            "open_questions": [],
+            "unresolved_items": [],
         }),
         reviewer="Reviewer",
     )
@@ -86,7 +88,7 @@ def test_discuss_answer_parser_requires_answer_fields_and_is_mode_isolated():
         validate_structured_discuss_answer(
             _discuss_answer_text({
                 "position": "answer", "rationale": "Reason", "confidence": "medium",
-                "open_questions": [],
+                "unresolved_items": [],
             }),
             reviewer="Reviewer",
         )
@@ -101,11 +103,11 @@ def test_discuss_answer_parser_requires_answer_fields_and_is_mode_isolated():
 
 
 def test_discuss_answer_parser_enforces_escalation_rebuttal_research_and_analyzer_rules():
-    with pytest.raises(AgentLoopError, match="open_questions must be non-empty"):
+    with pytest.raises(AgentLoopError, match="human-decision"):
         validate_structured_discuss_answer(
             _discuss_answer_text({
                 "position": "needs-human", "rationale": "Blocked", "confidence": "low",
-                "open_questions": [],
+                "unresolved_items": [],
             }),
             reviewer="Reviewer",
         )
@@ -113,13 +115,13 @@ def test_discuss_answer_parser_enforces_escalation_rebuttal_research_and_analyze
         validate_structured_discuss_answer(
             _discuss_answer_text({
                 "position": "answer", "answer": "Use an adapter.", "rationale": "Reason",
-                "confidence": "medium", "open_questions": [],
+                "confidence": "medium", "unresolved_items": [],
             }),
             reviewer="Reviewer", round_number=2,
         )
     base = {
         "position": "answer", "answer": "Use an adapter.", "rationale": "Reason",
-        "confidence": "medium", "open_questions": [], "analyzer_framing": "accurate",
+        "confidence": "medium", "unresolved_items": [], "analyzer_framing": "accurate",
         "rebuttal": "Addressed the objection.",
         "research": {"status": "sourced", "sourced_facts": [{"fact": "Fact", "source": "https://example.test"}]},
     }
@@ -143,6 +145,58 @@ def test_discuss_answer_parser_enforces_escalation_rebuttal_research_and_analyze
             _discuss_answer_text({k: v for k, v in base.items() if k != "research"}),
             reviewer="Reviewer", research_mode="required",
         )
+
+
+def test_discuss_answer_classifies_items_strictly_and_keeps_material_answers_valid():
+    material_answer = _discuss_answer_text({
+        "position": "answer", "answer": "Use the existing API.", "rationale": "It is compatible.",
+        "confidence": "medium", "unresolved_items": [
+            {"status": "blocker", "text": "Verify the capability before rollout."},
+            {"status": "human-decision", "text": "Choose the supported product tier."},
+            {"status": "follow-up", "text": "Refresh the pricing appendix."},
+        ],
+    })
+    parsed = validate_structured_discuss_answer(material_answer, reviewer="Reviewer")
+    assert parsed.unresolved_items == (
+        DiscussUnresolvedItem("blocker", "Verify the capability before rollout."),
+        DiscussUnresolvedItem("human-decision", "Choose the supported product tier."),
+        DiscussUnresolvedItem("follow-up", "Refresh the pricing appendix."),
+    )
+    for bad_item in (
+        {"status": "unknown", "text": "Question"},
+        {"status": "blocker", "text": "   "},
+        {"status": "blocker", "text": "Question", "extra": True},
+    ):
+        with pytest.raises(AgentLoopError):
+            validate_structured_discuss_answer(_discuss_answer_text({
+                "position": "answer", "answer": "Answer", "rationale": "Reason",
+                "confidence": "medium", "unresolved_items": [bad_item],
+            }), reviewer="Reviewer")
+    with pytest.raises(AgentLoopError, match="unknown field"):
+        validate_structured_discuss_answer(_discuss_answer_text({
+            "position": "answer", "answer": "Answer", "rationale": "Reason",
+            "confidence": "medium", "unresolved_items": [], "open_questions": [],
+        }), reviewer="Reviewer")
+
+
+def test_discuss_answer_needs_human_contract_and_legacy_decoder_are_isolated():
+    with pytest.raises(AgentLoopError, match="must be omitted"):
+        validate_structured_discuss_answer(_discuss_answer_text({
+            "position": "needs-human", "answer": "Do it", "rationale": "Reason",
+            "confidence": "low", "unresolved_items": [
+                {"status": "human-decision", "text": "Choose a policy."},
+            ],
+        }), reviewer="Reviewer")
+    legacy = _discuss_answer_text({
+        "position": "answer", "answer": "Use an API.", "rationale": "Reason",
+        "confidence": "medium", "open_questions": ["Verify availability."],
+    })
+    with pytest.raises(AgentLoopError, match="unresolved_items"):
+        validate_structured_discuss_answer(legacy, reviewer="Reviewer")
+    decoded = parse_legacy_structured_discuss_answer(legacy, reviewer="Reviewer")
+    assert decoded and decoded.unresolved_items == (
+        DiscussUnresolvedItem("blocker", "Verify availability."),
+    )
 from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER
 from coding_review_agent_loop.errors import UnknownPriorItemDispositionError
 from coding_review_agent_loop.orchestrator import (

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -18,7 +18,7 @@ def test_answer_repair_prompt_has_mode_specific_schema_and_examples():
     )
     assert '"kind": "discuss_answer"' in prompt
     assert '"position": "needs-human"' in prompt
-    assert '"open_questions"' in prompt
+    assert '"unresolved_items"' in prompt
     assert "Do not repair answer mode into `discuss_review`" in prompt
     assert "split_proposals" in prompt
 
@@ -27,13 +27,13 @@ def test_answer_repair_shape_preserves_answer_and_rejects_triage_fields():
     valid = json.dumps({
         "schema_version": 1, "kind": "discuss_answer", "position": "answer",
         "answer": "Use an adapter.", "rationale": "It isolates policy.",
-        "confidence": "medium", "open_questions": [],
+        "confidence": "medium", "unresolved_items": [],
     }) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Reviewer"
     assert validate_structured_discuss_answer(valid, reviewer="Reviewer").position == "answer"
     malformed = json.dumps({
         "schema_version": 1, "kind": "discuss_answer", "position": "answer",
         "answer": "Use an adapter.", "rationale": "Reason", "confidence": "medium",
-        "open_questions": [], "outcome": "implement",
+        "unresolved_items": [], "outcome": "implement",
     }) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Reviewer"
     with pytest.raises(AgentLoopError, match="unknown field.*outcome"):
         validate_structured_discuss_answer(malformed, reviewer="Reviewer")


### PR DESCRIPTION
Fixes #536

## Summary
- replace answer-mode open questions with typed blocker, human-decision, and follow-up items
- apply final-round material-item precedence and render each status separately
- preserve legacy persisted answer transcripts through an opt-in resume decoder

## Tests
- pytest tests/ -q