### PR TITLE
Reject invalid issue implementation PR markers

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1049,10 +1049,15 @@ Agent responses are parsed using HTML comment markers:
 <!-- AGENT_CLARIFY -->
 ```
 
-`AGENT_PR` is required after a coder creates a PR. Review/fix responses must
-include a final `AGENT_STATE` marker. Plan-first coder/reviewer responses use
-`AGENT_PLAN_STATE` instead. If a response quotes older markers, the final
-matching marker is treated as authoritative.
+`AGENT_PR` is required after a coder creates a PR and must be a positive base-10
+integer. `0`, negative, empty, and malformed identifiers are rejected before
+any GitHub lookup; a final explicit invalid marker is authoritative and is not
+rescued by an incidental PR URL. An issue implementation that cannot safely
+continue may instead end with `AGENT_STATE: blocking` or a final
+`AGENT_CLARIFY`; it stops without PR review and surfaces that state. Review/fix
+responses must include a final `AGENT_STATE` marker. Plan-first coder/reviewer
+responses use `AGENT_PLAN_STATE` instead. If a response quotes older markers,
+the final matching marker is treated as authoritative.
 
 Structured-response runs follow this fallback order:
 

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -77,7 +77,7 @@ _CANNED_IMPLEMENTATION = """\
 Implemented the approved plan (dry-run stub): created a branch, made the changes,
 and opened a pull request.
 
-<!-- AGENT_PR: 0 -->
+<!-- AGENT_PR: 1 -->
 -- Codex (dry-run stub)
 """
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -136,6 +136,8 @@ from .protocol import (
     StructuredPlanState,
     StructuredPlanRevision,
     UnresolvedReviewItem,
+    PrReference,
+    classify_pr_reference,
     human_requirements_resolved,
     is_clarification_request,
     parse_human_requirements_acknowledgement,
@@ -2297,10 +2299,38 @@ def _run_validated_agent(
     raise AgentInvocationError(message, failure_category=last_failure_category)
 
 
+@dataclass(frozen=True)
+class _TerminalNoPrImplementation:
+    state: str
+
+
+def _require_issue_implementation_result(text: str) -> int | _TerminalNoPrImplementation:
+    """Accept a positive PR, or an explicit terminal blocking/clarify outcome."""
+    reference: PrReference = classify_pr_reference(text)
+    if reference.is_valid:
+        assert reference.number is not None
+        return reference.number
+
+    if is_clarification_request(text):
+        return _TerminalNoPrImplementation("clarification")
+    try:
+        state = parse_agent_state(text)
+    except AgentLoopError:
+        state = None
+    if state == "blocking":
+        return _TerminalNoPrImplementation("blocking")
+
+    reference_error = "invalid PR marker or PR URL" if reference.kind == "invalid" else "PR marker or PR URL"
+    raise AgentLoopError(
+        f"Coder did not create a valid PR: response did not include a valid {reference_error} "
+        "or a terminal blocking/clarification marker."
+    )
+
+
 def _require_pr_number(text: str) -> int:
     pr_number = parse_pr_number(text)
     if pr_number is None:
-        raise AgentLoopError("Agent response did not include a PR marker or PR URL.")
+        raise AgentLoopError("Agent response did not include a valid positive PR marker or PR URL.")
     return pr_number
 
 
@@ -2902,14 +2932,8 @@ def _implement_approved_issue(
             staged_parent_issue=staged_parent_issue,
         ),
         session_id=implementation_session_id,
-        marker_description="<!-- AGENT_PR: <number> --> or PR URL",
-        validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
-            text,
-            marker_validator=_require_pr_number,
-            human_requirements=human_requirements,
-            requirement_scope="implementation requirements",
-            full_omission_fallback="Fetch the issue discussion directly before implementing.",
-        ),
+        marker_description="positive <!-- AGENT_PR: <number> -->, PR URL, blocking, or clarification",
+        validate=_require_issue_implementation_result,
         usage_context=usage_context,
         salvage_context=SalvageContext(
             repo=implementation_config.repo,
@@ -2922,7 +2946,19 @@ def _implement_approved_issue(
         operation_description="approved-plan implementation",
     )
     coder_output = coder_response.text
-    pr_number = int(coder_response.marker_value)
+    implementation_result = coder_response.marker_value
+    if isinstance(implementation_result, _TerminalNoPrImplementation):
+        raise AgentLoopError(
+            "Coder did not create a valid PR; implementation is " + implementation_result.state + "."
+        )
+    pr_number = int(implementation_result)
+    _validate_response_with_human_requirements(
+        coder_output,
+        marker_validator=_require_pr_number,
+        human_requirements=issue_context.human_requirements,
+        requirement_scope="implementation requirements",
+        full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
     _validate_response_tests_with_post_pr_context(
         coder_output,
         runner=runner,
@@ -3974,14 +4010,8 @@ def run_issue_loop(
                 issue_context=issue_context,
                 salvage_summary=salvage_summary,
             ),
-            marker_description="<!-- AGENT_PR: <number> --> or PR URL",
-            validate=lambda text, human_requirements=issue_context.human_requirements: _validate_response_with_human_requirements(
-                text,
-                marker_validator=_require_pr_number,
-                human_requirements=human_requirements,
-                requirement_scope="implementation requirements",
-                full_omission_fallback="Fetch the issue discussion directly before implementing.",
-            ),
+            marker_description="positive <!-- AGENT_PR: <number> -->, PR URL, blocking, or clarification",
+            validate=_require_issue_implementation_result,
             usage_context=usage_context,
             salvage_context=SalvageContext(
                 repo=config.repo,
@@ -3994,7 +4024,19 @@ def run_issue_loop(
         )
         coder_output = coder_response.text
         coder_session_id = coder_response.session_id
-        pr_number = int(coder_response.marker_value)
+        implementation_result = coder_response.marker_value
+        if isinstance(implementation_result, _TerminalNoPrImplementation):
+            raise AgentLoopError(
+                "Coder did not create a valid PR; implementation is " + implementation_result.state + "."
+            )
+        pr_number = int(implementation_result)
+        _validate_response_with_human_requirements(
+            coder_output,
+            marker_validator=_require_pr_number,
+            human_requirements=issue_context.human_requirements,
+            requirement_scope="implementation requirements",
+            full_omission_fallback="Fetch the issue discussion directly before implementing.",
+        )
         _validate_response_tests_with_post_pr_context(
             coder_output,
             runner=runner,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2320,9 +2320,13 @@ def _require_issue_implementation_result(text: str) -> int | _TerminalNoPrImplem
     if state == "blocking":
         return _TerminalNoPrImplementation("blocking")
 
-    reference_error = "invalid PR marker or PR URL" if reference.kind == "invalid" else "PR marker or PR URL"
+    reference_error = (
+        "the AGENT_PR marker or PR URL present was invalid"
+        if reference.kind == "invalid"
+        else "response did not include a PR marker or PR URL"
+    )
     raise AgentLoopError(
-        f"Coder did not create a valid PR: response did not include a valid {reference_error} "
+        f"Coder did not create a valid PR: {reference_error} "
         "or a terminal blocking/clarification marker."
     )
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -968,11 +968,23 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_salvage_summary_block(salvage_summary)}
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
-you create the PR. Use blocking here to hand the PR to {reviewer_name} for review. Do not place
-your signature before the AGENT_STATE marker. Your response must end with, in this exact order:
+you create the PR. Use blocking here to hand the PR to {reviewer_name} for review. If you cannot
+safely proceed and cannot create a PR, explain the blocker and end with `AGENT_STATE: blocking`
+(without an `AGENT_PR` marker), or ask a final focused question with `AGENT_CLARIFY`. Otherwise,
+use a positive PR number; do not invent placeholders such as `AGENT_PR: 0`. Do not place your
+signature before the AGENT_STATE marker. Your response must end with, in this exact order for a
+completed implementation:
 
 <!-- AGENT_PR: <number> -->
 <!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For a no-PR blocking result:
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For clarification:
+<!-- AGENT_CLARIFY -->
 -- {coder_signature}
 """
 
@@ -1572,11 +1584,23 @@ Approved implementation plan:
 
 Do not wait for {reviewer_name} yourself; this local orchestrator will run
 {reviewer_name} after you create the PR. Use blocking here to hand the PR to
-{reviewer_name} for review. Do not place your signature before the AGENT_STATE
-marker. Your response must end with, in this exact order:
+{reviewer_name} for review. If you cannot safely proceed and cannot create a
+PR, explain the blocker and end with `AGENT_STATE: blocking` (without an
+`AGENT_PR` marker), or ask a final focused question with `AGENT_CLARIFY`.
+Otherwise, use a positive PR number. Do not invent placeholder identifiers such
+as `AGENT_PR: 0`. Do not place your signature before the AGENT_STATE marker.
+Your response must end with, in this exact order for a completed implementation:
 
 <!-- AGENT_PR: <number> -->
 <!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For a no-PR blocking result:
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For clarification:
+<!-- AGENT_CLARIFY -->
 -- {coder_signature}
 """
 

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -19,7 +19,6 @@ HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK = (
 
 STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->", re.I)
 PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->", re.I)
-PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
 _PR_MARKER_VALUE_RE = re.compile(r"(?m)^\s*<!--\s*AGENT_PR:\s*(.*?)\s*-->\s*$", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -20,6 +20,7 @@ HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK = (
 STATE_RE = re.compile(r"<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->", re.I)
 PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->", re.I)
 PR_RE = re.compile(r"<!--\s*AGENT_PR:\s*(\d+)\s*-->", re.I)
+_PR_MARKER_VALUE_RE = re.compile(r"(?m)^\s*<!--\s*AGENT_PR:\s*(.*?)\s*-->\s*$", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
 # Standalone variants: marker must occupy its own line.
@@ -476,6 +477,22 @@ class ParsedHumanRequirementsAcknowledgement:
     section_text: str
 
 
+@dataclass(frozen=True)
+class PrReference:
+    """Classify the PR reference supplied in an agent response.
+
+    Explicit markers are authoritative, including invalid ones, so an
+    incidental URL cannot turn ``AGENT_PR: 0`` into a real PR handoff.
+    """
+
+    kind: str
+    number: int | None = None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.kind == "valid"
+
+
 def parse_agent_state(text: str) -> str:
     matches = STATE_RE.findall(text)
     if not matches:
@@ -493,15 +510,39 @@ def parse_plan_state(text: str) -> str:
     return matches[-1].lower()
 
 
-def parse_pr_number(text: str) -> int | None:
-    # Use the final marker as authoritative, consistent with parse_agent_state.
-    markers = list(PR_RE.finditer(text))
+def classify_pr_reference(text: str) -> PrReference:
+    """Return whether a response has an absent, valid, or invalid PR reference.
+
+    Only standalone, non-fenced protocol markers count. The final explicit
+    marker wins and is never rescued by a URL elsewhere in the response.
+    """
+    code_ranges = _fenced_code_block_ranges(text)
+
+    def active(matches):
+        return [m for m in matches if not any(start <= m.start() < end for start, end in code_ranges)]
+
+    markers = active(list(_PR_MARKER_VALUE_RE.finditer(text)))
     if markers:
-        return int(markers[-1].group(1))
-    urls = list(GH_PR_URL_RE.finditer(text))
+        value = markers[-1].group(1).strip()
+        if re.fullmatch(r"\d+", value):
+            number = int(value)
+            if number > 0:
+                return PrReference("valid", number)
+        return PrReference("invalid")
+
+    urls = active(list(GH_PR_URL_RE.finditer(text)))
     if urls:
-        return int(urls[-1].group(1))
-    return None
+        number = int(urls[-1].group(1))
+        if number > 0:
+            return PrReference("valid", number)
+        return PrReference("invalid")
+    return PrReference("absent")
+
+
+def parse_pr_number(text: str) -> int | None:
+    """Compatibility parser that returns only a positive PR number."""
+    reference = classify_pr_reference(text)
+    return reference.number if reference.is_valid else None
 
 
 def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -313,7 +313,7 @@ def test_issue_loop_requires_claude_to_report_pr_number(tmp_path):
     runner = FakeRunner(claude_outputs=["Created something.\n<!-- AGENT_STATE: blocking -->"])
     config = make_config(tmp_path)
 
-    with pytest.raises(AgentLoopError, match="PR marker"):
+    with pytest.raises(AgentLoopError, match="valid PR"):
         run_issue_loop(runner, issue_number=56, config=config)
 
 def test_issue_loop_rejects_missing_initial_issue_human_requirements_acknowledgement(tmp_path):
@@ -2298,10 +2298,38 @@ def test_codex_issue_loop_requires_codex_to_report_pr_number(tmp_path):
     )
     config = make_config(tmp_path, coder="codex", reviewer="claude")
 
-    with pytest.raises(AgentLoopError, match="PR marker"):
+    with pytest.raises(AgentLoopError, match="valid PR"):
         run_issue_loop(runner, issue_number=56, config=config)
 
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
+@pytest.mark.parametrize("terminal_marker, expected_state", [
+    ("<!-- AGENT_STATE: blocking -->", "blocking"),
+    ("<!-- AGENT_CLARIFY -->", "clarification"),
+])
+def test_issue_loop_stops_before_pr_lookup_for_invalid_pr_terminal_result(
+    tmp_path, terminal_marker, expected_state
+):
+    runner = FakeRunner(codex_outputs=[f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}"])
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError, match=f"implementation is {expected_state}"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert runner.comments == []
+
+
+def test_issue_loop_invalid_pr_without_terminal_state_is_protocol_error(tmp_path):
+    runner = FakeRunner(codex_outputs=["Cannot proceed.\n<!-- AGENT_PR: malformed -->"])
+    config = make_config(tmp_path, coder="codex", reviewer="claude")
+
+    with pytest.raises(AgentLoopError, match="did not create a valid PR"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
 
 def test_issue_loop_rejects_outside_workdir_tests_before_posting_pr_comment(tmp_path):
     runner = FakeRunner(
@@ -3008,6 +3036,37 @@ def test_approved_plan_implementation_rerun_discovers_remote_salvage_with_matchi
     assert "Previous failed implementation attempt salvage:" in coder_prompt
     assert "recovered from a GitHub issue comment" in coder_prompt
     assert "remote approved-plan failure" in coder_prompt
+
+
+@pytest.mark.parametrize("terminal_marker, expected_state", [
+    ("<!-- AGENT_STATE: blocking -->", "blocking"),
+    ("<!-- AGENT_CLARIFY -->", "clarification"),
+])
+def test_approved_plan_no_pr_terminal_result_bypasses_human_requirements_and_pr_checks(
+    tmp_path, terminal_marker, expected_state
+):
+    runner = FakeRunner(
+        issue_payload={"body": "Keep the public API stable.\n\n-- Human Reviewer"},
+        claude_outputs=[f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}"],
+    )
+    config = make_config(tmp_path)
+    issue_context = get_issue_context(runner, config=config, issue_number=56)
+
+    with pytest.raises(AgentLoopError, match=f"implementation is {expected_state}"):
+        orchestrator_module._implement_approved_issue(
+            runner,
+            issue_number=56,
+            approved_plan="Plan:\n- Do the thing.",
+            config=config,
+            memory=None,
+            issue_context=issue_context,
+            coder_session_id=None,
+            usage_context=orchestrator_module._new_usage_context(config),
+        )
+
+    assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:1] == ["codex"] for cmd, _cwd in runner.commands)
+    assert runner.comments == []
 
 
 def test_approved_plan_implementation_rerun_ignores_remote_salvage_on_plan_hash_mismatch(tmp_path):

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -2326,7 +2326,10 @@ def test_issue_loop_invalid_pr_without_terminal_state_is_protocol_error(tmp_path
     runner = FakeRunner(codex_outputs=["Cannot proceed.\n<!-- AGENT_PR: malformed -->"])
     config = make_config(tmp_path, coder="codex", reviewer="claude")
 
-    with pytest.raises(AgentLoopError, match="did not create a valid PR"):
+    with pytest.raises(
+        AgentLoopError,
+        match="AGENT_PR marker or PR URL present was invalid",
+    ):
         run_issue_loop(runner, issue_number=56, config=config)
 
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -1,5 +1,5 @@
 from agent_loop_helpers import *  # noqa: F403
-from coding_review_agent_loop.protocol import StructuredCoderFollowup
+from coding_review_agent_loop.protocol import StructuredCoderFollowup, classify_pr_reference
 from coding_review_agent_loop.unresolved_items import (
     CODER_DISPUTE_NOTE_PREFIX,
     _apply_dispute_evidence,
@@ -443,6 +443,34 @@ def test_parse_pr_number_uses_final_marker():
     )
     # Marker takes precedence over URL when both present (marker checked first).
     assert parse_pr_number("https://github.com/OWNER/REPO/pull/5\n<!-- AGENT_PR: 7 -->") == 7
+
+
+@pytest.mark.parametrize("response", [
+    "<!-- AGENT_PR: 0 -->",
+    "<!-- AGENT_PR: -1 -->",
+    "<!-- AGENT_PR: -->",
+    "<!-- AGENT_PR: abc -->",
+    "<!-- AGENT_PR: 12abc -->",
+    "https://github.com/OWNER/REPO/pull/0",
+])
+def test_pr_reference_classifier_rejects_invalid_identifiers(response):
+    assert classify_pr_reference(response).kind == "invalid"
+    assert parse_pr_number(response) is None
+
+
+def test_pr_reference_classifier_preserves_absent_and_authoritative_final_marker():
+    assert classify_pr_reference("no PR yet").kind == "absent"
+    assert classify_pr_reference("<!-- AGENT_PR: 8 -->").number == 8
+    assert classify_pr_reference("https://github.com/OWNER/REPO/pull/9").number == 9
+    assert classify_pr_reference("<!-- AGENT_PR: 8 -->\n<!-- AGENT_PR: 0 -->").kind == "invalid"
+    assert classify_pr_reference(
+        "https://github.com/OWNER/REPO/pull/9\n<!-- AGENT_PR: 0 -->"
+    ).kind == "invalid"
+
+
+def test_pr_reference_classifier_ignores_fenced_and_inline_examples():
+    assert classify_pr_reference("```\n<!-- AGENT_PR: 7 -->\n```").kind == "absent"
+    assert classify_pr_reference("Use <!-- AGENT_PR: 7 --> as the footer.").kind == "absent"
 
 def test_validate_human_requirements_acknowledgement_accepts_multiple_bullet_styles():
     response = f"""Implemented the fix.

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2680,7 +2680,7 @@ class TestRunExternalImplStub:
                 "--dry-run",
             )
             assert result.returncode == 0
-            assert "<!-- AGENT_PR:" in out.read_text(encoding="utf-8")
+            assert "<!-- AGENT_PR: 1 -->" in out.read_text(encoding="utf-8")
 
 
 class TestRunExternalDecomposeStub:
@@ -3182,7 +3182,7 @@ class TestRunImplement:
             )
             assert result.returncode == 0, result.stderr
             output = self._last_json(result.stdout)
-            assert output["pr"] == 0 and output["issue"] == 9992
+            assert output["pr"] == 1 and output["issue"] == 9992
             # Launcher base behavior is observable (not only the prompt text).
             assert "release-x" in result.stdout
 
@@ -3634,7 +3634,7 @@ class TestRunImplementByPhase:
             assert output["state"] == "would-implement"
             assert output["phase"]["automation"] == "agent-pr"
             assert output["would_post_phase_handoff"] is True
-            assert output["child_implementation_preview"]["pr"] == 0
+            assert output["child_implementation_preview"]["pr"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #570

- classify explicit PR references as absent, valid, or invalid and require positive IDs
- preserve blocking and clarification implementation outcomes before PR-dependent checks
- document the no-PR contract and cover it with parser/orchestrator regressions