### PR TITLE
Add opt-in parallel execution for plan and PR reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,30 @@ fresh evaluation from round 1. If a resumed run's next round would exceed a
 orchestrator immediately posts a final `deadlock` summary from the last
 completed round instead of silently exiting without a result.
 
+Pass `--review-parallel` to `issue`, `pr`, or `task` to run same-round plan or
+PR reviewers concurrently instead of sequentially (`discuss` mode is rejected;
+it has its own `--discuss-parallel`, unaffected by this flag). Every
+reviewer's prompt is built from the same pre-round plan/PR state before any
+reviewer launches, and same-round reviewers never see each other's feedback.
+All outcomes are collected before any round state is mutated: healthy
+reviewers are applied — comment posted, items numbered — in configured
+reviewer order, then any fatal failure is raised only afterward (a quota
+failure takes priority; otherwise the first configured-order failure), so a
+rerun resumes the reviewers that already succeeded instead of re-invoking
+them. Existing per-reviewer retry, repair, unavailable-reviewer, and
+incomplete-review policies are unchanged, and one failed reviewer never
+cancels a healthy concurrent review. Parallel mode requires a distinct
+workdir per reviewer — even with `--allow-shared-dir` — following the same
+guardrail as `--discuss-parallel`. The coder is never parallelized with
+reviewers, and review rounds never overlap. Sequential execution remains the
+default; keep it if you are concerned about concurrent quota/API pressure.
+
+```bash
+agent-loop pr 456 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --review-parallel
+```
+
 When `--base` is omitted, `pr` mode uses the pull request's base branch.
 `issue` and `task` modes use the repository default branch. If PR metadata does
 not include a base branch, `pr` mode also falls back to the repository default.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -725,6 +725,59 @@ Two companion flags apply in both sequential and parallel discuss runs:
     vote can never match real outcomes — so a partial final round ends in a
     `needs-human` deadlock, with the failures noted in the summary.
 
+### Parallel plan/PR reviewer execution
+
+`--review-parallel` (#594) runs same-round plan or PR reviewers concurrently
+instead of one after another. It is accepted by `issue`, `pr`, and `task`
+only — `discuss` rejects it with a usage error since it has its own
+`--discuss-parallel`, which this flag does not change:
+
+```bash
+agent-loop pr 456 --repo OWNER/REPO \
+  --reviewer codex --reviewer antigravity \
+  --review-parallel
+```
+
+Execution model:
+
+- Every pending reviewer's prompt is built up front from the same pre-round
+  plan/PR state (current plan or PR diff, prior unresolved items, PR checks
+  snapshot), then all pending turns are submitted to a thread pool. Same-round
+  reviewers never see each other's in-progress output.
+- All outcomes are collected before any round state is mutated. Healthy
+  reviewers are applied — comment posted, unresolved items numbered, session
+  IDs recorded — from the main thread, in configured `--reviewer` order, so
+  transcripts and resume state stay deterministic regardless of completion
+  order.
+- Only after every healthy outcome is applied does the orchestrator raise a
+  fatal failure, if any: a quota-reset failure takes priority; otherwise the
+  first failure in configured `--reviewer` order. Because healthy reviewers
+  were already posted, a rerun resumes them instead of re-invoking them.
+- Existing per-reviewer policies are unchanged and isolated per turn: retry,
+  structured repair, the unavailable-reviewer / incomplete-review
+  distinction, and the PR flow's single-reviewer-fatal rule. One reviewer's
+  failure never cancels a healthy concurrent reviewer's turn.
+- For PR review, a reviewer's pre-launch `sync_reviewer_pr_before_review` is
+  attempted for every pending reviewer before any turn launches; a sync
+  failure only removes that reviewer from the launch set and is classified
+  (fatal or unavailable) alongside turn failures after the round settles, so
+  the remaining reviewers still launch. A single shared PR-checks snapshot is
+  used for every concurrently launched reviewer's prompt in the round,
+  instead of one fetch per reviewer as sequential mode does.
+- Resume works unchanged: already-posted round reviews are reused without
+  re-invoking their reviewers, and when every configured reviewer's review
+  resumes from comments (or a round is entirely skipped, e.g. head-advance
+  recovery routing), no thread pool is constructed at all.
+- Parallel mode requires a distinct workdir per reviewer and rejects the run
+  otherwise — deliberately not bypassed by `--allow-shared-dir`, the same
+  guardrail `--discuss-parallel` uses, because concurrent git/tool activity in
+  a single worktree can corrupt it. The coder may still share a reviewer's
+  directory since it only runs after the reviewer synchronization point.
+- The coder is never parallelized with reviewers, and review rounds never
+  overlap with each other.
+- Sequential execution remains the default; prefer it when concurrent
+  quota/API pressure across providers is a concern.
+
 ### Split issue materialization
 
 By default, a discuss `split` consensus or a plan-first plan that narrows

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -60,6 +60,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    def add_review_parallel(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--review-parallel",
+            action="store_true",
+            help=(
+                "Run same-round plan/PR reviewers concurrently instead of "
+                "sequentially (#594). Every reviewer's prompt is built from the "
+                "same pre-round state before any reviewer is launched, and "
+                "same-round reviewers never see one another's feedback. "
+                "Sequential remains the default. Requires a distinct workdir "
+                "per reviewer, even with --allow-shared-dir. Discuss mode has "
+                "its own --discuss-parallel flag."
+            ),
+        )
+
     def add_common(subparser: argparse.ArgumentParser) -> None:
         subparser.add_argument("--repo", help="GitHub repo as owner/name. Defaults to gh repo view.")
         subparser.add_argument(
@@ -472,10 +487,12 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     add_common(issue)
+    add_review_parallel(issue)
 
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
     pr.add_argument("pr_number", type=int)
     add_common(pr)
+    add_review_parallel(pr)
 
     task = subparsers.add_parser(
         "task",
@@ -505,6 +522,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Maximum clarification rounds when --interactive is set (default: 3).",
     )
     add_common(task)
+    add_review_parallel(task)
 
     discuss = subparsers.add_parser(
         "discuss",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -146,6 +146,10 @@ class AgentLoopConfig:
     # working with the new behavior enabled.
     salvage_comments: bool = True
     salvage_comment_patch_max_bytes: int = 20000
+    # Parallel plan/PR reviewer execution (#594). Opt-in for `issue`/`pr`/`task`
+    # only; sequential stays the default. Distinct from --discuss-parallel
+    # (#475), which covers discuss-mode debaters and is unaffected.
+    review_parallel: bool = False
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -884,6 +888,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         split_stage=getattr(args, "split_stage", None),
         salvage_comments=getattr(args, "salvage_comments", True),
         salvage_comment_patch_max_bytes=getattr(args, "salvage_comment_patch_max_bytes", 20000),
+        review_parallel=getattr(args, "review_parallel", False),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
         ci_check_name=args.ci_check_name,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3650,6 +3650,47 @@ def _decompose_approved_plan(
     return created
 
 
+@dataclass(frozen=True)
+class _ReviewerTurnResult:
+    """Outcome of one plan/PR reviewer turn: a validated response or a captured failure.
+
+    Worker threads in the --review-parallel path return these instead of
+    raising, so exceptions never cross the thread boundary; the main thread
+    applies the existing failure policy in configured reviewer order after
+    every launched turn settles (#594).
+    """
+
+    reviewer_name: str
+    response: ValidatedAgentResponse | None = None
+    error: AgentLoopError | None = None
+
+
+def _launch_reviewer_turns(
+    runner: Runner,
+    pending: Sequence[AgentName],
+    *,
+    thread_name_prefix: str,
+    run_turn: Callable[[AgentName], _ReviewerTurnResult],
+) -> dict[AgentName, _ReviewerTurnResult]:
+    """Run one worker per pending reviewer concurrently and join before returning.
+
+    ``run_turn`` must never let an exception escape; it is responsible for
+    capturing any failure into the returned ``_ReviewerTurnResult`` so the
+    thread pool never needs to propagate a worker exception. On
+    KeyboardInterrupt, active agent processes are killed so worker wait loops
+    return promptly before the interrupt is re-raised.
+    """
+    executor = ThreadPoolExecutor(max_workers=len(pending), thread_name_prefix=thread_name_prefix)
+    try:
+        futures = {reviewer: executor.submit(run_turn, reviewer) for reviewer in pending}
+        return {reviewer: future.result() for reviewer, future in futures.items()}
+    except KeyboardInterrupt:
+        runner.terminate_active_processes()
+        raise
+    finally:
+        executor.shutdown(wait=True, cancel_futures=True)
+
+
 def _run_plan_first_loop(
     runner: Runner,
     *,
@@ -3660,6 +3701,8 @@ def _run_plan_first_loop(
     implement_after_approval: bool,
     usage_context: RunUsageContext,
 ) -> int:
+    if config.review_parallel:
+        _ensure_parallel_reviewer_workdirs(config, flag_name="--review-parallel", role_label="reviewer")
     coder_name = agent_display_name(config.coder)
     configured_reviewers = reviewers(config)
     coder_session_id: str | None = None
@@ -3785,6 +3828,99 @@ def _run_plan_first_loop(
         resumed_by_name = {
             record.metadata.agent: record for record in (current_resume.completed_reviews if current_resume is not None else ())
         }
+
+        def _build_plan_review_prompt(reviewer: AgentName) -> str:
+            # Built once per reviewer from pre-round state only, so the same
+            # prompt is produced regardless of sequential or parallel launch.
+            return build_plan_review_prompt(
+                issue_number,
+                round_number,
+                current_plan,
+                config,
+                reviewer=reviewer,
+                memory=memory,
+                issue_context=issue_context,
+                unresolved_items=prior_unresolved_items,
+                compact_context=use_compact_context,
+                compact_prior=CompactPriorContext(tuple(compact_prior_summaries)),
+                compact_tail=CompactPlanTailContext(
+                    subject=current_plan_subject,
+                    action=(
+                        "Review the current plan for correctness, architecture fit, "
+                        "missing edge cases, test strategy, and ambiguity."
+                    ),
+                ),
+            )
+
+        plan_fatal_errors: list[tuple[str, AgentLoopError]] = []
+        plan_turn_results: dict[AgentName, _ReviewerTurnResult] = {}
+        if config.review_parallel:
+            pending_plan_reviewers = [
+                reviewer for reviewer in configured_reviewers
+                if resumed_by_name.get(agent_display_name(reviewer)) is None
+            ]
+            if pending_plan_reviewers:
+                plan_prompts = {
+                    reviewer: _build_plan_review_prompt(reviewer) for reviewer in pending_plan_reviewers
+                }
+                pending_plan_names = [agent_display_name(reviewer) for reviewer in pending_plan_reviewers]
+                log(
+                    config,
+                    f"Planning round {round_number}: invoking {', '.join(pending_plan_names)} "
+                    f"in parallel on issue #{issue_number}",
+                )
+
+                def _plan_reviewer_worker(reviewer: AgentName) -> _ReviewerTurnResult:
+                    reviewer_name = agent_display_name(reviewer)
+                    try:
+                        response = _run_validated_agent(
+                            runner,
+                            agent=reviewer,
+                            config=config,
+                            prompt=plan_prompts[reviewer],
+                            session_id=reviewer_session_ids.get(reviewer),
+                            marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
+                            validate=lambda text, reviewer_name=reviewer_name: _validate_plan_review_response(
+                                text,
+                                reviewer=reviewer_name,
+                                unresolved_items=prior_unresolved_items,
+                                # Never share the mutable round_new_unresolved_items list
+                                # with concurrent workers (#594): it only enriches the
+                                # UnknownPriorItemDispositionError message, so an empty
+                                # tuple here changes no validation outcome.
+                                current_round_items=(),
+                                surfaced_requirement_ids=_surfaced_reviewer_requirement_ids(
+                                    issue_context.human_requirements,
+                                    requirement_scope="planning requirements",
+                                ),
+                            ),
+                            usage_context=usage_context,
+                            use_repair=True,
+                            repair_expected_kind="plan_review",
+                            repair_reviewer_requirement_ids=_surfaced_reviewer_requirement_ids(
+                                issue_context.human_requirements,
+                                requirement_scope="planning requirements",
+                            ),
+                            repair_allowed_prior_item_ids=tuple(
+                                item.item_id for item in prior_unresolved_items
+                            ),
+                            ledger_incomplete=round_ledger_incomplete,
+                            role="reviewer",
+                            operation_description="plan review",
+                        )
+                    except AgentLoopError as exc:
+                        # Includes QuotaResetExceededError: captured here and
+                        # re-raised on the main thread with priority.
+                        return _ReviewerTurnResult(reviewer_name=reviewer_name, error=exc)
+                    return _ReviewerTurnResult(reviewer_name=reviewer_name, response=response)
+
+                plan_turn_results = _launch_reviewer_turns(
+                    runner,
+                    pending_plan_reviewers,
+                    thread_name_prefix=f"plan-review-r{round_number}",
+                    run_turn=_plan_reviewer_worker,
+                )
+
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             resumed_record = resumed_by_name.get(reviewer_name)
@@ -3812,6 +3948,34 @@ def _run_plan_first_loop(
                 review_state = parsed_review.state
                 log(config, f"Planning round {round_number}: resuming {reviewer_name}'s completed review")
                 reviewer_new_unresolved_items = list(resumed_record.metadata.new_items)
+            elif config.review_parallel:
+                turn = plan_turn_results[reviewer]
+                if turn.error is not None:
+                    category = getattr(turn.error, "failure_category", None) or "error"
+                    log(
+                        config,
+                        f"Planning round {round_number}: {reviewer_name} failed ({category}); "
+                        "will raise after the remaining reviewers in this round are applied",
+                    )
+                    plan_fatal_errors.append((reviewer_name, turn.error))
+                    continue
+                review_response = turn.response
+                assert review_response is not None
+                review_output = review_response.text
+                review_model_used = review_response.model_used
+                reviewer_session_ids[reviewer] = review_response.session_id
+                parsed_review = review_response.marker_value
+                assert isinstance(parsed_review, ParsedPlanReview)
+                parsed_review = dataclasses_replace(
+                    parsed_review,
+                    items=_drop_repeated_carried_plan_future_followups(
+                        parsed_review.items,
+                        prior_items=prior_unresolved_items,
+                        dispositions=parsed_review.dispositions,
+                    ),
+                )
+                review_state = parsed_review.state
+                reviewer_new_unresolved_items = []
             else:
                 log(
                     config,
@@ -3822,25 +3986,7 @@ def _run_plan_first_loop(
                     runner,
                     agent=reviewer,
                     config=config,
-                    prompt=build_plan_review_prompt(
-                        issue_number,
-                        round_number,
-                        current_plan,
-                        config,
-                        reviewer=reviewer,
-                        memory=memory,
-                        issue_context=issue_context,
-                        unresolved_items=prior_unresolved_items,
-                        compact_context=use_compact_context,
-                        compact_prior=CompactPriorContext(tuple(compact_prior_summaries)),
-                        compact_tail=CompactPlanTailContext(
-                            subject=current_plan_subject,
-                            action=(
-                                "Review the current plan for correctness, architecture fit, "
-                                "missing edge cases, test strategy, and ambiguity."
-                            ),
-                        ),
-                    ),
+                    prompt=_build_plan_review_prompt(reviewer),
                     session_id=reviewer_session_ids.get(reviewer),
                     marker_description="<!-- AGENT_PLAN_STATE: approved|blocking -->",
                     validate=lambda text, reviewer_name=reviewer_name, items=prior_unresolved_items: _validate_plan_review_response(
@@ -3888,12 +4034,16 @@ def _run_plan_first_loop(
                     "and reported no actionable blocking plan issues or Same-Plan follow-ups; "
                     "stopping without a coder follow-up",
                 )
-                raise AgentLoopError(
+                incomplete_review_error = AgentLoopError(
                     f"{reviewer_name} did not complete plan review and reported no actionable "
                     "blocking plan issues or Same-Plan follow-ups. This is a reviewer-internal error; "
                     "agent-loop stopped before a coder follow-up. Rerun or switch the reviewer/model "
                     "after resolving the reviewer environment."
                 )
+                if config.review_parallel:
+                    plan_fatal_errors.append((reviewer_name, incomplete_review_error))
+                    continue
+                raise incomplete_review_error
 
             log(
                 config,
@@ -3982,6 +4132,16 @@ def _run_plan_first_loop(
                 )
             else:
                 round_new_unresolved_items.extend(reviewer_new_unresolved_items)
+
+        if plan_fatal_errors:
+            # Every healthy reviewer above was already applied (comment
+            # posted, items numbered) in configured order, so a rerun resumes
+            # them instead of re-invoking (#594). Raise only now: quota resets
+            # take priority, otherwise the first configured-order failure.
+            for _reviewer_name, error in plan_fatal_errors:
+                if isinstance(error, QuotaResetExceededError):
+                    raise error
+            raise plan_fatal_errors[0][1]
 
         unresolved_items, _ = _apply_unresolved_item_dispositions(
             prior_unresolved_items,
@@ -4990,6 +5150,8 @@ def run_pr_loop(
         )
         if not workdirs_ready:
             ensure_agent_workdirs(config, runner)
+        if config.review_parallel:
+            _ensure_parallel_reviewer_workdirs(config, flag_name="--review-parallel", role_label="reviewer")
         log(config, f"Validating PR #{pr_number}")
         validate_open_pr(runner, config=config, pr_number=pr_number)
         memory = prepare_agent_memory(runner, config)
@@ -5093,6 +5255,161 @@ def run_pr_loop(
                     "without current-head coder metadata; routing recovered prior items "
                     f"through {coder_name} before review",
                 )
+
+            pr_fatal_errors: list[tuple[str, AgentLoopError]] = []
+            pr_prep_failures: dict[AgentName, AgentLoopError] = {}
+            pr_turn_results: dict[AgentName, _ReviewerTurnResult] = {}
+            shared_reviewer_pr_checks: PullRequestChecks | None = None
+
+            def _pr_reviewer_prelaunch_kind(reviewer: AgentName) -> str:
+                # Pure classification, no agent calls: mirrors the resumed/
+                # carried-approval branching below so the pre-round parallel
+                # launch list matches what the per-reviewer loop would decide.
+                reviewer_name = agent_display_name(reviewer)
+                if reviewer in unavailable_reviewer_failures:
+                    return "skip"
+                if resumed_by_name.get(reviewer_name) is not None:
+                    return "resumed"
+                prior_approval = unchanged_head_approvals.get(reviewer_name)
+                if (
+                    prior_approval is not None
+                    and prior_approval.metadata.round_number < round_number
+                    and (
+                        not human_requirements
+                        or (
+                            human_requirements_resolved(prior_approval.body)
+                            and set(surfaced_reviewer_requirement_ids).issubset(
+                                prior_approval.metadata.surfaced_reviewer_requirement_ids
+                            )
+                        )
+                    )
+                ):
+                    return "carried"
+                return "turn"
+
+            if config.review_parallel and not skip_reviewers_for_recovery:
+                pending_pr_reviewers = [
+                    reviewer for reviewer in configured_reviewers
+                    if _pr_reviewer_prelaunch_kind(reviewer) == "turn"
+                ]
+                if pending_pr_reviewers:
+                    launchable_pr_reviewers: list[AgentName] = []
+                    for reviewer in pending_pr_reviewers:
+                        reviewer_name = agent_display_name(reviewer)
+                        try:
+                            sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
+                        except AgentLoopError as exc:
+                            log(
+                                config,
+                                f"Round {round_number}: {reviewer_name} failed pre-review PR sync "
+                                f"({getattr(exc, 'failure_category', None) or 'error'}); skipping its "
+                                "launch while the remaining reviewers still run",
+                            )
+                            pr_prep_failures[reviewer] = exc
+                            continue
+                        launchable_pr_reviewers.append(reviewer)
+                    if launchable_pr_reviewers:
+                        # One shared checks snapshot for the whole round (#594),
+                        # instead of one fetch per reviewer as sequential mode
+                        # does, so every concurrently launched prompt and the
+                        # post-turn pending-CI-only downgrade agree.
+                        shared_reviewer_pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+                        pr_parallel_compact_tail = (
+                            CompactPrReviewTailContext(
+                                head_sha=pr_metadata.head_sha,
+                                round_number=round_number,
+                            )
+                            if use_compact_pr_context
+                            else None
+                        )
+                        pr_prompts = {
+                            reviewer: build_review_prompt(
+                                pr_number,
+                                round_number,
+                                config,
+                                reviewer=reviewer,
+                                pr_metadata=pr_metadata,
+                                pr_checks=shared_reviewer_pr_checks,
+                                memory=memory,
+                                issue_context=issue_context,
+                                human_requirements=human_requirements,
+                                unresolved_items=prior_unresolved_items,
+                                compact_context=use_compact_pr_context,
+                                compact_prior=(
+                                    CompactPriorContext(tuple(pr_compact_prior_summaries))
+                                    if use_compact_pr_context
+                                    else None
+                                ),
+                                compact_tail=pr_parallel_compact_tail,
+                                compact_coder_summary=compact_coder_summary,
+                                compact_coder_tests_run=compact_coder_tests_run,
+                            )
+                            for reviewer in launchable_pr_reviewers
+                        }
+                        launchable_pr_names = [
+                            agent_display_name(reviewer) for reviewer in launchable_pr_reviewers
+                        ]
+                        log(
+                            config,
+                            f"Round {round_number}: invoking {', '.join(launchable_pr_names)} "
+                            f"in parallel on PR #{pr_number}",
+                        )
+
+                        def _pr_reviewer_worker(reviewer: AgentName) -> _ReviewerTurnResult:
+                            reviewer_name = agent_display_name(reviewer)
+                            try:
+                                response = _run_validated_agent(
+                                    runner,
+                                    agent=reviewer,
+                                    config=config,
+                                    prompt=pr_prompts[reviewer],
+                                    session_id=(
+                                        None if use_compact_pr_context else reviewer_session_ids.get(reviewer)
+                                    ),
+                                    marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                                    validate=lambda text, reviewer_name=reviewer_name: _validate_review_response(
+                                        text,
+                                        reviewer=reviewer_name,
+                                        unresolved_items=prior_unresolved_items,
+                                        # Never share the mutable round_new_unresolved_items
+                                        # list with concurrent workers (#594): it only
+                                        # enriches the UnknownPriorItemDispositionError
+                                        # message, so an empty tuple changes no outcome.
+                                        current_round_items=(),
+                                    ),
+                                    usage_context=usage_context,
+                                    use_repair=True,
+                                    repair_expected_kind="pr_review",
+                                    repair_reviewer_requirement_ids=_surfaced_reviewer_requirement_ids(
+                                        human_requirements,
+                                        requirement_scope="PR requirements",
+                                    ),
+                                    repair_allowed_prior_item_ids=tuple(
+                                        item.item_id for item in prior_unresolved_items
+                                    ),
+                                    ledger_incomplete=round_ledger_incomplete,
+                                    role="reviewer",
+                                    operation_description="PR review",
+                                )
+                            except AgentLoopError as exc:
+                                # Includes QuotaResetExceededError: captured here
+                                # and re-raised on the main thread with priority.
+                                return _ReviewerTurnResult(reviewer_name=reviewer_name, error=exc)
+                            return _ReviewerTurnResult(reviewer_name=reviewer_name, response=response)
+
+                        pr_turn_results = _launch_reviewer_turns(
+                            runner,
+                            launchable_pr_reviewers,
+                            thread_name_prefix=f"pr-review-r{round_number}",
+                            run_turn=_pr_reviewer_worker,
+                        )
+                    else:
+                        log(
+                            config,
+                            f"Round {round_number}: every pending reviewer failed pre-review "
+                            "PR sync; nothing to launch in parallel this round",
+                        )
+
             for reviewer in (() if skip_reviewers_for_recovery else configured_reviewers):
                 reviewer_name = agent_display_name(reviewer)
                 if reviewer in unavailable_reviewer_failures:
@@ -5149,6 +5466,46 @@ def run_pr_loop(
                         f"Round {round_number}: skipping {reviewer_name}; it approved unchanged "
                         f"PR head {current_pr_subject} in round {prior_approval.metadata.round_number}",
                     )
+                elif config.review_parallel:
+                    review_failure: AgentInvocationError | AgentLoopError | None = (
+                        pr_prep_failures.get(reviewer)
+                    )
+                    turn = pr_turn_results.get(reviewer) if review_failure is None else None
+                    if turn is not None and turn.error is not None:
+                        review_failure = turn.error
+                    if review_failure is not None:
+                        if (
+                            len(configured_reviewers) == 1
+                            or getattr(review_failure, "failure_category", None) in {None, "deterministic"}
+                        ):
+                            pr_fatal_errors.append((reviewer_name, review_failure))
+                            continue
+                        unavailable_reviewer_failures[reviewer] = review_failure
+                        category = getattr(review_failure, "failure_category", None) or "unknown"
+                        log(
+                            config,
+                            f"Round {round_number}: {reviewer_name} became unavailable "
+                            f"({category}); continuing with the remaining reviewers",
+                        )
+                        continue
+                    assert turn is not None and turn.response is not None
+                    review_response = turn.response
+                    reviewer_pr_checks = shared_reviewer_pr_checks
+                    review_output = review_response.text
+                    review_model_used = review_response.model_used
+                    reviewer_session_ids[reviewer] = review_response.session_id
+                    parsed_review = review_response.marker_value
+                    assert isinstance(parsed_review, ParsedReview)
+                    parsed_review = dataclasses_replace(
+                        parsed_review,
+                        followups=_drop_repeated_carried_future_followups(
+                            parsed_review.followups,
+                            prior_items=prior_unresolved_items,
+                            dispositions=parsed_review.dispositions,
+                        ),
+                    )
+                    review_state = parsed_review.state
+                    reviewer_new_unresolved_items = []
                 else:
                     context_mode = "compact" if use_compact_pr_context else "full"
                     log(
@@ -5266,12 +5623,16 @@ def run_pr_loop(
 
                 if _is_incomplete_pr_review(parsed_review):
                     if len(configured_reviewers) == 1:
-                        raise AgentLoopError(
+                        incomplete_pr_review_error = AgentLoopError(
                             f"{reviewer_name} did not complete PR review and reported no actionable "
                             "blocking items or Same-PR follow-ups. This is a reviewer-internal error; "
                             "agent-loop stopped before a coder follow-up. Rerun or switch the reviewer/model "
                             "after resolving the reviewer environment."
                         )
+                        if config.review_parallel:
+                            pr_fatal_errors.append((reviewer_name, incomplete_pr_review_error))
+                            continue
+                        raise incomplete_pr_review_error
                     unavailable_reviewer_failures[reviewer] = AgentInvocationError(
                         f"{reviewer_name} reported an incomplete PR review without actionable "
                         "blocking items or Same-PR follow-ups.",
@@ -5451,6 +5812,17 @@ def run_pr_loop(
                 else:
                     if resumed_record is not None:
                         round_new_unresolved_items.extend(reviewer_new_unresolved_items)
+
+            if pr_fatal_errors:
+                # Every healthy reviewer above was already applied (comment
+                # posted, items numbered, unavailable failures recorded) in
+                # configured order, so a rerun resumes them instead of
+                # re-invoking (#594). Raise only now: quota resets take
+                # priority, otherwise the first configured-order failure.
+                for _reviewer_name, error in pr_fatal_errors:
+                    if isinstance(error, QuotaResetExceededError):
+                        raise error
+                raise pr_fatal_errors[0][1]
 
             if use_compact_pr_context:
                 unresolved_items, future_from_prior_items = _apply_unresolved_item_dispositions(
@@ -6595,29 +6967,34 @@ class _DiscussDebaterTurnResult:
         return getattr(self.error, "failure_category", None) or "error"
 
 
-def _ensure_parallel_discuss_workdirs(config: AgentLoopConfig) -> None:
-    """Reject shared workdirs among concurrently scheduled debaters (#475).
+def _ensure_parallel_reviewer_workdirs(
+    config: AgentLoopConfig, *, flag_name: str, role_label: str
+) -> None:
+    """Reject shared workdirs among concurrently scheduled reviewers (#475, #594).
 
     Deliberately NOT bypassed by --allow-shared-dir: concurrent git/tool
-    activity from two agents in one worktree can race and corrupt it. The
-    analyzer (or the coder) may still share a debater's directory because it
-    runs only after the debater synchronization point.
+    activity from two agents in one worktree can race and corrupt it. A
+    later, non-concurrent role (the discuss analyzer, the plan/PR coder) may
+    still share a reviewer's directory because it only runs after the
+    reviewer synchronization point.
     """
-    from .config import reviewers as _reviewers
-
     seen: dict[Path, AgentName] = {}
-    for reviewer in _reviewers(config):
+    for reviewer in reviewers(config):
         path = get_backend(reviewer).workdir(config).resolve()
         other = seen.get(path)
         if other is not None:
             raise AgentLoopError(
-                "--discuss-parallel requires a distinct workdir per debater: "
+                f"{flag_name} requires a distinct workdir per {role_label}: "
                 f"{agent_display_name(other)} and {agent_display_name(reviewer)} "
-                f"both resolve to {path}. Use separate clones/worktrees per debater "
-                "or drop --discuss-parallel; --allow-shared-dir does not lift this "
+                f"both resolve to {path}. Use separate clones/worktrees per {role_label} "
+                f"or drop {flag_name}; --allow-shared-dir does not lift this "
                 "requirement."
             )
         seen[path] = reviewer
+
+
+def _ensure_parallel_discuss_workdirs(config: AgentLoopConfig) -> None:
+    _ensure_parallel_reviewer_workdirs(config, flag_name="--discuss-parallel", role_label="debater")
 
 
 def _validate_structured_discuss_vote_with_evidence(

--- a/tests/test_review_parallel.py
+++ b/tests/test_review_parallel.py
@@ -1,0 +1,473 @@
+"""Tests for opt-in parallel plan/PR reviewer execution (#594)."""
+import threading
+from unittest.mock import patch
+
+import pytest
+
+import coding_review_agent_loop.orchestrator as orchestrator
+from coding_review_agent_loop.cli import AgentLoopError, build_parser, run_issue_loop, run_pr_loop
+from coding_review_agent_loop.errors import QuotaResetExceededError
+from agent_loop_helpers import (
+    FakeRunner,
+    make_config,
+    structured_plan_review,
+    structured_plan_state,
+    structured_pr_review,
+)
+
+
+def _initial_plan() -> str:
+    return structured_plan_state(
+        state="blocking", summary="Initial plan.", plan_steps=["Make the change."]
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI / config plumbing
+# ---------------------------------------------------------------------------
+
+def test_review_parallel_flag_scoped_to_issue_pr_task_not_discuss():
+    for command, extra_args in (
+        ("issue", ["56"]),
+        ("pr", ["77"]),
+        ("task", ["do the thing"]),
+    ):
+        args = build_parser().parse_args(
+            [command, *extra_args, "--repo", "OWNER/REPO", "--review-parallel"]
+        )
+        assert args.review_parallel is True
+        plain = build_parser().parse_args([command, *extra_args, "--repo", "OWNER/REPO"])
+        assert plain.review_parallel is False
+
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(
+            ["discuss", "56", "--repo", "OWNER/REPO", "--review-parallel"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concurrency probes
+# ---------------------------------------------------------------------------
+
+class _ReviewConcurrencyProbeRunner(FakeRunner):
+    """Each reviewer blocks until the other has started, so a timeout means
+    same-round reviewers did not truly overlap."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.codex_started = threading.Event()
+        self.gemini_started = threading.Event()
+        self.overlap_confirmed = True
+
+    def run_with_log(self, args, *, cwd, **kwargs):
+        cmd = [str(arg) for arg in args]
+        if cmd[:2] == ["codex", "exec"]:
+            self.codex_started.set()
+            if not self.gemini_started.wait(timeout=10):
+                self.overlap_confirmed = False
+        elif cmd[:1] == ["gemini"]:
+            self.gemini_started.set()
+            if not self.codex_started.wait(timeout=10):
+                self.overlap_confirmed = False
+        return super().run_with_log(args, cwd=cwd, **kwargs)
+
+
+def test_plan_first_parallel_runs_same_round_reviewers_concurrently(tmp_path):
+    runner = _ReviewConcurrencyProbeRunner(
+        claude_outputs=[_initial_plan()],
+        codex_outputs=[structured_plan_review(summary="Codex plan review complete.")],
+        gemini_outputs=[
+            structured_plan_review(summary="Gemini plan review complete.", reviewer="Google Gemini")
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert runner.overlap_confirmed, "same-round plan reviewers did not run concurrently"
+    assert "Codex plan review complete." in runner.comments[1]
+    assert "-- OpenAI Codex" in runner.comments[1]
+    assert "Gemini plan review complete." in runner.comments[2]
+    assert "-- Google Gemini" in runner.comments[2]
+
+
+def test_pr_loop_parallel_runs_same_round_reviewers_concurrently(tmp_path):
+    runner = _ReviewConcurrencyProbeRunner(
+        codex_outputs=[structured_pr_review(summary="Codex PR review complete.")],
+        gemini_outputs=[
+            structured_pr_review(summary="Gemini PR review complete.", reviewer="Google Gemini")
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.overlap_confirmed, "same-round PR reviewers did not run concurrently"
+    assert "Codex PR review complete." in runner.comments[0]
+    assert "-- OpenAI Codex" in runner.comments[0]
+    assert "Gemini PR review complete." in runner.comments[1]
+    assert "-- Google Gemini" in runner.comments[1]
+
+
+# ---------------------------------------------------------------------------
+# Parity with sequential
+# ---------------------------------------------------------------------------
+
+def test_plan_first_parallel_matches_sequential_comments(tmp_path):
+    claude_outputs = [_initial_plan()]
+    codex_outputs = [structured_plan_review(summary="Codex approves the plan.")]
+    gemini_outputs = [
+        structured_plan_review(summary="Gemini approves the plan.", reviewer="Google Gemini")
+    ]
+
+    sequential_runner = FakeRunner(
+        claude_outputs=list(claude_outputs),
+        codex_outputs=list(codex_outputs),
+        gemini_outputs=list(gemini_outputs),
+    )
+    sequential_config = make_config(
+        tmp_path / "seq", reviewer=("codex", "gemini"), log_dir=tmp_path / "seq" / "logs"
+    )
+    parallel_runner = FakeRunner(
+        claude_outputs=list(claude_outputs),
+        codex_outputs=list(codex_outputs),
+        gemini_outputs=list(gemini_outputs),
+    )
+    parallel_config = make_config(
+        tmp_path / "par",
+        reviewer=("codex", "gemini"),
+        log_dir=tmp_path / "par" / "logs",
+        review_parallel=True,
+    )
+
+    assert run_issue_loop(sequential_runner, issue_number=56, config=sequential_config, plan_first=True) == 0
+    assert run_issue_loop(parallel_runner, issue_number=56, config=parallel_config, plan_first=True) == 0
+
+    assert parallel_runner.comments == sequential_runner.comments
+
+
+def test_pr_loop_parallel_matches_sequential_comments(tmp_path):
+    codex_outputs = [structured_pr_review(summary="Codex approves the PR.")]
+    gemini_outputs = [
+        structured_pr_review(summary="Gemini approves the PR.", reviewer="Google Gemini")
+    ]
+
+    sequential_runner = FakeRunner(codex_outputs=list(codex_outputs), gemini_outputs=list(gemini_outputs))
+    sequential_config = make_config(
+        tmp_path / "seq", reviewer=("codex", "gemini"), log_dir=tmp_path / "seq" / "logs"
+    )
+    parallel_runner = FakeRunner(codex_outputs=list(codex_outputs), gemini_outputs=list(gemini_outputs))
+    parallel_config = make_config(
+        tmp_path / "par",
+        reviewer=("codex", "gemini"),
+        log_dir=tmp_path / "par" / "logs",
+        review_parallel=True,
+    )
+
+    assert run_pr_loop(sequential_runner, pr_number=77, config=sequential_config) == 0
+    assert run_pr_loop(parallel_runner, pr_number=77, config=parallel_config) == 0
+
+    assert parallel_runner.comments == sequential_runner.comments
+
+
+# ---------------------------------------------------------------------------
+# Collect-then-apply-then-raise, with resume
+# ---------------------------------------------------------------------------
+
+def test_plan_first_parallel_collects_healthy_review_before_raising_then_resumes(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[_initial_plan()],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                summary="Review incomplete: could not confirm the prior finding.",
+            )
+        ],
+        gemini_outputs=[
+            structured_plan_review(summary="Gemini approves the plan.", reviewer="Google Gemini")
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    with pytest.raises(AgentLoopError, match="Codex"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    # Gemini's healthy review is posted (comment[0] is the coder's plan) even
+    # though Codex's failure aborts the round afterward.
+    assert len(runner.comments) == 2
+    assert "Gemini approves the plan." in runner.comments[1]
+
+    # A rerun resumes Gemini's posted review instead of re-invoking it.
+    commands_before_rerun = len(runner.commands)
+    runner.codex_outputs.append(
+        structured_plan_review(summary="Codex approves after rerun.")
+    )
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+    new_commands = runner.commands[commands_before_rerun:]
+    gemini_calls_after = [cmd for cmd, _cwd in new_commands if cmd[:1] == ["gemini"]]
+    assert len(gemini_calls_after) == 0
+
+
+def test_pr_loop_parallel_collects_healthy_review_before_raising_then_resumes(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[("codex exploded", 1)],
+        gemini_outputs=[
+            structured_pr_review(summary="Gemini approves the PR.", reviewer="Google Gemini")
+        ],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), review_parallel=True, agent_max_retries=0
+    )
+
+    with pytest.raises(AgentLoopError, match="Codex"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(runner.comments) == 1
+    assert "Gemini approves the PR." in runner.comments[0]
+
+    commands_before_rerun = len(runner.commands)
+    runner.codex_outputs.append(structured_pr_review(summary="Codex approves after rerun."))
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    new_commands = runner.commands[commands_before_rerun:]
+    gemini_calls_after = [cmd for cmd, _cwd in new_commands if cmd[:1] == ["gemini"]]
+    assert len(gemini_calls_after) == 0
+
+
+# ---------------------------------------------------------------------------
+# PR pre-launch sync failure isolation
+# ---------------------------------------------------------------------------
+
+def test_pr_loop_parallel_sync_failure_isolated_from_healthy_reviewer(tmp_path):
+    real_sync = orchestrator.sync_reviewer_pr_before_review
+
+    def fake_sync(config, runner, reviewer, pr_number, pr_metadata):
+        if reviewer == "codex":
+            raise AgentLoopError("Codex checkout is desynced from the PR head.")
+        return real_sync(config, runner, reviewer, pr_number, pr_metadata)
+
+    runner = FakeRunner(
+        gemini_outputs=[
+            structured_pr_review(summary="Gemini approves the PR.", reviewer="Google Gemini")
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    with patch("coding_review_agent_loop.orchestrator.sync_reviewer_pr_before_review", fake_sync):
+        with pytest.raises(AgentLoopError, match="desynced"):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert len(runner.comments) == 1
+    assert "Gemini approves the PR." in runner.comments[0]
+
+
+# ---------------------------------------------------------------------------
+# Unavailable (non-deterministic) reviewer failure policy
+# ---------------------------------------------------------------------------
+
+def test_pr_loop_parallel_unavailable_reviewer_alongside_healthy_reviewer(tmp_path):
+    import json
+
+    unavailable = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "agent_unavailable",
+            "retryable": False,
+            "category": "environment",
+            "summary": "The review checkout cannot access the diff.",
+            "suggested_action": "Repair the reviewer sandbox before retrying it.",
+        }
+    ) + "\n<!-- AGENT_UNAVAILABLE -->\n-- OpenAI Codex"
+    runner = FakeRunner(
+        codex_outputs=[unavailable],
+        gemini_outputs=[
+            structured_pr_review(summary="Gemini approves the PR.", reviewer="Google Gemini")
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    with pytest.raises(AgentLoopError, match="missing required input from Codex"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert "**Review status: Incomplete**" in runner.comments[-1]
+    assert "Codex" in runner.comments[-1]
+    # Gemini's healthy approval is recorded even though the round ultimately
+    # reports an incomplete review because of Codex.
+    assert any("Gemini approves the PR." in comment for comment in runner.comments)
+
+
+# ---------------------------------------------------------------------------
+# Quota precedence
+# ---------------------------------------------------------------------------
+
+class _OtherFatalError(AgentLoopError):
+    pass
+
+
+def test_pr_loop_parallel_quota_error_takes_precedence_over_other_fatal_error(tmp_path):
+    # Configured order puts the plain fatal failure (Gemini) BEFORE the quota
+    # failure (Codex), so this only passes if the raise phase scans every
+    # captured failure for a quota error instead of just raising the first
+    # one encountered in configured order.
+    config = make_config(
+        tmp_path, reviewer=("gemini", "codex"), review_parallel=True, agent_max_retries=0
+    )
+    runner = FakeRunner()
+
+    def fake_run_validated_agent(runner_arg, *, agent, **kwargs):
+        if agent == "codex":
+            raise QuotaResetExceededError("Codex quota exhausted; resets in 2h.")
+        raise _OtherFatalError("Gemini failed deterministically.")
+
+    with patch.object(orchestrator, "_run_validated_agent", side_effect=fake_run_validated_agent):
+        with pytest.raises(QuotaResetExceededError):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Mixed resumed/pending: zero-pending resume constructs no executor
+# ---------------------------------------------------------------------------
+
+def test_plan_first_parallel_zero_pending_resume_constructs_no_executor(tmp_path):
+    from coding_review_agent_loop.orchestrator import (
+        PostedRoundMetadata,
+        _attach_round_metadata,
+        _plan_subject,
+    )
+
+    current_plan = "Revised plan.\n- Add state reconstruction.\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    coder_comment = _attach_round_metadata(
+        current_plan,
+        PostedRoundMetadata(
+            flow="plan", role="coder", agent="Claude", round_number=2,
+            subject=_plan_subject(current_plan), prior_items=(),
+        ),
+    )
+    codex_comment = _attach_round_metadata(
+        "Plan looks sound.\n<!-- AGENT_PLAN_STATE: approved -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="plan", role="reviewer", agent="Codex", round_number=2,
+            subject=_plan_subject(current_plan), state="approved",
+        ),
+    )
+    gemini_comment = _attach_round_metadata(
+        "Plan looks sound too.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Google Gemini",
+        PostedRoundMetadata(
+            flow="plan", role="reviewer", agent="Gemini", round_number=2,
+            subject=_plan_subject(current_plan), state="approved",
+        ),
+    )
+    runner = FakeRunner(
+        issue_comments=[
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:00:00Z", "body": coder_comment},
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:05:00Z", "body": codex_comment},
+            {"author": {"login": "bot"}, "createdAt": "2026-05-20T09:06:00Z", "body": gemini_comment},
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("no reviewer turn was pending; a thread pool should not be constructed")
+
+    with patch("coding_review_agent_loop.orchestrator.ThreadPoolExecutor", side_effect=_boom):
+        assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    agent_commands = [cmd[0] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"], ["gemini"])]
+    assert agent_commands == []
+
+
+# ---------------------------------------------------------------------------
+# Shared reviewer workdir rejection
+# ---------------------------------------------------------------------------
+
+def test_plan_first_parallel_rejects_shared_reviewer_workdirs(tmp_path):
+    shared = tmp_path / "shared"
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        codex_dir=shared,
+        gemini_dir=shared,
+        allow_shared_dir=True,
+        review_parallel=True,
+    )
+    runner = FakeRunner(claude_outputs=[], codex_outputs=[], gemini_outputs=[])
+
+    with pytest.raises(AgentLoopError, match="distinct workdir per reviewer"):
+        run_issue_loop(runner, issue_number=56, config=config, plan_first=True)
+
+    assert len(runner.comments) == 0
+
+
+def test_pr_loop_parallel_rejects_shared_reviewer_workdirs(tmp_path):
+    shared = tmp_path / "shared"
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        codex_dir=shared,
+        gemini_dir=shared,
+        allow_shared_dir=True,
+        review_parallel=True,
+    )
+    runner = FakeRunner(codex_outputs=[], gemini_outputs=[])
+
+    with pytest.raises(AgentLoopError, match="distinct workdir per reviewer"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert len(runner.comments) == 0
+
+
+def test_pr_loop_parallel_rejects_shared_reviewer_workdirs_with_workdirs_ready_handoff(tmp_path):
+    shared = tmp_path / "shared"
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        codex_dir=shared,
+        gemini_dir=shared,
+        allow_shared_dir=True,
+        review_parallel=True,
+        create_dirs=False,
+    )
+    shared.mkdir(parents=True)
+    config.claude_dir.mkdir(parents=True)
+    runner = FakeRunner(codex_outputs=[], gemini_outputs=[])
+
+    with pytest.raises(AgentLoopError, match="distinct workdir per reviewer"):
+        run_pr_loop(runner, pr_number=77, config=config, workdirs_ready=True)
+
+    assert len(runner.comments) == 0
+
+
+# ---------------------------------------------------------------------------
+# Repair/retry isolation
+# ---------------------------------------------------------------------------
+
+def test_plan_first_parallel_repair_isolated_between_reviewers(tmp_path):
+    malformed_codex = "Plan looks fine but this response is missing the state marker."
+    repaired_codex = structured_plan_review(summary="Codex approves after repair.")
+    gemini_ok = structured_plan_review(summary="Gemini approves the plan.", reviewer="Google Gemini")
+
+    lock = threading.Lock()
+    repair_calls = []
+
+    def fake_attempt_repair(raw, gemini_cmd, *, expected_kind=None, **kwargs):
+        with lock:
+            repair_calls.append(raw)
+        if raw == malformed_codex:
+            return repaired_codex
+        return None
+
+    runner = FakeRunner(
+        claude_outputs=[_initial_plan()],
+        codex_outputs=[malformed_codex],
+        gemini_outputs=[gemini_ok],
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), review_parallel=True, agent_max_retries=0
+    )
+
+    with patch("coding_review_agent_loop.orchestrator.attempt_repair", fake_attempt_repair):
+        assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len(repair_calls) == 1
+    assert "Codex approves after repair." in runner.comments[1]
+    assert "Gemini approves the plan." in runner.comments[2]


### PR DESCRIPTION
## Summary

Extends the `--discuss-parallel` concept (#475) to plan-first and PR review rounds. Adds an opt-in `--review-parallel` flag (`issue`/`pr`/`task` only; rejected by `discuss`, which keeps its own `--discuss-parallel` unchanged) that runs same-round plan/PR reviewers concurrently instead of sequentially.

Fixes #594

## Design

- Every pending reviewer's prompt is built from the same immutable pre-round state before any reviewer launches, so same-round reviewers never see each other's feedback.
- All outcomes are collected on the main thread before any round state is mutated. Healthy reviewers are applied (comment posted, items numbered, session IDs recorded) in configured `--reviewer` order, regardless of completion order.
- Any fatal failure is raised only after every healthy outcome is applied — a quota-reset failure takes priority, otherwise the first failure in configured order — so a rerun resumes the reviewers that already succeeded instead of re-invoking them.
- One failed/unavailable reviewer never cancels a healthy concurrent reviewer's turn. Existing per-reviewer retry, structured repair, unavailable-reviewer, incomplete-review, and PR single-reviewer-fatal policies are preserved and isolated per turn.
- For PR review, `sync_reviewer_pr_before_review` is attempted per pending reviewer before any turn launches; a sync failure only removes that reviewer from the launch set (classified fatal/unavailable alongside turn failures after settle) instead of aborting the whole round. A single shared PR-checks snapshot is used for every concurrently launched reviewer's prompt in the round.
- Parallel mode requires a distinct workdir per reviewer — not bypassed by `--allow-shared-dir` — mirroring the existing `--discuss-parallel` guardrail.
- Sequential execution remains the default and is unchanged when the flag is absent.

## Test plan

- [x] New `tests/test_review_parallel.py`: CLI/config scoping, concurrency proof for plan/PR flows, parity with sequential output, collect-then-apply-then-raise with resume (plan + PR), PR pre-launch sync failure isolation, unavailable-reviewer alongside a healthy reviewer, quota-error precedence, zero-pending resume constructs no thread pool, shared-workdir rejection (plan, PR, and the `workdirs_ready=True` handoff path), and repair-isolation between concurrent reviewers.
- [x] `python3 -m pytest tests/ -q` — 1652 passed (full suite, includes 15 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)