### PR TITLE
Recover Claude completion waiting on background work

### DIFF
--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -49,7 +49,7 @@ def is_transient_agent_output(text: str) -> bool:
 BACKGROUNDED_COMPLETION_RE = re.compile(
     r"(?i)"
     r"\bi(?:'|')?ll wait\b|"
-    r"\bwait(?:ing)? for (?:the )?background|"
+    r"\bwait(?:ing)? (?:for|on) (?:the )?background|"
     r"\brun(?:s|ning)? (?:it |them )?in the background\b|"
     r"\b(?:test|build|suite)\w*\b.{0,60}\bin the background\b|"
     r"\bin the background\b.{0,60}\b(?:test|build|suite)|"

--- a/tests/test_completion_recovery.py
+++ b/tests/test_completion_recovery.py
@@ -344,6 +344,38 @@ def test_issue_loop_recovers_after_one_bounded_resume_then_succeeds(tmp_path):
     )
 
 
+def test_issue_loop_recovers_from_claude_waiting_on_background_wording(tmp_path):
+    """Match the exact #531 completion text, not only ``waiting for`` variants."""
+    runner = FakeRunner(
+        claude_outputs=[
+            json.dumps(
+                {
+                    "result": (
+                        "Waiting on the background test run and the exit-monitor; "
+                        "I'll continue once results arrive."
+                    ),
+                    "session_id": "sess-waiting-on",
+                }
+            ),
+            "Created PR.\n<!-- AGENT_PR: 88 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            "Fixed review.\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={"body": "Fixes #56"},
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    resume_commands = [
+        cmd for cmd in _claude_resume_commands(runner) if "--resume" in cmd
+    ]
+    assert len(resume_commands) == 1
+    assert resume_commands[0][resume_commands[0].index("--resume") + 1] == "sess-waiting-on"
+
+
 def test_issue_loop_exhausts_recovery_and_raises_with_terminal_public_response(tmp_path):
     runner = FakeRunner(
         claude_outputs=[

--- a/tests/test_transient.py
+++ b/tests/test_transient.py
@@ -43,6 +43,9 @@ def test_backgrounded_completion_phrases_match() -> None:
         "Waiting for background tests to complete."
     )
     assert transient.looks_like_backgrounded_completion(
+        "Waiting on the background test run and the exit-monitor; I'll continue once results arrive."
+    )
+    assert transient.looks_like_backgrounded_completion(
         "I started the full suite in the background; will get notified when it finishes."
     )
     assert transient.looks_like_backgrounded_completion(


### PR DESCRIPTION
## Summary

Claude can end an implementation turn with `Waiting on the background test run...` after starting tests asynchronously. The completion-recovery matcher only recognized `waiting for`, so this wording bypassed the bounded same-session `--resume` pass and left a salvage-only failure.

This expands the matcher to accept `waiting on` and adds both a phrase-level test and an issue-loop regression using the exact #531 output. The recovery remains bounded to one resume attempt.

## Verification

`/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_transient.py tests/test_completion_recovery.py -q`

21 passed.
