### PR TITLE
Skip approvals for unchanged PR heads

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -4389,6 +4389,10 @@ def run_pr_loop(
                 if use_compact_pr_context
                 else None
             )
+            surfaced_reviewer_requirement_ids = _surfaced_reviewer_requirement_ids(
+                human_requirements,
+                requirement_scope="PR requirements",
+            )
             approved_review_outputs: list[tuple[str, str]] = []
             resumed_by_name = {
                 record.metadata.agent: record for record in (current_resume.completed_reviews if current_resume is not None else ())
@@ -4431,7 +4435,12 @@ def run_pr_loop(
                     and prior_approval.metadata.round_number < round_number
                     and (
                         not human_requirements
-                        or human_requirements_resolved(prior_approval.body)
+                        or (
+                            human_requirements_resolved(prior_approval.body)
+                            and set(surfaced_reviewer_requirement_ids).issubset(
+                                prior_approval.metadata.surfaced_reviewer_requirement_ids
+                            )
+                        )
                     )
                 ):
                     carried_approval_record = prior_approval
@@ -4644,6 +4653,7 @@ def run_pr_loop(
                                     new_items=tuple(reviewer_new_unresolved_items),
                                     state=review_state,
                                     model_used=review_model_used,
+                                    surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
                                 ),
                             ),
                         )
@@ -4694,6 +4704,7 @@ def run_pr_loop(
                                 new_items=tuple(reviewer_new_unresolved_items),
                                 state=review_state,
                                 model_used=review_model_used,
+                                surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
                             ),
                         ),
                     )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -256,6 +256,7 @@ from .round_state import (
     _deserialize_unresolved_item,
     _encode_round_metadata,
     _extract_round_metadata_records,
+    _latest_pr_approved_reviews_for_head,
     _max_unresolved_item_number_from_records,
     _plan_subject,
     _prior_item_ledger_signature,
@@ -4392,6 +4393,11 @@ def run_pr_loop(
             resumed_by_name = {
                 record.metadata.agent: record for record in (current_resume.completed_reviews if current_resume is not None else ())
             }
+            unchanged_head_approvals = _latest_pr_approved_reviews_for_head(
+                pr_comments,
+                head_sha=pr_metadata.head_sha,
+                configured_reviewers=configured_reviewers,
+            )
             skip_reviewers_for_recovery = bool(
                 current_resume is not None and current_resume.unrecorded_head_advance
             )
@@ -4405,6 +4411,7 @@ def run_pr_loop(
             for reviewer in (() if skip_reviewers_for_recovery else configured_reviewers):
                 reviewer_name = agent_display_name(reviewer)
                 resumed_record = resumed_by_name.get(reviewer_name)
+                carried_approval_record: PostedRoundRecord | None = None
                 if resumed_record is not None:
                     review_output = resumed_record.body
                     review_model_used = resumed_record.metadata.model_used
@@ -4419,6 +4426,32 @@ def run_pr_loop(
                     review_state = parsed_review.state
                     reviewer_new_unresolved_items = list(resumed_record.metadata.new_items)
                     log(config, f"Round {round_number}: resuming {reviewer_name}'s completed review")
+                elif (
+                    (prior_approval := unchanged_head_approvals.get(reviewer_name)) is not None
+                    and prior_approval.metadata.round_number < round_number
+                    and (
+                        not human_requirements
+                        or human_requirements_resolved(prior_approval.body)
+                    )
+                ):
+                    carried_approval_record = prior_approval
+                    review_output = prior_approval.body
+                    review_model_used = prior_approval.metadata.model_used
+                    reparsed_review = parse_review(review_output, reviewer=reviewer_name)
+                    parsed_review = ParsedReview(
+                        state="approved",
+                        summary=review_freeform_summary_text(review_output),
+                        blocking_items=reparsed_review.blocking_items,
+                        followups=reparsed_review.followups,
+                        dispositions=(),
+                    )
+                    review_state = parsed_review.state
+                    reviewer_new_unresolved_items = []
+                    log(
+                        config,
+                        f"Round {round_number}: skipping {reviewer_name}; it approved unchanged "
+                        f"PR head {current_pr_subject} in round {prior_approval.metadata.round_number}",
+                    )
                 else:
                     context_mode = "compact" if use_compact_pr_context else "full"
                     log(
@@ -4527,7 +4560,7 @@ def run_pr_loop(
                     f"{_describe_pr_review_outcome(parsed_review, has_blocking_summary=has_blocking_summary)}",
                 )
                 if review_state == "blocking":
-                    if resumed_record is None:
+                    if resumed_record is None and carried_approval_record is None:
                         if parsed_review.blocking_items:
                             for blocking_item in parsed_review.blocking_items:
                                 tracked_item = _next_unresolved_item(
@@ -4615,11 +4648,12 @@ def run_pr_loop(
                             ),
                         )
                     else:
-                        round_new_unresolved_items.extend(reviewer_new_unresolved_items)
+                        if resumed_record is not None:
+                            round_new_unresolved_items.extend(reviewer_new_unresolved_items)
                     continue
 
                 approved_review_outputs.append((reviewer_name, review_output))
-                if resumed_record is None:
+                if resumed_record is None and carried_approval_record is None:
                     if config.approved_followups != "ignore":
                         for followup in parsed_review.followups.future:
                             tracked_item = _next_unresolved_item(
@@ -4664,7 +4698,8 @@ def run_pr_loop(
                         ),
                     )
                 else:
-                    round_new_unresolved_items.extend(reviewer_new_unresolved_items)
+                    if resumed_record is not None:
+                        round_new_unresolved_items.extend(reviewer_new_unresolved_items)
 
             if use_compact_pr_context:
                 unresolved_items, future_from_prior_items = _apply_unresolved_item_dispositions(

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -77,6 +77,11 @@ class PostedRoundMetadata:
     # Canonical bounded #535 evidence artifact on final summaries.  Keeping it
     # here makes resume idempotent without feeding evidence into analyzer agenda.
     evidence_reconciliation: dict | None = None
+    # Requirement IDs shown to a PR reviewer when this comment was posted.
+    # Persisting this lets a later round distinguish an approval that covered
+    # the current signed requirements from one made before new requirements
+    # were surfaced for the same immutable PR head.
+    surfaced_reviewer_requirement_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -178,6 +183,7 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "split_proposals": list(metadata.split_proposals),
         "result_mode": metadata.result_mode,
         "evidence_reconciliation": metadata.evidence_reconciliation,
+        "surfaced_reviewer_requirement_ids": list(metadata.surfaced_reviewer_requirement_ids),
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -245,6 +251,9 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
                 payload.get("evidence_reconciliation")
                 if isinstance(payload.get("evidence_reconciliation"), dict)
                 else None
+            ),
+            surfaced_reviewer_requirement_ids=tuple(
+                str(item) for item in payload.get("surfaced_reviewer_requirement_ids", [])
             ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -306,6 +306,34 @@ def _extract_round_metadata_records(comments: Sequence[object], *, flow: str) ->
     return tuple(records)
 
 
+def _latest_pr_approved_reviews_for_head(
+    comments: Sequence[object],
+    *,
+    head_sha: str | None,
+    configured_reviewers: Sequence[AgentName],
+) -> dict[str, PostedRoundRecord]:
+    """Return each reviewer's latest approval for the current immutable PR head."""
+    if not head_sha:
+        return {}
+    configured_names = {agent_display_name(agent) for agent in configured_reviewers}
+    latest_by_reviewer: dict[str, PostedRoundRecord] = {}
+    for record in reversed(_extract_round_metadata_records(comments, flow="pr")):
+        metadata = record.metadata
+        if (
+            metadata.subject != head_sha
+            or metadata.role != "reviewer"
+            or metadata.agent not in configured_names
+            or metadata.agent in latest_by_reviewer
+        ):
+            continue
+        latest_by_reviewer[metadata.agent] = record
+    return {
+        reviewer: record
+        for reviewer, record in latest_by_reviewer.items()
+        if record.metadata.state == "approved"
+    }
+
+
 def _prior_item_ledger_signature(items: Sequence[UnresolvedReviewItem]) -> tuple[tuple[str, str, int, str, str, str | None, tuple[str, ...]], ...]:
     return tuple(
         (

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -236,6 +236,7 @@ class FakeRunner(Runner):
         issue_urls=None,
         public_response_outputs=None,
         advance_git_head_on_pr=True,
+        advance_pr_head_on_coder_followup=True,
         search_issues_payload=None,
         open_prs_payload=None,
     ):
@@ -317,6 +318,8 @@ class FakeRunner(Runner):
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
         self.advance_git_head_on_pr = advance_git_head_on_pr
+        self.advance_pr_head_on_coder_followup = advance_pr_head_on_coder_followup
+        self._coder_followup_counter = 0
         # Results returned by the next `gh issue list --search` call (#476).
         # A list of dicts with number/title/url/body keys; consumed one call
         # at a time when a list of lists is provided, otherwise reused as-is.
@@ -480,6 +483,17 @@ class FakeRunner(Runner):
         self._agent_pr_counter += 1
         self.git_head = f"{self.git_head}-agent-{self._agent_pr_counter}"
 
+    def _maybe_advance_pr_head_for_coder_followup(self, cmd) -> None:
+        if not self.advance_pr_head_on_coder_followup:
+            return
+        if '"kind": "coder_followup"' not in "\n".join(cmd):
+            return
+        self._coder_followup_counter += 1
+        head_sha = self.pr_payload.get("headRefOid", self.git_head)
+        new_head_sha = f"{head_sha}-coder-{self._coder_followup_counter}"
+        self.pr_payload["headRefOid"] = new_head_sha
+        self.git_head = new_head_sha
+
     def _mark_agent_command_seen(self) -> None:
         self._agent_command_seen = True
 
@@ -551,6 +565,7 @@ class FakeRunner(Runner):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             self._maybe_advance_git_head_for_agent_pr(output)
+            self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
@@ -573,6 +588,7 @@ class FakeRunner(Runner):
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
             self._maybe_advance_git_head_for_agent_pr(public_response)
+            self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\ncodex completed", encoding="utf-8")
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
@@ -591,6 +607,7 @@ class FakeRunner(Runner):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_write_public_response_file(cmd)
             self._maybe_advance_git_head_for_agent_pr(output)
+            self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{output}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, output, "", returncode)
@@ -606,6 +623,7 @@ class FakeRunner(Runner):
                 stdout, returncode = output
             self._maybe_write_public_response_file(cmd)
             self._maybe_advance_git_head_for_agent_pr(stdout)
+            self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()
             log_path.write_text(f"$ {' '.join(cmd)}\n\n{stdout}", encoding="utf-8")
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
@@ -624,6 +642,7 @@ class FakeRunner(Runner):
             if isinstance(output, str):
                 output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
             self._maybe_advance_git_head_for_agent_pr(output)
+            self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()
             return CommandResult(cmd, cwd_path, output, "", returncode)
 
@@ -644,6 +663,7 @@ class FakeRunner(Runner):
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")
             self._maybe_advance_git_head_for_agent_pr(public_response)
+            self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()
             return CommandResult(cmd, cwd_path, stdout, "", returncode)
 

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -723,6 +723,7 @@ def test_pr_loop_revalidates_latest_coder_output_against_refreshed_human_require
             ],
             "reviews": [],
         },
+        advance_pr_head_on_coder_followup=False,
     )
     config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=2)
     metadata = PullRequestMetadata(
@@ -1392,6 +1393,57 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
     assert len(metadata_fetches) == 1
     assert ["pytest", "tests/test_agent_loop.py"] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+
+
+def test_pr_loop_skips_prior_approval_when_pr_head_is_unchanged(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves the initial head.",
+                reviewer="OpenAI Codex",
+            )
+        ],
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Claude needs one fix.",
+                blocking_items=["Fix the admission cleanup race."],
+                reviewer="Anthropic Claude",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Claude accepts the follow-up.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                reviewer="Anthropic Claude",
+            ),
+        ],
+        gemini_outputs=[
+            structured_coder_followup(
+                addressed_items=["item-1"],
+                remaining_items=[],
+                reviewer="Google Gemini",
+            )
+        ],
+        advance_pr_head_on_coder_followup=False,
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        max_rounds=2,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    codex_reviews = [
+        cmd
+        for cmd, _cwd in runner.commands
+        if cmd[:2] == ["codex", "exec"]
+    ]
+    assert len(codex_reviews) == 1
+    assert "round 1" in codex_reviews[0][-1]
+
 
 def test_pr_loop_ignores_approved_followups_by_default(tmp_path):
     runner = FakeRunner(
@@ -3216,6 +3268,7 @@ def test_pr_loop_routes_unrecorded_head_advance_through_coder_before_reviewers(t
                 {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:01:00Z", "body": old_review_comment},
             ],
         },
+        advance_pr_head_on_coder_followup=False,
     )
     config = make_config(tmp_path, reviewer="codex")
 

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1445,6 +1445,110 @@ def test_pr_loop_skips_prior_approval_when_pr_head_is_unchanged(tmp_path):
     assert "round 1" in codex_reviews[0][-1]
 
 
+def test_pr_loop_rereviews_unchanged_head_when_new_human_requirement_is_surfaced(
+    tmp_path, monkeypatch
+):
+    requirement_1 = HumanReviewRequirement(
+        source_type="PR comment",
+        author="maintainer",
+        created_at="2026-05-18T10:00:00Z",
+        url="https://github.com/OWNER/REPO/pull/77#issuecomment-1",
+        body="Keep the current audit trail.",
+    )
+    requirement_2 = HumanReviewRequirement(
+        source_type="PR comment",
+        author="maintainer",
+        created_at="2026-05-18T10:10:00Z",
+        url="https://github.com/OWNER/REPO/pull/77#issuecomment-2",
+        body="Also preserve the reviewer attribution.",
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves the initial requirement.",
+                human_requirements_resolved=True,
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Codex approves after reviewing the new requirement.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"},
+                    {"item_id": HUMAN_REQUIREMENTS_ACK_ITEM_ID, "disposition": "resolved"},
+                ],
+                human_requirements_resolved=True,
+            ),
+        ],
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Claude needs one fix.",
+                blocking_items=["Fix the admission cleanup race."],
+                reviewer="Anthropic Claude",
+                human_requirements_resolved=True,
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Claude accepts the follow-up.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"},
+                    {"item_id": HUMAN_REQUIREMENTS_ACK_ITEM_ID, "disposition": "resolved"},
+                ],
+                reviewer="Anthropic Claude",
+                human_requirements_resolved=True,
+            ),
+        ],
+        gemini_outputs=[
+            structured_coder_followup(
+                addressed_items=["item-1"],
+                remaining_items=[],
+                human_requirement_ids=["Requirement 1"],
+                reviewer="Google Gemini",
+            )
+        ],
+        advance_pr_head_on_coder_followup=False,
+    )
+    metadata = PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Improve review prompt context",
+        head_branch="feature/review-context",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/77",
+    )
+    contexts = iter(
+        [
+            PullRequestReviewContext(
+                metadata=metadata,
+                comments=(),
+                human_requirements=(requirement_1,),
+            ),
+            PullRequestReviewContext(
+                metadata=metadata,
+                comments=(),
+                human_requirements=(requirement_1, requirement_2),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "coding_review_agent_loop.orchestrator.get_pr_review_context",
+        lambda *args, **kwargs: next(contexts),
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        max_rounds=2,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    codex_reviews = [cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(codex_reviews) == 2
+    assert "Requirement 2" in codex_reviews[1][-1]
+
+
 def test_pr_loop_ignores_approved_followups_by_default(tmp_path):
     runner = FakeRunner(
         codex_outputs=[


### PR DESCRIPTION
## Summary
- reuse a reviewer approval when its latest persisted approval targets the unchanged PR head
- keep all reviewers eligible immediately after a new commit, and retain signed-human-requirement acknowledgement checks
- avoid duplicate review comments and ledger entries for carried approvals

## Verification
- PYTHONPATH=src /home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_orchestrator_pr.py tests/test_protocol.py tests/test_prompts.py -q