### PR TITLE
Require structured initial plan state

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -300,7 +300,7 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
     re.I,
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
-    {"plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_semantic_comparison", "discuss_answer_confirmation"}
+    {"plan_state", "plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 )
 PLAN_REVISION_FOOTER_RE = re.compile(r"(?m)^<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$")
 STRUCTURED_FENCE_RE = re.compile(
@@ -2271,7 +2271,12 @@ def _require_pr_number_or_clarification(text: str) -> int | str:
 def _require_plan_state_or_clarification(text: str) -> str:
     if is_clarification_request(text):
         return "clarification"
-    return parse_plan_state(text)
+    structured_plan = validate_structured_plan_state(text)
+    if structured_plan is None:
+        raise AgentLoopError(
+            "Initial planning response must include a structured `plan_state` JSON object."
+        )
+    return structured_plan.state
 def _validate_response_with_human_requirements(
     text: str,
     *,
@@ -3010,6 +3015,8 @@ def _run_plan_first_loop(
                 full_omission_fallback="Fetch the issue discussion directly before finalizing the plan.",
             ),
             usage_context=usage_context,
+            use_repair=True,
+            repair_expected_kind="plan_state",
             operation_description="planning",
         )
         plan_output = plan_response.text

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -953,8 +953,26 @@ def build_issue_plan_prompt(
 
 Use this local checkout only to inspect context. Do not edit files, create a
 branch, commit, push, or open a pull request during this planning stage.
-Write a concise implementation plan covering the intended approach, key files or
-areas to change, edge cases, and test strategy.
+For a plan (rather than a clarification), respond with exactly one structured JSON
+`plan_state` object. It must have this complete contract:
+
+{{
+  "schema_version": 1,
+  "kind": "plan_state",
+  "state": "blocking",
+  "summary": "<non-empty concise implementation summary>",
+  "plan_steps": ["<non-empty step>"]
+}}
+
+`plan_steps` must be a non-empty list of non-empty strings and should cover the
+intended approach, key files or areas to change, edge cases, and test strategy.
+The optional `deferred_stages` field is a list of objects with non-empty `title`
+and `summary` strings.
+Do not substitute a generic `implementation_plan` object or markdown plan for this
+schema. If signed human-requirements acknowledgement is required, put its
+`<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` marker and `### Human requirements` section
+after the JSON object and before the AGENT_PLAN_STATE footer. Do not put any other
+prose between the JSON object and footer.
 {_coder_workdir_guidance(config, implementation=False)}
 {_scratch_file_guidance()}
 {human_requirements_context.block}{_coder_human_requirements_guidance(

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -1061,6 +1061,7 @@ def _extract_structured_plan_state_payload(text: str) -> dict[str, object] | Non
         state_re=PLAN_STATE_RE,
         state_marker_name="AGENT_PLAN_STATE",
         context_label="Structured plan state",
+        allow_human_requirements_prefix=True,
     )
 
 
@@ -1622,19 +1623,19 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
     payload = _extract_structured_plan_state_payload(text)
     if payload is None:
         return None
-    if "schema_version" in payload:
-        _require_supported_schema_version(payload)
+    _require_supported_schema_version(payload)
     kind = payload.get("kind")
-    if isinstance(kind, str) and kind != "plan_state":
+    if kind != "plan_state":
         raise AgentLoopError("Structured response kind mismatch: expected `plan_state`.")
     _expect_exact_keys(
         payload,
         context="plan_state",
-        required={"kind", "summary", "plan_steps"},
-        optional={"schema_version", "state", "deferred_stages"},
+        required={"schema_version", "kind", "state", "summary", "plan_steps"},
+        optional={"deferred_stages"},
     )
-    if "state" in payload:
-        _expect_state(payload["state"], context="plan_state.state")
+    state = _expect_state(payload["state"], context="plan_state.state")
+    if state != "blocking":
+        raise AgentLoopError("plan_state.state must be `blocking`.")
     return StructuredPlanState(
         schema_version=int(payload.get("schema_version", 1)),
         kind="plan_state",

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -85,7 +85,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
+    if expected_kind not in {"plan_state", "pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
         return None
 
     stripped = raw.lstrip()
@@ -100,7 +100,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 
     json_text = stripped[:json_end].rstrip()
     trailing = stripped[json_end:]
-    state_re = PLAN_STATE_RE if expected_kind in {"plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"} else STATE_RE
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_state", "plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"} else STATE_RE
     state_match = state_re.search(trailing)
     if state_match is None:
         return None
@@ -133,7 +133,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
             preserved_before = before_lstripped[: marker_match.end()].strip()
         elif before_footer.strip():
             return None
-    elif expected_kind == "plan_revision" and before_footer.strip():
+    elif expected_kind in {"plan_state", "plan_revision"} and before_footer.strip():
         parsed_human_requirements = parse_human_requirements_acknowledgement(before_footer)
         if (
             parsed_human_requirements.marker_present
@@ -196,7 +196,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 # Uses str.replace("{raw_response}", raw, 1) for substitution because the prompt
 # itself contains literal { } characters in the JSON examples.
 _REPAIR_PROMPT = """\
-You are a format-repair assistant. An AI agent produced a code review, plan review, plan revision, coder follow-up, discuss review, discuss agenda, semantic comparison, or answer confirmation that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
+You are a format-repair assistant. An AI agent produced an initial plan state, code review, plan review, plan revision, coder follow-up, discuss review, discuss agenda, semantic comparison, or answer confirmation that failed strict schema validation. Extract its intent and reformat it into one of these valid formats.
 
 {expected_kind_instruction}
 
@@ -394,6 +394,25 @@ Notes:
 - If no agenda content is recoverable, return the closest faithful output even if it remains invalid; the orchestrator will fall back mechanically.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
+## Valid Format J — Initial Plan State:
+
+{
+  "schema_version": 1,
+  "kind": "plan_state",
+  "state": "blocking",
+  "summary": "<short implementation summary>",
+  "plan_steps": ["Update the parser.", "Add regression tests."]
+}
+<!-- HUMAN_REQUIREMENTS_ADDRESSED -->
+
+### Human requirements
+
+- Requirement 1: <how the plan addresses this signed human requirement, if present in the original>
+<!-- AGENT_PLAN_STATE: blocking -->
+-- <Coder Name>
+
+Only include the optional signed human requirements acknowledgement when it was present in the malformed original.
+
 ## Valid Format D — Plan Revision:
 
 When the malformed plan_revision did not include a signed human requirements
@@ -478,7 +497,8 @@ the `### Human requirements` section from Format D.
 ## FORMAT SELECTION:
 - If an expected response kind is provided above, use ONLY that format. Do not infer a different kind from keywords in the malformed response.
 - Use Format C if the original contains "coder_followup" or "addressed_items" or "remaining_items".
-- Use Format D if the original contains "plan_revision" or "plan_steps".
+- Use Format D if the original contains "plan_revision".
+- Use Format J if the original contains "plan_state" or "plan_steps".
 - Use Format H if the original contains "discuss_semantic_comparison" or "remaining_decisions".
 - Use Format I if the original contains "discuss_answer_confirmation" or "decision".
 - Use Format F if the original contains "discuss_agenda" or "question_for_next_round".
@@ -963,8 +983,8 @@ sourced fact. Do not repair answer mode into `discuss_review`, and do not add
 1. Start DIRECTLY with { — no prose, no markdown fences.
 2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,
    place that marker immediately after the JSON and before the AGENT_STATE/AGENT_PLAN_STATE footer.
-   For `plan_revision`, place the optional signed human requirements acknowledgement before the footer only when it was present in the malformed original.
-   Then: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_review or plan_revision). DIFFERENT MARKERS.
+   For `plan_state` or `plan_revision`, place the optional signed human requirements acknowledgement before the footer only when it was present in the malformed original.
+   Then: <!-- AGENT_STATE: X --> (pr_review or coder_followup) OR <!-- AGENT_PLAN_STATE: X --> (plan_state, plan_review, or plan_revision). DIFFERENT MARKERS.
 3. JSON "state" matches X. Then: -- Agent Name. STOP. Nothing else.
 
 Output ONLY the repaired response. No explanations.
@@ -974,7 +994,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
+_SUPPORTED_EXPECTED_KINDS = {"plan_state", "pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output"
 ]

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -962,7 +962,7 @@ def structured_plan_revision(
 
 def structured_plan_state(
     *,
-    state: str = "approved",
+    state: str = "blocking",
     summary: str = "Implementation plan.",
     plan_steps: list[str] | None = None,
     reviewer: str = "Anthropic Claude",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -73,6 +73,7 @@ from agent_loop_helpers import (
     structured_coder_followup,
     structured_plan_review,
     structured_plan_revision,
+    structured_plan_state,
     structured_pr_review,
 )
 
@@ -304,7 +305,7 @@ def test_plan_review_does_not_post_diagnostics_without_plan_state(tmp_path):
     diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Update the CLI.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Update the CLI.", plan_steps=["Update the CLI."]),
         ],
         gemini_outputs=[diagnostic, diagnostic, diagnostic],
     )
@@ -314,7 +315,7 @@ def test_plan_review_does_not_post_diagnostics_without_plan_state(tmp_path):
         run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
 
     assert len(runner.comments) == 1
-    assert runner.comments[0].startswith("Plan:")
+    assert runner.comments[0].startswith("## Plan")
     assert not any(diagnostic in comment for comment in runner.comments)
 
 
@@ -323,7 +324,7 @@ def test_plan_loop_retries_plain_agent_plan_state_near_miss_once(tmp_path):
     valid = "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini"
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Update the CLI.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Update the CLI.", plan_steps=["Update the CLI."]),
         ],
         gemini_outputs=[near_miss, valid],
     )

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -199,12 +199,14 @@ def test_render_structured_plan_state_to_public_markdown():
     raw = (
         json.dumps(
             {
+                "schema_version": 1,
                 "kind": "plan_state",
+                "state": "blocking",
                 "summary": "Plan the renderer fix.",
                 "plan_steps": ["Detect structured plan_state.", "Render public markdown."],
             }
         )
-        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Antigravity"
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Google Antigravity"
     )
     parsed = validate_structured_plan_state(raw)
 
@@ -222,7 +224,7 @@ def test_render_structured_plan_state_to_public_markdown():
         "### Plan steps\n"
         "1. Detect structured plan_state.\n"
         "2. Render public markdown.\n\n"
-        "<!-- AGENT_PLAN_STATE: approved -->\n\n"
+        "<!-- AGENT_PLAN_STATE: blocking -->\n\n"
         "-- Google Antigravity: Gemini 3.1 Pro (High)"
     )
     assert '"kind": "plan_state"' not in public

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -13,7 +13,13 @@ from coding_review_agent_loop.decomposition import (
 )
 from coding_review_agent_loop.github import IssueComment
 from coding_review_agent_loop.orchestrator import PostedRoundMetadata, _attach_round_metadata, _plan_subject
-from agent_loop_helpers import FakeRunner, make_config, plan_decomposition_json, structured_plan_review
+from agent_loop_helpers import (
+    FakeRunner,
+    make_config,
+    plan_decomposition_json,
+    structured_plan_review,
+    structured_plan_state,
+)
 
 
 def test_parse_plan_decomposition_accepts_agent_and_human_phases():
@@ -173,7 +179,7 @@ def test_parse_plan_decomposition_rejects_duplicates_and_over_cap():
 def test_issue_loop_plan_first_decompose_only_summarizes_instead_of_filing_plan_followups(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Split the implementation into phases.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Split the implementation into phases."),
             plan_decomposition_json(
                 {
                     "title": "Schema helpers",
@@ -221,7 +227,7 @@ def test_issue_loop_plan_first_decompose_only_summarizes_instead_of_filing_plan_
 def test_issue_loop_plan_first_decompose_only_creates_child_issues(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Add schema helpers."),
             plan_decomposition_json(
                 {
                     "title": "Schema helpers",
@@ -273,7 +279,7 @@ def test_issue_loop_plan_first_decompose_only_creates_child_issues(tmp_path):
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
 
 def test_issue_loop_plan_first_decompose_only_is_idempotent(tmp_path):
-    plan = "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan = structured_plan_state(summary="Add schema helpers.")
     summary = format_decomposition_parent_summary(
         parent_issue=56,
         mode="decompose-only",
@@ -322,7 +328,7 @@ def test_issue_loop_plan_first_decompose_only_is_idempotent(tmp_path):
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
 def test_issue_loop_plan_first_implement_by_phase_rerun_without_handoff_implements_once(tmp_path):
-    plan = "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan = structured_plan_state(summary="Add schema helpers.")
     child = CreatedPhaseIssue(
         phase=RecordedPhase(title="Schema helpers", automation="agent-pr"),
         issue_url="https://github.com/OWNER/REPO/issues/99",
@@ -386,7 +392,7 @@ def test_issue_loop_plan_first_implement_by_phase_rerun_without_handoff_implemen
     assert "GitHub issue #99" in claude_calls[0][-1]
 
 def test_issue_loop_plan_first_implement_by_phase_rerun_with_handoff_stops(tmp_path, capsys):
-    plan = "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan = structured_plan_state(summary="Add schema helpers.")
     child = CreatedPhaseIssue(
         phase=RecordedPhase(title="Schema helpers", automation="agent-pr"),
         issue_url="https://github.com/OWNER/REPO/issues/99",
@@ -452,7 +458,7 @@ def test_issue_loop_plan_first_implement_by_phase_rerun_with_handoff_stops(tmp_p
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
 
 def test_issue_loop_plan_first_implement_by_phase_human_first_rerun_does_not_handoff(tmp_path):
-    plan = "Plan:\n- Validate migration manually first.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan = structured_plan_state(summary="Validate migration manually first.")
     child = CreatedPhaseIssue(
         phase=RecordedPhase(title="Manual readiness check", automation="human-action"),
         issue_url="https://github.com/OWNER/REPO/issues/99",
@@ -509,7 +515,7 @@ def test_issue_loop_plan_first_implement_by_phase_human_first_rerun_does_not_han
 def test_issue_loop_plan_first_implement_by_phase_stops_on_human_first_phase(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Validate migration manually first.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Validate migration manually first."),
             plan_decomposition_json(
                 {
                     "title": "Manual readiness check",
@@ -538,7 +544,7 @@ def test_issue_loop_plan_first_implement_by_phase_stops_on_human_first_phase(tmp
 def test_issue_loop_plan_first_implement_by_phase_implements_first_agent_phase(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Add schema helpers."),
             plan_decomposition_json(),
             "Implemented first phase.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],
@@ -572,7 +578,7 @@ def test_issue_loop_plan_first_implement_by_phase_implements_first_agent_phase(t
 def test_issue_loop_plan_first_implement_by_phase_missing_child_number_does_not_handoff(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Add schema helpers.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Add schema helpers."),
             plan_decomposition_json(),
         ],
         codex_outputs=[
@@ -603,4 +609,3 @@ def test_phase_implementation_handoff_rejects_malformed_marker():
             phase_index=1,
             child_issue_number=99,
         )
-

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -44,8 +44,37 @@ class FakeRunner(_FakeRunner):
     """Issue-loop fixtures model the PR created for issue #56 explicitly."""
 
     def __init__(self, **kwargs):
+        # Most of these long-lived fixtures predate the initial plan_state
+        # contract. Upgrade their two common initial-plan shorthands while
+        # leaving malformed marker-only cases with non-blocking states intact
+        # for their explicit rejection tests below.
+        legacy_initial_plans = {
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- OpenAI Codex",
+            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Google Gemini",
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Google Gemini",
+        }
+        for output_key in ("claude_outputs", "codex_outputs", "gemini_outputs", "antigravity_outputs"):
+            outputs = kwargs.get(output_key)
+            if outputs is None:
+                continue
+            kwargs[output_key] = [
+                structured_plan_state(summary="Initial plan.", plan_steps=["Make the change."])
+                if output in legacy_initial_plans
+                else output
+                for output in outputs
+            ]
         kwargs.setdefault("pr_payload", {"body": "Fixes #56"})
         super().__init__(**kwargs)
+
+
+def _initial_plan_state(*, summary: str = "Initial plan.", human_requirements: str = "") -> str:
+    return structured_plan_state(summary=summary).replace(
+        "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        human_requirements + "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        1,
+    )
 
 
 def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
@@ -254,7 +283,10 @@ def test_issue_loop_rejects_pr_number_before_running_claude(tmp_path):
 def test_issue_loop_plan_first_stops_after_approved_plan(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Plan:\n- Update the CLI.\n- Add tests.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(
+                summary="Update the CLI and cover it with regression tests.",
+                plan_steps=["Update the CLI.", "Add tests."],
+            ),
         ],
         codex_outputs=[
             "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
@@ -268,7 +300,7 @@ def test_issue_loop_plan_first_stops_after_approved_plan(tmp_path):
     assert any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
     assert len(runner.comments) == 3
-    assert runner.comments[0].startswith("Plan:")
+    assert runner.comments[0].startswith("## Plan")
     assert runner.comments[1].startswith("**Review verdict:** Approved\n\nPlan looks sound.")
     assert "Outcome: implement" in runner.comments[2]
     assert not any(cmd[:2] == ["git", "fetch"] for cmd, _cwd in runner.commands)
@@ -284,7 +316,7 @@ def test_issue_loop_plan_first_rejects_missing_initial_plan_human_requirements_a
             "body": "Keep the public API unchanged.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Plan:\n- Update the parser.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+            structured_plan_state()
         ],
     )
     config = make_config(tmp_path)
@@ -300,11 +332,15 @@ def test_issue_loop_plan_first_accepts_initial_plan_human_requirements_acknowled
             "body": "Keep the public API unchanged.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Plan:\n- Update the parser.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the plan keeps the public API unchanged.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+            structured_plan_state().replace(
+                "\n<!-- AGENT_PLAN_STATE: blocking -->",
+                "\n"
+                f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                "### Human requirements\n"
+                "- Requirement 1: the plan keeps the public API unchanged.\n"
+                "<!-- AGENT_PLAN_STATE: blocking -->",
+                1,
+            )
         ],
         codex_outputs=[structured_plan_review(summary="Plan looks sound.", human_requirements_resolved=True)],
     )
@@ -315,7 +351,7 @@ def test_issue_loop_plan_first_accepts_initial_plan_human_requirements_acknowled
 def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(summary="Initial plan."),
             structured_plan_revision(summary="Revised plan with tests."),
         ],
         codex_outputs=[
@@ -360,7 +396,7 @@ def test_issue_loop_structured_plan_state_public_comment_renders_markdown_and_pr
     assert metadata.canonical_plan == raw_structured_plan
     assert metadata.raw_structured_coder_response == raw_structured_plan
 
-def test_issue_loop_markdown_plan_state_public_comment_passes_through(tmp_path):
+def test_issue_loop_plan_first_rejects_marker_only_plan_before_posting_or_reviewer_dispatch(tmp_path):
     markdown_plan = "Initial markdown plan.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
     runner = FakeRunner(
         claude_outputs=[markdown_plan],
@@ -368,21 +404,26 @@ def test_issue_loop_markdown_plan_state_public_comment_passes_through(tmp_path):
     )
     config = make_config(tmp_path, reviewer="codex")
 
-    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+    with pytest.raises(AgentLoopError, match="structured `plan_state` JSON object"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
 
-    raw_comment = runner.issue_comments[0]["body"]
-    metadata_match = re.search(
-        r"\n?<!--\s*AGENT_LOOP_META:\s*[A-Za-z0-9+/=_-]+\s*-->\n?",
-        raw_comment,
-    )
-    assert metadata_match is not None
-    assert raw_comment.replace(metadata_match.group(0), "\n").strip() == markdown_plan
-    metadata = _decode_round_metadata(
-        re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", raw_comment)
-        .group("payload")
-    )
-    assert metadata.canonical_plan is None
-    assert metadata.raw_structured_coder_response is None
+    assert runner.comments == []
+    assert not any(command[:2] == ["codex", "exec"] for command, _cwd in runner.commands)
+
+
+def test_issue_loop_plan_first_rejects_generic_implementation_plan_before_posting(tmp_path):
+    generic_plan = json.dumps({
+        "summary": "Plan the fix.",
+        "implementation_plan": ["Update the parser.", "Add tests."],
+    }) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    runner = FakeRunner(claude_outputs=[generic_plan])
+    config = make_config(tmp_path, agent_max_retries=0)
+
+    with pytest.raises(AgentLoopError, match="kind mismatch|missing required field"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert runner.comments == []
+    assert not any(command[:2] == ["codex", "exec"] for command, _cwd in runner.commands)
 
 def test_issue_loop_plan_revision_stores_raw_structured_metadata(tmp_path):
     raw_structured_revision = (
@@ -402,7 +443,7 @@ def test_issue_loop_plan_revision_stores_raw_structured_metadata(tmp_path):
     )
     runner = FakeRunner(
         claude_outputs=[
-            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(),
             raw_structured_revision,
         ],
         codex_outputs=[
@@ -437,11 +478,11 @@ def test_issue_loop_plan_revision_rejects_missing_human_requirements_acknowledge
             "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Initial plan.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the plan preserves backward compatibility.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(human_requirements=(
+                f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                "### Human requirements\n"
+                "- Requirement 1: the plan preserves backward compatibility."
+            )),
             structured_plan_revision(summary="Revised plan."),
             "Revised plan.\n"
             f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
@@ -470,11 +511,11 @@ def test_issue_loop_plan_revision_accepts_human_requirements_acknowledgement(tmp
             "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Initial plan.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the plan preserves backward compatibility.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(human_requirements=(
+                f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                "### Human requirements\n"
+                "- Requirement 1: the plan preserves backward compatibility."
+            )),
             structured_plan_revision(
                 summary="Revised plan.",
                 human_requirements=(
@@ -542,11 +583,11 @@ def test_issue_loop_plan_revision_repair_preserves_signed_human_requirements(tmp
             "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Initial plan.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the plan preserves backward compatibility.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(human_requirements=(
+                f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                "### Human requirements\n"
+                "- Requirement 1: the plan preserves backward compatibility."
+            )),
             malformed_revision,
         ],
         codex_outputs=[
@@ -613,11 +654,11 @@ def test_issue_loop_plan_revision_repair_rejects_wrong_kind_from_human_requireme
             "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Initial plan.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the plan preserves backward compatibility.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(human_requirements=(
+                f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                "### Human requirements\n"
+                "- Requirement 1: the plan preserves backward compatibility."
+            )),
             malformed_revision,
         ],
         codex_outputs=[
@@ -661,11 +702,11 @@ def test_issue_loop_plan_revision_repair_without_human_ack_fails_clearly(tmp_pat
             "body": "Preserve backward compatibility.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Initial plan.\n"
-            f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-            "### Human requirements\n"
-            "- Requirement 1: the plan preserves backward compatibility.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(human_requirements=(
+                f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+                "### Human requirements\n"
+                "- Requirement 1: the plan preserves backward compatibility."
+            )),
             malformed_revision,
         ],
         codex_outputs=[
@@ -878,11 +919,14 @@ def test_issue_loop_plan_first_requires_reviewer_human_requirements_resolution(t
             "body": "Keep compact context cache-aware.\n\n-- Human Reviewer",
         },
         claude_outputs=[
-            "Initial plan covers cache-aware compact context.\n"
-            "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
-            "### Human requirements\n"
-            "- Requirement 1: The plan keeps compact context cache-aware.\n"
-            "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            _initial_plan_state(
+                summary="Initial plan covers cache-aware compact context.",
+                human_requirements=(
+                    "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n\n"
+                    "### Human requirements\n"
+                    "- Requirement 1: The plan keeps compact context cache-aware."
+                ),
+            ),
             structured_plan_revision(
                 summary="Revised plan requires explicit reviewer acknowledgement.",
                 prior_plan_item_dispositions=[
@@ -1620,7 +1664,9 @@ def test_issue_loop_plan_first_can_override_implementation_model(tmp_path):
         claude_outputs=[
             json.dumps(
                 {
-                    "result": "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+                    "result": structured_plan_state(
+                        summary="Make the change.", plan_steps=["Make the change."]
+                    ),
                     "session_id": "planning-session",
                 }
             ),
@@ -1707,7 +1753,7 @@ def test_issue_loop_plan_first_implementation_rejects_pr_without_issue_reference
     assert "rerun the orchestrator as `agent-loop pr 77` to continue the review" in str(excinfo.value)
 
 def test_issue_loop_plan_first_one_shot_posts_handoff_after_pr_creation(tmp_path):
-    plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan = _initial_plan_state(summary="Make the change.")
     runner = FakeRunner(
         claude_outputs=[
             plan,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -115,6 +115,19 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
         assert "`pwd` and `git status --branch --short`" in prompt
 
 
+def test_issue_plan_prompt_requires_complete_structured_plan_state_contract(tmp_path):
+    prompt = build_issue_plan_prompt(56, make_config(tmp_path))
+
+    assert '"schema_version": 1' in prompt
+    assert '"kind": "plan_state"' in prompt
+    assert '"state": "blocking"' in prompt
+    assert '"summary": "<non-empty concise implementation summary>"' in prompt
+    assert '"plan_steps": ["<non-empty step>"]' in prompt
+    assert "optional `deferred_stages`" in prompt
+    assert "generic `implementation_plan`" in prompt
+    assert "after the JSON object and before the AGENT_PLAN_STATE footer" in prompt
+
+
 def test_issue_prompts_include_salvage_guardrail_block(tmp_path):
     config = make_config(tmp_path)
     salvage_summary = (

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2533,6 +2533,38 @@ def test_validate_structured_plan_state_accepts_deferred_stages():
     )
 
 
+def test_validate_structured_plan_state_accepts_signed_human_requirements_before_footer():
+    acknowledgement = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"
+        "### Human requirements\n"
+        "- Requirement 1: The plan keeps the public API unchanged."
+    )
+    plan_state = structured_plan_state().replace(
+        "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        acknowledgement + "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        1,
+    )
+
+    parsed = validate_structured_plan_state(plan_state)
+
+    assert parsed is not None
+    assert parsed.state == "blocking"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"kind": "plan_state", "summary": "Plan", "plan_steps": ["Add tests."]},
+        {"schema_version": 1, "kind": "implementation_plan", "summary": "Plan", "plan_steps": ["Add tests."], "state": "blocking"},
+    ],
+)
+def test_validate_structured_plan_state_requires_complete_plan_state_schema(payload):
+    text = json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+
+    with pytest.raises(AgentLoopError):
+        validate_structured_plan_state(text)
+
+
 def test_render_canonical_plan_revision_includes_deferred_stages_section():
     revision = structured_plan_revision(
         deferred_stages=[{"title": "Auth flow overhaul", "summary": "Split out follow-up work."}],

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -8,7 +8,24 @@ from coding_review_agent_loop.repair import (
     attempt_repair,
     execute_repair,
 )
-from coding_review_agent_loop.protocol import validate_structured_discuss_answer
+from coding_review_agent_loop.protocol import (
+    validate_structured_discuss_answer,
+    validate_structured_plan_state,
+)
+from coding_review_agent_loop.orchestrator import _structured_response_candidates
+
+
+def _initial_plan_with_human_requirements() -> str:
+    acknowledgement = (
+        f"\n{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
+        "### Human requirements\n"
+        "- Requirement 1: keep the public API unchanged."
+    )
+    return structured_plan_state().replace(
+        "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        acknowledgement + "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        1,
+    )
 
 
 def test_answer_repair_prompt_has_mode_specific_schema_and_examples():
@@ -100,6 +117,48 @@ def test_envelope_normalization_duplicate_plan_state_footer():
         ("item-1", "resolved")
     ]
     assert normalized.count("<!-- AGENT_PLAN_STATE: approved -->") == 1
+
+
+def test_envelope_normalization_plan_state_preserves_signed_human_requirements():
+    acknowledgement = (
+        "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"
+        "### Human requirements\n"
+        "- Requirement 1: Keep the public API unchanged."
+    )
+    raw = structured_plan_state().replace(
+        "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        acknowledgement + "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        1,
+    ) + "\nExtra prose"
+
+    normalized = attempt_envelope_normalization(raw, expected_kind="plan_state")
+
+    assert normalized is not None
+    assert "<!-- HUMAN_REQUIREMENTS_ADDRESSED -->" in normalized
+    assert "### Human requirements" in normalized
+    assert "Extra prose" not in normalized
+    assert validate_structured_plan_state(normalized) is not None
+
+
+def test_envelope_normalization_plan_state_rejects_invalid_prefix_material():
+    raw = structured_plan_state().replace(
+        "\n<!-- AGENT_PLAN_STATE: blocking -->",
+        "\nUnauthorized prose\n<!-- AGENT_PLAN_STATE: blocking -->",
+        1,
+    )
+
+    assert attempt_envelope_normalization(raw, expected_kind="plan_state") is None
+
+
+def test_fenced_plan_state_is_recoverable_as_a_structured_candidate():
+    plan_state = structured_plan_state()
+    json_text, footer = plan_state.split("\n<!-- AGENT_PLAN_STATE:", 1)
+    wrapped = f"Response:\n```json\n{json_text}\n```\n<!-- AGENT_PLAN_STATE:{footer}"
+
+    candidates = _structured_response_candidates(wrapped)
+
+    assert plan_state in candidates
+    assert validate_structured_plan_state(plan_state) is not None
 
 def test_envelope_normalization_preserves_hr_resolved_before_footer_for_reviews():
     for expected_kind, raw, parser in (
@@ -1686,13 +1745,7 @@ def _issue_with_human_requirement():
 
 def test_plan_loop_repair_missing_hr_marker_recovers_approved(tmp_path):
     """Plan loop: repair returning approved+marker suppresses synthetic."""
-    plan = (
-        "Initial plan.\n"
-        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-        "### Human requirements\n"
-        "- Requirement 1: keep the public API unchanged.\n"
-        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
-    )
+    plan = _initial_plan_with_human_requirements()
     approved_without_marker = structured_plan_review(
         state="approved",
         reviewer="OpenAI Codex",
@@ -1729,13 +1782,7 @@ def test_plan_loop_repair_missing_hr_marker_recovers_approved(tmp_path):
 
 def test_plan_loop_repair_missing_hr_marker_returns_blocking_not_synthetic(tmp_path):
     """Plan loop: repair returning blocking is treated as reviewer's blocking, not synthetic."""
-    plan = (
-        "Initial plan.\n"
-        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-        "### Human requirements\n"
-        "- Requirement 1: keep the public API unchanged.\n"
-        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
-    )
+    plan = _initial_plan_with_human_requirements()
     approved_without_marker = structured_plan_review(
         state="approved",
         reviewer="OpenAI Codex",
@@ -1792,13 +1839,7 @@ def test_plan_loop_repair_missing_hr_marker_returns_blocking_not_synthetic(tmp_p
 
 def test_plan_loop_repair_missing_hr_marker_failure_uses_synthetic(tmp_path):
     """Plan loop: when repair fails, synthetic blocking item is injected."""
-    plan = (
-        "Initial plan.\n"
-        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-        "### Human requirements\n"
-        "- Requirement 1: keep the public API unchanged.\n"
-        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
-    )
+    plan = _initial_plan_with_human_requirements()
     approved_without_marker = structured_plan_review(
         state="approved",
         reviewer="OpenAI Codex",
@@ -1990,13 +2031,7 @@ def test_pr_loop_repair_blocking_records_same_pr_followups(tmp_path):
 
 def test_plan_loop_repair_blocking_records_same_plan_followups(tmp_path):
     """When repair returns blocking with same_plan_followups, those are recorded as same-plan items."""
-    plan = (
-        "Initial plan.\n"
-        f"{HUMAN_REQUIREMENTS_ADDRESSED_MARKER}\n"
-        "### Human requirements\n"
-        "- Requirement 1: keep the public API unchanged.\n"
-        "<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
-    )
+    plan = _initial_plan_with_human_requirements()
     approved_without_marker = structured_plan_review(
         state="approved",
         reviewer="OpenAI Codex",

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2326,12 +2326,14 @@ class TestRetryValidateCoder:
             raw_plan = (
                 json.dumps(
                     {
+                        "schema_version": 1,
                         "kind": "plan_state",
+                        "state": "blocking",
                         "summary": "Plan the renderer fix.",
                         "plan_steps": ["Detect structured plan_state.", "Render markdown."],
                     }
                 )
-                + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Codex"
+                + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Codex"
             )
             (repair_dir / "raw.md").write_text(raw_plan, encoding="utf-8")
 

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -108,7 +108,7 @@ def test_plan_first_deferred_stage_title_with_colon_round_trips_through_canonica
     runner = FakeRunner(
         pr_payload={"body": "Fixes #56"},
         claude_outputs=[
-            "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude",
+            structured_plan_state(state="blocking", summary="Initial plan."),
             structured_plan_revision(
                 summary="Implement the core parser change.",
                 deferred_stages=[

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -76,7 +76,9 @@ def test_plan_first_issue_run_writes_one_summary_for_planning_implementation_and
     runner = FakeRunner(
         pr_payload={"body": "Fixes #56"},
         claude_outputs=[
-            "Plan:\n- Implement usage logging.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude",
+            structured_plan_state(
+                state="blocking", summary="Implement usage logging."
+            ),
             "Opened PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],
         codex_outputs=[


### PR DESCRIPTION
## Summary
- require fresh issue planning responses to use the complete structured `plan_state` schema before posting or reviewer dispatch
- preserve signed human-requirements acknowledgements and recoverable plan-state envelopes
- add prompt, protocol, recovery, and orchestration regression coverage

## Tests
- `python3 -m pytest tests/test_prompts.py tests/test_protocol.py tests/test_repair.py tests/test_orchestrator_issue.py tests/test_agent_loop.py`

Fixes #549