### PR TITLE
Enforce human requirement ledgers in PR follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,9 +592,12 @@ run again.
 Structured JSON is also the preferred coder format for follow-up and plan
 revision rounds. Coder follow-up responses use `kind: "coder_followup"` with
 `state`, `summary`, `addressed_items`, `remaining_items`,
-`human_requirements`, optional `addressed_item_notes` / `remaining_item_notes`,
-and optional `tests_run`; every carried reviewer item ID must appear exactly
+`human_requirement_dispositions`, and `human_requirements`, plus optional
+`addressed_item_notes` / `remaining_item_notes`, and `tests_run`; every carried reviewer item ID must appear exactly
 once in either `addressed_items` or `remaining_items`.
+The disposition ledger must contain one entry per surfaced signed requirement,
+marked `addressed`, `blocked`, or `not-applicable` with non-blank evidence;
+use an empty ledger when no signed requirements were surfaced.
 Plan-revision responses use `kind: "plan_revision"` with `state: "blocking"`,
 `summary`, `prior_plan_item_dispositions`, and `plan_steps`. Structured
 responses must start with one top-level JSON object, place the matching

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1110,6 +1110,7 @@ response must classify every carried reviewer item exactly once:
   "remaining_items": [],
   "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},
   "remaining_item_notes": {},
+  "human_requirement_dispositions": [],
   "human_requirements": {
     "addressed_ids": [],
     "checked_discussion_directly": false
@@ -1117,6 +1118,11 @@ response must classify every carried reviewer item exactly once:
   "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]
 }
 ```
+
+`human_requirement_dispositions` is an auditable ledger: include exactly one
+entry for each surfaced signed requirement, with disposition `addressed`,
+`blocked`, or `not-applicable` and non-blank evidence. It must be empty when
+no signed requirements were surfaced.
 
 A plan revision uses:
 

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -543,6 +543,18 @@ def _render_public_coder_followup_comment(
         sections.append(
             "\n".join(["### Tests run", *[f"- {test}" for test in parsed_followup.tests_run]])
         )
+    if parsed_followup.human_requirement_dispositions:
+        sections.append(
+            "\n".join(
+                [
+                    "### Human requirements",
+                    *[
+                        f"- {disposition.requirement_id}: {disposition.disposition} — {disposition.evidence}"
+                        for disposition in parsed_followup.human_requirement_dispositions
+                    ],
+                ]
+            )
+        )
     sections.append(f"<!-- AGENT_STATE: {parsed_followup.state} -->")
     sections.append(f"-- {_comment_signature(agent, config, model_used)}")
     return "\n\n".join(section for section in sections if section)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2150,9 +2150,13 @@ def _run_validated_agent(
                         )
                     elif (
                         repair_expected_kind == "coder_followup"
-                        and repair_surfaced_requirement_ids is not None
+                        and (
+                            repair_surfaced_requirement_ids is not None
+                            or repair_requires_direct_discussion_ack
+                        )
                     ):
-                        repair_kwargs["surfaced_requirement_ids"] = tuple(repair_surfaced_requirement_ids)
+                        repair_kwargs["surfaced_requirement_ids"] = tuple(repair_surfaced_requirement_ids or ())
+                        repair_kwargs["requires_direct_discussion_ack"] = repair_requires_direct_discussion_ack
                     elif (
                         repair_expected_kind in {"plan_review", "pr_review"}
                         and repair_reviewer_requirement_ids is not None
@@ -4946,6 +4950,7 @@ def run_pr_loop(
                 repair_expected_kind="coder_followup",
                 repair_unresolved_item_ids=repair_unresolved_item_ids,
                 repair_surfaced_requirement_ids=coder_human_requirements_context.surfaced_requirement_ids,
+                repair_requires_direct_discussion_ack=coder_human_requirements_context.requires_direct_discussion_ack,
                 salvage_context=SalvageContext(
                     repo=config.repo,
                     issue_number=None if issue_context is None else issue_context.number,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -529,6 +529,7 @@ def _structured_coder_followup_guidance(
         '  "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},',
         '  "remaining_item_notes": {"item-2": "Deferred because it requires a separate UI change."},',
         '  "dispute_evidence": {"item-3": "Checked Google pricing page (https://...): $1.50/1M tokens is correct per the official docs."},',
+        '  "human_requirement_dispositions": [],',
         '  "human_requirements": {',
         f'    "addressed_ids": {example_human_requirement_ids_json},',
         '    "checked_discussion_directly": false',
@@ -536,7 +537,7 @@ def _structured_coder_followup_guidance(
         '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
         "}",
         "",
-        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, and `human_requirements`. `addressed_item_notes`, `remaining_item_notes`, `disputed_items`, `dispute_evidence`, and `tests_run` are optional.",
+        "Required structured fields: `schema_version`, `kind`, `state`, `summary`, `addressed_items`, `remaining_items`, `human_requirements`, and `human_requirement_dispositions`. `addressed_item_notes`, `remaining_item_notes`, `disputed_items`, `dispute_evidence`, and `tests_run` are optional.",
         "Your response and public response file must start directly with `{`, contain exactly one top-level JSON object, and must not include stdout filtering markers, prose, headings, or code fences before or between the JSON and footer.",
         "After the JSON object, add exactly one footer `<!-- AGENT_STATE: approved|blocking -->`, then only your standalone signature. The JSON `state` must match the `AGENT_STATE` footer exactly.",
         "Use `addressed_items`, `remaining_items`, and `disputed_items` to classify every unresolved reviewer item ID shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
@@ -549,13 +550,16 @@ def _structured_coder_followup_guidance(
             "In structured replies, set `human_requirements.addressed_ids` to exactly the surfaced signed human requirement IDs you addressed in this prompt: "
             f"{surfaced}. Only exact surfaced labels such as `Requirement 1` are valid."
         )
+        lines.append(
+            "Set `human_requirement_dispositions` to exactly one object per surfaced label, using the exact `requirement_id`, disposition `addressed`, `blocked`, or `not-applicable`, and non-blank evidence. This ledger is separate from reviewer item classifications and the legacy `human_requirements` acknowledgement."
+        )
     elif human_requirements_context.requires_direct_discussion_ack:
         lines.append(
-            "If the prompt omitted detailed signed human requirements, set `human_requirements.addressed_ids` to `[]` and `human_requirements.checked_discussion_directly` to `true` only after checking the GitHub discussion directly. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`."
+            "If the prompt omitted detailed signed human requirements, set `human_requirement_dispositions` to `[]`, set `human_requirements.addressed_ids` to `[]`, and set `human_requirements.checked_discussion_directly` to `true` only after checking the GitHub discussion directly. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`."
         )
     else:
         lines.append(
-            "No signed human requirements are surfaced in this prompt, so structured replies must set `human_requirements.addressed_ids` to `[]`. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`; only exact surfaced signed requirement labels are valid when such labels are actually shown."
+            "No signed human requirements are surfaced in this prompt, so structured replies must set both `human_requirement_dispositions` and `human_requirements.addressed_ids` to `[]`, with `checked_discussion_directly` false. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`; only exact surfaced signed requirement labels are valid when such labels are actually shown."
         )
     return "\n".join(lines) + "\n"
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -210,6 +210,7 @@ class StructuredCoderFollowup:
     tests_run: tuple[str, ...] | None = None
     disputed_items: tuple[str, ...] = ()
     dispute_evidence: dict[str, str] = field(default_factory=dict)
+    human_requirement_dispositions: tuple[HumanRequirementDisposition, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -661,6 +662,11 @@ def validate_structured_human_requirements_acknowledgement(
                 "requirements were surfaced. Use `human_requirements.addressed_ids: []`; issue "
                 "acceptance criteria, reviewer item IDs, reviewer comments, and arbitrary labels "
                 "are not signed human requirements."
+            )
+        if checked_discussion_directly:
+            raise AgentLoopError(
+                "Coder response must set `human_requirements.checked_discussion_directly` to false "
+                "when no signed human requirements are surfaced and direct discussion acknowledgement is not required."
             )
         return
 
@@ -1548,6 +1554,7 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
             "addressed_items",
             "remaining_items",
             "human_requirements",
+            "human_requirement_dispositions",
         },
         optional={
             "addressed_item_notes",
@@ -1560,6 +1567,10 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
     human_requirements_payload = _expect_object(
         payload["human_requirements"],
         context="coder_followup.human_requirements",
+    )
+    human_requirement_dispositions = _expect_human_requirement_dispositions(
+        payload["human_requirement_dispositions"],
+        context="coder_followup.human_requirement_dispositions",
     )
     _expect_exact_keys(
         human_requirements_payload,
@@ -1636,6 +1647,7 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
                 context="coder_followup.human_requirements.checked_discussion_directly",
             ),
         ),
+        human_requirement_dispositions=human_requirement_dispositions,
         addressed_item_notes=addressed_item_notes,
         remaining_item_notes=remaining_item_notes,
         tests_run=tests_run,

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1067,7 +1067,9 @@ def _build_repair_prompt(
         expected_kind, unresolved_item_ids
     )
     coder_followup_human_requirements_instruction = (
-        _coder_followup_human_requirements_instruction(expected_kind, surfaced_requirement_ids)
+        _coder_followup_human_requirements_instruction(
+            expected_kind, surfaced_requirement_ids, requires_direct_discussion_ack
+        )
         if expected_kind == "coder_followup"
         else ""
     )
@@ -1288,21 +1290,32 @@ def _coder_followup_required_items_instruction(
 def _coder_followup_human_requirements_instruction(
     expected_kind: str | None,
     surfaced_requirement_ids: Sequence[str] | None,
+    requires_direct_discussion_ack: bool,
 ) -> str:
-    if surfaced_requirement_ids is None:
+    if surfaced_requirement_ids is None and not requires_direct_discussion_ack:
         return ""
     if expected_kind != "coder_followup":
         raise ValueError("surfaced_requirement_ids may only be used for coder_followup repair")
-    rendered_ids = "\n".join(f"- `{item_id}`" for item_id in surfaced_requirement_ids)
-    if not surfaced_requirement_ids:
+    ids = tuple(surfaced_requirement_ids or ())
+    rendered_ids = "\n".join(f"- `{item_id}`" for item_id in ids)
+    if not ids:
         rendered_ids = "- (none)"
+    if not ids and requires_direct_discussion_ack:
+        return (
+            "## Bounded direct-discussion human-requirements context for coder follow-up:\n"
+            "The detailed signed requirements were omitted. Repair with `human_requirement_dispositions: []`, "
+            "`human_requirements.addressed_ids: []`, and `human_requirements.checked_discussion_directly: true` "
+            "after checking the discussion directly. Do not invent requirement labels.\n"
+        )
     return (
         "## Surfaced signed human requirement labels for coder follow-up:\n"
         f"{rendered_ids}\n"
+        "Include exactly one `human_requirement_dispositions` object per listed ID, with the exact ID, disposition "
+        "`addressed`, `blocked`, or `not-applicable`, and non-blank evidence.\n"
         "Only the exact labels above may appear in `human_requirements.addressed_ids`.\n"
         "When the list is `(none)`, set `human_requirements.addressed_ids` to `[]`. "
         "Do not use issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, "
-        "summaries, or arbitrary labels as human requirement IDs.\n"
+        "summaries, or arbitrary labels as human requirement IDs. When the list is `(none)` without direct-discussion acknowledgement, both ledgers must be empty.\n"
     )
 
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1315,7 +1315,8 @@ def _coder_followup_human_requirements_instruction(
         "Only the exact labels above may appear in `human_requirements.addressed_ids`.\n"
         "When the list is `(none)`, set `human_requirements.addressed_ids` to `[]`. "
         "Do not use issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, "
-        "summaries, or arbitrary labels as human requirement IDs. When the list is `(none)` without direct-discussion acknowledgement, both ledgers must be empty.\n"
+        "summaries, or arbitrary labels as human requirement IDs.\n"
+        + ("When the list is `(none)` without direct-discussion acknowledgement, both ledgers must be empty.\n" if not ids else "")
     )
 
 

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -239,6 +239,11 @@ def _reconcile_human_requirements_ack_item(
     try:
         structured_followup = validate_structured_coder_followup(coder_output)
         if structured_followup is not None:
+            validate_human_requirement_dispositions(
+                structured_followup.human_requirement_dispositions,
+                surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+                context="coder_followup.human_requirement_dispositions",
+            )
             validate_structured_human_requirements_acknowledgement(
                 structured_followup.human_requirements.addressed_ids,
                 checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
@@ -311,6 +316,11 @@ def _validate_coder_followup_response(
         _validate_structured_coder_followup_items(
             structured_followup,
             unresolved_items=unresolved_items,
+        )
+        validate_human_requirement_dispositions(
+            structured_followup.human_requirement_dispositions,
+            surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+            context="coder_followup.human_requirement_dispositions",
         )
         validate_structured_human_requirements_acknowledgement(
             structured_followup.human_requirements.addressed_ids,

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -1030,12 +1030,12 @@ def structured_coder_followup(
             human_requirement_dispositions
             if human_requirement_dispositions is not None
             else [
-            {
-                "requirement_id": requirement_id,
-                "disposition": "addressed",
-                "evidence": "The follow-up addresses the surfaced requirement.",
-            }
-            for requirement_id in (human_requirement_ids or [])
+                {
+                    "requirement_id": requirement_id,
+                    "disposition": "addressed",
+                    "evidence": "The follow-up addresses the surfaced requirement.",
+                }
+                for requirement_id in (human_requirement_ids or [])
             ]
         ),
     }

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -1006,6 +1006,7 @@ def structured_coder_followup(
     addressed_item_notes: dict[str, str] | None = None,
     remaining_item_notes: dict[str, str] | None = None,
     human_requirement_ids: list[str] | None = None,
+    human_requirement_dispositions: list[dict[str, str]] | None = None,
     checked_discussion_directly: bool = False,
     tests_run: list[str] | None = None,
     disputed_items: list[str] | None = None,
@@ -1025,6 +1026,18 @@ def structured_coder_followup(
             "addressed_ids": human_requirement_ids or [],
             "checked_discussion_directly": checked_discussion_directly,
         },
+        "human_requirement_dispositions": (
+            human_requirement_dispositions
+            if human_requirement_dispositions is not None
+            else [
+            {
+                "requirement_id": requirement_id,
+                "disposition": "addressed",
+                "evidence": "The follow-up addresses the surfaced requirement.",
+            }
+            for requirement_id in (human_requirement_ids or [])
+            ]
+        ),
     }
     if tests_run is not None:
         payload["tests_run"] = tests_run

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -684,6 +684,7 @@ def test_structured_coder_followup_transient_terms_before_footer_runs_repair(tmp
                 "summary": "Updated timeout and capacity handling without treating prose as transient.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -240,6 +240,7 @@ def test_render_public_coder_followup_comment():
                 "summary": "Added the requested regression test.",
                 "addressed_items": ["item-1", "item-2"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "addressed_item_notes": {
                     "item-1": "Added coverage for the parser.",
                     "item-2": "Updated the helper.",
@@ -306,6 +307,7 @@ def test_render_public_coder_followup_comment():
                 "summary": "Still working through the review.",
                 "addressed_items": [],
                 "remaining_items": ["item-3"],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
@@ -339,6 +341,7 @@ def test_render_public_coder_followup_comment_expands_carried_items_with_notes_a
                 "summary": "Fixed the blocker and deferred the follow-up.",
                 "addressed_items": ["item-1"],
                 "remaining_items": ["item-2"],
+                "human_requirement_dispositions": [],
                 "addressed_item_notes": {"item-1": "Restored the missing validation branch."},
                 "human_requirements": {
                     "addressed_ids": [],
@@ -394,6 +397,7 @@ def test_render_public_coder_followup_comment_expands_pr_220_remaining_items():
                 "summary": "Hardened markdown stripping; two follow-ups remain.",
                 "addressed_items": ["item-3", "item-4"],
                 "remaining_items": ["item-5", "item-6"],
+                "human_requirement_dispositions": [],
                 "remaining_item_notes": {
                     "item-5": "Deferred because URL canonicalization needs product confirmation.",
                     "item-6": "Deferred because the helper move should be isolated from this fix.",

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -727,6 +727,7 @@ def test_issue_loop_plan_revision_repair_rejects_wrong_kind_from_human_requireme
                 "summary": "Revised the plan.",
                 "addressed_items": [],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -554,6 +554,7 @@ def test_pr_loop_accepts_structured_coder_followup_in_pr_round(tmp_path):
                     "summary": "Added the requested regression test.",
                     "addressed_items": ["item-1"],
                     "remaining_items": [],
+                    "human_requirement_dispositions": [],
                     "addressed_item_notes": {
                         "item-1": "Added the structured coder follow-up regression case."
                     },
@@ -603,6 +604,7 @@ def test_pr_loop_rejects_malformed_structured_coder_followup_before_re_review(tm
                     "summary": "Tried to handle the feedback.",
                     "addressed_items": ["item-9"],
                     "remaining_items": [],
+                    "human_requirement_dispositions": [],
                     "human_requirements": {
                         "addressed_ids": [],
                         "checked_discussion_directly": False,
@@ -2613,6 +2615,7 @@ def test_resume_pr_round_prefers_structured_coder_followup_metadata():
                 "summary": "Added the requested regression test.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,
@@ -3303,9 +3306,16 @@ def test_reconcile_human_requirements_ack_item_accepts_stored_structured_coder_f
                 "schema_version": 1,
                 "kind": "coder_followup",
                 "state": "blocking",
-                "summary": "Implemented the requested URL fix.",
-                "addressed_items": ["item-1"],
-                "remaining_items": [],
+                    "summary": "Implemented the requested URL fix.",
+                    "addressed_items": ["item-1"],
+                    "remaining_items": [],
+                    "human_requirement_dispositions": [
+                        {
+                            "requirement_id": "Requirement 1",
+                            "disposition": "addressed",
+                            "evidence": "The URL fix is implemented.",
+                        }
+                    ],
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -3306,16 +3306,16 @@ def test_reconcile_human_requirements_ack_item_accepts_stored_structured_coder_f
                 "schema_version": 1,
                 "kind": "coder_followup",
                 "state": "blocking",
-                    "summary": "Implemented the requested URL fix.",
-                    "addressed_items": ["item-1"],
-                    "remaining_items": [],
-                    "human_requirement_dispositions": [
-                        {
-                            "requirement_id": "Requirement 1",
-                            "disposition": "addressed",
-                            "evidence": "The URL fix is implemented.",
-                        }
-                    ],
+                "summary": "Implemented the requested URL fix.",
+                "addressed_items": ["item-1"],
+                "remaining_items": [],
+                "human_requirement_dispositions": [
+                    {
+                        "requirement_id": "Requirement 1",
+                        "disposition": "addressed",
+                        "evidence": "The URL fix is implemented.",
+                    }
+                ],
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1258,7 +1258,7 @@ def test_followup_prompt_with_no_human_requirements_guides_empty_addressed_ids(t
     assert "issue acceptance criteria" in prompt
     assert "reviewer item IDs" in prompt
 
-def test_non_plan_prompts_do_not_request_plan_disposition_json(tmp_path):
+def test_non_plan_prompts_request_human_requirement_dispositions_not_plan_dispositions(tmp_path):
     config = make_config(tmp_path, reviewer=("codex",))
     requirements = (
         HumanReviewRequirement(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1289,7 +1289,9 @@ def test_non_plan_prompts_do_not_request_plan_disposition_json(tmp_path):
         build_issue_implementation_prompt(56, "Approved plan.", config, issue_context=issue_context),
     ]
 
-    for prompt in prompts:
+    assert '"human_requirement_dispositions"' in prompts[0]
+    assert '"human_requirement_dispositions"' in prompts[1]
+    for prompt in prompts[2:]:
         assert '"human_requirement_dispositions"' not in prompt
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2098,6 +2098,8 @@ def test_validate_structured_coder_followup_accepts_v1_payload():
                 "summary": "Addressed the first item; one remains.",
                 "addressed_items": ["item-1"],
                 "remaining_items": ["item-2"],
+                "human_requirement_dispositions": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,
@@ -2129,8 +2131,9 @@ def test_validate_structured_coder_followup_accepts_optional_item_notes():
                 "addressed_items": ["item-1"],
                 "remaining_items": ["item-2"],
                 "addressed_item_notes": {"item-1": "Added parsing coverage."},
-                "remaining_item_notes": {"item-2": "Deferred until the docs owner weighs in."},
-                "human_requirements": {
+                    "remaining_item_notes": {"item-2": "Deferred until the docs owner weighs in."},
+                    "human_requirement_dispositions": [],
+                    "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },
@@ -2158,6 +2161,8 @@ def test_validate_structured_coder_followup_rejects_note_for_unlisted_item():
                 "summary": "Addressed one item.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
+                "human_requirement_dispositions": [],
                 "addressed_item_notes": {"item-2": "This note is stale."},
                 "human_requirements": {
                     "addressed_ids": [],
@@ -2183,6 +2188,8 @@ def test_validate_structured_coder_followup_rejects_invalid_note_values(bad_note
                 "summary": "Addressed one item.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
+                "human_requirement_dispositions": [],
                 "addressed_item_notes": {"item-1": bad_note},
                 "human_requirements": {
                     "addressed_ids": [],
@@ -2216,6 +2223,8 @@ def test_validate_structured_coder_followup_rejects_unknown_keys_in_structured_c
                 "summary": "Done.",
                 "addressed_items": [],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": True,
@@ -2240,6 +2249,7 @@ def test_validate_structured_coder_followup_rejects_footer_state_mismatch():
                 "summary": "Done.",
                 "addressed_items": [],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": True,
@@ -2263,6 +2273,7 @@ def test_validate_structured_coder_followup_rejects_trailing_prose_after_footer(
                 "summary": "Done.",
                 "addressed_items": [],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": True,
@@ -2286,6 +2297,7 @@ def test_validate_structured_coder_followup_accepts_disputed_items_with_evidence
                 "summary": "Fixed item-1; disputing item-2 with evidence.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "disputed_items": ["item-2"],
                 "dispute_evidence": {"item-2": "Checked the official docs: $1.50/1M is correct."},
                 "human_requirements": {
@@ -2316,6 +2328,7 @@ def test_validate_structured_coder_followup_accepts_empty_disputed_items():
                 "summary": "No disputes.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "disputed_items": [],
                 "human_requirements": {
                     "addressed_ids": [],
@@ -2344,8 +2357,9 @@ def test_validate_structured_coder_followup_rejects_disputed_item_also_in_addres
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
                 "disputed_items": ["item-1"],
-                "dispute_evidence": {"item-1": "Evidence provided but item also in addressed."},
-                "human_requirements": {
+                    "dispute_evidence": {"item-1": "Evidence provided but item also in addressed."},
+                    "human_requirement_dispositions": [],
+                    "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },
@@ -2369,8 +2383,9 @@ def test_validate_structured_coder_followup_rejects_evidence_for_non_disputed_it
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
                 "disputed_items": [],
-                "dispute_evidence": {"item-1": "Evidence for an addressed item, not disputed."},
-                "human_requirements": {
+                    "dispute_evidence": {"item-1": "Evidence for an addressed item, not disputed."},
+                    "human_requirement_dispositions": [],
+                    "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },
@@ -2394,8 +2409,9 @@ def test_validate_structured_coder_followup_rejects_disputed_item_without_eviden
                 "addressed_items": [],
                 "remaining_items": [],
                 "disputed_items": ["item-1"],
-                "dispute_evidence": {},
-                "human_requirements": {
+                    "dispute_evidence": {},
+                    "human_requirement_dispositions": [],
+                    "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2099,7 +2099,6 @@ def test_validate_structured_coder_followup_accepts_v1_payload():
                 "addressed_items": ["item-1"],
                 "remaining_items": ["item-2"],
                 "human_requirement_dispositions": [],
-                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": ["Requirement 1"],
                     "checked_discussion_directly": False,
@@ -2131,9 +2130,9 @@ def test_validate_structured_coder_followup_accepts_optional_item_notes():
                 "addressed_items": ["item-1"],
                 "remaining_items": ["item-2"],
                 "addressed_item_notes": {"item-1": "Added parsing coverage."},
-                    "remaining_item_notes": {"item-2": "Deferred until the docs owner weighs in."},
-                    "human_requirement_dispositions": [],
-                    "human_requirements": {
+                "remaining_item_notes": {"item-2": "Deferred until the docs owner weighs in."},
+                "human_requirement_dispositions": [],
+                "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },
@@ -2162,7 +2161,6 @@ def test_validate_structured_coder_followup_rejects_note_for_unlisted_item():
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
                 "human_requirement_dispositions": [],
-                "human_requirement_dispositions": [],
                 "addressed_item_notes": {"item-2": "This note is stale."},
                 "human_requirements": {
                     "addressed_ids": [],
@@ -2188,7 +2186,6 @@ def test_validate_structured_coder_followup_rejects_invalid_note_values(bad_note
                 "summary": "Addressed one item.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
-                "human_requirement_dispositions": [],
                 "human_requirement_dispositions": [],
                 "addressed_item_notes": {"item-1": bad_note},
                 "human_requirements": {
@@ -2223,7 +2220,6 @@ def test_validate_structured_coder_followup_rejects_unknown_keys_in_structured_c
                 "summary": "Done.",
                 "addressed_items": [],
                 "remaining_items": [],
-                "human_requirement_dispositions": [],
                 "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
@@ -2357,9 +2353,9 @@ def test_validate_structured_coder_followup_rejects_disputed_item_also_in_addres
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
                 "disputed_items": ["item-1"],
-                    "dispute_evidence": {"item-1": "Evidence provided but item also in addressed."},
-                    "human_requirement_dispositions": [],
-                    "human_requirements": {
+                "dispute_evidence": {"item-1": "Evidence provided but item also in addressed."},
+                "human_requirement_dispositions": [],
+                "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },
@@ -2383,9 +2379,9 @@ def test_validate_structured_coder_followup_rejects_evidence_for_non_disputed_it
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
                 "disputed_items": [],
-                    "dispute_evidence": {"item-1": "Evidence for an addressed item, not disputed."},
-                    "human_requirement_dispositions": [],
-                    "human_requirements": {
+                "dispute_evidence": {"item-1": "Evidence for an addressed item, not disputed."},
+                "human_requirement_dispositions": [],
+                "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },
@@ -2409,9 +2405,9 @@ def test_validate_structured_coder_followup_rejects_disputed_item_without_eviden
                 "addressed_items": [],
                 "remaining_items": [],
                 "disputed_items": ["item-1"],
-                    "dispute_evidence": {},
-                    "human_requirement_dispositions": [],
-                    "human_requirements": {
+                "dispute_evidence": {},
+                "human_requirement_dispositions": [],
+                "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
                 },

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -277,6 +277,7 @@ def test_envelope_normalization_recovers_reversed_signature_before_footer(expect
             "summary": "All done.",
             "addressed_items": [],
             "remaining_items": [],
+            "human_requirement_dispositions": [],
             "addressed_item_notes": {},
             "remaining_item_notes": {},
             "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
@@ -1442,6 +1443,7 @@ def test_run_pr_loop_uses_repair_pass_on_coder_followup_format_failure(tmp_path)
     repaired_followup = (
         '{"schema_version":1,"kind":"coder_followup","state":"blocking","summary":"Fixed the bug.",'
         '"addressed_items":["item-1"],"remaining_items":[],'
+        '"human_requirement_dispositions": [],'
         '"human_requirements":{"addressed_ids":[],"checked_discussion_directly":false}}'
         "\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
     )
@@ -3140,6 +3142,7 @@ def test_envelope_normalization_coder_followup_returns_none_when_prose_before_fo
                 "summary": "Done.",
                 "addressed_items": [],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
             }
         )

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -80,6 +80,7 @@ def test_validate_coder_followup_response_accepts_structured_item_partition():
                 "summary": "Addressed the test, helper rename still pending.",
                 "addressed_items": ["item-1"],
                 "remaining_items": ["item-2"],
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
@@ -128,6 +129,7 @@ def test_validate_coder_followup_response_rejects_requirement_label_when_none_su
         addressed_items=["item-1"],
         remaining_items=[],
         human_requirement_ids=["Requirement 1"],
+        human_requirement_dispositions=[],
         reviewer="OpenAI Codex",
     )
 
@@ -249,6 +251,7 @@ def test_validate_coder_followup_response_rejects_invalid_structured_item_partit
                 "summary": "Status update.",
                 "addressed_items": addressed_items,
                 "remaining_items": remaining_items,
+                "human_requirement_dispositions": [],
                 "human_requirements": {
                     "addressed_ids": [],
                     "checked_discussion_directly": False,
@@ -554,6 +557,7 @@ def test_validate_coder_followup_response_accepts_disputed_items():
                 "summary": "Disputed item-1 with evidence; fixed item-2.",
                 "addressed_items": ["item-2"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "disputed_items": ["item-1"],
                 "dispute_evidence": {
                     "item-1": "Checked Google pricing page: $1.50/1M tokens is correct per official docs."
@@ -605,6 +609,7 @@ def test_validate_coder_followup_response_rejects_missing_item_when_disputed_not
                 "summary": "Only addressed one item.",
                 "addressed_items": ["item-1"],
                 "remaining_items": [],
+                "human_requirement_dispositions": [],
                 "disputed_items": [],
                 "human_requirements": {
                     "addressed_ids": [],

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1241,6 +1241,7 @@ class TestStructuredSkillRecovery:
             "summary": "Fixed.",
             "addressed_items": ["item-1"],
             "remaining_items": [],
+            "human_requirement_dispositions": [],
             "addressed_item_notes": {"item-1": "Implemented."},
             "remaining_item_notes": {},
             "human_requirements": {
@@ -2821,12 +2822,19 @@ def _structured_pr_fix_output() -> str:
             "summary": "Fixed the blocking item.",
             "addressed_items": ["item-1"],
             "remaining_items": [],
+            "human_requirement_dispositions": [
+                {
+                    "requirement_id": "Requirement 1",
+                    "disposition": "addressed",
+                    "evidence": "The requested fix is implemented.",
+                }
+            ],
             "addressed_item_notes": {"item-1": "Implemented the requested fix."},
             "remaining_item_notes": {},
             "tests_run": ["python3 -m pytest tests/test_skill_helpers.py -k run_pr_fix"],
             "human_requirements": {
                 "addressed_ids": ["Requirement 1"],
-                "checked_discussion_directly": True,
+                "checked_discussion_directly": False,
             },
         }
     ) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex\n"
@@ -3015,6 +3023,9 @@ class TestRunPrFix:
                 recovered_output = _structured_pr_fix_output().replace(
                     '"addressed_ids": ["Requirement 1"]',
                     '"addressed_ids": []',
+                ).replace(
+                    '"human_requirement_dispositions": [{"requirement_id": "Requirement 1", "disposition": "addressed", "evidence": "The requested fix is implemented."}]',
+                    '"human_requirement_dispositions": []',
                 )
                 out.write_text(recovered_output + "trailing prose", encoding="utf-8")
             elif args[:2] == ("helpers.state_manager", "attach-metadata"):
@@ -4037,6 +4048,7 @@ def test_render_response_coder_followup_stamps_model_signature():
             "summary": "Addressed feedback.",
             "addressed_items": [],
             "remaining_items": [],
+            "human_requirement_dispositions": [],
             "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
         }
     ) + "\n<!-- AGENT_STATE: approved -->\n-- Google Antigravity\n"


### PR DESCRIPTION
Fixes #559

Implements the approved plan for auditable human-requirement handling in post-plan-approval PR coder follow-ups.

- Requires and validates the top-level disposition ledger.
- Preserves direct-discussion fallback acknowledgement semantics.
- Threads fallback context through repair and renders evidenced ledgers in public comments.
- Updates regression coverage and structured fixtures.