### PR TITLE
Record and resume the canonical issue-to-PR handoff record

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -247,14 +247,26 @@ The modes are:
   `agent-loop issue <child>`. Older decomposition summaries without this marker
   are treated as not yet handed off, so the first child handoff is recorded once.
 
-Before invoking the coder for an approved-plan implementation, the
-orchestrator also checks GitHub directly for an already-open PR that
-references the target issue, independent of any handoff marker. This closes a
-crash window that a marker-only check cannot cover: if implementation created
-a PR but the run aborted afterward — before the `AGENT_PLAN_ONE_SHOT_IMPL`
-handoff comment (or the first PR round-metadata comment) could be posted — a
-rerun still resumes PR review on that PR instead of invoking the coder again
-and creating a duplicate. If more than one open PR references the issue, the
+Before invoking a coder for an issue — in direct `agent-loop issue <n>` mode or
+approved-plan implementation alike — the orchestrator resolves the canonical
+`AGENT_ISSUE_PR_HANDOFF` record: an authoritative, machine-readable comment
+posted once an implementation PR passes validation, recording the PR number,
+URL, head SHA, flow (`issue-implementation` or `approved-plan-implementation`),
+and (for plan-first runs) the approved-plan hash. If a valid record names a
+still-open PR, the rerun resumes PR review on that PR directly instead of
+invoking the coder again. A record whose PR is closed, merged, or otherwise
+unresolvable fails safely with an actionable message rather than falling back
+to a fresh implementation; fix or select the correct PR and rerun
+`agent-loop pr <number>` directly.
+
+Issues that predate this marker (or crashed before it could be posted) fall
+back to the legacy check: searching GitHub directly for an already-open PR
+that already references the target issue, independent of any handoff marker.
+This closes the same crash window as before: if implementation created a PR
+but the run aborted afterward — before any handoff comment could be posted —
+a rerun still resumes PR review on that PR instead of invoking the coder again
+and creating a duplicate, and backfills a canonical handoff record so later
+reruns take the fast path. If more than one open PR references the issue, the
 orchestrator raises an error instead of guessing which one to resume; close or
 merge the extra PR and rerun `agent-loop pr <number>` directly.
 

--- a/src/coding_review_agent_loop/issue_pr_handoff.py
+++ b/src/coding_review_agent_loop/issue_pr_handoff.py
@@ -1,0 +1,308 @@
+"""Canonical issue-to-PR handoff record for issue reruns (#589).
+
+After an issue implementation creates a validated open PR, a rerun of
+`agent-loop issue <n>` (direct or plan-first) should resume reviewing that PR
+instead of invoking a coder again and creating a duplicate. This module
+defines the `AGENT_ISSUE_PR_HANDOFF` marker that records which PR is the
+authoritative implementation PR for an issue, and the resolver that consults
+it (falling back to the legacy exactly-one-open-PR GitHub search for issues
+predating this marker) before any coder invocation.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlparse
+
+from .config import AgentLoopConfig
+from .errors import AgentLoopError
+from .github import (
+    IssueContext,
+    PullRequestMetadata,
+    find_open_pr_referencing_issue,
+    get_pr_state,
+    post_issue_comment,
+    validate_pr_references_issue,
+)
+from .runner import Runner
+
+SCHEMA_VERSION = 1
+_VALID_FLOWS = {"issue-implementation", "approved-plan-implementation"}
+
+AGENT_ISSUE_PR_HANDOFF_RE = re.compile(
+    r"<!--\s*AGENT_ISSUE_PR_HANDOFF:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class IssuePrHandoffMetadata:
+    schema_version: int
+    issue_number: int
+    pr_number: int
+    pr_url: str
+    pr_head_sha: str
+    flow: str
+    plan_hash: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedIssuePr:
+    pr_number: int
+    source: Literal["canonical", "legacy"]
+
+
+def _encode_json_payload(payload: dict[str, object]) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_json_payload(encoded: str) -> dict[str, object]:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise AgentLoopError("Invalid AGENT_ISSUE_PR_HANDOFF payload.") from exc
+    if not isinstance(payload, dict):
+        raise AgentLoopError("Invalid AGENT_ISSUE_PR_HANDOFF payload.")
+    return payload
+
+
+def _encode_issue_pr_handoff_metadata(metadata: IssuePrHandoffMetadata) -> str:
+    return _encode_json_payload(
+        {
+            "schema_version": metadata.schema_version,
+            "issue_number": metadata.issue_number,
+            "pr_number": metadata.pr_number,
+            "pr_url": metadata.pr_url,
+            "pr_head_sha": metadata.pr_head_sha,
+            "flow": metadata.flow,
+            "plan_hash": metadata.plan_hash,
+        }
+    )
+
+
+def _require_non_empty_str(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AgentLoopError(
+            f"Invalid AGENT_ISSUE_PR_HANDOFF payload: `{key}` must be a non-empty string."
+        )
+    return value
+
+
+def _decode_issue_pr_handoff_metadata(encoded: str) -> IssuePrHandoffMetadata:
+    payload = _decode_json_payload(encoded)
+    try:
+        schema_version = int(payload["schema_version"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError(
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: missing/invalid `schema_version`."
+        ) from exc
+    if schema_version != SCHEMA_VERSION:
+        raise AgentLoopError(
+            f"Invalid AGENT_ISSUE_PR_HANDOFF payload: unsupported schema_version {schema_version}."
+        )
+    flow = payload.get("flow")
+    if flow not in _VALID_FLOWS:
+        raise AgentLoopError(f"Invalid AGENT_ISSUE_PR_HANDOFF payload: unknown flow {flow!r}.")
+    try:
+        issue_number = int(payload["issue_number"])
+        pr_number = int(payload["pr_number"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError(
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: `issue_number`/`pr_number` must be integers."
+        ) from exc
+    if issue_number <= 0 or pr_number <= 0:
+        raise AgentLoopError(
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: `issue_number`/`pr_number` must be positive."
+        )
+    pr_url = _require_non_empty_str(payload, "pr_url")
+    pr_head_sha = _require_non_empty_str(payload, "pr_head_sha")
+    plan_hash = payload.get("plan_hash")
+    if flow == "approved-plan-implementation":
+        if not isinstance(plan_hash, str) or not plan_hash.strip():
+            raise AgentLoopError(
+                "Invalid AGENT_ISSUE_PR_HANDOFF payload: `plan_hash` is required for "
+                "approved-plan-implementation flow."
+            )
+    elif plan_hash is not None:
+        raise AgentLoopError(
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: `plan_hash` must be absent for "
+            "issue-implementation flow."
+        )
+    return IssuePrHandoffMetadata(
+        schema_version=schema_version,
+        issue_number=issue_number,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        pr_head_sha=pr_head_sha,
+        flow=str(flow),
+        plan_hash=plan_hash if isinstance(plan_hash, str) else None,
+    )
+
+
+def _validate_issue_pr_handoff_url(url: str, *, repo: str, pr_number: int) -> None:
+    parsed = urlparse(url)
+    expected_path = f"/{repo}/pull/{pr_number}"
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "github.com"
+        or parsed.path.rstrip("/") != expected_path
+    ):
+        raise AgentLoopError(
+            f"Invalid AGENT_ISSUE_PR_HANDOFF payload: `pr_url` {url!r} does not match "
+            f"https://github.com/{repo}/pull/{pr_number}."
+        )
+
+
+def find_latest_issue_pr_handoff(
+    comments: Sequence[object], *, issue_number: int, repo: str
+) -> IssuePrHandoffMetadata | None:
+    found: IssuePrHandoffMetadata | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in AGENT_ISSUE_PR_HANDOFF_RE.finditer(body):
+            metadata = _decode_issue_pr_handoff_metadata(match.group("payload"))
+            if metadata.issue_number != issue_number:
+                continue
+            _validate_issue_pr_handoff_url(metadata.pr_url, repo=repo, pr_number=metadata.pr_number)
+            found = metadata
+    return found
+
+
+def resolve_canonical_pr_for_issue(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    issue_context: IssueContext,
+) -> ResolvedIssuePr | None:
+    """Resolve the PR a rerun of `agent-loop issue <issue_number>` should resume.
+
+    Consults the canonical `AGENT_ISSUE_PR_HANDOFF` record first; if none
+    exists, falls back to the legacy exactly-one-open-PR GitHub search so
+    issues predating this marker still recover. Returns `None` when neither
+    source finds a PR, meaning normal coder invocation should proceed.
+    """
+    if config.dry_run:
+        return None
+    canonical = find_latest_issue_pr_handoff(
+        issue_context.comments, issue_number=issue_number, repo=config.repo
+    )
+    if canonical is not None:
+        try:
+            state = get_pr_state(runner, config=config, pr_number=canonical.pr_number)
+        except AgentLoopError as exc:
+            raise AgentLoopError(
+                f"Canonical handoff record for issue #{issue_number} references PR "
+                f"#{canonical.pr_number}, but its state could not be determined in {config.repo} "
+                f"({exc}). Verify the PR exists and rerun `agent-loop pr {canonical.pr_number}` "
+                "directly to continue, or close/select the correct duplicate."
+            ) from exc
+        if state != "OPEN":
+            raise AgentLoopError(
+                f"Canonical handoff record for issue #{issue_number} references PR "
+                f"#{canonical.pr_number}, which is {state}, not OPEN. Rerun "
+                f"`agent-loop pr {canonical.pr_number}` directly if that PR should still be "
+                "reviewed, or close/select the correct duplicate before rerunning the issue."
+            )
+        validate_pr_references_issue(
+            runner, config=config, pr_number=canonical.pr_number, issue_number=issue_number
+        )
+        return ResolvedIssuePr(pr_number=canonical.pr_number, source="canonical")
+    legacy_pr_number = find_open_pr_referencing_issue(
+        runner, config=config, issue_number=issue_number
+    )
+    if legacy_pr_number is None:
+        return None
+    return ResolvedIssuePr(pr_number=legacy_pr_number, source="legacy")
+
+
+def require_pr_metadata_for_handoff(metadata: PullRequestMetadata) -> tuple[str, str]:
+    """Return `(pr_url, pr_head_sha)`, raising if either is unavailable.
+
+    Guards every handoff-posting call site so a record is never posted with
+    an incomplete PR URL or head SHA.
+    """
+    if not metadata.url:
+        raise AgentLoopError(
+            f"Cannot record issue-to-PR handoff for PR #{metadata.number}: PR URL is unavailable."
+        )
+    if not metadata.head_sha:
+        raise AgentLoopError(
+            f"Cannot record issue-to-PR handoff for PR #{metadata.number}: PR head SHA is unavailable."
+        )
+    return metadata.url, metadata.head_sha
+
+
+def format_issue_pr_handoff_comment(
+    *,
+    issue_number: int,
+    pr_number: int,
+    pr_url: str,
+    pr_head_sha: str,
+    flow: str,
+    plan_hash: str | None,
+) -> str:
+    metadata = IssuePrHandoffMetadata(
+        schema_version=SCHEMA_VERSION,
+        issue_number=issue_number,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        pr_head_sha=pr_head_sha,
+        flow=flow,
+        plan_hash=plan_hash,
+    )
+    lines = [
+        f"Issue #{issue_number} implementation handed off to PR #{pr_number}.",
+        "",
+        f"Flow: {flow}",
+        f"PR: {pr_url}",
+        f"PR head SHA: {pr_head_sha}",
+    ]
+    if plan_hash:
+        lines.append(f"Plan hash: {plan_hash}")
+    lines.extend(
+        [
+            "",
+            "Reruns of `agent-loop issue` for this issue will resume review of this PR instead of "
+            "invoking a coder again.",
+            "",
+            f"<!-- AGENT_ISSUE_PR_HANDOFF: {_encode_issue_pr_handoff_metadata(metadata)} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def post_issue_pr_handoff_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    pr_number: int,
+    pr_url: str,
+    pr_head_sha: str,
+    flow: str,
+    plan_hash: str | None,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body=format_issue_pr_handoff_comment(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_url=pr_url,
+            pr_head_sha=pr_head_sha,
+            flow=flow,
+            plan_hash=plan_hash,
+        ),
+    )

--- a/src/coding_review_agent_loop/issue_pr_handoff.py
+++ b/src/coding_review_agent_loop/issue_pr_handoff.py
@@ -97,12 +97,13 @@ def _require_non_empty_str(payload: dict[str, object], key: str) -> str:
 
 def _decode_issue_pr_handoff_metadata(encoded: str) -> IssuePrHandoffMetadata:
     payload = _decode_json_payload(encoded)
-    try:
-        schema_version = int(payload["schema_version"])
-    except (KeyError, TypeError, ValueError) as exc:
+    raw_schema_version = payload.get("schema_version")
+    if isinstance(raw_schema_version, bool) or not isinstance(raw_schema_version, int):
         raise AgentLoopError(
-            "Invalid AGENT_ISSUE_PR_HANDOFF payload: missing/invalid `schema_version`."
-        ) from exc
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: `schema_version` must be an integer "
+            "(not a bool or fractional value)."
+        )
+    schema_version = raw_schema_version
     if schema_version != SCHEMA_VERSION:
         raise AgentLoopError(
             f"Invalid AGENT_ISSUE_PR_HANDOFF payload: unsupported schema_version {schema_version}."
@@ -110,13 +111,19 @@ def _decode_issue_pr_handoff_metadata(encoded: str) -> IssuePrHandoffMetadata:
     flow = payload.get("flow")
     if flow not in _VALID_FLOWS:
         raise AgentLoopError(f"Invalid AGENT_ISSUE_PR_HANDOFF payload: unknown flow {flow!r}.")
-    try:
-        issue_number = int(payload["issue_number"])
-        pr_number = int(payload["pr_number"])
-    except (KeyError, TypeError, ValueError) as exc:
+    raw_issue_number = payload.get("issue_number")
+    raw_pr_number = payload.get("pr_number")
+    if (
+        isinstance(raw_issue_number, bool)
+        or not isinstance(raw_issue_number, int)
+        or isinstance(raw_pr_number, bool)
+        or not isinstance(raw_pr_number, int)
+    ):
         raise AgentLoopError(
             "Invalid AGENT_ISSUE_PR_HANDOFF payload: `issue_number`/`pr_number` must be integers."
-        ) from exc
+        )
+    issue_number = raw_issue_number
+    pr_number = raw_pr_number
     if issue_number <= 0 or pr_number <= 0:
         raise AgentLoopError(
             "Invalid AGENT_ISSUE_PR_HANDOFF payload: `issue_number`/`pr_number` must be positive."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -48,7 +48,6 @@ from .github import (
     IssueContext,
     PullRequestChecks,
     PullRequestReviewContext,
-    find_open_pr_referencing_issue,
     get_issue_context,
     parse_linked_issue_numbers,
     get_pr_checks,
@@ -62,6 +61,11 @@ from .github import (
     validate_pr_body_does_not_close_issue,
     validate_pr_references_issue,
     wait_for_ci,
+)
+from .issue_pr_handoff import (
+    post_issue_pr_handoff_comment,
+    require_pr_metadata_for_handoff,
+    resolve_canonical_pr_for_issue,
 )
 from .split_materialization import (
     DISCUSS_SPLIT_MARKER_RE,
@@ -3047,13 +3051,15 @@ def _implement_approved_issue(
 
     # A prior implementation attempt may have created a PR and then aborted
     # before recording any handoff marker/comment (e.g. the #493 test-report
-    # false positive, which produced the duplicate PR #494 for #492). Check
-    # GitHub directly for an already-open PR referencing this issue before
-    # invoking the coder again (#495).
-    existing_pr_number = find_open_pr_referencing_issue(
-        runner, config=config, issue_number=issue_number
+    # false positive, which produced the duplicate PR #494 for #492). Resolve
+    # the canonical AGENT_ISSUE_PR_HANDOFF record first, falling back to the
+    # legacy exactly-one-open-PR GitHub search when no record exists yet
+    # (#495, #589).
+    resolved_pr = resolve_canonical_pr_for_issue(
+        runner, config=config, issue_number=issue_number, issue_context=issue_context
     )
-    if existing_pr_number is not None:
+    if resolved_pr is not None:
+        existing_pr_number = resolved_pr.pr_number
         log(
             config,
             f"Existing implementation PR #{existing_pr_number} found for issue #{issue_number} "
@@ -3072,10 +3078,24 @@ def _implement_approved_issue(
                 pr_number=existing_pr_number,
                 issue_number=staged_parent_issue,
             )
-        if one_shot_parent_issue is not None:
+        resumed_pr_context = None
+        if resolved_pr.source == "legacy" or one_shot_parent_issue is not None:
             resumed_pr_context = get_pr_review_context(
                 runner, config=implementation_config, pr_number=existing_pr_number
             )
+        if resolved_pr.source == "legacy":
+            pr_url, pr_head_sha = require_pr_metadata_for_handoff(resumed_pr_context.metadata)
+            post_issue_pr_handoff_comment(
+                runner,
+                config=implementation_config,
+                issue_number=issue_number,
+                pr_number=existing_pr_number,
+                pr_url=pr_url,
+                pr_head_sha=pr_head_sha,
+                flow="approved-plan-implementation",
+                plan_hash=plan_hash,
+            )
+        if one_shot_parent_issue is not None:
             post_one_shot_impl_handoff_comment(
                 runner,
                 config=implementation_config,
@@ -3173,6 +3193,17 @@ def _implement_approved_issue(
             issue_number=staged_parent_issue,
         )
     initial_pr_context = get_pr_review_context(runner, config=implementation_config, pr_number=pr_number)
+    initial_pr_url, initial_pr_head_sha = require_pr_metadata_for_handoff(initial_pr_context.metadata)
+    post_issue_pr_handoff_comment(
+        runner,
+        config=implementation_config,
+        issue_number=issue_number,
+        pr_number=pr_number,
+        pr_url=initial_pr_url,
+        pr_head_sha=initial_pr_head_sha,
+        flow="approved-plan-implementation",
+        plan_hash=plan_hash,
+    )
     if one_shot_parent_issue is not None:
         post_one_shot_impl_handoff_comment(
             runner,
@@ -3992,6 +4023,56 @@ def _run_plan_first_loop(
                     )
                     staged_parent_issue = issue_number
 
+                # Canonical handoff resolution runs before the (older,
+                # plan-hash-scoped) one-shot handoff lookup below, so a stale
+                # canonical record fails safely instead of being bypassed by
+                # it (#589). It is scoped to the selected target issue, since
+                # a split-stage plan implements a child, not the parent.
+                resolved_pr = resolve_canonical_pr_for_issue(
+                    runner, config=config, issue_number=target_issue_number, issue_context=target_issue_context
+                )
+                if resolved_pr is not None:
+                    log(
+                        config,
+                        f"Issue #{target_issue_number}: resuming PR #{resolved_pr.pr_number} review for "
+                        "already-handed-off plan",
+                    )
+                    validate_pr_references_issue(
+                        runner,
+                        config=config,
+                        pr_number=resolved_pr.pr_number,
+                        issue_number=target_issue_number,
+                    )
+                    if staged_parent_issue is not None:
+                        validate_pr_body_does_not_close_issue(
+                            runner,
+                            config=config,
+                            pr_number=resolved_pr.pr_number,
+                            issue_number=staged_parent_issue,
+                        )
+                    if resolved_pr.source == "legacy":
+                        resumed_pr_context = get_pr_review_context(
+                            runner, config=config, pr_number=resolved_pr.pr_number
+                        )
+                        pr_url, pr_head_sha = require_pr_metadata_for_handoff(resumed_pr_context.metadata)
+                        post_issue_pr_handoff_comment(
+                            runner,
+                            config=config,
+                            issue_number=target_issue_number,
+                            pr_number=resolved_pr.pr_number,
+                            pr_url=pr_url,
+                            pr_head_sha=pr_head_sha,
+                            flow="approved-plan-implementation",
+                            plan_hash=plan_hash,
+                        )
+                    return run_pr_loop(
+                        runner,
+                        pr_number=resolved_pr.pr_number,
+                        config=config,
+                        issue_context=target_issue_context,
+                        usage_context=usage_context,
+                    )
+
                 existing_handoff = find_existing_one_shot_impl_handoff(
                     target_issue_context.comments,
                     parent_issue=target_issue_number,
@@ -4192,6 +4273,45 @@ def run_issue_loop(
         log(config, f"Validating issue #{issue_number}")
         validate_open_issue(runner, config=config, issue_number=issue_number)
         issue_context = get_issue_context(runner, config=config, issue_number=issue_number)
+
+        # Resolve the canonical AGENT_ISSUE_PR_HANDOFF record (or, failing
+        # that, the legacy exactly-one-open-PR search) before invoking a
+        # coder in either direct or plan-first mode, so a rerun after an
+        # interrupted PR review resumes that PR instead of creating a
+        # duplicate (#589).
+        resolved_pr = resolve_canonical_pr_for_issue(
+            runner, config=config, issue_number=issue_number, issue_context=issue_context
+        )
+        if resolved_pr is not None:
+            log(
+                config,
+                f"Issue #{issue_number}: resuming PR #{resolved_pr.pr_number} review instead of "
+                f"invoking {agent_display_name(config.coder)}.",
+            )
+            validate_pr_references_issue(
+                runner, config=config, pr_number=resolved_pr.pr_number, issue_number=issue_number
+            )
+            if resolved_pr.source == "legacy":
+                pr_context = get_pr_review_context(runner, config=config, pr_number=resolved_pr.pr_number)
+                pr_url, pr_head_sha = require_pr_metadata_for_handoff(pr_context.metadata)
+                post_issue_pr_handoff_comment(
+                    runner,
+                    config=config,
+                    issue_number=issue_number,
+                    pr_number=resolved_pr.pr_number,
+                    pr_url=pr_url,
+                    pr_head_sha=pr_head_sha,
+                    flow="issue-implementation",
+                    plan_hash=None,
+                )
+            return run_pr_loop(
+                runner,
+                pr_number=resolved_pr.pr_number,
+                config=config,
+                issue_context=issue_context,
+                usage_context=usage_context,
+            )
+
         memory = prepare_agent_memory(runner, config)
         if plan_first:
             return _run_plan_first_loop(
@@ -4271,6 +4391,17 @@ def run_issue_loop(
             issue_number=issue_number,
         )
         initial_pr_metadata = get_pr_review_context(runner, config=config, pr_number=pr_number).metadata
+        initial_pr_url, initial_pr_head_sha = require_pr_metadata_for_handoff(initial_pr_metadata)
+        post_issue_pr_handoff_comment(
+            runner,
+            config=config,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_url=initial_pr_url,
+            pr_head_sha=initial_pr_head_sha,
+            flow="issue-implementation",
+            plan_hash=None,
+        )
         post_pr_comment(
             runner,
             config=config,

--- a/tests/test_issue_pr_handoff.py
+++ b/tests/test_issue_pr_handoff.py
@@ -1,0 +1,251 @@
+import base64
+
+import pytest
+
+from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.github import IssueComment, PullRequestMetadata
+from coding_review_agent_loop.issue_pr_handoff import (
+    _decode_issue_pr_handoff_metadata,
+    _encode_issue_pr_handoff_metadata,
+    _validate_issue_pr_handoff_url,
+    IssuePrHandoffMetadata,
+    find_latest_issue_pr_handoff,
+    format_issue_pr_handoff_comment,
+    require_pr_metadata_for_handoff,
+)
+
+
+def _comment(body: str) -> IssueComment:
+    return IssueComment(author="bot", created_at="2026-05-23T00:00:00Z", body=body)
+
+
+def _metadata(**overrides) -> IssuePrHandoffMetadata:
+    defaults = dict(
+        schema_version=1,
+        issue_number=56,
+        pr_number=77,
+        pr_url="https://github.com/OWNER/REPO/pull/77",
+        pr_head_sha="abc123",
+        flow="issue-implementation",
+        plan_hash=None,
+    )
+    defaults.update(overrides)
+    return IssuePrHandoffMetadata(**defaults)
+
+
+def test_round_trips_metadata_through_marker():
+    metadata = _metadata()
+    encoded = _encode_issue_pr_handoff_metadata(metadata)
+    assert _decode_issue_pr_handoff_metadata(encoded) == metadata
+
+
+def test_round_trips_approved_plan_flow_with_plan_hash():
+    metadata = _metadata(flow="approved-plan-implementation", plan_hash="deadbeef01234567")
+    encoded = _encode_issue_pr_handoff_metadata(metadata)
+    assert _decode_issue_pr_handoff_metadata(encoded) == metadata
+
+
+def test_find_latest_issue_pr_handoff_returns_newest_when_multiple_markers_present():
+    older = format_issue_pr_handoff_comment(
+        issue_number=56,
+        pr_number=77,
+        pr_url="https://github.com/OWNER/REPO/pull/77",
+        pr_head_sha="oldsha",
+        flow="issue-implementation",
+        plan_hash=None,
+    )
+    newer = format_issue_pr_handoff_comment(
+        issue_number=56,
+        pr_number=90,
+        pr_url="https://github.com/OWNER/REPO/pull/90",
+        pr_head_sha="newsha",
+        flow="issue-implementation",
+        plan_hash=None,
+    )
+    comments = [_comment(older), _comment(newer)]
+
+    found = find_latest_issue_pr_handoff(comments, issue_number=56, repo="OWNER/REPO")
+
+    assert found is not None
+    assert found.pr_number == 90
+    assert found.pr_head_sha == "newsha"
+
+
+def test_find_latest_issue_pr_handoff_ignores_records_for_other_issues():
+    comment = format_issue_pr_handoff_comment(
+        issue_number=99,
+        pr_number=77,
+        pr_url="https://github.com/OWNER/REPO/pull/77",
+        pr_head_sha="abc123",
+        flow="issue-implementation",
+        plan_hash=None,
+    )
+
+    found = find_latest_issue_pr_handoff([_comment(comment)], issue_number=56, repo="OWNER/REPO")
+
+    assert found is None
+
+
+def test_find_latest_issue_pr_handoff_returns_none_with_no_matching_comments():
+    assert find_latest_issue_pr_handoff([_comment("just talk")], issue_number=56, repo="OWNER/REPO") is None
+
+
+def test_decode_raises_on_malformed_base64_payload():
+    with pytest.raises(AgentLoopError, match="Invalid AGENT_ISSUE_PR_HANDOFF payload"):
+        _decode_issue_pr_handoff_metadata("!!!not-base64!!!")
+
+
+def test_decode_raises_on_malformed_json_payload():
+    encoded = base64.urlsafe_b64encode(b"not json").decode("ascii")
+    with pytest.raises(AgentLoopError, match="Invalid AGENT_ISSUE_PR_HANDOFF payload"):
+        _decode_issue_pr_handoff_metadata(encoded)
+
+
+def test_decode_raises_on_unsupported_schema_version():
+    metadata = _metadata(schema_version=2)
+    with pytest.raises(AgentLoopError, match="unsupported schema_version"):
+        _decode_issue_pr_handoff_metadata(_encode_issue_pr_handoff_metadata(metadata))
+
+
+def test_decode_raises_on_unknown_flow():
+    encoded = _encode_issue_pr_handoff_metadata(_metadata())
+    payload = base64.urlsafe_b64decode(encoded)
+    import json as _json
+
+    data = _json.loads(payload)
+    data["flow"] = "something-else"
+    bad_encoded = base64.urlsafe_b64encode(_json.dumps(data).encode("utf-8")).decode("ascii")
+    with pytest.raises(AgentLoopError, match="unknown flow"):
+        _decode_issue_pr_handoff_metadata(bad_encoded)
+
+
+@pytest.mark.parametrize("field,value", [("issue_number", 0), ("pr_number", -1)])
+def test_decode_raises_on_non_positive_identifiers(field, value):
+    encoded = _encode_issue_pr_handoff_metadata(_metadata(**{field: value}))
+    with pytest.raises(AgentLoopError, match="must be positive"):
+        _decode_issue_pr_handoff_metadata(encoded)
+
+
+@pytest.mark.parametrize("field", ["issue_number", "pr_number"])
+def test_decode_raises_on_non_coercible_identifiers(field):
+    encoded = _encode_issue_pr_handoff_metadata(_metadata())
+    import json as _json
+
+    data = _json.loads(base64.urlsafe_b64decode(encoded))
+    data[field] = "not-a-number"
+    bad_encoded = base64.urlsafe_b64encode(_json.dumps(data).encode("utf-8")).decode("ascii")
+    with pytest.raises(AgentLoopError, match="must be integers"):
+        _decode_issue_pr_handoff_metadata(bad_encoded)
+
+
+@pytest.mark.parametrize("pr_url", [None, ""])
+def test_decode_raises_on_missing_or_empty_pr_url(pr_url):
+    encoded = _encode_issue_pr_handoff_metadata(_metadata(pr_url=pr_url or ""))
+    import json as _json
+
+    data = _json.loads(base64.urlsafe_b64decode(encoded))
+    data["pr_url"] = pr_url
+    bad_encoded = base64.urlsafe_b64encode(_json.dumps(data).encode("utf-8")).decode("ascii")
+    with pytest.raises(AgentLoopError, match="`pr_url` must be a non-empty string"):
+        _decode_issue_pr_handoff_metadata(bad_encoded)
+
+
+@pytest.mark.parametrize("pr_head_sha", [None, ""])
+def test_decode_raises_on_missing_or_empty_pr_head_sha(pr_head_sha):
+    encoded = _encode_issue_pr_handoff_metadata(_metadata())
+    import json as _json
+
+    data = _json.loads(base64.urlsafe_b64decode(encoded))
+    data["pr_head_sha"] = pr_head_sha
+    bad_encoded = base64.urlsafe_b64encode(_json.dumps(data).encode("utf-8")).decode("ascii")
+    with pytest.raises(AgentLoopError, match="`pr_head_sha` must be a non-empty string"):
+        _decode_issue_pr_handoff_metadata(bad_encoded)
+
+
+def test_decode_raises_when_plan_hash_present_for_issue_implementation_flow():
+    encoded = _encode_issue_pr_handoff_metadata(_metadata())
+    import json as _json
+
+    data = _json.loads(base64.urlsafe_b64decode(encoded))
+    data["plan_hash"] = "deadbeef01234567"
+    bad_encoded = base64.urlsafe_b64encode(_json.dumps(data).encode("utf-8")).decode("ascii")
+    with pytest.raises(AgentLoopError, match="`plan_hash` must be absent"):
+        _decode_issue_pr_handoff_metadata(bad_encoded)
+
+
+def test_decode_raises_when_plan_hash_absent_for_approved_plan_flow():
+    metadata = _metadata(flow="approved-plan-implementation", plan_hash=None)
+    encoded = _encode_issue_pr_handoff_metadata(metadata)
+    with pytest.raises(AgentLoopError, match="`plan_hash` is required"):
+        _decode_issue_pr_handoff_metadata(encoded)
+
+
+def test_validate_url_accepts_matching_url():
+    _validate_issue_pr_handoff_url(
+        "https://github.com/OWNER/REPO/pull/77", repo="OWNER/REPO", pr_number=77
+    )
+
+
+def test_validate_url_rejects_spoofed_host():
+    with pytest.raises(AgentLoopError, match="does not match"):
+        _validate_issue_pr_handoff_url(
+            "https://evil.example.com/OWNER/REPO/pull/77", repo="OWNER/REPO", pr_number=77
+        )
+
+
+def test_validate_url_rejects_prefix_collision():
+    with pytest.raises(AgentLoopError, match="does not match"):
+        _validate_issue_pr_handoff_url(
+            "https://github.com/OWNER/REPO/pull/770", repo="OWNER/REPO", pr_number=77
+        )
+
+
+def test_validate_url_rejects_non_https_scheme():
+    with pytest.raises(AgentLoopError, match="does not match"):
+        _validate_issue_pr_handoff_url(
+            "http://github.com/OWNER/REPO/pull/77", repo="OWNER/REPO", pr_number=77
+        )
+
+
+def test_require_pr_metadata_for_handoff_raises_on_missing_url():
+    metadata = PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Title",
+        head_branch="feature",
+        base_branch="main",
+        head_sha="abc123",
+        url=None,
+    )
+    with pytest.raises(AgentLoopError, match="PR URL is unavailable"):
+        require_pr_metadata_for_handoff(metadata)
+
+
+def test_require_pr_metadata_for_handoff_raises_on_missing_head_sha():
+    metadata = PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Title",
+        head_branch="feature",
+        base_branch="main",
+        head_sha=None,
+        url="https://github.com/OWNER/REPO/pull/77",
+    )
+    with pytest.raises(AgentLoopError, match="PR head SHA is unavailable"):
+        require_pr_metadata_for_handoff(metadata)
+
+
+def test_require_pr_metadata_for_handoff_returns_tuple_when_present():
+    metadata = PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Title",
+        head_branch="feature",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/77",
+    )
+    assert require_pr_metadata_for_handoff(metadata) == (
+        "https://github.com/OWNER/REPO/pull/77",
+        "abc123",
+    )

--- a/tests/test_issue_pr_handoff.py
+++ b/tests/test_issue_pr_handoff.py
@@ -107,6 +107,20 @@ def test_decode_raises_on_unsupported_schema_version():
         _decode_issue_pr_handoff_metadata(_encode_issue_pr_handoff_metadata(metadata))
 
 
+def test_decode_raises_on_fractional_schema_version():
+    metadata = _metadata(schema_version=1.9)
+    with pytest.raises(AgentLoopError, match="`schema_version` must be an integer"):
+        _decode_issue_pr_handoff_metadata(_encode_issue_pr_handoff_metadata(metadata))
+
+
+def test_decode_raises_on_boolean_schema_version():
+    # `True` coerces to `1` (== SCHEMA_VERSION) via a naive `int(...)` cast; the decoder
+    # must reject bool outright rather than silently accepting it as a valid version.
+    metadata = _metadata(schema_version=True)
+    with pytest.raises(AgentLoopError, match="`schema_version` must be an integer"):
+        _decode_issue_pr_handoff_metadata(_encode_issue_pr_handoff_metadata(metadata))
+
+
 def test_decode_raises_on_unknown_flow():
     encoded = _encode_issue_pr_handoff_metadata(_metadata())
     payload = base64.urlsafe_b64decode(encoded)
@@ -136,6 +150,20 @@ def test_decode_raises_on_non_coercible_identifiers(field):
     bad_encoded = base64.urlsafe_b64encode(_json.dumps(data).encode("utf-8")).decode("ascii")
     with pytest.raises(AgentLoopError, match="must be integers"):
         _decode_issue_pr_handoff_metadata(bad_encoded)
+
+
+@pytest.mark.parametrize("field", ["issue_number", "pr_number"])
+def test_decode_raises_on_boolean_identifiers(field):
+    encoded = _encode_issue_pr_handoff_metadata(_metadata(**{field: True}))
+    with pytest.raises(AgentLoopError, match="must be integers"):
+        _decode_issue_pr_handoff_metadata(encoded)
+
+
+@pytest.mark.parametrize("field", ["issue_number", "pr_number"])
+def test_decode_raises_on_fractional_identifiers(field):
+    encoded = _encode_issue_pr_handoff_metadata(_metadata(**{field: 56.5}))
+    with pytest.raises(AgentLoopError, match="must be integers"):
+        _decode_issue_pr_handoff_metadata(encoded)
 
 
 @pytest.mark.parametrize("pr_url", [None, ""])

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -9,6 +9,7 @@ from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
 from coding_review_agent_loop.decomposition import approved_plan_hash, format_one_shot_impl_handoff_comment
 from coding_review_agent_loop.errors import QuotaResetExceededError
 from coding_review_agent_loop.github import get_issue_context
+from coding_review_agent_loop.issue_pr_handoff import format_issue_pr_handoff_comment
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
     _attach_round_metadata,
@@ -191,7 +192,7 @@ def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     command_names = [cmd[:2] for cmd, _cwd in runner.commands]
     assert ["claude", "--print"] in command_names
     assert ["codex", "exec"] in command_names
-    assert len(runner.comments) == 4
+    assert len(runner.comments) == 5
     assert runner.comments[-1].startswith("**Review verdict:** Approved\n\nLGTM.")
     assert list((tmp_path / "logs").glob("*-claude.log"))
     assert list((tmp_path / "logs").glob("*-codex.log"))
@@ -288,7 +289,7 @@ def test_issue_loop_can_use_codex_as_coder_and_claude_as_reviewer(tmp_path):
         ["codex", "exec"],
         ["claude", "--print"],
     ]
-    assert len(runner.comments) == 4
+    assert len(runner.comments) == 5
     assert runner.comments[-1].startswith("**Review verdict:** Approved\n\nLGTM.")
 
 def test_issue_loop_runs_pre_review_tests_after_coder_changes(tmp_path):
@@ -1959,10 +1960,11 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     switch_index = command_index(runner.commands, ["git", "switch", "main"])
     second_claude_index = command_index(runner.commands, ["claude", "--print"], start=first_claude_index + 1)
     assert first_claude_index < fetch_index < switch_index < second_claude_index
-    assert len(runner.comments) == 6
-    assert "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in runner.comments[3]
-    assert runner.comments[4].startswith("Implemented approved plan.")
-    assert runner.comments[5].startswith("**Review verdict:** Approved\n\nLGTM.")
+    assert len(runner.comments) == 7
+    assert "<!-- AGENT_ISSUE_PR_HANDOFF:" in runner.comments[3]
+    assert "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in runner.comments[4]
+    assert runner.comments[5].startswith("Implemented approved plan.")
+    assert runner.comments[6].startswith("**Review verdict:** Approved\n\nLGTM.")
 
 
 def test_issue_loop_plan_first_can_override_implementation_model(tmp_path):
@@ -2005,7 +2007,7 @@ def test_issue_loop_plan_first_can_override_implementation_model(tmp_path):
     assert claude_calls[0][claude_calls[0].index("--model") + 1] == "claude-fable-5"
     assert claude_calls[1][claude_calls[1].index("--model") + 1] == "claude-sonnet-5"
     assert "--resume" not in claude_calls[1]
-    assert runner.comments[4].startswith("Implemented approved plan.")
+    assert runner.comments[5].startswith("Implemented approved plan.")
 
 
 def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
@@ -2308,9 +2310,9 @@ def test_issue_loop_plan_first_one_shot_resumes_existing_pr_after_crash_before_h
     )
 
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
-    handoff_comments = [c for c in runner.comments if "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in c]
+    handoff_comments = [c for c in runner.comments if "<!-- AGENT_ISSUE_PR_HANDOFF:" in c]
     assert len(handoff_comments) == 1
-    assert f"Plan hash: {approved_plan_hash(plan)}" in handoff_comments[0]
+    assert "Flow: issue-implementation" in handoff_comments[0]
     assert "PR #77" in handoff_comments[0]
 
 def test_issue_loop_plan_first_one_shot_resume_existing_pr_logs_clear_message(tmp_path, capsys):
@@ -2360,10 +2362,7 @@ def test_issue_loop_plan_first_one_shot_resume_existing_pr_logs_clear_message(tm
     )
 
     output = capsys.readouterr().err
-    assert (
-        f"Existing implementation PR #492 found for issue #56 / approved plan {approved_plan_hash(plan)}; "
-        "resuming PR review instead of invoking Claude." in output
-    )
+    assert "Issue #56: resuming PR #492 review instead of invoking Claude." in output
 
 def test_issue_loop_plan_first_one_shot_rerun_raises_on_ambiguous_existing_prs(tmp_path):
     plan = "Plan:\n- Make the change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
@@ -2411,6 +2410,141 @@ def test_issue_loop_plan_first_one_shot_rerun_raises_on_ambiguous_existing_prs(t
 
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
 
+def test_issue_loop_direct_mode_resumes_existing_canonical_pr(tmp_path, capsys):
+    """#589: direct `agent-loop issue <n>` (no --plan-first) must also consult
+    the canonical AGENT_ISSUE_PR_HANDOFF record before invoking a coder, so a
+    rerun after an interrupted PR review resumes the existing PR instead of
+    invoking the coder again and creating a duplicate."""
+    canonical_comment = {
+        "author": {"login": "bot"},
+        "createdAt": "2026-05-23T00:00:00Z",
+        "body": format_issue_pr_handoff_comment(
+            issue_number=56,
+            pr_number=77,
+            pr_url="https://github.com/OWNER/REPO/pull/77",
+            pr_head_sha="abc123",
+            flow="issue-implementation",
+            plan_hash=None,
+        ),
+    }
+    runner = FakeRunner(
+        issue_comments=[canonical_comment],
+        pr_payload={"body": "Fixes #56"},
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path, quiet=False)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert not any("<!-- AGENT_ISSUE_PR_HANDOFF:" in c for c in runner.comments)
+    output = capsys.readouterr().err
+    assert "Issue #56: resuming PR #77 review instead of invoking Claude." in output
+
+
+def test_issue_loop_direct_mode_legacy_search_resumes_and_backfills_canonical_record(tmp_path):
+    """Legacy issues with no canonical record yet must still recover through
+    the exactly-one-open-PR GitHub search, and the resume should backfill a
+    canonical record so later reruns hit the fast canonical path (#589)."""
+    runner = FakeRunner(
+        open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+        pr_payload={"body": "Fixes #56"},
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    handoff_comments = [c for c in runner.comments if "<!-- AGENT_ISSUE_PR_HANDOFF:" in c]
+    assert len(handoff_comments) == 1
+    assert "Flow: issue-implementation" in handoff_comments[0]
+    assert "PR #77" in handoff_comments[0]
+
+
+def test_issue_loop_direct_mode_stale_canonical_record_raises(tmp_path):
+    """A canonical record pointing at a closed/merged PR must fail safely
+    with an actionable message before any coder invocation, never falling
+    back to a fresh implementation (#589)."""
+    canonical_comment = {
+        "author": {"login": "bot"},
+        "createdAt": "2026-05-23T00:00:00Z",
+        "body": format_issue_pr_handoff_comment(
+            issue_number=56,
+            pr_number=77,
+            pr_url="https://github.com/OWNER/REPO/pull/77",
+            pr_head_sha="abc123",
+            flow="issue-implementation",
+            plan_hash=None,
+        ),
+    }
+    runner = FakeRunner(
+        issue_comments=[canonical_comment],
+        pr_payload={
+            "number": 77,
+            "state": "CLOSED",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "Fixes #56",
+        },
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match=r"agent-loop pr 77"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert not any(cmd[:1] in (["claude"], ["codex"]) for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_direct_mode_ambiguous_open_prs_raises(tmp_path):
+    """No canonical record and multiple open PRs referencing the issue must
+    stop before any coder invocation with an actionable message (#589)."""
+    runner = FakeRunner(
+        open_prs_payload=[
+            {"number": 77, "body": "Fixes #56"},
+            {"number": 78, "body": "Closes #56"},
+        ],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match=r"Multiple open PRs \(#77, #78\)"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_direct_mode_canonical_record_mismatched_pr_body_raises(tmp_path):
+    """A canonical record whose PR no longer references the issue in its body
+    must fail safely via the existing mismatch error (#589)."""
+    canonical_comment = {
+        "author": {"login": "bot"},
+        "createdAt": "2026-05-23T00:00:00Z",
+        "body": format_issue_pr_handoff_comment(
+            issue_number=56,
+            pr_number=77,
+            pr_url="https://github.com/OWNER/REPO/pull/77",
+            pr_head_sha="abc123",
+            flow="issue-implementation",
+            plan_hash=None,
+        ),
+    }
+    runner = FakeRunner(
+        issue_comments=[canonical_comment],
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "No reference here.",
+        },
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="does not reference issue #56"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
 def test_codex_issue_loop_creates_pr_then_claude_approves(tmp_path):
     runner = FakeRunner(
         codex_outputs=[
@@ -2427,9 +2561,10 @@ def test_codex_issue_loop_creates_pr_then_claude_approves(tmp_path):
     command_names = [cmd[:2] for cmd, _cwd in runner.commands]
     assert ["codex", "exec"] in command_names
     assert ["claude", "--print"] in command_names
-    assert len(runner.comments) == 2
-    assert runner.comments[0].startswith("Fixed issue.")
-    assert runner.comments[1].startswith("**Review verdict:** Approved\n\nLooks good.")
+    assert len(runner.comments) == 3
+    assert "<!-- AGENT_ISSUE_PR_HANDOFF:" in runner.comments[0]
+    assert runner.comments[1].startswith("Fixed issue.")
+    assert runner.comments[2].startswith("**Review verdict:** Approved\n\nLooks good.")
 
 def test_codex_issue_loop_alternates_until_claude_approval(tmp_path):
     runner = FakeRunner(
@@ -2448,7 +2583,7 @@ def test_codex_issue_loop_alternates_until_claude_approval(tmp_path):
 
     assert run_issue_loop(runner, issue_number=56, config=config) == 0
 
-    assert len(runner.comments) == 4
+    assert len(runner.comments) == 5
     assert runner.comments[-1].startswith("**Review verdict:** Approved\n\nLGTM.")
 
 def test_codex_issue_loop_requires_codex_to_report_pr_number(tmp_path):
@@ -2605,9 +2740,10 @@ def test_gemini_issue_loop_creates_pr_then_codex_approves(tmp_path):
 
     agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["gemini"], ["codex"])]
     assert agent_commands == [["gemini", "--prompt"], ["codex", "exec"]]
-    assert len(runner.comments) == 2
-    assert runner.comments[0].startswith("Fixed issue.")
-    assert runner.comments[1].startswith("**Review verdict:** Approved\n\nLooks good.")
+    assert len(runner.comments) == 3
+    assert "<!-- AGENT_ISSUE_PR_HANDOFF:" in runner.comments[0]
+    assert runner.comments[1].startswith("Fixed issue.")
+    assert runner.comments[2].startswith("**Review verdict:** Approved\n\nLooks good.")
 
 def test_gemini_issue_loop_resumes_session_for_followup(tmp_path):
     runner = FakeRunner(

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -10,6 +10,7 @@ from coding_review_agent_loop.decomposition import (
     format_one_shot_impl_handoff_comment,
 )
 from coding_review_agent_loop.github import validate_pr_body_does_not_close_issue
+from coding_review_agent_loop.issue_pr_handoff import format_issue_pr_handoff_comment
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
     _attach_round_metadata,
@@ -19,6 +20,7 @@ from coding_review_agent_loop.split_materialization import (
     MaterializedSplitChild,
     SplitMaterializationMetadata,
     format_split_materialization_summary,
+    format_split_stage_handoff_comment,
     split_stage_proposal_from_text,
 )
 from agent_loop_helpers import (
@@ -717,3 +719,172 @@ def test_validate_pr_body_does_not_close_issue_accepts_refs_url(tmp_path):
     runner = FakeRunner(pr_payload={"body": "Refs https://github.com/OWNER/REPO/issues/56"})
     config = make_config(tmp_path)
     validate_pr_body_does_not_close_issue(runner, config=config, pr_number=77, issue_number=56)
+
+
+def _selected_child_split_setup(*, plan_hash: str, plan_subject: str):
+    """Shared fixture for the #589 canonical-resolution selected-child tests:
+    a materialized split with one child (#101) and a pre-existing stage
+    handoff selecting it for `plan_hash`."""
+    split_metadata = SplitMaterializationMetadata(
+        parent_issue=56,
+        subject=plan_subject,
+        children=(
+            MaterializedSplitChild(
+                title="Auth flow",
+                key=split_stage_proposal_from_text("Auth flow").key,
+                url="https://github.com/OWNER/REPO/issues/101",
+                number=101,
+                origin="created",
+            ),
+        ),
+    )
+    return [
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:02Z",
+            "body": format_split_materialization_summary(parent_issue=56, metadata=split_metadata),
+        },
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:03Z",
+            "body": format_split_stage_handoff_comment(
+                parent_issue=56, plan_hash=plan_hash, child=split_metadata.children[0]
+            ),
+        },
+    ]
+
+
+def _approved_plan_round_comments(plan: str, *, plan_subject: str) -> list[dict]:
+    return [
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:00Z",
+            "body": _attach_round_metadata(
+                plan,
+                PostedRoundMetadata(
+                    flow="plan", role="coder", agent="Claude", round_number=1, subject=plan_subject
+                ),
+            ),
+        },
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:01Z",
+            "body": _attach_round_metadata(
+                "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+                PostedRoundMetadata(
+                    flow="plan",
+                    role="reviewer",
+                    agent="Codex",
+                    round_number=1,
+                    subject=plan_subject,
+                    state="approved",
+                ),
+            ),
+        },
+    ]
+
+
+def test_plan_first_one_shot_selected_child_stale_canonical_record_raises(tmp_path):
+    """#589 item-1: a canonical AGENT_ISSUE_PR_HANDOFF record on the *selected
+    split-stage child* (#101, not the parent #56) must be resolved, and a
+    stale (closed) PR it references must fail safely with an actionable
+    `agent-loop pr <number>` message *before* the older plan-hash-scoped
+    one-shot-handoff lookup ever runs, and without invoking the coder."""
+    plan = "Plan:\n- Auth flow change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan_subject = _plan_subject(plan)
+    plan_hash = approved_plan_hash(plan)
+    issue_comments = _approved_plan_round_comments(plan, plan_subject=plan_subject)
+    issue_comments += _selected_child_split_setup(plan_hash=plan_hash, plan_subject=plan_subject)
+    issue_comments.append(
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:04Z",
+            "body": format_issue_pr_handoff_comment(
+                issue_number=101,
+                pr_number=77,
+                pr_url="https://github.com/OWNER/REPO/pull/77",
+                pr_head_sha="deadbeef",
+                flow="approved-plan-implementation",
+                plan_hash=plan_hash,
+            ),
+        }
+    )
+    runner = FakeRunner(
+        pr_payload={
+            "number": 77,
+            "state": "CLOSED",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "Fixes #101",
+        },
+        issue_comments=issue_comments,
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    with pytest.raises(AgentLoopError, match=r"agent-loop pr 77"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+
+
+def test_plan_first_one_shot_selected_child_valid_canonical_record_resumes(tmp_path):
+    """#589 item-1: a valid canonical record on the selected child resumes PR
+    review directly (no coder call), taking priority over a present-but-stale
+    old-style one-shot-handoff marker that points at a different PR."""
+    plan = "Plan:\n- Auth flow change.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    plan_subject = _plan_subject(plan)
+    plan_hash = approved_plan_hash(plan)
+    issue_comments = _approved_plan_round_comments(plan, plan_subject=plan_subject)
+    issue_comments += _selected_child_split_setup(plan_hash=plan_hash, plan_subject=plan_subject)
+    issue_comments.append(
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:04Z",
+            "body": format_one_shot_impl_handoff_comment(
+                parent_issue=101,
+                mode="implement-one-shot",
+                plan_hash=plan_hash,
+                plan_subject=plan_subject,
+                pr_number=999,
+                pr_head_sha="stalesha",
+            ),
+        }
+    )
+    issue_comments.append(
+        {
+            "author": {"login": "bot"},
+            "createdAt": "2026-05-23T00:00:05Z",
+            "body": format_issue_pr_handoff_comment(
+                issue_number=101,
+                pr_number=77,
+                pr_url="https://github.com/OWNER/REPO/pull/77",
+                pr_head_sha="deadbeef",
+                flow="approved-plan-implementation",
+                plan_hash=plan_hash,
+            ),
+        }
+    )
+    runner = FakeRunner(
+        pr_payload={
+            "number": 77,
+            "state": "OPEN",
+            "url": "https://github.com/OWNER/REPO/pull/77",
+            "body": "Fixes #101",
+        },
+        issue_comments=issue_comments,
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+    )
+    config = make_config(tmp_path, materialize_split_issues=True)
+
+    assert (
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True, implement_after_approval=True)
+        == 0
+    )
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    # No new handoff comment posted for an already-canonical resume.
+    assert not any(
+        "<!-- AGENT_ISSUE_PR_HANDOFF:" in comment for comment in runner.comments
+    )


### PR DESCRIPTION
## Summary
- Add `src/coding_review_agent_loop/issue_pr_handoff.py`: a versioned `AGENT_ISSUE_PR_HANDOFF` marker (`IssuePrHandoffMetadata`, with `pr_url`/`pr_head_sha` as required non-empty fields), strict decode validation (schema version, flow, positive identifiers, host/path-exact URL check, plan-hash-by-flow rules), `find_latest_issue_pr_handoff` (newest-wins lookup), `resolve_canonical_pr_for_issue` (canonical record first, legacy exactly-one-open-PR search fallback, `dry_run` no-op), and `require_pr_metadata_for_handoff` guarding every posting call site.
- Wire the resolver into `run_issue_loop`'s direct-mode branch, `_implement_approved_issue`, and the `implement-one-shot` branch of `_run_plan_first_loop` in `orchestrator.py`, so both direct `agent-loop issue <n>` and plan-first implementation resume an already-open validated PR instead of invoking a coder again after an interrupted review — matching the acceptance criteria in #589.
- Post the canonical record right after each existing PR-references-issue validation for freshly created PRs, and backfill exactly one record when resuming via the legacy search.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 1607 passed (includes new `tests/test_issue_pr_handoff.py` unit coverage for encode/decode/find/URL-validation/`require_pr_metadata_for_handoff`, plus updated `tests/test_orchestrator_issue.py` and `tests/test_split_orchestration.py` covering direct-mode resume, plan-first one-shot resume, legacy-search backfill, stale/closed/merged records, ambiguous multiple-PR records, and mismatched PR bodies)
- [x] Updated `docs/local_agent_loop.md` to describe the new canonical-record-first / legacy-search-fallback behavior for both direct and plan-first modes

Fixes #589

-- Anthropic Claude