### PR TITLE
Recover Claude implementation turns that end with pending background work

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1197,6 +1197,29 @@ an agent exits or returns only diagnostics, empty output, or normal prose
 without the required marker, the loop fails locally with `AgentLoopError` and
 the attempt log path instead of posting that raw output as a review.
 
+Coder prompts for a direct issue implementation explicitly forbid launching
+required tests or other completion work (builds, commits, pushes, PR creation)
+in the background and ending the turn early; the coder must finish that work
+in the foreground and wait for it before responding. If a Claude
+implementation turn still ends this way — no valid `AGENT_PR`/`AGENT_STATE`/
+`AGENT_CLARIFY` marker, and text like "I'll wait for the background test run
+to finish" or "you'll be notified when it's done" — the loop performs one
+bounded `claude --resume <session>` completion-recovery pass instead of
+failing immediately. The resume turn is told to inspect the existing checkout,
+finish only foreground work, and either complete the PR or end with a real
+terminal marker. Its result is validated exactly like a normal implementation
+response: a valid PR, a no-PR `AGENT_STATE: blocking`, or `AGENT_CLARIFY` is
+accepted and posted like any other outcome. If the resume turn instead
+declares `AGENT_UNAVAILABLE` itself, or if the resume command fails or still
+does not produce a valid terminal response, the loop renders (or reuses the
+agent's own verbatim) protocol-valid `AGENT_UNAVAILABLE` text, persists it to
+that attempt's own response file, and posts it to the GitHub issue before
+failing locally with `AgentLoopError` and the usual salvage artifacts — there
+is never more than one resume attempt, regardless of what the agent's own
+response says about retrying. A genuine, non-recovery no-PR
+`AGENT_STATE: blocking` or `AGENT_CLARIFY` result is likewise posted to the
+issue, matching how a successful PR-creating implementation is already posted.
+
 For structured plan reviews, plan revisions, PR reviews, and coder follow-ups,
 a present but malformed structured response may get a repair pass before the
 local failure is raised. By default the repair pass calls Antigravity through

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -17,6 +17,7 @@ from .protocol import (
     PRIOR_UNRESOLVED_ITEM_DISPOSITIONS_HEADING_RE,
     PRIOR_UNRESOLVED_PLAN_ITEM_DISPOSITIONS_HEADING_RE,
     SIGNATURE_RE,
+    AgentUnavailable,
     DeferredStage,
     HumanRequirementDisposition,
     ParsedDiscussAgenda,
@@ -47,6 +48,27 @@ _AGENT_BY_DISPLAY_NAME = {
     agent_display_name(agent): agent
     for agent in ("claude", "codex", "gemini", "antigravity")
 }
+
+
+def render_agent_unavailable_comment(unavailable: AgentUnavailable, *, signature: str) -> str:
+    """Render a protocol-valid ``agent_unavailable`` envelope that parse_agent_unavailable accepts.
+
+    Used only for orchestrator-synthesized outcomes (e.g. an exhausted
+    completion-recovery attempt, #588) where there is no agent-authored
+    envelope to post verbatim. The JSON payload, footer, and signature must
+    exactly match the grammar in protocol.py's
+    _consume_agent_unavailable_footer_and_signature: no prose between the JSON
+    and the footer, and nothing but the signature after it.
+    """
+    payload = {
+        "schema_version": unavailable.schema_version,
+        "kind": "agent_unavailable",
+        "retryable": unavailable.retryable,
+        "category": unavailable.category,
+        "summary": unavailable.summary,
+        "suggested_action": unavailable.suggested_action,
+    }
+    return f"{json.dumps(payload, ensure_ascii=False)}\n<!-- AGENT_UNAVAILABLE -->\n-- {signature}"
 
 
 def _review_freeform_summary_text(text: str) -> str:

--- a/src/coding_review_agent_loop/errors.py
+++ b/src/coding_review_agent_loop/errors.py
@@ -37,9 +37,20 @@ class AgentInvocationError(AgentLoopError):
     without re-parsing the message.
     """
 
-    def __init__(self, message: str, *, failure_category: str | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_category: str | None = None,
+        terminal_public_response: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.failure_category = failure_category
+        # Protocol-valid text (agent-declared AGENT_UNAVAILABLE text verbatim,
+        # or an orchestrator-synthesized rendering) already persisted/posted by
+        # a bounded completion-recovery attempt (#588). None for every other
+        # failure path, which is unchanged.
+        self.terminal_public_response = terminal_public_response
 
 
 class QuotaResetExceededError(AgentLoopError):

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, replace as dataclasses_replace
 from pathlib import Path
 
 from .agents.base import AgentName, AgentResult
-from .agents.registry import agent_display_name, get_backend, run_agent_result
+from .agents.registry import agent_display_name, agent_signature, get_backend, run_agent_result
 from .config import (
     AgentLoopConfig,
     ensure_agent_workdirs,
@@ -102,6 +102,7 @@ from .prompts import (
     build_discuss_answer_confirmation_prompt,
     build_discuss_semantic_comparison_prompt,
     build_discuss_review_prompt,
+    build_completion_recovery_prompt,
     build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
@@ -189,6 +190,7 @@ from .transient import (
     NON_RETRYABLE_AGENT_OUTPUT_RE,
     TRANSIENT_AGENT_OUTPUT_RE,
     is_transient_agent_output,
+    looks_like_backgrounded_completion,
 )
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
@@ -226,6 +228,7 @@ from .comment_rendering import (
     normalize_freeform_signature,
     render_discuss_round_summary_comment,
     render_public_agent_comment,
+    render_agent_unavailable_comment,
     render_canonical_plan_revision,
     render_canonical_plan_steps,
     _render_discuss_agenda_lines,
@@ -1753,6 +1756,241 @@ def _run_structured_repair(
     )
 
 
+@dataclass(frozen=True)
+class CompletionRecoveryPolicy:
+    """Explicit opt-in for the bounded same-session completion-recovery pass (#588).
+
+    Passed only by the direct issue-implementation call sites that already
+    validate with `_require_issue_implementation_result`; every other
+    `_run_validated_agent` caller (planning, plan/PR review, discuss, task,
+    and the coder follow-up/PR loop) leaves this `None` and is therefore
+    ineligible by construction -- eligibility is never inferred from the
+    agent name or response text alone.
+    """
+
+    issue_number: int
+
+
+@dataclass(frozen=True)
+class _CompletionRecoveryOutcome:
+    validated: ValidatedAgentResponse | None
+    result: AgentResult
+    error: str
+    classification_text: str
+    failure_category: str
+    # Protocol-valid text already persisted to the recovery attempt's own
+    # response file and posted to the GitHub issue; set only when validated
+    # is None.
+    terminal_public_response: str | None
+
+
+def _post_completion_recovery_terminal_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    completion_recovery: CompletionRecoveryPolicy,
+    recovery_result: AgentResult,
+    terminal_text: str,
+) -> None:
+    if recovery_result.response_file_path is not None:
+        recovery_result.response_file_path.write_text(terminal_text, encoding="utf-8")
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=completion_recovery.issue_number,
+        body=terminal_text,
+    )
+
+
+def _synthesized_completion_recovery_unavailable(
+    *, config: AgentLoopConfig, recovery_result: AgentResult, category: str, summary: str
+) -> tuple[AgentUnavailable, str]:
+    unavailable = AgentUnavailable(
+        schema_version=1,
+        kind="agent_unavailable",
+        retryable=False,
+        category=category,
+        summary=summary,
+        suggested_action=(
+            "Inspect the completion-recovery log and salvage artifacts, "
+            "then retry the implementation manually."
+        ),
+    )
+    signature = agent_signature("claude", config, model_used=recovery_result.model_used)
+    return unavailable, render_agent_unavailable_comment(unavailable, signature=signature)
+
+
+def _attempt_claude_completion_recovery(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    completion_recovery: CompletionRecoveryPolicy,
+    session_id: str,
+    validate: Callable[[str], object],
+    usage_context: RunUsageContext | None,
+    run_id: str | None,
+    role: str | None,
+    label: str | None,
+    timeout_seconds: float | None,
+) -> _CompletionRecoveryOutcome:
+    """One bounded ``claude --resume`` completion-recovery pass (#588).
+
+    Entirely self-contained and attempt-local: every variable here is scoped
+    to this one recovery call, never the caller's original (failed) attempt.
+    The caller's original ``AgentResult`` is not even passed in, so isolation
+    is structural rather than merely asserted. Three outcomes:
+
+    - a valid PR/blocking/clarify per ``validate()`` -> success, returned as
+      a normal ``ValidatedAgentResponse`` subject to ordinary PR validation;
+    - the resume turn itself declares a protocol-valid ``AGENT_UNAVAILABLE``
+      -> terminal, posted/persisted verbatim, never passed to ``validate()``,
+      and always terminal regardless of its own ``retryable`` flag (the
+      bounded one-recovery-attempt policy overrides the agent's preference);
+    - anything else (transport failure, or text that still fails
+      ``validate()``) -> terminal, with a synthesized non-retryable
+      ``AGENT_UNAVAILABLE`` rendered, persisted, and posted.
+
+    In every terminal case there is exactly one ``--resume`` call total.
+    """
+    recovery_prompt = build_completion_recovery_prompt(config)
+    recovery_result = run_agent_result(
+        runner,
+        agent="claude",
+        config=config,
+        prompt=recovery_prompt,
+        session_id=session_id,
+        run_id=run_id,
+        role=role,
+        label=label,
+        timeout_seconds=timeout_seconds,
+    )
+    if usage_context is not None:
+        recovery_usage = _resolve_usage_metadata(
+            config=config, prompt=recovery_prompt, result=recovery_result
+        )
+        if recovery_usage is not None:
+            usage_context.add_record(
+                agent="claude",
+                session_id=recovery_result.session_id,
+                returncode=recovery_result.returncode,
+                usage=recovery_usage,
+                raw_backend_usage=recovery_result.raw_usage,
+                role="completion-recovery",
+            )
+    else:
+        recovery_usage = None
+
+    def _terminal(category: str, summary: str, *, error: str) -> _CompletionRecoveryOutcome:
+        _unavailable, rendered = _synthesized_completion_recovery_unavailable(
+            config=config, recovery_result=recovery_result, category=category, summary=summary
+        )
+        _post_completion_recovery_terminal_comment(
+            runner,
+            config=config,
+            completion_recovery=completion_recovery,
+            recovery_result=recovery_result,
+            terminal_text=rendered,
+        )
+        return _CompletionRecoveryOutcome(
+            validated=None,
+            result=recovery_result,
+            error=error,
+            classification_text=recovery_result.raw_output or recovery_result.text,
+            failure_category="agent-unavailable",
+            terminal_public_response=rendered,
+        )
+
+    if recovery_result.returncode is None:
+        limit = f" after {timeout_seconds:g}s" if timeout_seconds is not None else ""
+        return _terminal(
+            "environment",
+            "The bounded claude --resume completion-recovery pass timed out.",
+            error=f"completion-recovery resume timed out{limit}",
+        )
+    if recovery_result.returncode != 0:
+        return _terminal(
+            "tooling",
+            "The bounded claude --resume completion-recovery pass exited with a non-zero status.",
+            error=f"completion-recovery resume exited with {recovery_result.returncode}",
+        )
+    recovery_text = recovery_result.text
+    if not recovery_text.strip():
+        return _terminal(
+            "tooling",
+            "The bounded claude --resume completion-recovery pass produced no output.",
+            error="completion-recovery resume produced no output",
+        )
+
+    try:
+        unavailable = parse_agent_unavailable(recovery_text)
+    except AgentLoopError:
+        unavailable = None
+    if unavailable is not None:
+        # Agent-declared: post/persist verbatim, never validate()'d, and
+        # always terminal regardless of unavailable.retryable.
+        _post_completion_recovery_terminal_comment(
+            runner,
+            config=config,
+            completion_recovery=completion_recovery,
+            recovery_result=recovery_result,
+            terminal_text=recovery_text,
+        )
+        return _CompletionRecoveryOutcome(
+            validated=None,
+            result=recovery_result,
+            error=(
+                "agent explicitly reported it cannot continue after completion "
+                f"recovery ({unavailable.category}): {unavailable.summary}"
+            ),
+            classification_text=recovery_text,
+            failure_category="agent-unavailable",
+            terminal_public_response=recovery_text,
+        )
+
+    try:
+        marker_value = validate(recovery_text)
+    except AgentLoopError as exc:
+        _unavailable, rendered = _synthesized_completion_recovery_unavailable(
+            config=config,
+            recovery_result=recovery_result,
+            category="tooling",
+            summary=(
+                "The bounded claude --resume completion-recovery pass did not "
+                f"produce a valid terminal response: {exc}"
+            ),
+        )
+        _post_completion_recovery_terminal_comment(
+            runner,
+            config=config,
+            completion_recovery=completion_recovery,
+            recovery_result=recovery_result,
+            terminal_text=rendered,
+        )
+        return _CompletionRecoveryOutcome(
+            validated=None,
+            result=recovery_result,
+            error=str(exc),
+            classification_text=recovery_text,
+            failure_category="agent-unavailable",
+            terminal_public_response=rendered,
+        )
+
+    return _CompletionRecoveryOutcome(
+        validated=ValidatedAgentResponse(
+            text=recovery_text,
+            session_id=recovery_result.session_id,
+            marker_value=marker_value,
+            usage=recovery_usage,
+            model_used=recovery_result.model_used,
+        ),
+        result=recovery_result,
+        error="",
+        classification_text="",
+        failure_category="",
+        terminal_public_response=None,
+    )
+
+
 def _log_repair_attempts(config: AgentLoopConfig, prefix: str, attempts: Sequence[RepairAttemptResult]) -> None:
     for attempt in attempts:
         diagnostic = attempt.diagnostic or "(none)"
@@ -1789,6 +2027,7 @@ def _run_validated_agent(
     timeout_seconds: float | None = None,
     salvage_context: SalvageContext | None = None,
     operation_description: str | None = None,
+    completion_recovery: CompletionRecoveryPolicy | None = None,
 ) -> ValidatedAgentResponse:
     agent_name = agent_display_name(agent)
     operation_description = operation_description or _operation_description_from_context(
@@ -1804,6 +2043,13 @@ def _run_validated_agent(
     last_result: AgentResult | None = None
     last_classification_text = ""
     last_failure_category = "empty-response"
+    # Set only by an exhausted completion-recovery attempt (#588): the
+    # protocol-valid text already persisted to the recovery attempt's own
+    # response file and posted to the GitHub issue, attached to the final
+    # AgentInvocationError so callers/tests can assert on it without
+    # re-parsing the message.
+    terminal_public_response: str | None = None
+    completion_recovery_attempted = False
 
     for attempt in range(1, max_attempts + 1):
         result = run_agent_result(
@@ -1900,6 +2146,38 @@ def _run_validated_agent(
                     public_response=True,
                     repair_expected_kind=repair_expected_kind,
                 )
+                if (
+                    completion_recovery is not None
+                    and not completion_recovery_attempted
+                    and agent == "claude"
+                    and result.session_id
+                    and looks_like_backgrounded_completion(classification_text)
+                ):
+                    # At most one same-session resume, ever, for this call
+                    # (#588): mark it attempted before invoking so a failure
+                    # cannot loop back into this branch on a later attempt.
+                    completion_recovery_attempted = True
+                    recovery_outcome = _attempt_claude_completion_recovery(
+                        runner,
+                        config=config,
+                        completion_recovery=completion_recovery,
+                        session_id=result.session_id,
+                        validate=validate,
+                        usage_context=usage_context,
+                        run_id=usage_context.run_id if usage_context is not None else None,
+                        role=role,
+                        label=label,
+                        timeout_seconds=timeout_seconds,
+                    )
+                    if recovery_outcome.validated is not None:
+                        return recovery_outcome.validated
+                    last_result = recovery_outcome.result
+                    last_error = recovery_outcome.error
+                    last_classification_text = recovery_outcome.classification_text
+                    last_failure_category = recovery_outcome.failure_category
+                    terminal_public_response = recovery_outcome.terminal_public_response
+                    should_retry = False
+                    break
                 response_failure_is_unsupported = last_failure_category == "unsupported_model"
                 # Marker near-misses are a separate first-attempt nudge for common footer typos;
                 # structured JSON protocol drift still remains repairable when retries are exhausted.
@@ -2347,7 +2625,11 @@ def _run_validated_agent(
         classification_text=last_classification_text,
     )
     message += diagnostics.format_for_error()
-    raise AgentInvocationError(message, failure_category=last_failure_category)
+    raise AgentInvocationError(
+        message,
+        failure_category=last_failure_category,
+        terminal_public_response=terminal_public_response,
+    )
 
 
 @dataclass(frozen=True)
@@ -2379,6 +2661,32 @@ def _require_issue_implementation_result(text: str) -> int | _TerminalNoPrImplem
     raise AgentLoopError(
         f"Coder did not create a valid PR: {reference_error} "
         "or a terminal blocking/clarification marker."
+    )
+
+
+def _post_no_pr_implementation_terminal_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    coder_response: ValidatedAgentResponse,
+) -> None:
+    """Post a genuine coder-declared no-PR blocking/clarify result to GitHub (#588).
+
+    Matches how a PR-success implementation result is already posted
+    (post_pr_comment / post_issue_pr_handoff_comment): the coder's own text
+    is the actionable public record, whether or not a PR was created.
+    """
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body=normalize_freeform_signature(
+            coder_response.text,
+            agent=config.coder,
+            config=config,
+            model_used=coder_response.model_used,
+        ),
     )
 
 
@@ -3151,10 +3459,17 @@ def _implement_approved_issue(
             approved_plan_hash=plan_hash,
         ),
         operation_description="approved-plan implementation",
+        completion_recovery=CompletionRecoveryPolicy(issue_number=issue_number),
     )
     coder_output = coder_response.text
     implementation_result = coder_response.marker_value
     if isinstance(implementation_result, _TerminalNoPrImplementation):
+        _post_no_pr_implementation_terminal_comment(
+            runner,
+            config=implementation_config,
+            issue_number=issue_number,
+            coder_response=coder_response,
+        )
         raise AgentLoopError(
             "Coder did not create a valid PR; implementation is " + implementation_result.state + "."
         )
@@ -4355,11 +4670,18 @@ def run_issue_loop(
                 run_id=usage_context.run_id,
             ),
             operation_description="issue implementation",
+            completion_recovery=CompletionRecoveryPolicy(issue_number=issue_number),
         )
         coder_output = coder_response.text
         coder_session_id = coder_response.session_id
         implementation_result = coder_response.marker_value
         if isinstance(implementation_result, _TerminalNoPrImplementation):
+            _post_no_pr_implementation_terminal_comment(
+                runner,
+                config=config,
+                issue_number=issue_number,
+                coder_response=coder_response,
+            )
             raise AgentLoopError(
                 "Coder did not create a valid PR; implementation is " + implementation_result.state + "."
             )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -87,7 +87,12 @@ def _coder_test_reporting_guidance() -> str:
         "Before opening or updating the PR, run the relevant tests you can run "
         "locally. In your final response, include a short `Tests:` line listing "
         "the exact commands run and whether they passed. If you cannot run tests, "
-        "explain why in that `Tests:` line.\n"
+        "explain why in that `Tests:` line. Run tests and any other required "
+        "completion work (builds, commits, pushes, PR creation) in the "
+        "foreground and wait for them to finish before ending this turn. Do not "
+        "launch them in the background and end the turn saying you will wait for "
+        "them; a turn that ends without a real terminal marker because required "
+        "work is still running in the background cannot be validated.\n"
     )
 
 
@@ -519,6 +524,40 @@ def _agent_unavailable_guidance(signature: str) -> str:
 -- {signature}
 
 Use `retryable: true` only when a fresh invocation may succeed without changing code or configuration. This is an agent-operational failure, not review feedback; do not use it for a genuine code blocker, a request for clarification, or a normal disagreement.
+"""
+
+
+def _issue_implementation_terminal_marker_guidance(
+    *, reviewer_name: str, coder_signature: str
+) -> str:
+    """Shared terminal-marker grammar for a direct issue-implementation turn.
+
+    Used by build_issue_prompt, build_issue_implementation_prompt, and
+    build_completion_recovery_prompt so all three stay in sync on the exact
+    marker grammar (#588); a discrepancy here would let a completion-recovery
+    resume diverge from what the original turn was told.
+    """
+    return f"""{_agent_unavailable_guidance(coder_signature)}
+Do not wait for {reviewer_name} yourself; this local orchestrator will run
+{reviewer_name} after you create the PR. Use blocking here to hand the PR to
+{reviewer_name} for review. If you cannot safely proceed and cannot create a
+PR, explain the blocker and end with `AGENT_STATE: blocking` (without an
+`AGENT_PR` marker), or ask a final focused question with `AGENT_CLARIFY`.
+Otherwise, use a positive PR number. Do not invent placeholder identifiers such
+as `AGENT_PR: 0`. Do not place your signature before the AGENT_STATE marker.
+Your response must end with, in this exact order for a completed implementation:
+
+<!-- AGENT_PR: <number> -->
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For a no-PR blocking result:
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For clarification:
+<!-- AGENT_CLARIFY -->
+-- {coder_signature}
 """
 
 
@@ -987,27 +1026,7 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_memory_block(memory)}
 {_salvage_summary_block(salvage_summary)}
 
-{_agent_unavailable_guidance(coder_signature)}
-Do not wait for {reviewer_name} yourself; this local orchestrator will run {reviewer_name} after
-you create the PR. Use blocking here to hand the PR to {reviewer_name} for review. If you cannot
-safely proceed and cannot create a PR, explain the blocker and end with `AGENT_STATE: blocking`
-(without an `AGENT_PR` marker), or ask a final focused question with `AGENT_CLARIFY`. Otherwise,
-use a positive PR number; do not invent placeholders such as `AGENT_PR: 0`. Do not place your
-signature before the AGENT_STATE marker. Your response must end with, in this exact order for a
-completed implementation:
-
-<!-- AGENT_PR: <number> -->
-<!-- AGENT_STATE: blocking -->
--- {coder_signature}
-
-For a no-PR blocking result:
-<!-- AGENT_STATE: blocking -->
--- {coder_signature}
-
-For clarification:
-<!-- AGENT_CLARIFY -->
--- {coder_signature}
-"""
+{_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
 
 def build_issue_plan_prompt(
@@ -1606,28 +1625,37 @@ Approved implementation plan:
 
 {approved_plan}
 
-{_agent_unavailable_guidance(coder_signature)}
-Do not wait for {reviewer_name} yourself; this local orchestrator will run
-{reviewer_name} after you create the PR. Use blocking here to hand the PR to
-{reviewer_name} for review. If you cannot safely proceed and cannot create a
-PR, explain the blocker and end with `AGENT_STATE: blocking` (without an
-`AGENT_PR` marker), or ask a final focused question with `AGENT_CLARIFY`.
-Otherwise, use a positive PR number. Do not invent placeholder identifiers such
-as `AGENT_PR: 0`. Do not place your signature before the AGENT_STATE marker.
-Your response must end with, in this exact order for a completed implementation:
+{_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
-<!-- AGENT_PR: <number> -->
-<!-- AGENT_STATE: blocking -->
--- {coder_signature}
 
-For a no-PR blocking result:
-<!-- AGENT_STATE: blocking -->
--- {coder_signature}
+def build_completion_recovery_prompt(config: AgentLoopConfig) -> str:
+    """One bounded same-session continuation for a stalled implementation turn (#588).
 
-For clarification:
-<!-- AGENT_CLARIFY -->
--- {coder_signature}
-"""
+    Sent via ``claude --resume <session>`` when a prior implementation turn
+    ended with no valid terminal marker and language suggesting it deferred to
+    background work still pending. This is the only continuation the agent
+    gets: the orchestrator will not send another one, regardless of what this
+    turn's own text says about retrying.
+    """
+    reviewer_name = format_agent_list(reviewers(config))
+    coder_signature = agent_signature(config.coder, config)
+    return f"""Your previous turn on this same implementation ended without a valid
+terminal response, and its text suggested required work (tests, a build, or
+similar) was left running in the background instead of being finished before
+the turn ended. This is a one-time, bounded continuation of that same session;
+the orchestrator will not send another one after this turn.
+{_coder_workdir_guidance(config)}
+{_scratch_file_guidance()}
+
+Inspect the existing checkout now (`git status`, `git diff`, `git log`) to see
+what you already did. Do not restart the implementation from scratch. Finish
+only foreground work from here: if you started tests or a build in the
+background, check on it or re-run it in the foreground now and wait for it to
+finish; do not launch anything new in the background. Then commit, push, and
+open the pull request if that is not already done, or continue exactly where
+you left off.
+{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
 
 def build_task_prompt(

--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -37,3 +37,34 @@ def is_transient_agent_output(text: str) -> bool:
     return bool(TRANSIENT_AGENT_OUTPUT_RE.search(text)) and not bool(
         NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
     )
+
+
+# Phrases an agent uses when it has started required work (tests, builds) in
+# the background and ends its turn waiting on it instead of finishing in the
+# foreground (#588). This is purely textual: it makes no assumption about
+# marker presence/absence. Eligibility for completion recovery is gated
+# separately by the caller's own terminal-result validator having already
+# rejected the response, so an embedded (but invalid-for-that-validator)
+# marker never exempts a response from matching here.
+BACKGROUNDED_COMPLETION_RE = re.compile(
+    r"(?i)"
+    r"\bi(?:'|')?ll wait\b|"
+    r"\bwait(?:ing)? for (?:the )?background|"
+    r"\brun(?:s|ning)? (?:it |them )?in the background\b|"
+    r"\b(?:test|build|suite)\w*\b.{0,60}\bin the background\b|"
+    r"\bin the background\b.{0,60}\b(?:test|build|suite)|"
+    r"\b(?:you(?:'|')?ll|i(?:'|')?ll|we(?:'|')?ll) (?:get|be) notified\b|"
+    r"\bwill (?:get|be) notified\b|"
+    r"\blet me wait for\b|"
+    r"\bonce (?:the |it )?(?:background )?(?:test|build|suite).{0,40}finish"
+)
+
+
+def looks_like_backgrounded_completion(text: str) -> bool:
+    """Return True if ``text`` reads like the agent deferred to background work.
+
+    Purely a phrase match; callers must independently confirm the response
+    failed the relevant terminal-result validator before treating this as
+    grounds for a completion-recovery attempt (#588).
+    """
+    return bool(BACKGROUNDED_COMPLETION_RE.search(text))

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -89,7 +89,7 @@ class UsageCallRecord:
     usage: UsageMetadata
     validation_status: Literal["validated", "invalid"] = "invalid"
     raw_backend_usage: object | None = None
-    role: Literal["repair"] | None = None
+    role: Literal["repair", "completion-recovery"] | None = None
     model: str | None = None
     outcome: Literal[
         "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
@@ -198,7 +198,7 @@ class RunUsageContext:
         returncode: int | None,
         usage: UsageMetadata,
         raw_backend_usage: object | None = None,
-        role: Literal["repair"] | None = None,
+        role: Literal["repair", "completion-recovery"] | None = None,
         model: str | None = None,
         outcome: Literal[
             "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -138,6 +138,7 @@ from coding_review_agent_loop.prompts import (
     _build_followup_guidance,
     _build_unresolved_items_guidance,
     _phased_plan_guard,
+    build_completion_recovery_prompt,
     build_followup_prompt,
     build_issue_implementation_prompt,
     build_issue_plan_prompt,

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -16,6 +16,7 @@ from coding_review_agent_loop.comment_rendering import (
     _render_public_pr_review_comment,
     decode_deferred_stages_marker,
     normalize_freeform_signature,
+    render_agent_unavailable_comment,
     render_deferred_stages_section,
     render_discuss_round_summary_comment,
 )
@@ -54,6 +55,26 @@ from agent_loop_helpers import (
     structured_plan_state,
     structured_pr_review,
 )
+
+
+def test_render_agent_unavailable_comment_round_trips_through_parser():
+    from coding_review_agent_loop.protocol import AgentUnavailable, parse_agent_unavailable
+
+    unavailable = AgentUnavailable(
+        schema_version=1,
+        kind="agent_unavailable",
+        retryable=False,
+        category="tooling",
+        summary="The bounded claude --resume completion-recovery pass timed out.",
+        suggested_action="Inspect the completion-recovery log and salvage artifacts.",
+    )
+
+    rendered = render_agent_unavailable_comment(unavailable, signature="Anthropic Claude")
+
+    assert rendered.startswith("{")
+    assert "<!-- AGENT_UNAVAILABLE -->" in rendered
+    assert rendered.endswith("-- Anthropic Claude")
+    assert parse_agent_unavailable(rendered) == unavailable
 
 
 def test_answer_research_rendering_ignores_failed_resume_placeholder():

--- a/tests/test_completion_recovery.py
+++ b/tests/test_completion_recovery.py
@@ -1,0 +1,415 @@
+"""Tests for the bounded Claude completion-recovery pass (#588).
+
+Covers the low-level ``_attempt_claude_completion_recovery`` helper directly
+(all terminal outcomes: success, agent-declared unavailable, transport
+failure, still-invalid text, and response-file attempt-isolation) plus
+end-to-end wiring through ``run_issue_loop``'s direct implementation path
+(exactly-one-resume bounded retry, GitHub posting, and negative controls for
+call sites that never opt in).
+"""
+
+import json
+
+import pytest
+
+from coding_review_agent_loop.cli import run_issue_loop
+from coding_review_agent_loop.errors import AgentInvocationError, AgentLoopError
+from coding_review_agent_loop.orchestrator import (
+    CompletionRecoveryPolicy,
+    ValidatedAgentResponse,
+    _attempt_claude_completion_recovery,
+    _new_usage_context,
+    _require_issue_implementation_result,
+    _TerminalNoPrImplementation,
+)
+from coding_review_agent_loop.protocol import AgentUnavailable, parse_agent_unavailable
+
+from agent_loop_helpers import FakeRunner, make_config
+
+
+def _claude_resume_commands(runner):
+    return [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+
+
+def test_recovery_success_returns_validated_response_and_resumes_session(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 99 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path, coder="claude")
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    assert outcome.validated is not None
+    assert isinstance(outcome.validated, ValidatedAgentResponse)
+    assert outcome.validated.marker_value == 99
+    assert outcome.terminal_public_response is None
+    claude_commands = _claude_resume_commands(runner)
+    assert len(claude_commands) == 1
+    assert "--resume" in claude_commands[0]
+    assert claude_commands[0][claude_commands[0].index("--resume") + 1] == "sess-1"
+    # Success is never posted by the recovery helper itself; the caller
+    # (_implement_approved_issue / run_issue_loop) posts PR-success comments
+    # through the existing post_pr_comment/post_issue_pr_handoff_comment path.
+    assert runner.comments == []
+
+
+def test_recovery_success_no_pr_blocking_result_is_not_posted_by_helper(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Cannot proceed.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path, coder="claude")
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    assert outcome.validated is not None
+    assert isinstance(outcome.validated.marker_value, _TerminalNoPrImplementation)
+    assert outcome.validated.marker_value.state == "blocking"
+    # Posting a genuine no-PR terminal to the issue is the caller's job
+    # (_post_no_pr_implementation_terminal_comment), not this helper's.
+    assert runner.comments == []
+
+
+@pytest.mark.parametrize("retryable", [True, False])
+def test_recovery_agent_declared_unavailable_is_terminal_regardless_of_retryable(
+    tmp_path, retryable
+):
+    unavailable_text = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "agent_unavailable",
+                "retryable": retryable,
+                "category": "environment",
+                "summary": "Sandbox lost network access mid-resume.",
+                "suggested_action": "Retry once connectivity is restored.",
+            }
+        )
+        + "\n<!-- AGENT_UNAVAILABLE -->\n-- Anthropic Claude"
+    )
+    runner = FakeRunner(claude_outputs=[unavailable_text])
+    config = make_config(tmp_path, coder="claude")
+    validate_calls = []
+
+    def _validate(text):
+        validate_calls.append(text)
+        return _require_issue_implementation_result(text)
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_validate,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    assert outcome.validated is None
+    assert outcome.failure_category == "agent-unavailable"
+    # Never sent through the ordinary implementation validator/PR checks: the
+    # bounded one-recovery-attempt policy overrides the agent's own retryable
+    # preference, so there is no second --resume and no PR validation either
+    # way.
+    assert validate_calls == []
+    assert outcome.terminal_public_response == unavailable_text
+    assert runner.comments == [unavailable_text]
+    assert outcome.result.response_file_path.read_text(encoding="utf-8") == unavailable_text
+    assert len(_claude_resume_commands(runner)) == 1
+
+
+def test_recovery_transport_failure_nonzero_exit_synthesizes_unavailable(tmp_path):
+    runner = FakeRunner(claude_outputs=[("agent crashed", 1)])
+    config = make_config(tmp_path, coder="claude")
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    assert outcome.validated is None
+    assert outcome.failure_category == "agent-unavailable"
+    parsed = parse_agent_unavailable(outcome.terminal_public_response)
+    assert parsed is not None
+    assert parsed.retryable is False
+    assert parsed.category == "tooling"
+    assert runner.comments == [outcome.terminal_public_response]
+    assert outcome.result.response_file_path.read_text(encoding="utf-8") == outcome.terminal_public_response
+    assert len(_claude_resume_commands(runner)) == 1
+
+
+def test_recovery_transport_failure_empty_output_synthesizes_unavailable(tmp_path):
+    runner = FakeRunner(claude_outputs=[("", 0)])
+    config = make_config(tmp_path, coder="claude")
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    assert outcome.validated is None
+    assert parse_agent_unavailable(outcome.terminal_public_response) is not None
+    assert len(_claude_resume_commands(runner)) == 1
+
+
+def test_recovery_transport_failure_timeout_synthesizes_unavailable(tmp_path):
+    runner = FakeRunner(claude_outputs=[("", None)])
+    config = make_config(tmp_path, coder="claude")
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=30.0,
+    )
+
+    assert outcome.validated is None
+    parsed = parse_agent_unavailable(outcome.terminal_public_response)
+    assert parsed is not None
+    assert parsed.category == "environment"
+    assert "30" in outcome.error
+    assert len(_claude_resume_commands(runner)) == 1
+
+
+def test_recovery_still_incomplete_text_synthesizes_unavailable(tmp_path):
+    # Two incomplete textual responses in a row (the original attempt and the
+    # resume attempt): the resume attempt still has no valid PR/blocking/
+    # clarify marker.
+    runner = FakeRunner(
+        claude_outputs=["I'll wait for the background test run to finish, one more time."],
+    )
+    config = make_config(tmp_path, coder="claude")
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    assert outcome.validated is None
+    assert outcome.failure_category == "agent-unavailable"
+    parsed = parse_agent_unavailable(outcome.terminal_public_response)
+    assert parsed is not None
+    assert parsed.retryable is False
+    assert parsed.category == "tooling"
+    assert "did not create a valid PR" in outcome.error
+    assert len(_claude_resume_commands(runner)) == 1
+
+
+def test_recovery_response_file_is_attempt_local_even_when_original_file_still_has_content(
+    tmp_path,
+):
+    # The original (failed) attempt's public response file stays on disk with
+    # real content; the resume attempt writes nothing to its own (distinct)
+    # response file. Validation, the terminal payload, and salvage must all
+    # come from the recovery attempt's own state, never the original's.
+    from coding_review_agent_loop.agents.registry import run_agent_result
+
+    runner = FakeRunner(
+        # Only the original attempt's file gets written; the resume
+        # attempt's own (distinct, freshly minted) response file is never
+        # written by the fake agent, simulating a resume that produced no
+        # response file at all.
+        public_response_outputs=["I'll wait for the background test run to finish."],
+        claude_outputs=[
+            "I'll wait for the background test run to finish.",
+            "I'll wait for the background test run to finish, again.",
+        ],
+    )
+    config = make_config(tmp_path, coder="claude")
+
+    original_result = run_agent_result(
+        runner,
+        agent="claude",
+        config=config,
+        prompt="Implement issue 56.",
+        session_id=None,
+        run_id="run-1",
+    )
+    assert original_result.response_file_text == "I'll wait for the background test run to finish."
+
+    outcome = _attempt_claude_completion_recovery(
+        runner,
+        config=config,
+        completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1",
+        validate=_require_issue_implementation_result,
+        usage_context=_new_usage_context(config),
+        run_id="run-1",
+        role=None,
+        label=None,
+        timeout_seconds=None,
+    )
+
+    # Attempt-local by construction: a distinct (freshly minted) response
+    # file, and no fallback to the original attempt's file text even though
+    # that file is still on disk with real content.
+    assert outcome.result.response_file_path != original_result.response_file_path
+    assert outcome.result.response_file_text is None
+    assert outcome.result.text == "I'll wait for the background test run to finish, again."
+    assert original_result.response_file_path.read_text(encoding="utf-8") == (
+        "I'll wait for the background test run to finish."
+    )
+    assert outcome.validated is None
+    assert "did not create a valid PR" in outcome.error
+
+
+def test_issue_loop_recovers_after_one_bounded_resume_then_succeeds(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            json.dumps(
+                {
+                    "result": "I'll wait for the background test run to finish.",
+                    "session_id": "sess-1",
+                }
+            ),
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Fixed review.\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            "LGTM."
+            + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={"body": "Fixes #56"},
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    claude_commands = _claude_resume_commands(runner)
+    resume_commands = [cmd for cmd in claude_commands if "--resume" in cmd]
+    assert len(resume_commands) == 1
+    assert resume_commands[0][resume_commands[0].index("--resume") + 1] == "sess-1"
+    # No spurious AGENT_UNAVAILABLE comment: the recovered PR flow posts
+    # normally through the existing PR-review comment path.
+    assert not any(
+        '"kind": "agent_unavailable"' in comment for comment in runner.comments
+    )
+
+
+def test_issue_loop_exhausts_recovery_and_raises_with_terminal_public_response(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            json.dumps(
+                {
+                    "result": "I'll wait for the background test run to finish.",
+                    "session_id": "sess-1",
+                }
+            ),
+            ("", 1),
+        ],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentInvocationError) as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert excinfo.value.terminal_public_response is not None
+    parsed = parse_agent_unavailable(excinfo.value.terminal_public_response)
+    assert parsed is not None
+    assert parsed.retryable is False
+
+    claude_commands = _claude_resume_commands(runner)
+    resume_commands = [cmd for cmd in claude_commands if "--resume" in cmd]
+    assert len(resume_commands) == 1
+    # Bounded: no ordinary retries stacked on top of the single resume call.
+    assert len(claude_commands) == 2
+    assert runner.comments == [excinfo.value.terminal_public_response]
+
+
+def test_issue_loop_does_not_resume_for_unrelated_failure_text(tmp_path):
+    # Missing marker, but nothing about backgrounded/deferred completion work:
+    # this must fall back to today's existing failure/retry behavior, never a
+    # resume attempt.
+    config = make_config(tmp_path)
+    plain_failure = "I do not have enough information to proceed."
+    runner = FakeRunner(claude_outputs=[plain_failure] * (config.agent_max_retries + 1))
+
+    with pytest.raises(AgentInvocationError) as excinfo:
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert excinfo.value.terminal_public_response is None
+    claude_commands = _claude_resume_commands(runner)
+    assert not any("--resume" in cmd for cmd in claude_commands)
+    assert runner.comments == []
+
+
+def test_coder_followup_pr_loop_never_resumes_even_with_backgrounding_language(tmp_path):
+    # The coder follow-up / PR loop call site does not pass completion_recovery
+    # (#588 scopes the bounded resume to the two direct implementation call
+    # sites only), so a backgrounded-sounding follow-up failure must exhaust
+    # ordinary retries/repair instead of triggering a --resume.
+    config = make_config(tmp_path)
+    backgrounded_followup_failure = "I'll wait for the background test run to finish."
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ]
+        + [backgrounded_followup_failure] * (config.agent_max_retries + 1),
+        codex_outputs=[
+            "Finding: bug remains.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        ],
+    )
+
+    with pytest.raises(AgentLoopError):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    claude_commands = _claude_resume_commands(runner)
+    assert not any("--resume" in cmd for cmd in claude_commands)

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -2613,7 +2613,9 @@ def test_issue_loop_stops_before_pr_lookup_for_invalid_pr_terminal_result(
 
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
-    assert runner.comments == []
+    # A genuine coder-declared no-PR terminal is posted to the issue like a
+    # PR-success implementation result already is (#588).
+    assert runner.comments == [f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}\n-- OpenAI Codex"]
 
 
 def test_issue_loop_invalid_pr_without_terminal_state_is_protocol_error(tmp_path):
@@ -3364,7 +3366,9 @@ def test_approved_plan_no_pr_terminal_result_bypasses_human_requirements_and_pr_
 
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
     assert not any(cmd[:1] == ["codex"] for cmd, _cwd in runner.commands)
-    assert runner.comments == []
+    # A genuine coder-declared no-PR terminal is posted to the issue like a
+    # PR-success implementation result already is (#588).
+    assert runner.comments == [f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}\n-- Anthropic Claude"]
 
 
 def test_approved_plan_implementation_rerun_ignores_remote_salvage_on_plan_hash_mismatch(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -107,6 +107,7 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
         build_task_prompt("Fix the bug.", config),
         build_followup_prompt(77, 1, "Needs tests.", config),
         build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+        build_completion_recovery_prompt(config),
     ]
 
     for prompt in prompts:
@@ -115,6 +116,66 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
         assert "must stay in that directory" in prompt
         assert "Do not `cd` into sibling, home, deployment, or duplicate clones" in prompt
         assert "`pwd` and `git status --branch --short`" in prompt
+
+
+def test_coder_test_reporting_guidance_forbids_background_completion_work(tmp_path):
+    config = make_config(tmp_path)
+
+    prompts = [
+        build_issue_prompt(56, config),
+        build_issue_implementation_prompt(56, "1. Fix it.", config),
+        build_task_prompt("Fix the bug.", config),
+        build_completion_recovery_prompt(config),
+    ]
+
+    for prompt in prompts:
+        assert "run the relevant tests you can run" in prompt
+        assert "in the foreground and wait for them to finish" in prompt
+        assert "Do not launch them in the background" in prompt
+
+
+def test_completion_recovery_prompt_includes_workdir_and_scratch_guidance(tmp_path):
+    config = make_config(tmp_path, coder="claude")
+    assigned = str(config.claude_dir.resolve())
+
+    prompt = build_completion_recovery_prompt(config)
+
+    assert f"Assigned checkout: `{assigned}`" in prompt
+    assert "`AGENT_LOOP_WORKDIR` is set to this path" in prompt
+    assert "must stay in that directory" in prompt
+    assert "write them outside the repository checkout" in prompt
+
+
+def test_completion_recovery_prompt_instructs_foreground_only_continuation(tmp_path):
+    config = make_config(tmp_path, coder="claude")
+
+    prompt = build_completion_recovery_prompt(config)
+
+    assert "one-time, bounded continuation" in prompt
+    assert "will not send another one after this turn" in prompt
+    assert "Do not restart the implementation from scratch" in prompt
+    assert "do not launch anything new in the background" in prompt
+    assert "Inspect the existing checkout now" in prompt
+
+
+def test_completion_recovery_prompt_shares_terminal_marker_grammar_with_implementation_prompt(
+    tmp_path,
+):
+    config = make_config(tmp_path, coder="claude")
+
+    recovery_prompt = build_completion_recovery_prompt(config)
+    implementation_prompt = build_issue_implementation_prompt(56, "1. Fix it.", config)
+
+    for marker_line in (
+        "<!-- AGENT_PR: <number> -->",
+        "<!-- AGENT_STATE: blocking -->",
+        "<!-- AGENT_CLARIFY -->",
+        "<!-- AGENT_UNAVAILABLE -->",
+        "For a no-PR blocking result:",
+        "For clarification:",
+    ):
+        assert marker_line in recovery_prompt
+        assert marker_line in implementation_prompt
 
 
 def test_issue_plan_prompt_requires_complete_structured_plan_state_contract(tmp_path):

--- a/tests/test_transient.py
+++ b/tests/test_transient.py
@@ -33,3 +33,51 @@ def test_non_retryable_overrides_transient_signal() -> None:
 def test_orchestrator_alias_preserves_identity() -> None:
     # orchestrator keeps the old private name as an alias to the moved implementation.
     assert orchestrator._is_transient_agent_output is transient.is_transient_agent_output
+
+
+def test_backgrounded_completion_phrases_match() -> None:
+    assert transient.looks_like_backgrounded_completion(
+        "I'll wait for the background test run to finish."
+    )
+    assert transient.looks_like_backgrounded_completion(
+        "Waiting for background tests to complete."
+    )
+    assert transient.looks_like_backgrounded_completion(
+        "I started the full suite in the background; will get notified when it finishes."
+    )
+    assert transient.looks_like_backgrounded_completion(
+        "You will be notified once the background build finishes."
+    )
+    assert transient.looks_like_backgrounded_completion(
+        "Let me wait for the tests in the background to complete before finishing this."
+    )
+    assert transient.looks_like_backgrounded_completion(
+        "Running the test suite in the background now."
+    )
+
+
+def test_unrelated_failure_text_does_not_match() -> None:
+    assert not transient.looks_like_backgrounded_completion(
+        "I do not have enough information to proceed."
+    )
+    assert not transient.looks_like_backgrounded_completion(
+        "Please wait while I review the diff."
+    )
+    assert not transient.looks_like_backgrounded_completion("The tests passed and the PR is ready.")
+    assert not transient.looks_like_backgrounded_completion("")
+
+
+def test_backgrounded_completion_phrase_matches_regardless_of_embedded_markers() -> None:
+    # The phrase heuristic is purely textual (#588): eligibility for a
+    # completion-recovery attempt is gated separately, by the caller's own
+    # terminal-result validator having already rejected the response -- not
+    # by whether some other (possibly invalid-for-that-validator) marker is
+    # present. An embedded AGENT_STATE: approved or a quoted AGENT_PLAN_STATE
+    # marker must never exempt matching text from this detector.
+    assert transient.looks_like_backgrounded_completion(
+        "I'll wait for the background test run to finish.\n<!-- AGENT_STATE: approved -->"
+    )
+    assert transient.looks_like_backgrounded_completion(
+        "As discussed in the prior round (<!-- AGENT_PLAN_STATE: blocking -->), "
+        "I'll wait for the background build to finish before continuing."
+    )

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,5 +1,23 @@
 from agent_loop_helpers import *  # noqa: F403
 
+from coding_review_agent_loop.usage import RunUsageContext, UsageMetadata
+
+
+def test_completion_recovery_role_survives_record_and_summary(tmp_path):
+    context = RunUsageContext(run_id="run-1", summary_path=tmp_path / "usage.json")
+    record = context.add_record(
+        agent="claude",
+        session_id="sess-1",
+        returncode=0,
+        usage=UsageMetadata(mode="estimated", input_tokens=10, output_tokens=5, total_tokens=15),
+        role="completion-recovery",
+    )
+    assert record.role == "completion-recovery"
+    assert record.to_dict()["role"] == "completion-recovery"
+
+    payload = context.summary_payload()
+    assert payload["calls"][0]["role"] == "completion-recovery"
+
 
 def test_codex_usage_summary_records_exact_tokens_from_jsonl_and_public_response(tmp_path):
     public_response = "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"


### PR DESCRIPTION
## Summary

- Add `looks_like_backgrounded_completion` (purely textual phrase heuristic) and explicitly instruct coders not to defer required tests/completion work to the background, ending a turn without a real terminal marker.
- Add a bounded, at-most-once `claude --resume <session>` completion-recovery pass, scoped only to the two direct issue-implementation call sites (`_implement_approved_issue`, `run_issue_loop`'s direct path) via an explicit `CompletionRecoveryPolicy` opt-in — every other `_run_validated_agent` caller (planning, plan/PR review, discuss, task, coder follow-up/PR loop) is ineligible by construction.
- The recovery attempt's own output is judged by the same implementation-result validator as a normal attempt (valid PR/blocking/clarify → normal success path, subject to ordinary PR validation).
- If the resume turn itself declares `AGENT_UNAVAILABLE`, that text is posted/persisted verbatim and is always terminal regardless of its own `retryable` flag (the bounded one-recovery-attempt policy overrides it). If the resume fails at the transport level or still produces an invalid response, a non-retryable `AGENT_UNAVAILABLE` is synthesized, rendered, persisted to that attempt's own (freshly minted) response file, and posted to the GitHub issue before `AgentInvocationError` (now carrying `terminal_public_response`) is raised with salvage preserved.
- Closes a related gap in the same flow: a genuine coder-declared no-PR `AGENT_STATE: blocking`/`AGENT_CLARIFY` implementation result is now posted to the GitHub issue, matching how a successful PR-creating implementation is already posted.

Fixes #588

## Test plan

- [x] `python3 -m pytest tests/ -q` — 1635 passed (1613 pre-existing + 22 new)
- [x] New `tests/test_completion_recovery.py`: direct unit coverage of `_attempt_claude_completion_recovery` (success, agent-declared unavailable for both `retryable` values, transport failure — nonzero/empty/timeout, still-incomplete text, response-file attempt-isolation) plus end-to-end `run_issue_loop` coverage (successful recovery, exhausted recovery, negative control for unrelated failures, and a regression proving the coder follow-up/PR loop never resumes)
- [x] Extended `tests/test_transient.py`, `tests/test_usage.py`, `tests/test_prompts.py`, `tests/test_comment_rendering.py` for the new helper functions
- [x] Updated two existing `tests/test_orchestrator_issue.py` cases whose expectations changed now that a genuine no-PR terminal result is posted to the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)