### PR TITLE
Handle unavailable reviewers without fake blockers

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -113,6 +113,7 @@ from .prompts import (
     render_coder_human_requirements_prompt_context,
 )
 from .protocol import (
+    AgentUnavailable,
     ApprovedFollowups,
     DISCUSS_FAILED_OUTCOME,
     DISCUSS_RESEARCH_TARGET_VALUES,
@@ -144,6 +145,7 @@ from .protocol import (
     is_clarification_request,
     parse_human_requirements_acknowledgement,
     parse_agent_state,
+    parse_agent_unavailable,
     parse_plan_review,
     parse_plan_review_items,
     parse_plan_state,
@@ -415,6 +417,23 @@ class ValidatedAgentResponse:
     # Model the agent actually ran, for the dynamic signature (#332). Carried from
     # AgentResult.model_used so the orchestrator render sites can stamp it.
     model_used: str | None = None
+
+
+class _AgentUnavailableResponse(AgentLoopError):
+    """Internal control flow for a validated agent-unavailable envelope."""
+
+    def __init__(self, unavailable: AgentUnavailable) -> None:
+        self.unavailable = unavailable
+        super().__init__(unavailable.summary)
+
+
+def _capture_agent_invocation(
+    invoke: Callable[[], ValidatedAgentResponse],
+) -> tuple[ValidatedAgentResponse | None, AgentInvocationError | None]:
+    try:
+        return invoke(), None
+    except AgentInvocationError as exc:
+        return None, exc
 
 
 @dataclass(frozen=True)
@@ -1220,6 +1239,11 @@ def _failure_suggestion(
     combined = f"{reason} {classification_text}"
     if category == "unsupported_model":
         return _unsupported_model_suggestion(unsupported_model_diagnostic)
+    if category == "agent-unavailable":
+        return (
+            "Suggestion: resolve the reported agent environment/provider/tooling problem, "
+            "or switch that agent/model before re-running."
+        )
     if category == "transient":
         if _QUOTA_RATE_LIMIT_RE.search(combined):
             return (
@@ -1307,6 +1331,8 @@ def _format_invalid_agent_response_error(
         category_hint = " Failure category: deterministic (may require a code fix)."
     elif category == "timeout":
         category_hint = " Failure category: timeout (the agent exceeded the configured time limit)."
+    elif category == "agent-unavailable":
+        category_hint = " Failure category: agent-unavailable (the agent explicitly could not continue)."
     if not classification_text:
         classification_text = (result.raw_output or result.text or "") if result is not None else ""
     unsupported_model_diagnostic = None
@@ -1832,6 +1858,9 @@ def _run_validated_agent(
                 else None
             )
             try:
+                unavailable = parse_agent_unavailable(text)
+                if unavailable is not None:
+                    raise _AgentUnavailableResponse(unavailable)
                 marker_value = validate(text)
                 if response_file_pre_status == "leading-public-response-marker-recovered":
                     log(
@@ -1839,6 +1868,21 @@ def _run_validated_agent(
                         f"{agent_name}: response file contained stdout filtering marker and "
                         "validated after stripping it",
                     )
+            except _AgentUnavailableResponse as exc:
+                unavailable = exc.unavailable
+                last_error = (
+                    f"agent explicitly reported it cannot continue ({unavailable.category}): "
+                    f"{unavailable.summary}. Suggested action: {unavailable.suggested_action}"
+                )
+                classification_text = text
+                last_classification_text = classification_text
+                last_failure_category = "agent-unavailable"
+                should_retry = unavailable.retryable
+                log(
+                    config,
+                    f"{agent_name}: explicitly reported agent-unavailable "
+                    f"({unavailable.category}, retryable={'yes' if unavailable.retryable else 'no'})",
+                )
             except AgentLoopError as exc:
                 last_error = str(exc)
                 classification_text = _agent_failure_classification_text(result, phase="validation")
@@ -2617,6 +2661,41 @@ def _describe_pr_review_outcome(parsed_review: ParsedReview, *, has_blocking_sum
     if has_same_pr:
         return "blocking with same-PR follow-ups"
     return "blocking with blocking findings"
+
+
+def _format_incomplete_pr_review_comment(
+    *,
+    pr_number: int,
+    unavailable_reviewers: Mapping[AgentName, AgentInvocationError],
+    approved_reviewer_names: Sequence[str],
+) -> str:
+    lines = [
+        "**Review status: Incomplete**",
+        "",
+        "No coder follow-up was started for the unavailable reviewer(s). "
+        "Their failure is not a code finding and does not count as approval.",
+        "",
+        "### Missing required reviewer input",
+    ]
+    for reviewer, failure in unavailable_reviewers.items():
+        category = failure.failure_category or "unknown"
+        lines.append(f"- {agent_display_name(reviewer)}: {category}")
+    if approved_reviewer_names:
+        lines.extend(
+            [
+                "",
+                "### Healthy reviewer approvals",
+                *[f"- {name}" for name in approved_reviewer_names],
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "Resolve the reviewer problem or rerun with a replacement reviewer/model "
+            f"before merging PR #{pr_number}.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
@@ -4407,6 +4486,7 @@ def run_pr_loop(
         validate_open_pr(runner, config=config, pr_number=pr_number)
         memory = prepare_agent_memory(runner, config)
         reviewer_session_ids: dict[AgentName, str | None] = {}
+        unavailable_reviewer_failures: dict[AgentName, AgentInvocationError] = {}
         configured_reviewers = reviewers(config)
         unresolved_items: list[UnresolvedReviewItem] = []
         pr_compact_prior_summaries: list[str] = []
@@ -4507,6 +4587,13 @@ def run_pr_loop(
                 )
             for reviewer in (() if skip_reviewers_for_recovery else configured_reviewers):
                 reviewer_name = agent_display_name(reviewer)
+                if reviewer in unavailable_reviewer_failures:
+                    log(
+                        config,
+                        f"Round {round_number}: skipping unavailable reviewer {reviewer_name}; "
+                        "it already exhausted its retry budget in this run",
+                    )
+                    continue
                 resumed_record = resumed_by_name.get(reviewer_name)
                 carried_approval_record: PostedRoundRecord | None = None
                 if resumed_record is not None:
@@ -4571,51 +4658,74 @@ def run_pr_loop(
                         if use_compact_pr_context
                         else None
                     )
-                    review_response = _run_validated_agent(
-                        runner,
-                        agent=reviewer,
-                        config=config,
-                        prompt=build_review_prompt(
-                            pr_number,
-                            round_number,
-                            config,
-                            reviewer=reviewer,
-                            pr_metadata=pr_metadata,
-                            pr_checks=reviewer_pr_checks,
-                            memory=memory,
-                            issue_context=issue_context,
-                            human_requirements=human_requirements,
-                            unresolved_items=prior_unresolved_items,
-                            compact_context=use_compact_pr_context,
-                            compact_prior=(
-                                CompactPriorContext(tuple(pr_compact_prior_summaries))
-                                if use_compact_pr_context
-                                else None
+                    review_response, review_failure = _capture_agent_invocation(
+                        lambda: _run_validated_agent(
+                            runner,
+                            agent=reviewer,
+                            config=config,
+                            prompt=build_review_prompt(
+                                pr_number,
+                                round_number,
+                                config,
+                                reviewer=reviewer,
+                                pr_metadata=pr_metadata,
+                                pr_checks=reviewer_pr_checks,
+                                memory=memory,
+                                issue_context=issue_context,
+                                human_requirements=human_requirements,
+                                unresolved_items=prior_unresolved_items,
+                                compact_context=use_compact_pr_context,
+                                compact_prior=(
+                                    CompactPriorContext(tuple(pr_compact_prior_summaries))
+                                    if use_compact_pr_context
+                                    else None
+                                ),
+                                compact_tail=compact_tail,
+                                compact_coder_summary=compact_coder_summary,
+                                compact_coder_tests_run=compact_coder_tests_run,
                             ),
-                            compact_tail=compact_tail,
-                            compact_coder_summary=compact_coder_summary,
-                            compact_coder_tests_run=compact_coder_tests_run,
-                        ),
-                        session_id=None if use_compact_pr_context else reviewer_session_ids.get(reviewer),
-                        marker_description="<!-- AGENT_STATE: approved|blocking -->",
-                        validate=lambda text, reviewer_name=reviewer_name, items=prior_unresolved_items: _validate_review_response(
-                            text,
-                            reviewer=reviewer_name,
-                            unresolved_items=items,
-                            current_round_items=round_new_unresolved_items,
-                        ),
-                        usage_context=usage_context,
-                        use_repair=True,
-                        repair_expected_kind="pr_review",
-                        repair_reviewer_requirement_ids=_surfaced_reviewer_requirement_ids(
-                            human_requirements,
-                            requirement_scope="PR requirements",
-                        ),
-                        repair_allowed_prior_item_ids=tuple(item.item_id for item in prior_unresolved_items),
-                        ledger_incomplete=round_ledger_incomplete,
-                        role="reviewer",
-                        operation_description="PR review",
+                            session_id=(
+                                None
+                                if use_compact_pr_context
+                                else reviewer_session_ids.get(reviewer)
+                            ),
+                            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                            validate=lambda text, reviewer_name=reviewer_name, items=prior_unresolved_items: _validate_review_response(
+                                text,
+                                reviewer=reviewer_name,
+                                unresolved_items=items,
+                                current_round_items=round_new_unresolved_items,
+                            ),
+                            usage_context=usage_context,
+                            use_repair=True,
+                            repair_expected_kind="pr_review",
+                            repair_reviewer_requirement_ids=_surfaced_reviewer_requirement_ids(
+                                human_requirements,
+                                requirement_scope="PR requirements",
+                            ),
+                            repair_allowed_prior_item_ids=tuple(
+                                item.item_id for item in prior_unresolved_items
+                            ),
+                            ledger_incomplete=round_ledger_incomplete,
+                            role="reviewer",
+                            operation_description="PR review",
+                        )
                     )
+                    if review_failure is not None:
+                        if (
+                            len(configured_reviewers) == 1
+                            or review_failure.failure_category in {None, "deterministic"}
+                        ):
+                            raise review_failure
+                        unavailable_reviewer_failures[reviewer] = review_failure
+                        category = review_failure.failure_category or "unknown"
+                        log(
+                            config,
+                            f"Round {round_number}: {reviewer_name} became unavailable "
+                            f"({category}); continuing with the remaining reviewers",
+                        )
+                        continue
+                    assert review_response is not None
                     review_output = review_response.text
                     review_model_used = review_response.model_used
                     reviewer_session_ids[reviewer] = review_response.session_id
@@ -4647,18 +4757,25 @@ def run_pr_loop(
                     review_state = parsed_review.state
 
                 if _is_incomplete_pr_review(parsed_review):
+                    if len(configured_reviewers) == 1:
+                        raise AgentLoopError(
+                            f"{reviewer_name} did not complete PR review and reported no actionable "
+                            "blocking items or Same-PR follow-ups. This is a reviewer-internal error; "
+                            "agent-loop stopped before a coder follow-up. Rerun or switch the reviewer/model "
+                            "after resolving the reviewer environment."
+                        )
+                    unavailable_reviewer_failures[reviewer] = AgentInvocationError(
+                        f"{reviewer_name} reported an incomplete PR review without actionable "
+                        "blocking items or Same-PR follow-ups.",
+                        failure_category="agent-unavailable",
+                    )
                     log(
                         config,
                         f"Round {round_number}: {reviewer_name} did not complete its PR review "
                         "and reported no actionable blocking items or Same-PR follow-ups; "
-                        "stopping without a coder follow-up",
+                        "continuing with the remaining reviewers",
                     )
-                    raise AgentLoopError(
-                        f"{reviewer_name} did not complete PR review and reported no actionable "
-                        "blocking items or Same-PR follow-ups. This is a reviewer-internal error; "
-                        "agent-loop stopped before a coder follow-up. Rerun or switch the reviewer/model "
-                        "after resolving the reviewer environment."
-                    )
+                    continue
 
                 for disposition in parsed_review.dispositions:
                     _record_prior_item_disposition(
@@ -4987,6 +5104,30 @@ def run_pr_loop(
                             must_fix_items = [
                                 item for item in unresolved_items if item.status in {"blocking", "same-pr"}
                             ]
+                if not must_fix_items and unavailable_reviewer_failures:
+                    approved_reviewer_names = [
+                        reviewer_name for reviewer_name, _review_output in approved_review_outputs
+                    ]
+                    post_pr_comment(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        body=_format_incomplete_pr_review_comment(
+                            pr_number=pr_number,
+                            unavailable_reviewers=unavailable_reviewer_failures,
+                            approved_reviewer_names=approved_reviewer_names,
+                        ),
+                    )
+                    missing = ", ".join(
+                        agent_display_name(reviewer)
+                        for reviewer in unavailable_reviewer_failures
+                    )
+                    healthy = ", ".join(approved_reviewer_names) or "(none)"
+                    raise AgentLoopError(
+                        f"PR #{pr_number} review incomplete: missing required input from {missing}. "
+                        f"Healthy reviewers approved: {healthy}. No coder follow-up or merge was attempted."
+                    )
+
                 sync_coder_pr_before_validation(config, runner, pr_number, pr_metadata)
                 migration_validation = validate_pr_migration_topology(
                     runner,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -987,6 +987,7 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_memory_block(memory)}
 {_salvage_summary_block(salvage_summary)}
 
+{_agent_unavailable_guidance(coder_signature)}
 Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
 you create the PR. Use blocking here to hand the PR to {reviewer_name} for review. If you cannot
 safely proceed and cannot create a PR, explain the blocker and end with `AGENT_STATE: blocking`

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -504,10 +504,29 @@ reason that you explicitly accept before approving.
 """ if require_plan_dispositions else "")
 
 
+def _agent_unavailable_guidance(signature: str) -> str:
+    return f"""If an internal environment, permission, provider, or tooling problem makes it impossible to complete this assigned operation after safe recovery attempts, do not invent a blocking code finding or claim approval. Return this instead of the normal response schema:
+
+{{
+  "schema_version": 1,
+  "kind": "agent_unavailable",
+  "retryable": false,
+  "category": "environment|permissions|provider|tooling|unknown",
+  "summary": "concise description of what prevented completion",
+  "suggested_action": "specific operator action"
+}}
+<!-- AGENT_UNAVAILABLE -->
+-- {signature}
+
+Use `retryable: true` only when a fresh invocation may succeed without changing code or configuration. This is an agent-operational failure, not review feedback; do not use it for a genuine code blocker, a request for clarification, or a normal disagreement.
+"""
+
+
 def _structured_coder_followup_guidance(
     *,
     reviewer_name: str,
     human_requirements_context: CoderHumanRequirementsPromptContext,
+    coder_signature: str,
 ) -> str:
     example_human_requirement_ids = (
         list(human_requirements_context.surfaced_requirement_ids[:1])
@@ -543,6 +562,7 @@ def _structured_coder_followup_guidance(
         "Use `addressed_items`, `remaining_items`, and `disputed_items` to classify every unresolved reviewer item ID shown in this prompt. Do not omit any listed reviewer item ID and do not list any item ID more than once.",
         "Use `addressed_item_notes` to summarize how each addressed item was resolved, and use `remaining_item_notes` to give a visible reason for each intentionally deferred remaining item.",
         "Use `disputed_items` when a reviewer claim is factually incorrect (wrong pricing, stale diff reading, incorrect behavior assumption) and you have verifiable counter-evidence. Put the item ID in `disputed_items` instead of `addressed_items` or `remaining_items`, and record your evidence in `dispute_evidence`. The reviewer will get one more turn to reconsider with your evidence attached. If the reviewer still blocks after seeing the evidence, the orchestrator will surface the disagreement to a human for resolution.",
+        _agent_unavailable_guidance(coder_signature),
     ]
     if human_requirements_context.surfaced_requirement_ids:
         surfaced = ", ".join(f"`{item}`" for item in human_requirements_context.surfaced_requirement_ids)
@@ -1042,6 +1062,7 @@ prose between the JSON object and footer.
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
 
+{_agent_unavailable_guidance(coder_signature)}
 Do not wait for {reviewer_name} yourself; this local orchestrator will run
 {reviewer_name} to review the plan. Use blocking to hand the plan to {reviewer_name}
 for review. If the issue is materially ambiguous before a useful plan can be written,
@@ -1173,7 +1194,7 @@ them forward explicitly.
 Signed human issue requirements are approval-critical issue constraints for this
 plan review.
 {human_requirements_guidance}
-{_phased_plan_guard(config)}Use blocking only when the current plan still has blocking plan issues or
+{_phased_plan_guard(config)}{_agent_unavailable_guidance(reviewer_signature)}Use blocking only when the current plan still has blocking plan issues or
 same-plan follow-ups. All configured reviewers ({reviewer_group}) must approve
 in the same planning round before implementation can proceed.
 Use approved only if there are no blocking plan issues, no Same-plan
@@ -1271,6 +1292,7 @@ Current implementation plan from {coder_name}:
 
 {plan}
 
+{_agent_unavailable_guidance(reviewer_signature)}
 All configured reviewers ({reviewer_group}) must approve in the same planning
 round before implementation can proceed. Use approved only if there are no
 blocking plan issues, no Same-plan follow-ups, and no carried-forward plan
@@ -1416,6 +1438,7 @@ Previous plan:
 
 {review}
 
+{_agent_unavailable_guidance(coder_signature)}
 Revise the plan item by item instead of replying only with free-form prose. If
 prior unresolved plan items are listed above, include this exact section in
 your response and address each item ID exactly once:
@@ -1582,6 +1605,7 @@ Approved implementation plan:
 
 {approved_plan}
 
+{_agent_unavailable_guidance(coder_signature)}
 Do not wait for {reviewer_name} yourself; this local orchestrator will run
 {reviewer_name} after you create the PR. Use blocking here to hand the PR to
 {reviewer_name} for review. If you cannot safely proceed and cannot create a
@@ -1632,6 +1656,7 @@ Use this local checkout as your workspace. Decide between two paths:
     the implementation, do NOT write code. Instead, ask focused clarifying
     questions.
 
+{_agent_unavailable_guidance(coder_signature)}
 Prefer (a) when reasonable assumptions can be documented in the PR description;
 choose (b) only for material ambiguity. Do not place your signature before the
 AGENT_STATE or AGENT_CLARIFY marker. Your response must end with, in this exact
@@ -1675,6 +1700,7 @@ again if a critical detail is still missing.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
 
+{_agent_unavailable_guidance(coder_signature)}
 Do not place your signature before the AGENT_STATE or AGENT_CLARIFY marker.
 Your response must end with, in this exact order:
 
@@ -1939,6 +1965,7 @@ available, or produce a blocking review explaining the limitation.
 Reviewer: {reviewer_name}
 Action for this call: {action}
 
+{_agent_unavailable_guidance(reviewer_signature)}
 Use blocking only for issues that should prevent merge. Do not place your
 signature before the AGENT_STATE footer. Your response must end with, in this
 exact order:
@@ -2172,6 +2199,7 @@ also listed in the active `Prior unresolved review items from earlier rounds`
 section above.
 {unresolved_items_guidance}
 {followup_guidance}
+{_agent_unavailable_guidance(reviewer_signature)}
 Use blocking only for issues that should prevent merge.
 All configured reviewers ({reviewer_group}) must approve in the same round for
 the pull request to be considered approved.
@@ -2261,6 +2289,7 @@ Do not create a new PR.
 {_structured_coder_followup_guidance(
     reviewer_name=reviewer_name,
     human_requirements_context=human_requirements_context,
+    coder_signature=coder_signature,
 )}This is round {round_number}. Use blocking to hand the updated PR back to {reviewer_name}.
 If you cannot safely address the review, explain why and still use the blocking
 marker so a human can intervene. Do not place your signature before the
@@ -2309,6 +2338,7 @@ Same-PR follow-ups:
 {_structured_coder_followup_guidance(
     reviewer_name=reviewer_name,
     human_requirements_context=human_requirements_context,
+    coder_signature=coder_signature,
 )}This is round {round_number}. Use blocking to hand the updated PR back to {reviewer_name}.
 If you cannot safely address the follow-ups, explain why and still use the
 blocking marker so a human can intervene. Do not place your signature before

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -22,8 +22,12 @@ PLAN_STATE_RE = re.compile(r"<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*--
 _PR_MARKER_VALUE_RE = re.compile(r"(?m)^\s*<!--\s*AGENT_PR:\s*(.*?)\s*-->\s*$", re.I)
 GH_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|$)")
 CLARIFY_RE = re.compile(r"<!--\s*AGENT_CLARIFY\s*-->", re.I)
+AGENT_UNAVAILABLE_RE = re.compile(r"<!--\s*AGENT_UNAVAILABLE\s*-->", re.I)
 # Standalone variants: marker must occupy its own line.
 _STANDALONE_CLARIFY_RE = re.compile(r"(?m)^\s*<!--\s*AGENT_CLARIFY\s*-->\s*$", re.I)
+_STANDALONE_AGENT_UNAVAILABLE_RE = re.compile(
+    r"(?m)^\s*<!--\s*AGENT_UNAVAILABLE\s*-->\s*$", re.I
+)
 _STANDALONE_STATE_RE = re.compile(r"(?m)^\s*<!--\s*AGENT_STATE:\s*(approved|blocking)\s*-->\s*$", re.I)
 _STANDALONE_PLAN_STATE_RE = re.compile(
     r"(?m)^\s*<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$", re.I
@@ -134,6 +138,23 @@ class ParsedReview:
     followups: ApprovedFollowups
     dispositions: tuple[ReviewItemDisposition, ...]
     raw_dispositions_text: str = ""
+
+
+@dataclass(frozen=True)
+class AgentUnavailable:
+    """An agent-declared inability to complete the assigned operation."""
+
+    schema_version: int
+    kind: str
+    retryable: bool
+    category: str
+    summary: str
+    suggested_action: str
+
+
+AGENT_UNAVAILABLE_CATEGORIES = frozenset(
+    {"environment", "permissions", "provider", "tooling", "unknown"}
+)
 
 
 @dataclass(frozen=True)
@@ -1106,6 +1127,74 @@ def _consume_structured_footer_and_signature(
                 f"{context_label} footer {state_marker_name} must match the payload state."
             )
     return payload
+
+
+def _consume_agent_unavailable_footer_and_signature(
+    *, payload: dict[str, object], trailing: str
+) -> dict[str, object]:
+    trailing = trailing.lstrip()
+    marker_match = _STANDALONE_AGENT_UNAVAILABLE_RE.search(trailing)
+    if marker_match is None:
+        raise AgentLoopError(
+            "Structured agent-unavailable response must place <!-- AGENT_UNAVAILABLE --> "
+            "after the JSON object."
+        )
+    if trailing[: marker_match.start()].strip():
+        raise AgentLoopError(
+            "Structured agent-unavailable response may not include prose between the JSON object "
+            "and the AGENT_UNAVAILABLE footer."
+        )
+    signature = trailing[marker_match.end() :].lstrip()
+    signature_match = re.match(r"^--\s+\S[^\n]*(?:\n)?$", signature)
+    if signature_match is None or signature[signature_match.end() :].strip():
+        raise AgentLoopError(
+            "Structured agent-unavailable response may not include trailing prose after "
+            "the footer and signature."
+        )
+    return payload
+
+
+def parse_agent_unavailable(text: str) -> AgentUnavailable | None:
+    """Parse the shared, terminal agent-unavailable response envelope."""
+    text, _status = normalize_response_file_structured_text(text)
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    if payload.get("kind") != "agent_unavailable":
+        return None
+    _consume_agent_unavailable_footer_and_signature(payload=payload, trailing=trailing)
+    _require_supported_schema_version(payload)
+    _expect_exact_keys(
+        payload,
+        context="agent_unavailable",
+        required={
+            "schema_version",
+            "kind",
+            "retryable",
+            "category",
+            "summary",
+            "suggested_action",
+        },
+    )
+    category = _expect_non_empty_string(
+        payload["category"], context="agent_unavailable.category"
+    )
+    if category not in AGENT_UNAVAILABLE_CATEGORIES:
+        allowed = ", ".join(sorted(AGENT_UNAVAILABLE_CATEGORIES))
+        raise AgentLoopError(
+            f"agent_unavailable.category must be one of: {allowed}."
+        )
+    return AgentUnavailable(
+        schema_version=_expect_int(payload["schema_version"], context="schema_version"),
+        kind="agent_unavailable",
+        retryable=_expect_bool(payload["retryable"], context="agent_unavailable.retryable"),
+        category=category,
+        summary=_expect_non_empty_string(payload["summary"], context="agent_unavailable.summary"),
+        suggested_action=_expect_non_empty_string(
+            payload["suggested_action"], context="agent_unavailable.suggested_action"
+        ),
+    )
 
 
 def _extract_structured_pr_review_payload(text: str) -> dict[str, object] | None:

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -2598,6 +2598,89 @@ def test_pr_loop_stops_on_incomplete_review_without_coder_followup(tmp_path):
     assert "Review incomplete" not in "\n".join(runner.comments)
 
 
+def test_pr_loop_quarantines_unavailable_reviewer_while_healthy_reviewer_finishes(tmp_path):
+    unavailable = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "agent_unavailable",
+            "retryable": False,
+            "category": "environment",
+            "summary": "The review checkout cannot access the diff.",
+            "suggested_action": "Repair the reviewer sandbox before retrying it.",
+        }
+    ) + "\n<!-- AGENT_UNAVAILABLE -->\n-- OpenAI Codex"
+    runner = FakeRunner(
+        codex_outputs=[unavailable],
+        claude_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="A regression test is required.",
+                blocking_items=["Add coverage for the unavailable-reviewer path."],
+                reviewer="Anthropic Claude",
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="The healthy-reviewer finding is resolved.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                reviewer="Anthropic Claude",
+            ),
+        ],
+        gemini_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Added the requested regression coverage.",
+                addressed_items=["item-1"],
+                reviewer="Google Gemini",
+            )
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        coder="gemini",
+        reviewer=("codex", "claude"),
+        max_rounds=3,
+    )
+
+    with pytest.raises(AgentLoopError, match="missing required input from Codex"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    codex_reviews = [cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    claude_reviews = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    gemini_coder_turns = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"]]
+    assert len(codex_reviews) == 1
+    assert len(claude_reviews) == 2
+    assert len(gemini_coder_turns) == 1
+    assert "**Review status: Incomplete**" in runner.comments[-1]
+    assert "Claude" in runner.comments[-1]
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+
+
+def test_pr_loop_retries_explicit_retryable_agent_unavailable_response(tmp_path):
+    retryable_unavailable = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "agent_unavailable",
+            "retryable": True,
+            "category": "provider",
+            "summary": "The provider returned a temporary unavailable response.",
+            "suggested_action": "Retry the review shortly.",
+        }
+    ) + "\n<!-- AGENT_UNAVAILABLE -->\n-- OpenAI Codex"
+    runner = FakeRunner(
+        codex_outputs=[
+            retryable_unavailable,
+            structured_pr_review(reviewer="OpenAI Codex"),
+        ]
+    )
+    config = make_config(tmp_path, reviewer="codex", agent_max_retries=1)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    codex_reviews = [cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+    assert len(codex_reviews) == 2
+    assert any(cmd[:1] == ["sleep"] for cmd, _cwd in runner.commands)
+
+
 def test_pr_loop_posts_human_readable_item_labels_in_new_and_prior_sections(tmp_path):
     runner = FakeRunner(
         claude_outputs=[

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2115,6 +2115,14 @@ def test_coder_prompt_includes_documentation_reminder(tmp_path):
         assert "user-facing subcommand" in prompt
 
 
+def test_issue_prompt_includes_agent_unavailable_guidance(tmp_path):
+    prompt = build_issue_prompt(1, make_config(tmp_path))
+
+    assert '"kind": "agent_unavailable"' in prompt
+    assert "<!-- AGENT_UNAVAILABLE -->" in prompt
+    assert "do not invent a blocking code finding or claim approval" in prompt
+
+
 def test_reviewer_prompt_includes_documentation_check(tmp_path):
     config = make_config(tmp_path, reviewer=("codex",))
     phrase = "Flag missing or stale documentation as a blocking item"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -36,6 +36,7 @@ from coding_review_agent_loop.protocol import (
     _extract_structured_plan_revision_payload,
     _extract_structured_pr_review_payload,
     normalize_response_file_structured_text,
+    parse_agent_unavailable,
     parse_approved_followups,
     parse_human_requirements_acknowledgement,
     parse_pr_review,
@@ -1697,6 +1698,29 @@ def test_parse_structured_pr_review_strips_verdict_and_sections_from_json_summar
 
     assert parsed is not None
     assert parsed.summary == "Need one more regression test."
+
+
+def test_parse_agent_unavailable_requires_terminal_envelope():
+    payload = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "agent_unavailable",
+                "retryable": False,
+                "category": "permissions",
+                "summary": "The review sandbox cannot read the assigned checkout.",
+                "suggested_action": "Grant read access and rerun the reviewer.",
+            }
+        )
+        + "\n<!-- AGENT_UNAVAILABLE -->\n-- OpenAI Codex"
+    )
+
+    parsed = parse_agent_unavailable(payload)
+
+    assert parsed is not None
+    assert parsed.retryable is False
+    assert parsed.category == "permissions"
+    assert parse_agent_unavailable(structured_pr_review()) is None
 
 
 def test_parse_structured_pr_review_rejects_kind_mismatch():


### PR DESCRIPTION
## Summary
- add a shared structured `agent_unavailable` response for agents that cannot complete their operation
- retry an explicitly retryable unavailable response; report terminal failures with a distinct category
- quarantine unavailable PR reviewers for the rest of the run while healthy reviewers continue through blockers and fixes
- stop with a GitHub `Review status: Incomplete` comment when required reviewer input remains missing; do not auto-merge

## Verification
- `PYTHONPATH=src /home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_orchestrator_pr.py tests/test_protocol.py tests/test_prompts.py -q` (486 passed)
- `PYTHONPATH=src /home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_agent_loop.py tests/test_orchestrator_issue.py tests/test_prompts.py tests/test_response_validation.py -q` (466 passed)
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m compileall -q src/coding_review_agent_loop`