### PR TITLE
Treat incomplete PR reviews as agent failures

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2521,6 +2521,32 @@ def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had
     return len(non_empty_lines[0]) >= 80
 
 
+_INCOMPLETE_PR_REVIEW_RE = re.compile(
+    r"\breview\s+(?:is\s+)?incomplete\b|"
+    r"\b(?:resolution|finding)\s+could\s+not\s+be\s+confirmed\b|"
+    r"\b(?:could\s+not|cannot|can't|unable\s+to)\s+"
+    r"(?:complete|confirm|verify|assess|review)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_incomplete_pr_review(parsed_review: ParsedReview) -> bool:
+    """Identify a reviewer failure reported as a blocking verdict.
+
+    A reviewer occasionally returns a syntactically valid blocking response that
+    only says it could not inspect the diff or confirm a prior item. That is
+    not actionable feedback for the coder. Keep this deliberately narrow so
+    substantive freeform blocking summaries retain their existing behavior.
+    """
+    if parsed_review.state != "blocking":
+        return False
+    if parsed_review.blocking_items or parsed_review.followups.same_pr:
+        return False
+    candidate_texts = [parsed_review.summary]
+    candidate_texts.extend(disposition.note for disposition in parsed_review.dispositions)
+    return any(text and _INCOMPLETE_PR_REVIEW_RE.search(text) for text in candidate_texts)
+
+
 def _describe_pr_review_outcome(parsed_review: ParsedReview, *, has_blocking_summary: bool) -> str:
     if parsed_review.state == "approved":
         return "approved"
@@ -4502,6 +4528,20 @@ def run_pr_loop(
                     )
                     parsed_review = dataclasses_replace(parsed_review, state="approved", blocking_items=())
                     review_state = parsed_review.state
+
+                if _is_incomplete_pr_review(parsed_review):
+                    log(
+                        config,
+                        f"Round {round_number}: {reviewer_name} did not complete its PR review "
+                        "and reported no actionable blocking items or Same-PR follow-ups; "
+                        "stopping without a coder follow-up",
+                    )
+                    raise AgentLoopError(
+                        f"{reviewer_name} did not complete PR review and reported no actionable "
+                        "blocking items or Same-PR follow-ups. This is a reviewer-internal error; "
+                        "agent-loop stopped before a coder follow-up. Rerun or switch the reviewer/model "
+                        "after resolving the reviewer environment."
+                    )
 
                 for disposition in parsed_review.dispositions:
                     _record_prior_item_disposition(

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -2341,6 +2341,34 @@ def test_pr_loop_carries_prior_item_notes_without_creating_duplicate_blocker_ite
     assert "Codex: include API error path too" in second_coder_prompt
     assert "[item-2]" not in second_coder_prompt
 
+def test_pr_loop_stops_on_incomplete_review_without_coder_followup(tmp_path):
+    """An explicit inability to review is an agent failure, not a new blocker."""
+    runner = FakeRunner(
+        codex_outputs=[
+            "Needs regression coverage.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+            "Review incomplete; item-1 requires further inspection of the PR diff "
+            "and referenced files before a disposition can be confirmed."
+            + prior_item_dispositions(
+                "[item-1] still blocking: Resolution could not be confirmed; "
+                "PR diff and referenced files need review."
+            )
+            + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        ],
+        claude_outputs=[
+            "Added regression coverage.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=3)
+
+    with pytest.raises(AgentLoopError, match="reviewer-internal error"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    coder_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(coder_commands) == 1
+    assert len(runner.comments) == 2
+    assert "Review incomplete" not in "\n".join(runner.comments)
+
+
 def test_pr_loop_posts_human_readable_item_labels_in_new_and_prior_sections(tmp_path):
     runner = FakeRunner(
         claude_outputs=[


### PR DESCRIPTION
## Summary
- classify explicit review-incomplete responses with no actionable findings as reviewer failures
- stop before recording synthetic blockers, posting a misleading review, or invoking the coder
- cover the PR #461 review-incomplete pattern with a regression test

## Verification
- PYTHONPATH=src /home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_protocol.py tests/test_prompts.py tests/test_orchestrator_pr.py -q