### PR TITLE
Mechanically cross-check checkout-inspected evidence claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,13 @@ bytes. The rendered ledger is capped at 50 entries / 16,000 bytes, prioritizing
 updates and targets, final-round claims, verified, reported, missing, then old
 history. Round comments and replay metadata retain the full raw audit trail.
 
+A `checkout-inspected` claim's `path:line` is mechanically cross-checked
+against the reviewer's assigned checkout at live, repair, resume, and split-
+recovery time: the path must resolve inside that checkout, exist as a file,
+and the line number must be in range, or the loop fails outright. This only
+confirms the referenced line exists, not that it supports the claim; see
+`docs/local_agent_loop.md` for the full current-checkout semantics.
+
 ### Test file layout
 
 The test suite is split across focused modules for faster, targeted runs:

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -632,6 +632,26 @@ final-round claims, verified, reported, missing, and old history. Omitted
 counts and a digest point to the complete per-round comments and replay
 metadata, which remain the audit trail.
 
+A `checkout-inspected` claim's `path:line` is mechanically cross-checked
+against the reviewer's assigned checkout: the path must resolve inside that
+checkout (no absolute paths, `..` traversal, or symlink escapes), exist as a
+file, and the line number must fall within its current line count, or the
+loop raises and fails the turn/resume/recovery outright. This is a bounded,
+structural guarantee only — it confirms the referenced line exists, not that
+it actually supports the claimed fact. The check always runs against
+whatever is on disk in the assigned checkout *right now*, at live, repair,
+resume, and legacy split-proposal-recovery time alike; there is no persisted
+historical snapshot to compare against, so a claim can stop resolving later
+if the checkout's contents have since changed. A default (tool-managed)
+reviewer checkout is kept at the current base-branch tip by the same
+`ensure_agent_workdirs` sync used everywhere else, so it can drift past a
+debater's persisted claim as the base branch advances. An explicit reviewer
+checkout (e.g. `--codex-dir`) is only checked for cleanliness and remote by
+`validate_explicit_workdir` when it happens to already be a Git work tree —
+a non-Git explicit directory receives no such check and is used exactly as
+the user left it — but its contents are still validated live against the
+persisted claim like any other checkout.
+
 ### Parallel debater execution
 
 `--discuss-parallel` runs same-round debaters concurrently instead of one

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -8,7 +8,7 @@ import json
 import re
 import sys
 import zoneinfo
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace as dataclasses_replace
 from pathlib import Path
@@ -183,6 +183,7 @@ from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
 from .workdir_guard import (
     validate_assigned_head_advanced,
+    validate_checkout_inspected_evidence,
     validate_response_tests_within_workdir,
     validate_test_commands_within_workdir,
 )
@@ -2492,10 +2493,15 @@ def _prior_discuss_split_proposals(
     latest = final_summaries[-1]
     if latest.metadata.split_proposals:
         return list(latest.metadata.split_proposals)
+    configured_reviewers = reviewers(config)
+    reviewer_workdirs = {
+        agent_display_name(agent): get_backend(agent).workdir(config) for agent in configured_reviewers
+    }
     recovered = _recover_final_discuss_split_proposals(
         issue_context,
         subject=latest.metadata.subject,
-        configured_reviewers=reviewers(config),
+        configured_reviewers=configured_reviewers,
+        reviewer_workdirs=reviewer_workdirs,
     )
     return list(recovered[0]) if recovered else []
 
@@ -5060,6 +5066,7 @@ def _recover_final_discuss_split_proposals(
     *,
     subject: str,
     configured_reviewers: Sequence[AgentName],
+    reviewer_workdirs: Mapping[str, Path],
 ) -> tuple[list[str], list[ParsedDiscussReview]] | None:
     """Legacy fallback (#476): reconstruct final-round votes and merged split
     proposals from debater comment metadata when `PostedRoundMetadata` has no
@@ -5084,7 +5091,9 @@ def _recover_final_discuss_split_proposals(
         record = by_name.get(name)
         if record is None:
             continue
-        final_votes.append(_decode_discuss_vote(record, round_number=final_round_number))
+        final_votes.append(
+            _decode_discuss_vote(record, round_number=final_round_number, reviewer_workdirs=reviewer_workdirs)
+        )
     if not final_votes:
         return None
     consensus = _detect_discuss_consensus(final_votes)
@@ -5589,6 +5598,30 @@ def _ensure_parallel_discuss_workdirs(config: AgentLoopConfig) -> None:
         seen[path] = reviewer
 
 
+def _validate_structured_discuss_vote_with_evidence(
+    text: str,
+    *,
+    reviewer_name: str,
+    round_number: int,
+    config: AgentLoopConfig,
+    assigned_workdir: Path,
+) -> ParsedDiscussResponse:
+    """Parse a debater's structured vote, then reject any checkout-inspected
+    evidence claim whose path:line reference does not resolve inside the
+    reviewer's own assigned checkout right now (#541)."""
+    parsed = (
+        validate_structured_discuss_answer(
+            text, reviewer=reviewer_name, round_number=round_number, research_mode=config.discuss_research
+        )
+        if config.discuss_result_mode == "answer"
+        else validate_structured_discuss_review(
+            text, reviewer=reviewer_name, round_number=round_number, research_mode=config.discuss_research
+        )
+    )
+    validate_checkout_inspected_evidence(parsed.evidence_claims, assigned_workdir=assigned_workdir)
+    return parsed
+
+
 def _run_discuss_debater_turn(
     runner: Runner,
     *,
@@ -5605,16 +5638,17 @@ def _run_discuss_debater_turn(
     from a worker thread; the caller posts the comment after the round's
     synchronization point.
     """
+    assigned_workdir = get_backend(reviewer).workdir(config)
     return _run_validated_agent(
         runner,
         agent=reviewer,
         config=config,
         prompt=prompt,
         marker_description="<!-- AGENT_PLAN_STATE: approved -->",
-        validate=lambda text, r=reviewer_name, rn=round_number: (
-            validate_structured_discuss_answer(text, reviewer=r, round_number=rn, research_mode=config.discuss_research)
-            if config.discuss_result_mode == "answer"
-            else validate_structured_discuss_review(text, reviewer=r, round_number=rn, research_mode=config.discuss_research)
+        validate=lambda text, r=reviewer_name, rn=round_number, wd=assigned_workdir: (
+            _validate_structured_discuss_vote_with_evidence(
+                text, reviewer_name=r, round_number=rn, config=config, assigned_workdir=wd
+            )
         ),
         usage_context=usage_context,
         use_repair=True,
@@ -5762,9 +5796,12 @@ def _run_discuss_loop(
     issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
     subject = _discuss_subject(issue_context)
     configured_reviewers = list(_reviewers(config))
+    reviewer_workdirs = {
+        agent_display_name(agent): get_backend(agent).workdir(config) for agent in configured_reviewers
+    }
     resume_state = _resume_discuss_round(
         issue_context.comments, subject=subject, configured_reviewers=configured_reviewers,
-        result_mode=config.discuss_result_mode,
+        reviewer_workdirs=reviewer_workdirs, result_mode=config.discuss_result_mode,
     )
 
     def _resolve_final_split_proposals() -> tuple[list[str], Sequence[ParsedDiscussReview]] | None:
@@ -5781,7 +5818,8 @@ def _run_discuss_loop(
             if consensus is not None and consensus[0] == "split" and consensus[1]:
                 return consensus[1], final_votes
         return _recover_final_discuss_split_proposals(
-            issue_context, subject=subject, configured_reviewers=configured_reviewers
+            issue_context, subject=subject, configured_reviewers=configured_reviewers,
+            reviewer_workdirs=reviewer_workdirs,
         )
 
     already_final = False

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -6,12 +6,14 @@ import base64
 import hashlib
 import json
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 from .agents.base import AgentName
 from .agents.registry import agent_display_name
 from .errors import AgentLoopError
+from .workdir_guard import validate_checkout_inspected_evidence
 from .protocol import (
     HTML_COMMENT_RE,
     SIGNATURE_RE,
@@ -641,7 +643,9 @@ def _decode_analyzer_agenda(raw: str | None) -> ParsedDiscussAgenda | None:
         return None
 
 
-def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> ParsedDiscussResponse:
+def _decode_discuss_vote(
+    record: PostedRoundRecord, *, round_number: int, reviewer_workdirs: Mapping[str, Path]
+) -> ParsedDiscussResponse:
     text = record.metadata.raw_structured_coder_response or record.body
     if record.metadata.result_mode == "answer":
         try:
@@ -663,6 +667,14 @@ def _decode_discuss_vote(record: PostedRoundRecord, *, round_number: int) -> Par
             f"(round {round_number}); the posted comment's structured payload is missing "
             "or invalid."
         )
+    workdir = reviewer_workdirs.get(record.metadata.agent)
+    if workdir is None:
+        raise AgentLoopError(
+            f"Discuss round metadata references reviewer {record.metadata.agent!r} "
+            "with no known assigned checkout (it is not in the currently configured "
+            "reviewers); a persisted vote from it cannot be checkout-validated."
+        )
+    validate_checkout_inspected_evidence(vote.evidence_claims, assigned_workdir=workdir)
     return vote
 
 
@@ -671,6 +683,7 @@ def _resume_discuss_round(
     *,
     subject: str,
     configured_reviewers: Sequence[AgentName],
+    reviewer_workdirs: Mapping[str, Path],
     result_mode: str = "triage",
 ) -> ResumedDiscussState | None:
     records = _extract_round_metadata_records(comments, flow="discuss")
@@ -718,7 +731,9 @@ def _resume_discuss_round(
                     f"comments for: {', '.join(missing)}."
                 )
             votes = tuple(
-                _decode_discuss_vote(debater_records[name], round_number=round_number)
+                _decode_discuss_vote(
+                    debater_records[name], round_number=round_number, reviewer_workdirs=reviewer_workdirs
+                )
                 if name in debater_records
                 else (
                     failed_discuss_answer_placeholder(name, failed_by_name[name])
@@ -742,7 +757,9 @@ def _resume_discuss_round(
         else:
             next_round_number = round_number
             for name, record in debater_records.items():
-                in_progress_votes[name] = _decode_discuss_vote(record, round_number=round_number)
+                in_progress_votes[name] = _decode_discuss_vote(
+                    record, round_number=round_number, reviewer_workdirs=reviewer_workdirs
+                )
             break
     return ResumedDiscussState(
         done=False,

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 from .errors import AgentLoopError
+from .protocol import DiscussEvidenceClaim
 
 
 TEST_SECTION_RE = re.compile(r"(?im)^\s*tests(?:\s+run)?\s*:\s*(?P<body>.*)$")
@@ -117,6 +118,62 @@ def validate_response_tests_within_workdir(text: str, *, assigned_workdir: Path)
         extract_reported_tests_from_response(text),
         assigned_workdir=assigned_workdir,
     )
+
+
+def validate_checkout_inspected_evidence(
+    claims: Sequence[DiscussEvidenceClaim],
+    *,
+    assigned_workdir: Path,
+) -> None:
+    """Reject a ``checkout-inspected`` evidence claim whose ``path:line``
+    source does not resolve to a real, in-range line inside the reviewer's
+    assigned checkout right now.
+
+    This is structural containment/existence checking only -- it does not
+    verify the claimed fact is actually supported by that line's content.
+    Claims with any other (or no) verification_basis are left untouched.
+    """
+    assigned = _canonical(assigned_workdir)
+    for claim in claims:
+        if claim.verification_basis != "checkout-inspected":
+            continue
+        # The parser (protocol.py) already guarantees `source` fullmatches
+        # `[^\s:][^:]*:\d+`, i.e. a single colon separating a path with no
+        # embedded colons from a trailing line number.
+        source = claim.source or ""
+        path_part, _, line_part = source.rpartition(":")
+        if path_part.startswith("/") or path_part.startswith("~"):
+            raise AgentLoopError(
+                "checkout-inspected evidence claim used an absolute path outside "
+                f"the assigned checkout: {source!r} for fact {claim.fact!r}."
+            )
+        if any(segment == ".." for segment in Path(path_part).parts):
+            raise AgentLoopError(
+                "checkout-inspected evidence claim used a path traversal segment: "
+                f"{source!r} for fact {claim.fact!r}."
+            )
+        resolved = _canonical(assigned / path_part)
+        if not _is_inside(resolved, assigned):
+            raise AgentLoopError(
+                "checkout-inspected evidence claim resolves outside the assigned "
+                f"checkout: {source!r} for fact {claim.fact!r}."
+            )
+        if not resolved.is_file():
+            raise AgentLoopError(
+                "checkout-inspected evidence claim references a path that is not "
+                f"a file in the assigned checkout: {source!r} for fact {claim.fact!r}."
+            )
+        line_number = int(line_part)
+        line_count = 0
+        with resolved.open("rb") as handle:
+            for line_count, _ in enumerate(handle, start=1):
+                pass
+        if not (1 <= line_number <= line_count):
+            raise AgentLoopError(
+                "checkout-inspected evidence claim references a line number "
+                f"outside the file's range: {source!r} for fact {claim.fact!r} "
+                f"(file has {line_count} lines)."
+            )
 
 
 def validate_assigned_head_advanced(

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -175,9 +175,20 @@ def validate_checkout_inspected_evidence(
             )
         line_number = int(line_part)
         line_count = 0
-        with resolved.open("rb") as handle:
-            for line_count, _ in enumerate(handle, start=1):
-                pass
+        try:
+            with resolved.open("rb") as handle:
+                for line_count, _ in enumerate(handle, start=1):
+                    pass
+        except OSError as exc:
+            # The already-validated path can still fail to open (deleted or
+            # made unreadable between is_file() and open()); translate this
+            # the same way as any other unresolvable reference instead of
+            # letting an OSError escape past the AgentLoopError/repair
+            # contract every other call site of this function relies on.
+            raise AgentLoopError(
+                "checkout-inspected evidence claim references a path that could "
+                f"not be read: {source!r} for fact {claim.fact!r} ({exc})."
+            ) from exc
         if not (1 <= line_number <= line_count):
             raise AgentLoopError(
                 "checkout-inspected evidence claim references a line number "

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -152,6 +152,16 @@ def validate_checkout_inspected_evidence(
                 "checkout-inspected evidence claim used a path traversal segment: "
                 f"{source!r} for fact {claim.fact!r}."
             )
+        # No real file has anywhere near this many lines; reject before ever
+        # calling int() on it. Python 3.11+ raises ValueError (not
+        # AgentLoopError) for int()/str() conversions beyond its default
+        # 4300-digit limit, and an unbounded `\d+` source is otherwise free
+        # to carry an arbitrarily long digit string.
+        if len(line_part) > 15:
+            raise AgentLoopError(
+                "checkout-inspected evidence claim references an implausibly "
+                f"large line number: {source!r} for fact {claim.fact!r}."
+            )
         resolved = _canonical(assigned / path_part)
         if not _is_inside(resolved, assigned):
             raise AgentLoopError(

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -153,6 +153,7 @@ from coding_review_agent_loop.prompts import (
 )
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
+    DiscussEvidenceClaim,
     _expect_string_list,
     _extract_structured_coder_followup_payload,
     _extract_structured_plan_review_payload,
@@ -182,6 +183,7 @@ from coding_review_agent_loop.protocol import (
 )
 from coding_review_agent_loop.workdir_guard import (
     extract_reported_tests_from_response,
+    validate_checkout_inspected_evidence,
     validate_response_tests_within_workdir,
     validate_test_commands_within_workdir,
 )

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -3132,6 +3132,34 @@ def test_discuss_debater_checkout_inspected_claim_invalid_reference_triggers_rep
     assert "Consensus kind: `unanimous` after round 1." in runner.comments[-1]
 
 
+def test_discuss_debater_checkout_inspected_claim_implausibly_large_line_triggers_repair(tmp_path):
+    # A debater cites a checkout-inspected line number far beyond Python
+    # 3.11+'s default int-conversion digit limit; this must be rejected as
+    # AgentLoopError (triggering the normal repair path) rather than crashing
+    # the debater turn with an uncaught ValueError (#541 review).
+    from unittest.mock import patch
+
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    huge_line = "9" * 4500
+    invalid = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence(f"src.py:{huge_line}")
+    )
+    repaired = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence("src.py:2")
+    )
+    runner = FakeRunner(
+        codex_outputs=[invalid],
+        gemini_outputs=[_discuss_review_text(outcome="implement")],
+    )
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired):
+        result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    assert "Consensus kind: `unanimous` after round 1." in runner.comments[-1]
+
+
 def test_discuss_parallel_rejects_shared_debater_workdirs_even_with_allow_shared_dir(tmp_path):
     shared = tmp_path / "shared"
     config = make_config(

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -3160,6 +3160,39 @@ def test_discuss_debater_checkout_inspected_claim_implausibly_large_line_trigger
     assert "Consensus kind: `unanimous` after round 1." in runner.comments[-1]
 
 
+def test_discuss_debater_checkout_inspected_claim_unreadable_file_triggers_repair(tmp_path):
+    # The referenced file exists (passes is_file()) but cannot be opened; an
+    # OSError from open() must be translated into AgentLoopError (triggering
+    # the normal repair path) rather than crashing the debater turn (#541
+    # review).
+    from unittest.mock import patch
+
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    unreadable = config.codex_dir / "secret.py"
+    unreadable.write_text("line one\nline two\n", encoding="utf-8")
+    unreadable.chmod(0o000)
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    invalid = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence("secret.py:1")
+    )
+    repaired = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence("src.py:2")
+    )
+    runner = FakeRunner(
+        codex_outputs=[invalid],
+        gemini_outputs=[_discuss_review_text(outcome="implement")],
+    )
+
+    try:
+        with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired):
+            result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+    finally:
+        unreadable.chmod(0o644)
+
+    assert result == 0
+    assert "Consensus kind: `unanimous` after round 1." in runner.comments[-1]
+
+
 def test_discuss_parallel_rejects_shared_debater_workdirs_even_with_allow_shared_dir(tmp_path):
     shared = tmp_path / "shared"
     config = make_config(

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -73,6 +73,7 @@ def _discuss_review_text(
     analyzer_framing: str | None = None,
     framing_note: str | None = None,
     research: dict | None = None,
+    evidence: dict | None = None,
 ) -> str:
     payload: dict = {
         "schema_version": 1,
@@ -90,7 +91,23 @@ def _discuss_review_text(
         payload["framing_note"] = framing_note
     if research is not None:
         payload["research"] = research
+    if evidence is not None:
+        payload["evidence"] = evidence
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
+
+
+def _checkout_inspected_evidence(source: str) -> dict:
+    return {
+        "claims": [
+            {
+                "fact": "The referenced line supports this outcome.",
+                "status": "verified",
+                "source": source,
+                "verification_basis": "checkout-inspected",
+            }
+        ],
+        "updates": [],
+    }
 
 
 def _discuss_answer_text(
@@ -103,6 +120,7 @@ def _discuss_answer_text(
     unresolved_items: list[dict[str, str]] | None = None,
     rebuttal: str | None = None,
     research: dict | None = None,
+    evidence: dict | None = None,
     reviewer: str = "OpenAI Codex",
 ) -> str:
     payload: dict = {
@@ -122,6 +140,8 @@ def _discuss_answer_text(
         payload["rebuttal"] = rebuttal
     if research is not None:
         payload["research"] = research
+    if evidence is not None:
+        payload["evidence"] = evidence
     return json.dumps(payload) + f"\n<!-- AGENT_PLAN_STATE: approved -->\n-- {reviewer}"
 
 
@@ -213,6 +233,7 @@ def _seed_debater_comment(
     rationale: str = "Well-scoped.",
     split_proposals: list[str] | None = None,
     rebuttal: str | None = None,
+    evidence: dict | None = None,
     config=None,
 ) -> dict:
     """Build an issue-comment payload matching what `_run_discuss_loop` posts for a debater."""
@@ -229,6 +250,7 @@ def _seed_debater_comment(
         split_proposals=split_proposals,
         rebuttal=rebuttal,
         reviewer=reviewer,
+        evidence=evidence,
     )
     body = render_public_agent_comment(
         kind="discuss_review",
@@ -254,7 +276,7 @@ def _seed_debater_comment(
 def _seed_answer_debater_comment(
     *, reviewer: str, round_number: int, subject: str, answer: str,
     rationale: str = "The evidence supports this recommendation.",
-    rebuttal: str | None = None, config=None, legacy: bool = False,
+    rebuttal: str | None = None, evidence: dict | None = None, config=None, legacy: bool = False,
 ) -> dict:
     vote = ParsedDiscussAnswer(
         position="answer", rationale=rationale, confidence="medium",
@@ -269,6 +291,7 @@ def _seed_answer_debater_comment(
     else:
         raw_text = _discuss_answer_text(
             answer=answer, rationale=rationale, rebuttal=rebuttal, reviewer=reviewer,
+            evidence=evidence,
         )
     body = render_public_agent_comment(
         kind="discuss_answer", parsed=vote, agent=reviewer, config=config,
@@ -713,6 +736,37 @@ def test_discuss_loop_resumes_answer_partial_round_and_is_idempotent(tmp_path):
 
     assert run_discuss_loop(runner, issue_number=56, config=config) == 0
     assert len(runner.comments) == comment_count
+
+
+def test_discuss_loop_resume_mid_round_answer_mode_accepts_valid_checkout_inspected_reference(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    seeded = _seed_answer_debater_comment(
+        reviewer="Codex", round_number=1, subject=subject,
+        answer="Use an API.", evidence=_checkout_inspected_evidence("src.py:2"), config=config,
+    )
+    answer = _discuss_answer_text(answer="Use an API.", reviewer="Google Gemini")
+    runner = FakeRunner(issue_comments=[seeded], gemini_outputs=[answer])
+
+    assert run_discuss_loop(runner, issue_number=56, config=config) == 0
+    assert "Consensus Answer" in runner.comments[-1]
+
+
+def test_discuss_loop_resume_mid_round_answer_mode_rejects_invalid_checkout_inspected_reference(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    seeded = _seed_answer_debater_comment(
+        reviewer="Codex", round_number=1, subject=subject,
+        answer="Use an API.", evidence=_checkout_inspected_evidence("src/missing.py:1"), config=config,
+    )
+    runner = FakeRunner(
+        issue_comments=[seeded],
+        gemini_outputs=[_discuss_answer_text(answer="Use an API.", reviewer="Google Gemini")],
+    )
+
+    with pytest.raises(AgentLoopError, match="not a file in the assigned checkout"):
+        run_discuss_loop(runner, issue_number=56, config=config)
 
 
 def test_discuss_loop_resumes_legacy_answer_metadata_conservatively(tmp_path):
@@ -1187,6 +1241,42 @@ def test_discuss_loop_split_consensus_rerun_materializes_nothing_new(tmp_path):
     assert len(runner.issues) == 1
 
 
+def test_discuss_loop_marker_only_final_recovers_split_proposals_via_legacy_fallback(tmp_path):
+    """An issue carries a bare `AGENT_DISCUSS_CONSENSUS` marker comment (from
+    an old run) with no matching final-round summary metadata, so
+    `resume_state.done` is False for this subject and `_run_discuss_loop`'s
+    own `_resolve_final_split_proposals` must fall through to
+    `_recover_final_discuss_split_proposals` -- the same shared,
+    reviewer-workdir-validated recovery function used by the plan-first path
+    -- to reconstruct and materialize the split proposal instead of crashing
+    on the now-required `reviewer_workdirs` parameter (#541)."""
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), materialize_split_issues=True)
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    seeded = [
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-01-01T00:00:00Z",
+            "body": f"Old consensus record.\n<!-- AGENT_DISCUSS_CONSENSUS: {subject} -->",
+        },
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject, outcome="split",
+            rationale="Too broad.", split_proposals=["Auth flow"],
+            evidence=_checkout_inspected_evidence("src.py:2"), config=config,
+        ),
+    ]
+    runner = FakeRunner(
+        issue_comments=seeded, codex_outputs=[], gemini_outputs=[],
+        issue_urls=["https://github.com/OWNER/REPO/issues/101"],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == "[#56 stage] Auth flow"
+
+
 def test_discuss_loop_converges_after_debate(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
@@ -1337,6 +1427,83 @@ def test_discuss_loop_resumes_missing_debater_mid_round(tmp_path):
     assert "Consensus: Implement" in runner.comments[-1]
 
 
+def test_discuss_loop_resume_mid_round_accepts_valid_checkout_inspected_reference(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    seeded = _seed_debater_comment(
+        reviewer="Codex",
+        round_number=1,
+        subject=subject,
+        outcome="implement",
+        rationale="Scoped.",
+        evidence=_checkout_inspected_evidence("src.py:2"),
+        config=config,
+    )
+    implement_text = _discuss_review_text(outcome="implement", rationale="Agreed.", reviewer="Gemini")
+    runner = FakeRunner(
+        issue_comments=[seeded],
+        codex_outputs=[],
+        gemini_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config)
+
+    assert result == 0
+    assert "Consensus: Implement" in runner.comments[-1]
+
+
+def test_discuss_loop_resume_mid_round_rejects_invalid_checkout_inspected_reference(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    seeded = _seed_debater_comment(
+        reviewer="Codex",
+        round_number=1,
+        subject=subject,
+        outcome="implement",
+        rationale="Scoped.",
+        evidence=_checkout_inspected_evidence("src/missing.py:1"),
+        config=config,
+    )
+    runner = FakeRunner(
+        issue_comments=[seeded],
+        codex_outputs=[],
+        gemini_outputs=[_discuss_review_text(outcome="implement", rationale="Agreed.", reviewer="Gemini")],
+    )
+
+    with pytest.raises(AgentLoopError, match="not a file in the assigned checkout"):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+
+def test_discuss_loop_resume_mid_round_rejects_unconfigured_reviewer_debater_comment(tmp_path):
+    # A debater comment posted by a reviewer who is no longer part of the
+    # configured --reviewers set (e.g. dropped before resuming an interrupted
+    # round) cannot be checkout-validated, since we have no known assigned
+    # workdir for it; only the in-progress mid-round decode loop can ever
+    # encounter this, since completed-round resume and legacy split recovery
+    # both key strictly off configured reviewer names (#541).
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Scoped.", config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="ThirdParty", round_number=1, subject=subject,
+            outcome="implement", rationale="Also scoped.", config=config,
+        ),
+    ]
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[],
+        gemini_outputs=[],
+    )
+
+    with pytest.raises(AgentLoopError, match="ThirdParty"):
+        run_discuss_loop(runner, issue_number=56, config=config)
+
+
 def test_discuss_loop_resumes_after_closed_non_final_round(tmp_path):
     subject = _issue_subject()
     config = make_config(tmp_path, reviewer=("codex", "gemini"))
@@ -1392,6 +1559,88 @@ def test_discuss_loop_resumes_after_closed_non_final_round(tmp_path):
     for command in round2_commands:
         prompt = " ".join(command)
         assert "Out of scope." in prompt
+
+
+def test_discuss_loop_resume_completed_round_accepts_valid_checkout_inspected_reference(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    gemini_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="Out of scope.", split_proposals=(), reviewer="Gemini")
+    agenda = (
+        "- Codex held `implement`: Scoped.",
+        "- Gemini held `do-not-implement`: Out of scope.",
+    )
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Scoped.",
+            evidence=_checkout_inspected_evidence("src.py:2"), config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            outcome="do-not-implement", rationale="Out of scope.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            split_proposals=[],
+            agenda=agenda,
+        ),
+    ]
+    implement_text = _discuss_review_text(
+        outcome="implement", rationale="Still scoped.", rebuttal="The split concern does not apply.",
+    )
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[implement_text],
+        gemini_outputs=[implement_text],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
+
+    assert result == 0
+    assert "Consensus: Implement" in runner.comments[-1]
+
+
+def test_discuss_loop_resume_completed_round_rejects_invalid_checkout_inspected_reference(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    codex_vote_r1 = ParsedDiscussReview(outcome="implement", rationale="Scoped.", split_proposals=(), reviewer="Codex")
+    gemini_vote_r1 = ParsedDiscussReview(outcome="do-not-implement", rationale="Out of scope.", split_proposals=(), reviewer="Gemini")
+    agenda = (
+        "- Codex held `implement`: Scoped.",
+        "- Gemini held `do-not-implement`: Out of scope.",
+    )
+    seeded = [
+        _seed_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            outcome="implement", rationale="Scoped.",
+            evidence=_checkout_inspected_evidence("src/missing.py:1"), config=config,
+        ),
+        _seed_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            outcome="do-not-implement", rationale="Out of scope.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1,
+            reviewer_votes=[codex_vote_r1, gemini_vote_r1],
+            is_final=False,
+            subject=subject,
+            split_proposals=[],
+            agenda=agenda,
+        ),
+    ]
+    runner = FakeRunner(
+        issue_comments=seeded,
+        codex_outputs=[],
+        gemini_outputs=[],
+    )
+
+    with pytest.raises(AgentLoopError, match="not a file in the assigned checkout"):
+        run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1)
 
 
 def test_discuss_loop_resume_reconstructs_full_round_history_across_multiple_closed_rounds(tmp_path):
@@ -2837,6 +3086,50 @@ def test_discuss_debater_timeout_is_partial_result_without_transient_retries(tmp
     summary_raw = runner.issue_comments[-1]["body"]
     metadata = _decode_round_metadata(ROUND_RESUME_MARKER_RE.search(summary_raw).group("payload"))
     assert metadata.failed_debaters == (("Gemini", "timeout"),)
+
+
+def test_discuss_debater_checkout_inspected_claim_valid_reference_passes_through(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    valid = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence("src.py:2")
+    )
+    runner = FakeRunner(
+        codex_outputs=[valid],
+        gemini_outputs=[_discuss_review_text(outcome="implement")],
+    )
+
+    result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    assert "Consensus kind: `unanimous` after round 1." in runner.comments[-1]
+
+
+def test_discuss_debater_checkout_inspected_claim_invalid_reference_triggers_repair(tmp_path):
+    # A debater cites a checkout-inspected path:line that does not exist in its
+    # own assigned checkout; the evidence check rejects the vote the same way
+    # any other malformed structured response is rejected, so the existing
+    # repair path re-checks the repaired text against the same validator (#541).
+    from unittest.mock import patch
+
+    config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    invalid = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence("src/missing.py:1")
+    )
+    repaired = _discuss_review_text(
+        outcome="implement", evidence=_checkout_inspected_evidence("src.py:2")
+    )
+    runner = FakeRunner(
+        codex_outputs=[invalid],
+        gemini_outputs=[_discuss_review_text(outcome="implement")],
+    )
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", return_value=repaired):
+        result = run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0)
+
+    assert result == 0
+    assert "Consensus kind: `unanimous` after round 1." in runner.comments[-1]
 
 
 def test_discuss_parallel_rejects_shared_debater_workdirs_even_with_allow_shared_dir(tmp_path):

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -1,5 +1,7 @@
 """Integration tests for plan-first split/deferred-stage materialization and
 the selected-stage implementation handoff (#476)."""
+import json
+
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
@@ -417,6 +419,133 @@ def test_plan_first_materializes_prior_discuss_split_and_hands_off_in_same_run(t
     assert "issue #101" in implementation_prompt
     assert "Closes #101" in implementation_prompt
     assert "Refs #56" in implementation_prompt
+
+
+def _legacy_split_debater_comment(*, evidence: dict | None = None) -> dict:
+    """A final-round debater comment predating the `split_proposals` metadata
+    field, forcing `_recover_final_discuss_split_proposals`'s legacy fallback
+    to reconstruct proposals from the debater's own vote."""
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "discuss_review",
+        "outcome": "split",
+        "rationale": "Too broad for one PR.",
+        "split_proposals": ["Auth flow", "Billing flow"],
+    }
+    if evidence is not None:
+        payload["evidence"] = evidence
+    body = _attach_round_metadata(
+        json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="discuss", role="debater", agent="Codex", round_number=1,
+            subject="prior-discuss-subject",
+        ),
+    )
+    return {"author": {"login": "bot"}, "createdAt": "2026-05-20T00:00:00Z", "body": body}
+
+
+def _legacy_split_final_summary_comment() -> dict:
+    """A final discuss summary predating `split_proposals` metadata (empty
+    here), so recovery must fall back to the debater comment above."""
+    return {
+        "author": {"login": "bot"},
+        "createdAt": "2026-05-20T00:00:01Z",
+        "body": _attach_round_metadata(
+            "Discuss consensus: split this into stages.\n-- coding-review-agent-loop",
+            PostedRoundMetadata(
+                flow="discuss",
+                role="summary",
+                agent="coding-review-agent-loop",
+                round_number=1,
+                subject="prior-discuss-subject",
+                is_final=True,
+            ),
+        ),
+    }
+
+
+def test_plan_first_recovers_legacy_split_proposals_with_valid_checkout_inspected_claim(tmp_path):
+    """`_prior_discuss_split_proposals`'s legacy fallback
+    (`_recover_final_discuss_split_proposals`) must checkout-validate a
+    `checkout-inspected` evidence claim on the reconstructed debater vote,
+    exactly like the primary discuss-loop recovery paths (#541)."""
+    config = make_config(tmp_path, materialize_split_issues=True)
+    (config.codex_dir / "src.py").write_text("line one\nline two\n", encoding="utf-8")
+    plan = structured_plan_state(state="blocking", summary="Auth flow")
+    runner = FakeRunner(
+        claude_outputs=[
+            plan,
+            "Implemented the auth-flow stage.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_comments=[
+            _legacy_split_debater_comment(
+                evidence={
+                    "claims": [
+                        {
+                            "fact": "The referenced line supports splitting the work.",
+                            "status": "verified",
+                            "source": "src.py:2",
+                            "verification_basis": "checkout-inspected",
+                        }
+                    ],
+                    "updates": [],
+                },
+            ),
+            _legacy_split_final_summary_comment(),
+        ],
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+        pr_payload={"body": "Closes #101\n\nRefs #56"},
+    )
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+
+    assert {issue["title"] for issue in runner.issues} == {
+        "[#56 stage] Auth flow",
+        "[#56 stage] Billing flow",
+    }
+    assert any("<!-- AGENT_SPLIT_STAGE_HANDOFF:" in comment for comment in runner.comments)
+
+
+def test_plan_first_legacy_split_recovery_rejects_invalid_checkout_inspected_claim(tmp_path):
+    config = make_config(tmp_path, materialize_split_issues=True)
+    plan = structured_plan_state(state="blocking", summary="Auth flow")
+    runner = FakeRunner(
+        claude_outputs=[plan],
+        codex_outputs=[structured_plan_review(state="approved")],
+        issue_comments=[
+            _legacy_split_debater_comment(
+                evidence={
+                    "claims": [
+                        {
+                            "fact": "The referenced line supports splitting the work.",
+                            "status": "verified",
+                            "source": "src/missing.py:1",
+                            "verification_basis": "checkout-inspected",
+                        }
+                    ],
+                    "updates": [],
+                },
+            ),
+            _legacy_split_final_summary_comment(),
+        ],
+    )
+
+    with pytest.raises(AgentLoopError, match="not a file in the assigned checkout"):
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
 
 
 def test_plan_first_excludes_own_scope_from_prior_discuss_proposals(tmp_path):

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -159,6 +159,24 @@ def test_checkout_inspected_evidence_rejects_implausibly_large_line_number_witho
         )
 
 
+def test_checkout_inspected_evidence_rejects_unreadable_file_without_crashing(tmp_path):
+    # is_file() only checks the path resolves to a regular file; it does not
+    # guarantee the file can actually be opened (deleted or made unreadable
+    # between the check and open() -- e.g. a permission race). An OSError
+    # from open() must be translated into AgentLoopError like every other
+    # unresolvable reference, not left to escape and bypass the repair path.
+    target = tmp_path / "src.py"
+    target.write_text("line1\nline2\n", encoding="utf-8")
+    target.chmod(0o000)
+    try:
+        with pytest.raises(AgentLoopError, match="could not be read"):
+            validate_checkout_inspected_evidence(
+                [_checkout_claim("src.py:1")], assigned_workdir=tmp_path
+            )
+    finally:
+        target.chmod(0o644)
+
+
 def test_checkout_inspected_evidence_rejects_line_zero(tmp_path):
     (tmp_path / "src.py").write_text("line1\n", encoding="utf-8")
 

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -145,6 +145,20 @@ def test_checkout_inspected_evidence_rejects_out_of_range_line(tmp_path):
         )
 
 
+def test_checkout_inspected_evidence_rejects_implausibly_large_line_number_without_crashing(tmp_path):
+    # Python 3.11+ raises ValueError (not AgentLoopError) converting a
+    # digit string beyond its default int-conversion digit limit; the
+    # parser's `\d+` source pattern is otherwise unbounded, so this must be
+    # rejected as AgentLoopError before ever calling int() on it.
+    (tmp_path / "src.py").write_text("line1\nline2\n", encoding="utf-8")
+    huge_line = "9" * 4500
+
+    with pytest.raises(AgentLoopError, match="implausibly large line number"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim(f"src.py:{huge_line}")], assigned_workdir=tmp_path
+        )
+
+
 def test_checkout_inspected_evidence_rejects_line_zero(tmp_path):
     (tmp_path / "src.py").write_text("line1\n", encoding="utf-8")
 

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -115,3 +115,88 @@ def test_workdir_guard_extracts_tests_section_only(tmp_path):
         "python -m pytest tests/test_agent_loop.py passed.",
     )
     validate_response_tests_within_workdir(text, assigned_workdir=assigned)
+
+
+def _checkout_claim(source, *, verification_basis="checkout-inspected", status="verified", fact="fact"):
+    return DiscussEvidenceClaim(fact=fact, status=status, source=source, verification_basis=verification_basis)
+
+
+def test_checkout_inspected_evidence_accepts_valid_in_range_reference(tmp_path):
+    (tmp_path / "src.py").write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+    validate_checkout_inspected_evidence(
+        [_checkout_claim("src.py:2")], assigned_workdir=tmp_path
+    )
+
+
+def test_checkout_inspected_evidence_rejects_missing_file(tmp_path):
+    with pytest.raises(AgentLoopError, match="not a file"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim("nope.py:1")], assigned_workdir=tmp_path
+        )
+
+
+def test_checkout_inspected_evidence_rejects_out_of_range_line(tmp_path):
+    (tmp_path / "src.py").write_text("line1\nline2\n", encoding="utf-8")
+
+    with pytest.raises(AgentLoopError, match="outside the file's range"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim("src.py:99")], assigned_workdir=tmp_path
+        )
+
+
+def test_checkout_inspected_evidence_rejects_line_zero(tmp_path):
+    (tmp_path / "src.py").write_text("line1\n", encoding="utf-8")
+
+    with pytest.raises(AgentLoopError, match="outside the file's range"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim("src.py:0")], assigned_workdir=tmp_path
+        )
+
+
+def test_checkout_inspected_evidence_rejects_absolute_path(tmp_path):
+    with pytest.raises(AgentLoopError, match="absolute path"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim("/etc/passwd:1")], assigned_workdir=tmp_path
+        )
+
+
+def test_checkout_inspected_evidence_rejects_parent_traversal(tmp_path):
+    outside = tmp_path.parent / "outside.py"
+    outside.write_text("secret\n", encoding="utf-8")
+    assigned = tmp_path / "repo"
+    assigned.mkdir()
+
+    with pytest.raises(AgentLoopError, match="traversal"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim("../outside.py:1")], assigned_workdir=assigned
+        )
+
+
+def test_checkout_inspected_evidence_rejects_symlink_escape(tmp_path):
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    target = outside_dir / "secret.py"
+    target.write_text("secret line\n", encoding="utf-8")
+    assigned = tmp_path / "repo"
+    assigned.mkdir()
+    link = assigned / "escape.py"
+    link.symlink_to(target)
+
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        validate_checkout_inspected_evidence(
+            [_checkout_claim("escape.py:1")], assigned_workdir=assigned
+        )
+
+
+def test_checkout_inspected_evidence_leaves_external_source_claim_alone(tmp_path):
+    validate_checkout_inspected_evidence(
+        [_checkout_claim("https://example.com/spec:1", verification_basis="external-source-inspected")],
+        assigned_workdir=tmp_path,
+    )
+
+
+def test_checkout_inspected_evidence_leaves_missing_status_claim_alone(tmp_path):
+    claim = DiscussEvidenceClaim(fact="fact", status="missing", source=None, verification_basis=None)
+
+    validate_checkout_inspected_evidence([claim], assigned_workdir=tmp_path)


### PR DESCRIPTION
## Summary

- Adds `validate_checkout_inspected_evidence` (`workdir_guard.py`) to reject a `checkout-inspected` evidence claim whose `path:line` reference doesn't resolve to a real, in-range line inside the reviewer's assigned checkout right now (rejects absolute paths, `..` traversal, and symlink escapes before touching the filesystem).
- Wires this into the live debater-turn validate callback (the existing repair path re-checks it automatically), resume decoding (`reviewer_workdirs` threaded through `_resume_discuss_round`/`_decode_discuss_vote`, with the in-progress mid-round loop rejecting a debater comment from a reviewer no longer in `--reviewers`), and both legacy split-proposal recovery call sites (`_recover_final_discuss_split_proposals`, reached from both the discuss loop and plan-first narrowing).
- Documents the bounded guarantee and current-checkout semantics (including the asymmetric explicit-vs-default reviewer workdir behavior) in `docs/local_agent_loop.md` and `README.md`.

Previously the loop trusted a debater's `checkout-inspected` structured claim the same way it trusted other structured output; this adds mechanical, structural cross-checking (not semantic fact verification) as defense-in-depth.

Fixes #541

## Test plan

- [x] `PYTHONPATH=src python3 -m pytest tests/ -q` — 1505 passed
- [x] New unit tests in `tests/test_workdir_guard.py` (valid/missing/out-of-range/line-zero/absolute/traversal/symlink-escape/external-source/missing-status cases)
- [x] New integration tests in `tests/test_discuss_loop.py` (live+repair, mid-round resume, completed-round resume, answer-mode resume, unconfigured-reviewer-name resume, legacy split-proposal fallback via the discuss loop's own consensus-marker path)
- [x] New integration tests in `tests/test_split_orchestration.py` (plan-first legacy split-proposal recovery, valid and invalid claims)

🤖 Generated with [Claude Code](https://claude.com/claude-code)