### PR TITLE
Avoid E2BIG for long Claude prompts

### DIFF
--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -20,6 +20,9 @@ from ..usage import UsageMetadata, coerce_int, first_present
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
+
+_STDIN_PROMPT_THRESHOLD_BYTES = 100_000
+
 def _normalize_claude_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
         return None
@@ -119,7 +122,14 @@ class ClaudeBackend:
             args += ["--model", config.claude_model]
         if session_id:
             args += ["--resume", session_id]
-        args.append(with_public_response_file_instruction(prompt, response_path))
+        prompt_with_response_instruction = with_public_response_file_instruction(prompt, response_path)
+        input_text = None
+        if len(prompt_with_response_instruction.encode("utf-8")) > _STDIN_PROMPT_THRESHOLD_BYTES:
+            # Linux limits a single exec argument to about 128 KiB. Long compact
+            # contexts can exceed that before the Claude CLI is launched.
+            input_text = prompt_with_response_instruction
+        else:
+            args.append(prompt_with_response_instruction)
         log_path = agent_log_path(config, "claude", run_id=run_id, label=label)
         log(config, f"Starting Claude in {config.claude_dir}; log: {log_path}; response: {response_path}")
         result = runner.run_with_log(
@@ -130,6 +140,7 @@ class ClaudeBackend:
             progress_interval_seconds=config.progress_interval_seconds,
             check=False,
             env={"AGENT_LOOP_WORKDIR": str(config.claude_dir.resolve())},
+            input_text=input_text,
             timeout_seconds=timeout_seconds,
         )
         log(config, f"Claude finished; log: {log_path}")

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -231,6 +232,7 @@ class Runner:
         progress_interval_seconds: int,
         check: bool = True,
         env: Mapping[str, str] | None = None,
+        input_text: str | None = None,
         use_pty: bool = False,
         timeout_seconds: float | None = None,
     ) -> CommandResult:
@@ -254,6 +256,7 @@ class Runner:
                 progress_interval_seconds=progress_interval_seconds,
                 check=check,
                 env=env,
+                input_text=input_text,
                 timeout_seconds=timeout_seconds,
             )
         started = time.monotonic()
@@ -268,52 +271,64 @@ class Runner:
             # so stderr capture is uniform across them (issue #266).
             # start_new_session isolates the child's process group so timeout
             # and interrupt handling can killpg the whole tree (#475).
-            proc = self._spawn_with_retry(
-                cmd,
-                lambda: subprocess.Popen(
+            # A regular file keeps large prompts out of argv and avoids blocking
+            # on a pipe before a child has started consuming stdin.
+            with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as input_file:
+                if input_text is not None:
+                    input_file.write(input_text)
+                    input_file.seek(0)
+
+                def spawn() -> subprocess.Popen[str]:
+                    if input_text is not None:
+                        input_file.seek(0)
+                    return subprocess.Popen(
+                        cmd,
+                        cwd=cwd,
+                        stdin=input_file if input_text is not None else subprocess.DEVNULL,
+                        stdout=log_file,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        start_new_session=True,
+                        env={**os.environ, **env} if env is not None else None,
+                    )
+
+                proc = self._spawn_with_retry(
                     cmd,
-                    cwd=cwd,
-                    stdin=subprocess.DEVNULL,
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    start_new_session=True,
-                    env={**os.environ, **env} if env is not None else None,
-                ),
-            )
-            self._register_active_process(proc)
-            try:
-                while True:
-                    returncode = proc.poll()
-                    if returncode is not None:
-                        break
-                    now = time.monotonic()
-                    if deadline is not None and now >= deadline:
-                        # returncode=None marks the timeout for callers, matching
-                        # the pty branch.
-                        self._terminate_process_group(proc)
-                        returncode = None
-                        break
-                    if now >= next_progress:
-                        elapsed = int(now - started)
-                        print(
-                            f"[agent-loop {datetime.now().strftime('%H:%M:%S')}] "
-                            f"{label} still running ({elapsed}s); log: {log_path}",
-                            file=sys.stderr,
-                            flush=True,
-                        )
-                        next_progress = now + progress_interval_seconds
-                    if deadline is not None:
-                        time.sleep(min(1.0, max(0.05, deadline - now)))
-                    else:
-                        time.sleep(1)
-            except KeyboardInterrupt:
-                # The child runs in its own session and no longer receives the
-                # terminal SIGINT; kill its whole process group instead.
-                self._terminate_process_group(proc)
-                raise
-            finally:
-                self._unregister_active_process(proc)
+                    spawn,
+                )
+                self._register_active_process(proc)
+                try:
+                    while True:
+                        returncode = proc.poll()
+                        if returncode is not None:
+                            break
+                        now = time.monotonic()
+                        if deadline is not None and now >= deadline:
+                            # returncode=None marks the timeout for callers, matching
+                            # the pty branch.
+                            self._terminate_process_group(proc)
+                            returncode = None
+                            break
+                        if now >= next_progress:
+                            elapsed = int(now - started)
+                            print(
+                                f"[agent-loop {datetime.now().strftime('%H:%M:%S')}] "
+                                f"{label} still running ({elapsed}s); log: {log_path}",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                            next_progress = now + progress_interval_seconds
+                        if deadline is not None:
+                            time.sleep(min(1.0, max(0.05, deadline - now)))
+                        else:
+                            time.sleep(1)
+                except KeyboardInterrupt:
+                    # The child runs in its own session and no longer receives the
+                    # terminal SIGINT; kill its whole process group instead.
+                    self._terminate_process_group(proc)
+                    raise
+                finally:
+                    self._unregister_active_process(proc)
 
         full_output = log_path.read_text(encoding="utf-8")
         output = full_output[len(header):] if full_output.startswith(header) else full_output
@@ -335,6 +350,7 @@ class Runner:
         progress_interval_seconds: int,
         check: bool,
         env: Mapping[str, str] | None,
+        input_text: str | None,
         timeout_seconds: float | None = None,
     ) -> CommandResult:
         """Run a command attached to a pseudo-terminal, logging and capturing output.
@@ -348,6 +364,9 @@ class Runner:
         """
         import pty
         import select
+
+        if input_text is not None:
+            raise ValueError("stdin text is not supported for PTY-backed commands")
 
         started = time.monotonic()
         deadline = started + timeout_seconds if timeout_seconds is not None else None

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -262,7 +262,12 @@ class Runner:
         started = time.monotonic()
         deadline = started + timeout_seconds if timeout_seconds is not None else None
         next_progress = started + progress_interval_seconds
-        header = f"$ {' '.join(cmd)}\n\n"
+        header = f"$ {' '.join(cmd)}\n"
+        if input_text is not None:
+            # Preserve stdin-routed prompts in the log just as argv-routed
+            # prompts are preserved in the command header.
+            header += f"\n# stdin\n{input_text}\n"
+        header += "\n"
         with log_path.open("w", encoding="utf-8") as log_file:
             log_file.write(header)
             log_file.flush()

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -459,10 +459,10 @@ class FakeRunner(Runner):
         self.commands.append((cmd, cwd_path))
         return cmd, cwd_path
 
-    def _maybe_write_public_response_file(self, cmd):
+    def _maybe_write_public_response_file(self, cmd, *, prompt=None):
         if not self.public_response_outputs:
             return
-        prompt = "\n".join(cmd)
+        prompt = prompt or "\n".join(cmd)
         match = re.search(r"Write the final public response.*?\n\n([^\n]+/responses/[^\n]+\.md)", prompt, re.S)
         if not match:
             return
@@ -543,18 +543,21 @@ class FakeRunner(Runner):
         progress_interval_seconds,
         check=True,
         env=None,
+        input_text=None,
         use_pty=False,
         timeout_seconds=None,
     ):
         with self._scripted_lock:
+            self.last_input_text = input_text
             return self._run_with_log_locked(
                 args,
                 cwd=cwd,
                 log_path=log_path,
                 check=check,
+                input_text=input_text,
             )
 
-    def _run_with_log_locked(self, args, *, cwd, log_path, check):
+    def _run_with_log_locked(self, args, *, cwd, log_path, check, input_text=None):
         cmd, cwd_path = self._record_command(args, cwd)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_log_dir_ignored(log_path.parent)
@@ -562,8 +565,8 @@ class FakeRunner(Runner):
         if cmd[:1] == ["claude"]:
             output, returncode = self._next_agent_output(self.claude_outputs)
             if isinstance(output, str):
-                output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
-            self._maybe_write_public_response_file(cmd)
+                output = self._normalize_legacy_agent_output(output, input_text or "\n".join(cmd))
+            self._maybe_write_public_response_file(cmd, prompt=input_text)
             self._maybe_advance_git_head_for_agent_pr(output)
             self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3346,6 +3346,23 @@ def test_runner_pty_reports_tty_and_strips_ansi(tmp_path):
     assert result.returncode == 0
 
 
+def test_runner_with_log_passes_large_input_on_stdin(tmp_path):
+    import sys
+
+    prompt = "x" * 150_000
+    result = Runner().run_with_log(
+        [sys.executable, "-c", "import sys; print(len(sys.stdin.read()))"],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / "stdin.log",
+        label="Stdin probe",
+        progress_interval_seconds=999,
+        input_text=prompt,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(len(prompt))
+
+
 @pytest.mark.parametrize("use_pty", [False, True])
 def test_runner_retries_dangling_symlink_spawn_and_recovers(
     monkeypatch,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3361,6 +3361,8 @@ def test_runner_with_log_passes_large_input_on_stdin(tmp_path):
 
     assert result.returncode == 0
     assert result.stdout.strip() == str(len(prompt))
+    log_text = (tmp_path / "logs" / "stdin.log").read_text(encoding="utf-8")
+    assert f"# stdin\n{prompt}\n" in log_text
 
 
 @pytest.mark.parametrize("use_pty", [False, True])

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -403,12 +403,26 @@ def test_claude_backend_prefers_response_file_over_message_text(tmp_path):
 
     result = CLAUDE_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
 
+    assert runner.last_input_text is None
+    assert any("Review this PR." in arg for arg in runner.commands[-1][0])
     assert result.response_file_text == "response file text"
     assert result.response_file_path is not None
     assert result.response_file_path.read_text(encoding="utf-8").strip() == "response file text"
     assert result.message_text == "stdout message text"
     assert result.text == "response file text"
     assert result.session_id == "claude-session-1"
+
+
+def test_claude_backend_sends_large_prompt_on_stdin(tmp_path):
+    runner = FakeRunner(claude_outputs=[json.dumps({"result": "ok"})])
+    config = make_config(tmp_path)
+    prompt = "x" * 150_000
+
+    CLAUDE_BACKEND.run(runner, config, prompt, run_id="run-1")
+
+    assert runner.last_input_text is not None
+    assert prompt in runner.last_input_text
+    assert all(prompt not in arg for arg in runner.commands[-1][0])
 
 
 def test_gemini_backend_prefers_response_file_over_message_text(tmp_path):
@@ -747,4 +761,3 @@ def test_codex_backend_invalid_rollout_falls_back_to_declared_model(tmp_path, mo
     result = CODEX_BACKEND.run(runner, config, "Review this PR.", run_id="run-1")
 
     assert result.model_used == "gpt-5.4"
-


### PR DESCRIPTION
Pass oversized Claude prompts through stdin, add file-backed runner input support, and cover 150 KB prompt transport. Focused test suite: 292 passed.