### PR TITLE
Fix plan-first recovery after answer-mode discussions

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2496,11 +2496,6 @@ def _prior_discuss_split_proposals(
     if not final_summaries:
         return []
     latest = final_summaries[-1]
-    # Open-ended answer-mode discussions have positions rather than triage
-    # outcomes, and cannot produce a `split` consensus. Do not feed their
-    # persisted debater records into the legacy triage recovery below.
-    if latest.metadata.result_mode == "answer":
-        return []
     if latest.metadata.split_proposals:
         return list(latest.metadata.split_proposals)
     configured_reviewers = reviewers(config)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2496,6 +2496,11 @@ def _prior_discuss_split_proposals(
     if not final_summaries:
         return []
     latest = final_summaries[-1]
+    # Open-ended answer-mode discussions have positions rather than triage
+    # outcomes, and cannot produce a `split` consensus. Do not feed their
+    # persisted debater records into the legacy triage recovery below.
+    if latest.metadata.result_mode == "answer":
+        return []
     if latest.metadata.split_proposals:
         return list(latest.metadata.split_proposals)
     configured_reviewers = reviewers(config)
@@ -5098,9 +5103,16 @@ def _recover_final_discuss_split_proposals(
         record = by_name.get(name)
         if record is None:
             continue
-        final_votes.append(
-            _decode_discuss_vote(record, round_number=final_round_number, reviewer_workdirs=reviewer_workdirs)
+        vote = _decode_discuss_vote(
+            record,
+            round_number=final_round_number,
+            reviewer_workdirs=reviewer_workdirs,
         )
+        # This is triage-only legacy recovery. A mixed or malformed transcript
+        # must not be interpreted as a split consensus.
+        if not isinstance(vote, ParsedDiscussReview):
+            return None
+        final_votes.append(vote)
     if not final_votes:
         return None
     consensus = _detect_discuss_consensus(final_votes)

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -484,6 +484,41 @@ def _answer_mode_final_summary_comment() -> dict:
     }
 
 
+def _answer_mode_debater_comment() -> dict:
+    """An answer-mode vote as `_post_discuss_debater_comment` persists it."""
+    response = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "discuss_answer",
+                "position": "answer",
+                "rationale": "The proposal is sufficiently scoped.",
+                "confidence": "high",
+                "unresolved_items": [],
+                "answer": "Proceed with the proposal.",
+                "rebuttal": "No triage outcome applies to answer-mode discussion.",
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex"
+    )
+    return {
+        "author": {"login": "bot"},
+        "createdAt": "2026-07-12T00:00:00Z",
+        "body": _attach_round_metadata(
+            "Proceed with the proposal.\n-- Codex",
+            PostedRoundMetadata(
+                flow="discuss",
+                role="debater",
+                agent="Codex",
+                round_number=6,
+                subject="prior-discuss-subject",
+                raw_structured_coder_response=response,
+                result_mode="answer",
+            ),
+        ),
+    }
+
+
 def test_plan_first_skips_split_recovery_for_answer_mode_discuss_summary(tmp_path):
     """An answer-mode summary has no triage outcome to recover.
 
@@ -500,7 +535,7 @@ def test_plan_first_skips_split_recovery_for_answer_mode_discuss_summary(tmp_pat
             structured_plan_review(state="approved"),
             structured_pr_review(state="approved", summary="LGTM."),
         ],
-        issue_comments=[_answer_mode_final_summary_comment()],
+        issue_comments=[_answer_mode_debater_comment(), _answer_mode_final_summary_comment()],
     )
     config = make_config(tmp_path)
 

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -464,6 +464,56 @@ def _legacy_split_final_summary_comment() -> dict:
     }
 
 
+def _answer_mode_final_summary_comment() -> dict:
+    """A current open-ended summary must not enter triage split recovery."""
+    return {
+        "author": {"login": "bot"},
+        "createdAt": "2026-07-12T00:00:01Z",
+        "body": _attach_round_metadata(
+            "Discuss answer consensus.\n-- coding-review-agent-loop",
+            PostedRoundMetadata(
+                flow="discuss",
+                role="summary",
+                agent="coding-review-agent-loop",
+                round_number=6,
+                subject="prior-discuss-subject",
+                is_final=True,
+                result_mode="answer",
+            ),
+        ),
+    }
+
+
+def test_plan_first_skips_split_recovery_for_answer_mode_discuss_summary(tmp_path):
+    """An answer-mode summary has no triage outcome to recover.
+
+    Plan-first must proceed to implementation instead of assuming every
+    persisted discuss response has `ParsedDiscussReview.outcome` (#335).
+    """
+    runner = FakeRunner(
+        pr_payload={"body": "Fixes #56"},
+        claude_outputs=[
+            structured_plan_state(state="blocking", summary="Implement the approved design."),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+        issue_comments=[_answer_mode_final_summary_comment()],
+    )
+    config = make_config(tmp_path)
+
+    assert (
+        run_issue_loop(
+            runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True
+        )
+        == 0
+    )
+    assert not runner.issues
+    assert any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
 def test_plan_first_recovers_legacy_split_proposals_with_valid_checkout_inspected_claim(tmp_path):
     """`_prior_discuss_split_proposals`'s legacy fallback
     (`_recover_final_discuss_split_proposals`) must checkout-validate a


### PR DESCRIPTION
## Summary
- skip legacy split-proposal recovery for final discuss summaries recorded in answer mode
- fail closed if legacy split recovery decodes a non-triage discussion response
- cover the plan-first handoff after an answer-mode final summary

## Verification
- ...............                                                          [100%]
15 passed in 0.72s