### PR TITLE
Avoid E2BIG for long agent prompts

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -32,6 +32,7 @@ from .base import (
     AgentName,
     AgentResult,
     AgentTextSource,
+    STDIN_PROMPT_THRESHOLD_BYTES,
     public_response_path,
     read_public_response_file,
     with_public_response_file_instruction,
@@ -107,7 +108,6 @@ _REVIEWER_SETTINGS_INJECTION = {
         ]
     },
 }
-_STDIN_PROMPT_THRESHOLD_BYTES = 100_000
 _OVERSIZED_PROMPT_DIRECTIVE = (
     "Follow the complete task included in the Agent Loop Task section of GEMINI.md."
 )
@@ -211,7 +211,7 @@ class AntigravityBackend:
             prompt_text = _with_public_response_marker_instruction(
                 with_public_response_file_instruction(prompt, response_path)
             )
-            oversized_prompt = len(prompt_text.encode("utf-8")) > _STDIN_PROMPT_THRESHOLD_BYTES
+            oversized_prompt = len(prompt_text.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES
             args = [config.antigravity_cmd, "--model", model, *config.antigravity_args]
             if role in {"reviewer", "repair"}:
                 args = [a for a in args if a != "--dangerously-skip-permissions"]

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -107,6 +107,10 @@ _REVIEWER_SETTINGS_INJECTION = {
         ]
     },
 }
+_STDIN_PROMPT_THRESHOLD_BYTES = 100_000
+_OVERSIZED_PROMPT_DIRECTIVE = (
+    "Follow the complete task included in the Agent Loop Task section of GEMINI.md."
+)
 _REPAIR_SETTINGS_INJECTION = {
     "toolPermission": "strict",
     "permissions": {"allow": []},
@@ -207,6 +211,7 @@ class AntigravityBackend:
             prompt_text = _with_public_response_marker_instruction(
                 with_public_response_file_instruction(prompt, response_path)
             )
+            oversized_prompt = len(prompt_text.encode("utf-8")) > _STDIN_PROMPT_THRESHOLD_BYTES
             args = [config.antigravity_cmd, "--model", model, *config.antigravity_args]
             if role in {"reviewer", "repair"}:
                 args = [a for a in args if a != "--dangerously-skip-permissions"]
@@ -216,7 +221,7 @@ class AntigravityBackend:
             if session_id:
                 args += ["--conversation", session_id]
             # The prompt is the value of --print (must be last), not a positional.
-            args += ["--print", prompt_text]
+            args += ["--print", _OVERSIZED_PROMPT_DIRECTIVE if oversized_prompt else prompt_text]
             log_path = log_path_override or agent_log_path(
                 config, "antigravity", run_id=run_id, label=label
             )
@@ -265,6 +270,13 @@ class AntigravityBackend:
                     " in this same turn before writing your response.\n\n"
                     "---\n\n"
                 )
+            injected_gemini_prefix = single_shot_instruction
+            if oversized_prompt:
+                injected_gemini_prefix += (
+                    "# Agent Loop Task\n\n"
+                    f"{prompt_text}\n\n"
+                    "---\n\n"
+                )
             settings_path = _antigravity_settings_path()
             settings_lock_path = settings_path.with_suffix(".json.lock")
             settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -300,7 +312,7 @@ class AntigravityBackend:
                             except FileNotFoundError:
                                 existing_gemini = None
                             gemini_md_path.write_text(
-                                single_shot_instruction + (existing_gemini or ""),
+                                injected_gemini_prefix + (existing_gemini or ""),
                                 encoding="utf-8",
                             )
                             try:
@@ -322,8 +334,8 @@ class AntigravityBackend:
                             finally:
                                 if gemini_md_path.exists():
                                     current = gemini_md_path.read_text(encoding="utf-8")
-                                    if current.startswith(single_shot_instruction):
-                                        remainder = current[len(single_shot_instruction):]
+                                    if current.startswith(injected_gemini_prefix):
+                                        remainder = current[len(injected_gemini_prefix):]
                                         if remainder:
                                             gemini_md_path.write_text(remainder, encoding="utf-8")
                                         else:
@@ -348,7 +360,7 @@ class AntigravityBackend:
                         except FileNotFoundError:
                             existing_gemini = None
                         gemini_md_path.write_text(
-                            single_shot_instruction + (existing_gemini or ""),
+                            injected_gemini_prefix + (existing_gemini or ""),
                             encoding="utf-8",
                         )
                         try:
@@ -366,8 +378,8 @@ class AntigravityBackend:
                         finally:
                             if gemini_md_path.exists():
                                 current = gemini_md_path.read_text(encoding="utf-8")
-                                if current.startswith(single_shot_instruction):
-                                    remainder = current[len(single_shot_instruction):]
+                                if current.startswith(injected_gemini_prefix):
+                                    remainder = current[len(injected_gemini_prefix):]
                                     if remainder:
                                         gemini_md_path.write_text(remainder, encoding="utf-8")
                                     else:

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 AgentName = Literal["claude", "codex", "gemini", "antigravity"]
 AgentTextSource = Literal["response_file", "stdout_marker", "stdout"]
 
+# Keep prompts below Linux's per-argument exec limit; longer prompts are sent
+# through stdin or backend-specific task context instead.
+STDIN_PROMPT_THRESHOLD_BYTES = 100_000
+
 
 def normalize_agent_name(value: str) -> AgentName:
     """Normalize input-only agent aliases to their canonical names."""

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from .base import (
     AgentName,
     AgentResult,
+    STDIN_PROMPT_THRESHOLD_BYTES,
     public_response_path,
     read_public_response_file,
     with_public_response_file_instruction,
@@ -20,8 +21,6 @@ from ..usage import UsageMetadata, coerce_int, first_present
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
 
-
-_STDIN_PROMPT_THRESHOLD_BYTES = 100_000
 
 def _normalize_claude_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
@@ -124,7 +123,7 @@ class ClaudeBackend:
             args += ["--resume", session_id]
         prompt_with_response_instruction = with_public_response_file_instruction(prompt, response_path)
         input_text = None
-        if len(prompt_with_response_instruction.encode("utf-8")) > _STDIN_PROMPT_THRESHOLD_BYTES:
+        if len(prompt_with_response_instruction.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES:
             # Linux limits a single exec argument to about 128 KiB. Long compact
             # contexts can exceed that before the Claude CLI is launched.
             input_text = prompt_with_response_instruction

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from .base import (
     AgentName,
     AgentResult,
+    STDIN_PROMPT_THRESHOLD_BYTES,
     public_response_path,
     read_public_response_file,
     with_public_response_file_instruction,
@@ -33,9 +34,6 @@ _CODEX_REASONING_EFFORT_KEYS = (
     "reasoning_effort",
     "model_reasoning_effort",
 )
-_STDIN_PROMPT_THRESHOLD_BYTES = 100_000
-
-
 def _normalize_codex_usage(payload: object) -> UsageMetadata | None:
     if not isinstance(payload, dict):
         return None
@@ -247,7 +245,7 @@ class CodexBackend:
         response_path = public_response_path(config, "codex")
         prompt_with_response_file = with_public_response_file_instruction(prompt, response_path)
         input_text = None
-        if len(prompt_with_response_file.encode("utf-8")) > _STDIN_PROMPT_THRESHOLD_BYTES:
+        if len(prompt_with_response_file.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES:
             # Linux limits a single exec argument to about 128 KiB. Long compact
             # contexts can exceed that before the Codex CLI is launched.
             input_text = prompt_with_response_file

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -33,6 +33,7 @@ _CODEX_REASONING_EFFORT_KEYS = (
     "reasoning_effort",
     "model_reasoning_effort",
 )
+_STDIN_PROMPT_THRESHOLD_BYTES = 100_000
 
 
 def _normalize_codex_usage(payload: object) -> UsageMetadata | None:
@@ -245,6 +246,11 @@ class CodexBackend:
         log_path = agent_log_path(config, "codex", run_id=run_id, label=label)
         response_path = public_response_path(config, "codex")
         prompt_with_response_file = with_public_response_file_instruction(prompt, response_path)
+        input_text = None
+        if len(prompt_with_response_file.encode("utf-8")) > _STDIN_PROMPT_THRESHOLD_BYTES:
+            # Linux limits a single exec argument to about 128 KiB. Long compact
+            # contexts can exceed that before the Codex CLI is launched.
+            input_text = prompt_with_response_file
         log(
             config,
             f"Starting Codex in {config.codex_dir}; log: {log_path}; response: {response_path}",
@@ -258,9 +264,10 @@ class CodexBackend:
                     str(config.codex_dir),
                     *_codex_model_args(config),
                     *config.codex_args,
-                    prompt,
+                    *([] if input_text is not None else [prompt]),
                 ],
                 cwd=config.codex_dir,
+                input_text=input_text,
                 env={"AGENT_LOOP_WORKDIR": str(config.codex_dir.resolve())},
             )
             log(config, f"Codex finished; log: {log_path}")
@@ -289,7 +296,7 @@ class CodexBackend:
                     output_path,
                     *_codex_model_args(config),
                     *config.codex_args,
-                    prompt_with_response_file,
+                    *([] if input_text is not None else [prompt_with_response_file]),
                 ],
                 cwd=config.codex_dir,
                 log_path=log_path,
@@ -297,6 +304,7 @@ class CodexBackend:
                 progress_interval_seconds=config.progress_interval_seconds,
                 check=False,
                 env={"AGENT_LOOP_WORKDIR": str(config.codex_dir.resolve())},
+                input_text=input_text,
                 timeout_seconds=timeout_seconds,
             )
             response_file_text = read_public_response_file(response_path)

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -586,7 +586,7 @@ class FakeRunner(Runner):
                 normalized = self._normalize_legacy_agent_output(public_response, "\n".join(cmd))
                 if normalized != public_response:
                     public_response = normalized
-            self._maybe_write_public_response_file(cmd)
+            self._maybe_write_public_response_file(cmd, prompt=input_text)
             if "--output-last-message" in cmd:
                 out_path = Path(cmd[cmd.index("--output-last-message") + 1])
                 out_path.write_text(public_response, encoding="utf-8")

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -40,6 +40,32 @@ def test_antigravity_backend_stdout_fallback(tmp_path):
     assert result.text == "plain stdout review"
     assert result.text_source == "stdout"
 
+
+def test_antigravity_backend_places_large_prompt_in_injected_gemini_md(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    agy_dir = tmp_path / "antigravity"
+    agy_dir.mkdir(parents=True, exist_ok=True)
+    captured: list[str] = []
+
+    class CapturingRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            captured.append((cwd / "GEMINI.md").read_text(encoding="utf-8"))
+            return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    prompt = "x" * 150_000
+    runner = CapturingRunner(antigravity_outputs=[("ok", 0)])
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+
+    AntigravityBackend().run(runner, config, prompt, run_id="r1")
+
+    cmd = runner.commands[-1][0]
+    assert cmd[-2] == "--print"
+    assert cmd[-1] == "Follow the complete task included in the Agent Loop Task section of GEMINI.md."
+    assert all(prompt not in arg for arg in cmd)
+    assert captured and prompt in captured[0]
+    assert not (agy_dir / "GEMINI.md").exists()
+
 def test_antigravity_backend_fallback_chain_on_quota_signal(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     agy_dir = tmp_path / "antigravity"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -488,6 +488,18 @@ def test_codex_backend_prefers_response_file_over_last_message_and_stdout(tmp_pa
     assert result.usage.total_tokens == 20
 
 
+def test_codex_backend_sends_large_prompt_on_stdin(tmp_path):
+    runner = FakeRunner(codex_outputs=[{"public_response": "last message text"}])
+    config = make_config(tmp_path)
+    prompt = "x" * 150_000
+
+    CODEX_BACKEND.run(runner, config, prompt, run_id="run-1")
+
+    assert runner.last_input_text is not None
+    assert prompt in runner.last_input_text
+    assert all(prompt not in arg for arg in runner.commands[-1][0])
+
+
 def test_codex_backend_prefers_last_message_over_stdout_without_response_file(tmp_path):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -489,15 +489,19 @@ def test_codex_backend_prefers_response_file_over_last_message_and_stdout(tmp_pa
 
 
 def test_codex_backend_sends_large_prompt_on_stdin(tmp_path):
-    runner = FakeRunner(codex_outputs=[{"public_response": "last message text"}])
+    runner = FakeRunner(
+        codex_outputs=[{"public_response": "last message text"}],
+        public_response_outputs=["response file text"],
+    )
     config = make_config(tmp_path)
     prompt = "x" * 150_000
 
-    CODEX_BACKEND.run(runner, config, prompt, run_id="run-1")
+    result = CODEX_BACKEND.run(runner, config, prompt, run_id="run-1")
 
     assert runner.last_input_text is not None
     assert prompt in runner.last_input_text
     assert all(prompt not in arg for arg in runner.commands[-1][0])
+    assert result.response_file_text == "response file text"
 
 
 def test_codex_backend_prefers_last_message_over_stdout_without_response_file(tmp_path):


### PR DESCRIPTION
## Summary
- Pass oversized Codex prompts through documented stdin mode.
- Move oversized Antigravity tasks into the temporary, locked GEMINI.md injection and invoke agy with a short directive.
- Preserve normal command-line prompt behavior for ordinary prompt sizes.
- Add 150 KB regression coverage for Codex and Antigravity.

## Verification
- Focused pytest suite: 337 passed.
- git diff --check.

This prevents Linux argument-list-too-long failures in long compact planning rounds.