### PR TITLE
Avoid duplicate carried future follow-up items

### DIFF
--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -205,6 +205,14 @@ def _followup_similarity(left: ApprovedFollowup, right: ApprovedFollowup) -> flo
             return 1.0
     if common_terms == left_terms or common_terms == right_terms:
         return 1.0
+    # A concise restatement of carried work can omit context while retaining
+    # most of its concrete terms. Treat that as the same follow-up before the
+    # broader Jaccard threshold below.
+    if (
+        len(common_terms) >= 4
+        and len(common_terms) / min(len(left_terms), len(right_terms)) >= 0.6
+    ):
+        return 0.55
     return len(common_terms) / len(left_terms | right_terms)
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -130,6 +130,7 @@ from .protocol import (
     failed_discuss_answer_placeholder,
     is_failed_discuss_response,
     ParsedPlanReview,
+    PlanReviewItems,
     ParsedReview,
     PUBLIC_RESPONSE_MARKER,
     ReviewItemDisposition,
@@ -2511,6 +2512,27 @@ def _drop_repeated_carried_future_followups(
     return ApprovedFollowups(same_pr=followups.same_pr, future=retained)
 
 
+def _drop_repeated_carried_plan_future_followups(
+    items: PlanReviewItems,
+    *,
+    prior_items: Sequence[UnresolvedReviewItem],
+    dispositions: Sequence[ReviewItemDisposition],
+) -> PlanReviewItems:
+    """Keep repeated carried plan follow-ups in their original ledger items."""
+    followups = _drop_repeated_carried_future_followups(
+        ApprovedFollowups(same_pr=items.same_plan, future=items.future),
+        prior_items=prior_items,
+        dispositions=dispositions,
+    )
+    if followups.future == items.future:
+        return items
+    return PlanReviewItems(
+        blocking=items.blocking,
+        same_plan=items.same_plan,
+        future=followups.future,
+    )
+
+
 def _is_pending_ci_only_review(parsed_review: ParsedReview, pr_checks: PullRequestChecks) -> bool:
     """Detect a blocking review whose only content restates pending/unavailable
     GitHub check status rather than an actionable code-level finding.
@@ -3356,6 +3378,14 @@ def _run_plan_first_loop(
                 reviewer_session_ids[reviewer] = review_response.session_id
                 parsed_review = review_response.marker_value
                 assert isinstance(parsed_review, ParsedPlanReview)
+                parsed_review = dataclasses_replace(
+                    parsed_review,
+                    items=_drop_repeated_carried_plan_future_followups(
+                        parsed_review.items,
+                        prior_items=prior_unresolved_items,
+                        dispositions=parsed_review.dispositions,
+                    ),
+                )
                 review_state = parsed_review.state
                 reviewer_new_unresolved_items = []
             log(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -113,6 +113,7 @@ from .prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from .protocol import (
+    ApprovedFollowups,
     DISCUSS_FAILED_OUTCOME,
     DISCUSS_RESEARCH_TARGET_VALUES,
     DeferredStage,
@@ -2474,6 +2475,42 @@ _PENDING_CI_TEXT_KEYWORDS = (
 )
 
 
+def _drop_repeated_carried_future_followups(
+    followups: ApprovedFollowups,
+    *,
+    prior_items: Sequence[UnresolvedReviewItem],
+    dispositions: Sequence[ReviewItemDisposition],
+) -> ApprovedFollowups:
+    """Keep carried future work in its original ledger item.
+
+    A reviewer records a carried item's status through `prior_item_dispositions`.
+    Repeating that same concern in `future_followups` used to allocate another
+    item ID, even though final follow-up publishing later grouped the two.
+    """
+    future_ids = {
+        disposition.item_id
+        for disposition in dispositions
+        if disposition.disposition == "future"
+    }
+    carried = [
+        _approved_followup_from_unresolved_item(item)
+        for item in prior_items
+        if item.item_id in future_ids
+    ]
+    if not carried or not followups.future:
+        return followups
+
+    carried_group_count = len(_dedupe_approved_followups(carried))
+    retained = tuple(
+        followup
+        for followup in followups.future
+        if len(_dedupe_approved_followups([*carried, followup])) > carried_group_count
+    )
+    if retained == followups.future:
+        return followups
+    return ApprovedFollowups(same_pr=followups.same_pr, future=retained)
+
+
 def _is_pending_ci_only_review(parsed_review: ParsedReview, pr_checks: PullRequestChecks) -> bool:
     """Detect a blocking review whose only content restates pending/unavailable
     GitHub check status rather than an actionable code-level finding.
@@ -4486,6 +4523,14 @@ def run_pr_loop(
                     reviewer_session_ids[reviewer] = review_response.session_id
                     parsed_review = review_response.marker_value
                     assert isinstance(parsed_review, ParsedReview)
+                    parsed_review = dataclasses_replace(
+                        parsed_review,
+                        followups=_drop_repeated_carried_future_followups(
+                            parsed_review.followups,
+                            prior_items=prior_unresolved_items,
+                            dispositions=parsed_review.dispositions,
+                        ),
+                    )
                     review_state = parsed_review.state
                     reviewer_new_unresolved_items = []
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -571,7 +571,7 @@ def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewI
         "Prior unresolved review items from earlier rounds",
         "",
         "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
-        "For carried future follow-ups, restate `future follow-up: reason` only when the item still deserves separate tracking; use `resolved` if later PR changes already handled it, or promote it to `same-pr`/`still blocking` if it must be fixed before merge.",
+        "For carried future follow-ups, record their status only in `prior_item_dispositions`; do not repeat the same concern in new `future_followups`. Use `resolved` if later PR changes already handled it, or promote it to `same-pr`/`still blocking` if it must be fixed before merge.",
         "",
     ]
     for item in unresolved_items:
@@ -596,7 +596,7 @@ def _format_unresolved_plan_items(unresolved_items: Sequence[UnresolvedReviewIte
         "Prior unresolved plan items from earlier rounds",
         "",
         "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
-        "For carried future follow-ups, restate `future follow-up: reason` only when the item still deserves separate tracking; use `resolved` if later plan changes already handled it, or promote it to `same-plan`/`still blocking` if it must be fixed before implementation.",
+        "For carried future follow-ups, record their status only in `prior_plan_item_dispositions`; do not repeat the same concern in new `future_followups`. Use `resolved` if later plan changes already handled it, or promote it to `same-plan`/`still blocking` if it must be fixed before implementation.",
         "",
     ]
     for item in unresolved_items:

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -1335,7 +1335,7 @@ def test_issue_loop_plan_first_files_approved_future_followups_before_implementa
     )
     assert issue_create_index < second_claude_index
 
-def test_issue_loop_plan_first_files_surviving_future_from_mixed_outcome_round(tmp_path):
+def test_issue_loop_plan_first_does_not_allocate_new_items_for_repeated_carried_future_followups(tmp_path):
     future_text = "Factor the shared follow-up guidance into a reusable helper."
     runner = FakeRunner(
         claude_outputs=[
@@ -1428,12 +1428,12 @@ def test_issue_loop_plan_first_files_surviving_future_from_mixed_outcome_round(t
 
     assert len(runner.issues) == 1
     issue_body = runner.issues[0]["body"]
-    assert "Planning round(s): 1, 2" in issue_body
-    assert "Reviewers: Codex, Gemini" in issue_body
-    assert "Original plan item ID(s): item-1, item-3" in issue_body
+    assert "Planning round(s): 1" in issue_body
+    assert "Reviewer: Codex" in issue_body
+    assert "Original plan item ID(s): item-1" in issue_body
     assert "Keep this as confirmed post-plan cleanup." in issue_body
     assert any(
-        "Reconciliation: 1 filed, 1 deduplicated, 0 skipped by cap." in comment
+        "Reconciliation: 1 filed, 0 deduplicated, 0 skipped by cap." in comment
         for comment in runner.comments
     )
 

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1646,6 +1646,79 @@ def test_pr_loop_files_earlier_future_followup_not_repeated_in_final_round(tmp_p
     )
     assert "Update from Codex: Still useful as separate tracking." in runner.issues[0]["body"]
 
+
+def test_pr_loop_does_not_allocate_new_items_for_repeated_carried_future_followups(tmp_path):
+    future_text = "Rate limit the preferences write endpoint to avoid provider validation abuse."
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves with a later hardening task.",
+                future_followups=[future_text],
+                reviewer="OpenAI Codex",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Codex final approval.",
+                future_followups=[
+                    "Add a rate limit to PUT /api/preferences because it triggers provider validation."
+                ],
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "future", "note": "Still separate work."},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="OpenAI Codex",
+            ),
+        ],
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Need one current-PR fix.",
+                blocking_items=["Fix the current sync regression."],
+                reviewer="Anthropic Claude",
+            ),
+            structured_coder_followup(
+                addressed_items=["item-2"],
+                remaining_items=["item-1"],
+                reviewer="Anthropic Claude",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Claude final approval.",
+                future_followups=[future_text],
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "future", "note": "Still useful."},
+                    {"item_id": "item-2", "disposition": "resolved"},
+                ],
+                reviewer="Anthropic Claude",
+            ),
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "claude"),
+        approved_followups="issue",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    reviewer_metadata = []
+    for comment in runner.pr_payload["comments"]:
+        match = re.search(
+            r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+            comment["body"],
+        )
+        if match:
+            metadata = _decode_round_metadata(match.group("payload"))
+            if metadata.role == "reviewer" and metadata.round_number == 2:
+                reviewer_metadata.append(metadata)
+
+    assert len(reviewer_metadata) == 2
+    assert all(not metadata.new_items for metadata in reviewer_metadata)
+    assert len(runner.issues) == 1
+    assert runner.issues[0]["title"] == f"Follow up future review note: {future_text}"
+
+
 def test_pr_loop_does_not_file_resolved_earlier_future_followup(tmp_path):
     runner = FakeRunner(
         codex_outputs=[


### PR DESCRIPTION
## Summary
- retain carried future work in its original unresolved-item ledger record when a reviewer repeats it in future_followups
- extend semantic matching for concise restatements with strong concrete-term overlap
- tell reviewers to use the prior-item disposition instead of re-emitting carried future work

## Verification
- PYTHONPATH=src /home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_orchestrator_pr.py tests/test_protocol.py tests/test_prompts.py -q