### PR TITLE
Skip duplicate analyzer call after answer confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ material conflict fails closed to deadlock; and compatible answers get at most
 one extra, budget-exempt confirmation phase. Every debater must then confirm
 the canonical recommendation or refine it, and the effective answers must be
 identical after whitespace/case normalization. The summary preserves the
-analyzer classification separately for audit.
+analyzer classification separately for audit. When that confirmation succeeds,
+the recorded semantic comparison is reused and no duplicate final-observations
+analyzer pass runs; the debaters' confirmation remains authoritative.
 
 Local command-line orchestration for a coding PR review loop.
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -376,8 +376,11 @@ bounded, budget-exempt confirmation phase: each original debater confirms the
 canonical recommendation or supplies a refinement, and only exact normalized
 agreement among those effective answers finalizes. Invalid comparator output,
 comparison failure, failed confirmation, or material conflict safely remains a
-deadlock. This makes resumed finalization idempotent once a final summary is
-recorded.
+deadlock. A successful debater-confirmed recommendation reuses the recorded
+semantic comparison audit and does not invoke a second final-observations pass
+over the same final answers; that advisory comparison remains distinct from the
+authoritative debater confirmation. This makes resumed finalization idempotent
+once a final summary is recorded.
 
 Discuss mode sends the issue title, body, and comments to all configured
 reviewers and asks each to return a `discuss_review` response with a single
@@ -506,12 +509,17 @@ Guardrails — the analyzer is never authoritative:
   result is rendered as "Final analyzer observations (not debater-confirmed)"
   after the authoritative debater vote table. It is rejected if it names a
   non-debater or asserts a position, topic, consensus, disagreement, or missing
-  fact unsupported by the final-round text.
+  fact unsupported by the final-round text. The exception is a successful
+  answer-mode compatible-answer confirmation: its semantic comparison already
+  analyzed those final answers, so the recorded comparison is reused instead
+  of making a duplicate advisory pass. Debater confirmation is still the
+  authoritative finalization step.
 - If an agenda from the preceding non-final round exists, the final summary
   renders it separately as "Agenda before final round." This is explicitly
   historical and is never presented as current disagreements. If final analysis
-  fails validation or the final round is partial, the observations are omitted
-  while the answer/vote table and mechanical outcome remain available.
+  fails validation, the observations are omitted while the answer/vote table
+  and mechanical outcome remain available. For a partial round, any retained
+  observations are grounded only in its successful final-round responses.
 - If the analyzer invocation fails even after the malformed-response repair
   pass, the orchestrator logs a warning and falls back to the plain mechanical
   agenda for that round (and full prior positions in the next debate prompt)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5438,10 +5438,8 @@ def _validate_discuss_final_analyzer_fidelity(
     analyzer: AgentName,
 ) -> None:
     """Validate an advisory final pass against final debater text only (#529)."""
-    if len(final_votes) != len(configured_reviewers) or any(
-        is_failed_discuss_response(vote) for vote in final_votes
-    ):
-        raise AgentLoopError("final analyzer requires a complete successful final round.")
+    if not final_votes or any(is_failed_discuss_response(vote) for vote in final_votes):
+        raise AgentLoopError("final analyzer requires successful final-round responses.")
     if agenda.research_required or agenda.research_questions or agenda.research_question_targets:
         raise AgentLoopError("final analyzer output must not include next-round research fields.")
     allowed_names = {agent_display_name(reviewer) for reviewer in configured_reviewers}
@@ -5484,9 +5482,7 @@ def _run_discuss_final_analyzer(
     usage_context: RunUsageContext,
 ) -> tuple[ParsedDiscussAgenda | None, str | None]:
     """Best-effort final-only analyzer pass; failures never affect finalization."""
-    if analyzer is None or len(final_votes) != len(configured_reviewers) or any(
-        is_failed_discuss_response(vote) for vote in final_votes
-    ):
+    if analyzer is None or not final_votes or any(is_failed_discuss_response(vote) for vote in final_votes):
         return None, None
 
 
@@ -6220,7 +6216,12 @@ def _run_discuss_loop(
                 configured_reviewers=configured_reviewers,
                 usage_context=usage_context,
             )
-        elif is_final:
+        elif is_final and consensus_kind != "debater-confirmed":
+            # Semantic finalization already used the configured analyzer to
+            # compare the completed final-round answers. When every debater
+            # confirms that recommendation, keep that audit as the final
+            # analyzer record rather than invoking the same analyzer again
+            # for advisory observations over identical input.
             final_analyzer_agenda, final_analyzer_response_raw = _run_discuss_final_analyzer(
                 runner,
                 issue_number=issue_number,

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -445,6 +445,10 @@ def test_discuss_loop_semantic_equivalent_paraphrases_converge(tmp_path):
     assert "Consensus kind: `semantic-equivalent`" in final
     assert "targeted, budget-capped verification subphase" in final
     assert "Semantic comparison (advisory; not a debater vote)" in final
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command in _claude_commands(runner)
+    )
     metadata = ROUND_RESUME_MARKER_RE.search(runner.issue_comments[-1]["body"])
     assert metadata is not None
     assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "semantic-equivalent"
@@ -479,9 +483,43 @@ def test_discuss_loop_semantic_compatible_answers_require_debater_confirmation(t
     assert "Consensus kind: `debater-confirmed`" in final
     assert "The recommendation above was explicitly confirmed by every debater." in final
     assert "Residual decisions:" in final
+    assert "### Final analyzer observations" not in final
+    claude_commands = _claude_commands(runner)
+    assert len(claude_commands) == 1
+    assert "discuss_semantic_comparison" in " ".join(claude_commands[0])
     metadata = ROUND_RESUME_MARKER_RE.search(runner.issue_comments[-1]["body"])
     assert metadata is not None
-    assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "debater-confirmed"
+    parsed_metadata = _decode_round_metadata(metadata.group("payload"))
+    assert parsed_metadata.consensus_kind == "debater-confirmed"
+    assert parsed_metadata.final_analyzer_response is None
+
+
+def test_discuss_loop_confirmation_failure_still_attempts_final_analyzer(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            _discuss_answer_text(answer="Add bounded verification."),
+            _answer_confirmation_text(reviewer="Codex"),
+        ],
+        gemini_outputs=[
+            _discuss_answer_text(answer="Use targeted verification with a cap."),
+            "not structured",
+        ],
+        claude_outputs=[_semantic_comparison_text(
+            classification="compatible_with_residual_decisions",
+            shared_recommendation="Add a targeted, budget-capped verification subphase.",
+            remaining_decisions=["Choose the cap."],
+        )],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer", discuss_analyzer="claude",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert "Consensus kind: `confirmation-failed`" in runner.comments[-1]
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command in _claude_commands(runner)
+    )
 
 
 @pytest.mark.parametrize("failed_comparison", [("comparator unavailable", 1), "not structured"])
@@ -505,6 +543,10 @@ def test_discuss_loop_semantic_material_conflict_and_failure_are_auditable_deadl
     assert "Deadlock" in conflict
     assert "Consensus kind: `material-conflict`" in conflict
     assert "Classification: `material_conflict`" in conflict
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command in _claude_commands(conflict_runner)
+    )
     metadata = ROUND_RESUME_MARKER_RE.search(conflict_runner.issue_comments[-1]["body"])
     assert metadata is not None
     assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "material-conflict"
@@ -514,6 +556,10 @@ def test_discuss_loop_semantic_material_conflict_and_failure_are_auditable_deadl
     assert "Deadlock" in failure
     assert "Consensus kind: `semantic-comparison-failed`" in failure
     assert "Classification: `failed`" in failure
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command in _claude_commands(failure_runner)
+    )
     metadata = ROUND_RESUME_MARKER_RE.search(failure_runner.issue_comments[-1]["body"])
     assert metadata is not None
     assert _decode_round_metadata(metadata.group("payload")).consensus_kind == "semantic-comparison-failed"
@@ -527,6 +573,10 @@ def test_discuss_loop_triage_mode_does_not_invoke_semantic_comparator(tmp_path):
     assert run_discuss_loop(runner, issue_number=56, config=config) == 0
     assert "Consensus: Implement" in runner.comments[-1]
     assert not any("discuss_semantic_comparison" in " ".join(command) for command, _ in runner.commands)
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command in _claude_commands(runner)
+    )
 
 
 def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_aware(tmp_path):
@@ -540,6 +590,10 @@ def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_awar
     assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
     assert "Use an API boundary." in runner.comments[-1]
     assert all('"kind": "discuss_answer"' in " ".join(cmd) for cmd, _ in runner.commands if cmd[:1] in (["codex"], ["gemini"]))
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command in _claude_commands(runner)
+    )
 
 
 def test_discuss_loop_answer_partial_live_round_records_failure_and_deadlocks(tmp_path):
@@ -554,6 +608,7 @@ def test_discuss_loop_answer_partial_live_round_records_failure_and_deadlocks(tm
         reviewer=("codex", "gemini", "claude"),
         discuss_result_mode="answer",
         discuss_on_debater_failure="partial",
+        discuss_analyzer="antigravity",
     )
 
     assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
@@ -562,6 +617,11 @@ def test_discuss_loop_answer_partial_live_round_records_failure_and_deadlocks(tm
     assert "Claude" in final
     assert "Debater failures" in final
     assert "Consensus Answer" not in final
+    assert any(
+        "Analyze only these completed final-round debater responses" in " ".join(command)
+        for command, _ in runner.commands
+        if command[:1] == ["agy"]
+    )
 
 
 def test_discuss_loop_answer_mode_never_materializes_split_issues(tmp_path):


### PR DESCRIPTION
## Summary
- reuse semantic comparison after debater-confirmed answer finalization
- retain advisory final analysis for other final outcomes, including partial rounds
- document and test analyzer dispatch behavior

## Tests
- python3 -m pytest tests/test_discuss_loop.py -q
- python3 -m pytest -q

Fixes #532