### PR TITLE
Retry preflighted CLI disappearance

### DIFF
--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -56,6 +56,7 @@ class Runner:
         self.dry_run = dry_run
         self._resolved_commands: dict[str, str] = {}
         self._command_override_flags: dict[str, str] = {}
+        self._preflighted_commands: set[str] = set()
         # Parallel discuss debaters call run_with_log from worker threads (#475):
         # guard the command caches and keep a registry of live agent processes so
         # the main thread can kill them on KeyboardInterrupt.
@@ -74,6 +75,7 @@ class Runner:
         with self._commands_lock:
             self._resolved_commands[command] = resolved_path
             self._command_override_flags[command] = override_flag
+            self._preflighted_commands.add(command)
 
     def _register_active_process(self, proc: subprocess.Popen) -> None:
         with self._active_procs_lock:
@@ -129,6 +131,17 @@ class Runner:
             f"{override_flag} <path>."
         )
 
+    def _command_disappeared_after_preflight_error(self, command: str) -> AgentLoopError:
+        override_flag = self._command_override_flags.get(command)
+        if override_flag is None:
+            command_name = Path(command).name
+            override_flag = f"--{command_name}-cmd"
+        return AgentLoopError(
+            f"{command} CLI disappeared after successful preflight and may be updating; "
+            f"it did not return on PATH after {_SPAWN_ATTEMPTS} spawn attempts. "
+            f"Retry shortly or pass {override_flag} <path>."
+        )
+
     @staticmethod
     def _is_dangling_symlink(path: str | None) -> bool:
         return bool(path and os.path.islink(path) and not os.path.exists(path))
@@ -144,6 +157,7 @@ class Runner:
             with self._commands_lock:
                 self._resolved_commands[command] = resolved
 
+        saw_preflight_disappearance = False
         for attempt in range(1, _SPAWN_ATTEMPTS + 1):
             try:
                 return spawn_attempt()
@@ -155,9 +169,14 @@ class Runner:
                     if current is not None:
                         self._resolved_commands[command] = current
                     candidate = current or self._resolved_commands.get(command)
-                if not self._is_dangling_symlink(candidate):
+                    preflighted = command in self._preflighted_commands
+                dangling_symlink = self._is_dangling_symlink(candidate)
+                saw_preflight_disappearance |= preflighted and current is None
+                if not dangling_symlink and not preflighted:
                     raise self._missing_command_error(command) from exc
                 if attempt == _SPAWN_ATTEMPTS:
+                    if saw_preflight_disappearance and not dangling_symlink:
+                        raise self._command_disappeared_after_preflight_error(command) from exc
                     raise self._missing_command_error(command) from exc
                 time.sleep(_SPAWN_RETRY_BACKOFF_SECONDS)
 

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -116,11 +116,15 @@ class Runner:
             if proc.poll() is None:
                 self._terminate_process_group(proc)
 
-    def _missing_command_error(self, command: str) -> AgentLoopError:
+    def _override_flag_for(self, command: str) -> str:
         override_flag = self._command_override_flags.get(command)
         if override_flag is None:
             command_name = Path(command).name
             override_flag = f"--{command_name}-cmd"
+        return override_flag
+
+    def _missing_command_error(self, command: str) -> AgentLoopError:
+        override_flag = self._override_flag_for(command)
         if os.path.isabs(command):
             return AgentLoopError(
                 f"{command} not found or not executable; "
@@ -132,10 +136,7 @@ class Runner:
         )
 
     def _command_disappeared_after_preflight_error(self, command: str) -> AgentLoopError:
-        override_flag = self._command_override_flags.get(command)
-        if override_flag is None:
-            command_name = Path(command).name
-            override_flag = f"--{command_name}-cmd"
+        override_flag = self._override_flag_for(command)
         return AgentLoopError(
             f"{command} CLI disappeared after successful preflight and may be updating; "
             f"it did not return on PATH after {_SPAWN_ATTEMPTS} spawn attempts. "

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3438,6 +3438,161 @@ def test_runner_dangling_symlink_spawn_retry_is_bounded(
     assert sleep_calls == [2, 2]
 
 
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_retries_preflighted_command_disappearance_and_recovers(
+    monkeypatch,
+    tmp_path,
+    use_pty,
+):
+    """A bare CLI that vanishes after preflight can return during spawn retry."""
+    import coding_review_agent_loop.runner as runner_module
+
+    command_name = "bare-agent"
+    command = tmp_path / command_name
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
+    runner = Runner()
+    runner.remember_agent_command(
+        command_name,
+        str(tmp_path / "preflight-agent-path"),
+        "--codex-cmd",
+    )
+    original_popen = runner_module.subprocess.Popen
+    original_which = runner_module.shutil.which
+    popen_calls = []
+    which_calls = []
+    sleep_calls = []
+
+    def tracking_which(name):
+        which_calls.append(name)
+        return original_which(name)
+
+    def flaky_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        if len(popen_calls) < 3:
+            raise FileNotFoundError(command_name)
+        return original_popen(*args, **kwargs)
+
+    def restore_command(delay):
+        sleep_calls.append(delay)
+        if delay == 2 and not command.exists():
+            command.symlink_to(sys.executable)
+
+    monkeypatch.setattr(runner_module.shutil, "which", tracking_which)
+    monkeypatch.setattr(runner_module.subprocess, "Popen", flaky_popen)
+    monkeypatch.setattr(runner_module.time, "sleep", restore_command)
+
+    result = runner.run_with_log(
+        [command_name, "-c", "print('recovered after preflight')"],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / f"preflight-retry-{use_pty}.log",
+        label="Preflight retry probe",
+        progress_interval_seconds=999,
+        use_pty=use_pty,
+    )
+
+    assert result.returncode == 0
+    assert "recovered after preflight" in result.stdout
+    assert len(popen_calls) == 3
+    assert which_calls == [command_name, command_name, command_name]
+    assert runner._resolved_commands[command_name] == str(command)
+    assert sleep_calls[:2] == [2, 2]
+    assert all(delay == 1 for delay in sleep_calls[2:])
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_preflighted_command_disappearance_retry_is_bounded(
+    monkeypatch,
+    tmp_path,
+    use_pty,
+):
+    """A post-preflight PATH disappearance gives a specific bounded error."""
+    import coding_review_agent_loop.runner as runner_module
+
+    command_name = "bare-agent"
+    runner = Runner()
+    runner.remember_agent_command(
+        command_name,
+        str(tmp_path / "preflight-agent-path"),
+        "--codex-cmd",
+    )
+    popen_calls = []
+    which_calls = []
+    sleep_calls = []
+
+    def missing_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        raise FileNotFoundError(command_name)
+
+    def missing_which(name):
+        which_calls.append(name)
+        return None
+
+    monkeypatch.setattr(runner_module.shutil, "which", missing_which)
+    monkeypatch.setattr(runner_module.subprocess, "Popen", missing_popen)
+    monkeypatch.setattr(
+        runner_module.time,
+        "sleep",
+        lambda delay: sleep_calls.append(delay),
+    )
+
+    with pytest.raises(
+        AgentLoopError,
+        match=r"disappeared after successful preflight and may be updating",
+    ):
+        runner.run_with_log(
+            [command_name, "--version"],
+            cwd=tmp_path,
+            log_path=tmp_path / "logs" / f"preflight-bounded-{use_pty}.log",
+            label="Preflight bounded retry probe",
+            progress_interval_seconds=999,
+            use_pty=use_pty,
+        )
+
+    assert len(popen_calls) == 3
+    assert which_calls == [command_name] * 4
+    assert sleep_calls == [2, 2]
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_preflighted_command_permission_error_does_not_retry(
+    monkeypatch,
+    tmp_path,
+    use_pty,
+):
+    """Only FileNotFoundError can use the preflighted-command retry."""
+    import coding_review_agent_loop.runner as runner_module
+
+    command_name = "bare-agent"
+    runner = Runner()
+    runner.remember_agent_command(command_name, "/bin/bare-agent", "--codex-cmd")
+    popen_calls = []
+    sleep_calls = []
+
+    def denied_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        raise PermissionError(command_name)
+
+    monkeypatch.setattr(runner_module.subprocess, "Popen", denied_popen)
+    monkeypatch.setattr(
+        runner_module.time,
+        "sleep",
+        lambda delay: sleep_calls.append(delay),
+    )
+
+    with pytest.raises(PermissionError):
+        runner.run_with_log(
+            [command_name, "--version"],
+            cwd=tmp_path,
+            log_path=tmp_path / "logs" / f"permission-no-retry-{use_pty}.log",
+            label="Permission no-retry probe",
+            progress_interval_seconds=999,
+            use_pty=use_pty,
+        )
+
+    assert len(popen_calls) == 1
+    assert sleep_calls == []
+
+
 def test_runner_missing_command_without_dangling_evidence_does_not_retry(
     monkeypatch,
     tmp_path,
@@ -3446,12 +3601,17 @@ def test_runner_missing_command_without_dangling_evidence_does_not_retry(
 
     popen_calls = []
     sleep_calls = []
+    which_calls = []
+
+    def runtime_only_which(command):
+        which_calls.append(command)
+        return "/tmp/runtime-agent" if len(which_calls) == 1 else None
 
     def missing_popen(*args, **kwargs):
         popen_calls.append(args[0])
         raise FileNotFoundError("missing-agent")
 
-    monkeypatch.setattr(runner_module.shutil, "which", lambda command: None)
+    monkeypatch.setattr(runner_module.shutil, "which", runtime_only_which)
     monkeypatch.setattr(runner_module.subprocess, "Popen", missing_popen)
     monkeypatch.setattr(
         runner_module.time,
@@ -3469,6 +3629,7 @@ def test_runner_missing_command_without_dangling_evidence_does_not_retry(
         )
 
     assert len(popen_calls) == 1
+    assert which_calls == ["missing-agent", "missing-agent"]
     assert sleep_calls == []
 
 


### PR DESCRIPTION
Fixes #525\n\n## Summary\n- retain explicit successful-preflight evidence separately from runtime command resolution\n- retry bare CLIs that disappear after preflight through the existing bounded spawn path\n- report a likely update-window disappearance after retry exhaustion\n\n## Tests\n- python3 -m pytest tests/test_agent_loop.py -k 'runner and (dangling_symlink or preflighted_command or missing_command_without_dangling_evidence or absolute_path_spawn)'\n- python3 -m pytest -q