### PR TITLE
Apply incomplete-review heuristic to the plan review flow

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2698,6 +2698,24 @@ def _format_incomplete_pr_review_comment(
     return "\n".join(lines)
 
 
+def _is_incomplete_plan_review(parsed_review: ParsedPlanReview) -> bool:
+    """Identify a plan reviewer failure reported as a blocking verdict.
+
+    Mirrors `_is_incomplete_pr_review` for the plan review flow: a reviewer
+    occasionally returns a syntactically valid blocking response that only
+    says it could not inspect the plan or confirm a prior item. That is not
+    actionable feedback for the coder. Keep this deliberately narrow so
+    substantive freeform blocking summaries retain their existing behavior.
+    """
+    if parsed_review.state != "blocking":
+        return False
+    if parsed_review.items.blocking or parsed_review.items.same_plan:
+        return False
+    candidate_texts = [parsed_review.summary]
+    candidate_texts.extend(disposition.note for disposition in parsed_review.dispositions)
+    return any(text and _INCOMPLETE_PR_REVIEW_RE.search(text) for text in candidate_texts)
+
+
 def _describe_plan_review_outcome(parsed_review: ParsedPlanReview) -> str:
     if parsed_review.state == "approved":
         return "approved"
@@ -3415,7 +3433,11 @@ def _run_plan_first_loop(
                 )
                 parsed_review = ParsedPlanReview(
                     state=resumed_record.metadata.state or parse_plan_state(review_output),
-                    summary=review_freeform_summary_text(review_output),
+                    summary=(
+                        structured_review.summary
+                        if structured_review is not None
+                        else review_freeform_summary_text(review_output)
+                    ),
                     items=(
                         structured_review.items
                         if structured_review is not None
@@ -3494,6 +3516,21 @@ def _run_plan_first_loop(
                 )
                 review_state = parsed_review.state
                 reviewer_new_unresolved_items = []
+
+            if _is_incomplete_plan_review(parsed_review):
+                log(
+                    config,
+                    f"Planning round {round_number}: {reviewer_name} did not complete its plan review "
+                    "and reported no actionable blocking plan issues or Same-Plan follow-ups; "
+                    "stopping without a coder follow-up",
+                )
+                raise AgentLoopError(
+                    f"{reviewer_name} did not complete plan review and reported no actionable "
+                    "blocking plan issues or Same-Plan follow-ups. This is a reviewer-internal error; "
+                    "agent-loop stopped before a coder follow-up. Rerun or switch the reviewer/model "
+                    "after resolving the reviewer environment."
+                )
+
             log(
                 config,
                 "Planning round "

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -20,7 +20,13 @@ from coding_review_agent_loop.prompts import (
     COMPACT_PLANNING_VOLATILE_TAIL_MARKER,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
 )
-from coding_review_agent_loop.protocol import UnresolvedReviewItem
+from coding_review_agent_loop.protocol import (
+    ApprovedFollowup,
+    ParsedPlanReview,
+    PlanReviewItems,
+    ReviewItemDisposition,
+    UnresolvedReviewItem,
+)
 from coding_review_agent_loop.salvage import (
     SalvageContext,
     capture_salvage_artifacts,
@@ -457,6 +463,159 @@ def test_issue_loop_plan_first_revises_until_all_reviewers_approve(tmp_path):
     config = make_config(tmp_path)
 
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+def test_issue_loop_plan_first_stops_on_incomplete_review_without_coder_followup(tmp_path):
+    """An explicit inability to review is an agent failure, not a new blocker."""
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(summary="Initial plan."),
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Review incomplete; unable to verify the retry path without further inspection.",
+            ),
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=3)
+
+    with pytest.raises(AgentLoopError, match="reviewer-internal error"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 1
+    assert "Review incomplete" not in "\n".join(runner.comments)
+
+def test_issue_loop_plan_first_resume_ignores_incomplete_wording_outside_summary(tmp_path):
+    """A resumed structured review must be scanned the same way a fresh one is.
+
+    Before the resumed-branch summary reconstruction fix, `summary` was
+    rebuilt from the raw (unrendered) response text even when a structured
+    review had already been parsed, so incomplete-review wording living in an
+    unrelated field (here, `future_followups`) could leak into the summary
+    candidate text and falsely trip the incomplete-review heuristic only
+    after a resume.
+    """
+    round1_plan = "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    coder_round1_comment = _attach_round_metadata(
+        round1_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=1,
+            subject=_plan_subject(round1_plan),
+        ),
+    )
+    resumed_reviewer_comment = _attach_round_metadata(
+        structured_plan_review(
+            state="blocking",
+            summary="Reviewed the updated plan; still recommend revisiting the retry approach later.",
+            future_followups=["Could not confirm the retry path in CI end-to-end; revisit later."],
+        ),
+        PostedRoundMetadata(
+            flow="plan",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject=_plan_subject(round1_plan),
+            state="blocking",
+        ),
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:00:00Z", "body": coder_round1_comment},
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:05:00Z", "body": resumed_reviewer_comment},
+        ],
+        claude_outputs=[structured_plan_revision(summary="Revised plan addressing round 1 feedback.")],
+        codex_outputs=[structured_plan_review(summary="Plan looks sound now.")],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer=("codex",), max_rounds=3)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 1
+
+def test_issue_loop_plan_first_resume_stops_on_incomplete_review_in_summary(tmp_path):
+    """Genuine incomplete-review wording must still be caught after a resume."""
+    round1_plan = "Initial plan.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    coder_round1_comment = _attach_round_metadata(
+        round1_plan,
+        PostedRoundMetadata(
+            flow="plan",
+            role="coder",
+            agent="Claude",
+            round_number=1,
+            subject=_plan_subject(round1_plan),
+        ),
+    )
+    resumed_reviewer_comment = _attach_round_metadata(
+        structured_plan_review(
+            state="blocking",
+            summary="Review incomplete; unable to confirm the retry path without further inspection.",
+        ),
+        PostedRoundMetadata(
+            flow="plan",
+            role="reviewer",
+            agent="Codex",
+            round_number=1,
+            subject=_plan_subject(round1_plan),
+            state="blocking",
+        ),
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:00:00Z", "body": coder_round1_comment},
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:05:00Z", "body": resumed_reviewer_comment},
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer=("codex",), max_rounds=3)
+
+    with pytest.raises(AgentLoopError, match="reviewer-internal error"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 0
+
+@pytest.mark.parametrize(
+    ("state", "blocking", "same_plan", "summary", "expected"),
+    [
+        ("blocking", (), (), "Unable to verify the plan without more context.", True),
+        (
+            "blocking",
+            (ApprovedFollowup(reviewer="Codex", text="Add a migration step."),),
+            (),
+            "Unable to verify the plan without more context.",
+            False,
+        ),
+        ("approved", (), (), "Unable to verify the plan without more context.", False),
+    ],
+)
+def test_is_incomplete_plan_review(state, blocking, same_plan, summary, expected):
+    parsed_review = ParsedPlanReview(
+        state=state,
+        summary=summary,
+        items=PlanReviewItems(blocking=blocking, same_plan=same_plan, future=()),
+        dispositions=(),
+    )
+    assert orchestrator_module._is_incomplete_plan_review(parsed_review) is expected
+
+def test_is_incomplete_plan_review_matches_disposition_note():
+    parsed_review = ParsedPlanReview(
+        state="blocking",
+        summary="",
+        items=PlanReviewItems(blocking=(), same_plan=(), future=()),
+        dispositions=(
+            ReviewItemDisposition(
+                item_id="item-1",
+                reviewer="Codex",
+                disposition="still blocking",
+                note="Resolution could not be confirmed; plan and referenced files need review.",
+            ),
+        ),
+    )
+    assert orchestrator_module._is_incomplete_plan_review(parsed_review) is True
 
 def test_issue_loop_structured_plan_state_public_comment_renders_markdown_and_preserves_metadata(tmp_path):
     raw_structured_plan = structured_plan_state(


### PR DESCRIPTION
## Summary
- Ports `_is_incomplete_pr_review` (added for the PR review flow in #575) to the plan review flow as `_is_incomplete_plan_review`: a plan reviewer that returns a syntactically valid `blocking` verdict with no blocking/same-plan items and only "review incomplete"/"could not verify" style prose is now treated as a reviewer-internal `AgentLoopError`, not a new blocking round — matching PR review behavior for consistency.
- Fixes a pre-existing bug found during plan review by Codex: in the resumed branch of `run_issue_loop`, `ParsedPlanReview.summary` was reconstructed from the raw comment text via `review_freeform_summary_text(review_output)` even when a structured review had already been parsed. That meant a resumed structured review's "summary" could pick up unrelated raw content (e.g. a `future_followups` entry), which would have caused the new heuristic to false-positive only after a resume. Fixed to reuse `structured_review.summary` when available, mirroring the existing `items` handling two lines below.
- `_is_pending_ci_only_review` is intentionally left PR-only, since it depends on `PullRequestChecks`/CI state that doesn't exist during plan review.
- No multi-reviewer quarantine/graceful-degradation was added for the plan flow — that infrastructure doesn't exist for plan reviews today (reviewers are invoked directly via `_run_validated_agent`, not the try/except pattern `run_pr_loop` uses), and adding it is out of scope for this consistency follow-up.

## Test plan
- [x] `python3 -m pytest tests/test_orchestrator_issue.py -q` — 93 passed, including 6 new tests: a fresh-path incomplete-review stop, a resumed-path false-positive regression (verified it fails without the summary-reconstruction fix), a resumed-path true-positive regression, a parametrized unit test for `_is_incomplete_plan_review`, and a disposition-note unit test.
- [x] `python3 -m pytest tests/ -q` — 1570 passed.

Fixes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)