### PR TITLE
Document phased decomposition vs. split materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,33 @@ coder is Codex, either explicitly with `--implementation-coder codex` or because
 declared Codex model via `--implementation-coder-model` or `--codex-model` so
 the implementation signature can name the model reliably.
 
+### Choosing a child-issue mechanism
+
+`decompose-only` / `implement-by-phase` and `--materialize-split-issues` are
+two separate child-issue creation paths. Combining them files duplicate
+children — decompose modes already create one detailed issue per phase, and
+`--materialize-split-issues` is not suppressed by them.
+
+| Situation | Correct mechanism |
+| --- | --- |
+| Approved detailed staged plan with phase contracts | `--plan-execution-mode decompose-only` |
+| Same plan, implement only the first phase now | `--plan-execution-mode implement-by-phase` |
+| Approved plan implemented as a single PR | `--plan-execution-mode implement-one-shot` |
+| Plan review only, no child issues | `--plan-execution-mode plan-only` (default) |
+| Discuss `split` consensus or plan-only deferred work, no phase decomposition | `--materialize-split-issues` |
+
+```bash
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode decompose-only
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode implement-by-phase
+agent-loop discuss 123 --repo OWNER/REPO --materialize-split-issues
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode plan-only --materialize-split-issues
+```
+
+See [Phased decomposition versus split
+materialization](docs/local_agent_loop.md#phased-decomposition-versus-split-materialization)
+for the full decision rule, stop points, worked examples, and the
+duplicate-issue failure mode.
+
 Each generated child issue copies the relevant parent-plan slice, constraints
 and invariants, dependency notes, scope and non-goals, rollout risk,
 validation/soak requirements, automation classification, and instructions for
@@ -326,7 +353,9 @@ the specific child the plan covers (via a unique title match or an explicit
 `--split-stage <child>` flag) instead of treating the whole parent as solved,
 and the resulting PR is required to use `Refs #<parent>` rather than a closing
 keyword against it. See [`docs/local_agent_loop.md`](docs/local_agent_loop.md#split-issue-materialization)
-for details.
+for details, and [Choosing a child-issue
+mechanism](#choosing-a-child-issue-mechanism) above if you are deciding
+between this and `decompose-only` / `implement-by-phase`.
 
 Provide a one-off task directly when there is no issue yet:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -253,6 +253,12 @@ The modes are:
   `agent-loop issue <child>`. Older decomposition summaries without this marker
   are treated as not yet handed off, so the first child handoff is recorded once.
 
+`decompose-only` and `implement-by-phase` already create one detailed child
+issue per phase; see [Phased decomposition versus split
+materialization](#phased-decomposition-versus-split-materialization) before
+also passing `--materialize-split-issues`, which is a separate,
+non-suppressed child-issue creation path.
+
 Before invoking a coder for an issue — in direct `agent-loop issue <n>` mode or
 approved-plan implementation alike — the orchestrator resolves the canonical
 `AGENT_ISSUE_PR_HANDOFF` record: an authoritative, machine-readable comment
@@ -305,7 +311,10 @@ implementation signature can name the model reliably.
 If the plan narrows scope (via `deferred_stages` or a prior discuss `split`
 consensus), see [Split issue materialization](#split-issue-materialization)
 below for how those follow-up stages are filed (or warned about) and how
-`implement-one-shot` targets the correct stage instead of the whole parent.
+`implement-one-shot` targets the correct stage instead of the whole parent. If
+you are deciding between that mechanism and `decompose-only` /
+`implement-by-phase`, read [Phased decomposition versus split
+materialization](#phased-decomposition-versus-split-materialization) first.
 
 Generated child issues are self-contained: each body includes the parent issue
 link, the relevant approved parent-plan slice, constraints/invariants,
@@ -783,6 +792,113 @@ Execution model:
   overlap with each other.
 - Sequential execution remains the default; prefer it when concurrent
   quota/API pressure across providers is a concern.
+
+### Phased decomposition versus split materialization
+
+There are two separate child-issue creation paths, and combining them files
+duplicate children. Pick the one row that matches your situation:
+
+| Situation | Correct mechanism |
+| --- | --- |
+| Approved detailed staged plan with phase contracts | `--plan-execution-mode decompose-only` |
+| Same plan, but implement only the first phase now | `--plan-execution-mode implement-by-phase` |
+| Approved plan you want implemented as a single PR, no phase breakdown | `--plan-execution-mode implement-one-shot` (or `--implement-after-approval`) |
+| Plan review only, no implementation, no detailed child issues | `--plan-execution-mode plan-only` (the default) |
+| Discuss `split` consensus, or plan-only deferred work with no detailed phase decomposition | `--materialize-split-issues` |
+
+**Do not combine `--materialize-split-issues` with `--plan-execution-mode
+decompose-only` or `implement-by-phase`.** Those two modes already create one
+detailed child issue per phase. `--materialize-split-issues` is a second,
+independent child-issue creation path — the CLI does not suppress it in
+decompose modes, and it is not suppressed by them either, so combining the
+two yields two overlapping sets of children: shallow generic `[#<parent>
+stage] ...` placeholders from split materialization *and* detailed per-phase
+issues from decomposition, describing overlapping work. Nothing closes the
+duplicates automatically; someone has to notice and close them by hand. This
+is the exact failure mode this section exists to prevent.
+
+What each mechanism produces and where the run stops:
+
+- **`plan-only`** (default): posts the approved-plan summary and stops. No
+  implementation, no detailed child issues. One nuance: if
+  `--materialize-split-issues` is also passed, generic split children are
+  still filed even in `plan-only`, because that materialization step runs
+  before the mode is dispatched — `plan-only` only skips decomposition and
+  implementation, not split materialization.
+- **`decompose-only`**: validates the coder's structured phase decomposition
+  (max 8 phases; an over-cap response is a validation failure and must be
+  consolidated, never silently truncated), creates one child issue per phase,
+  posts the parent summary table, and stops. The summary table is not a
+  substitute for the child issues.
+- **`implement-by-phase`**: creates every phase child issue, records a
+  one-time `AGENT_PLAN_PHASE_IMPLEMENTATION` handoff, then implements only the
+  first `agent-pr` phase and stops after that phase's PR review loop. If the
+  first phase is `human-action` or `manual-close`, it stops after creating the
+  child issues without implementing anything. Resume the remaining phases with
+  `agent-loop issue <child>`, not by rerunning the parent.
+- **`--materialize-split-issues`**: files one linked, generic child issue per
+  remaining discuss `split` proposal or plan `deferred_stages` entry. It is
+  idempotent (tracked by the parent's `AGENT_DISCUSS_SPLIT` marker), capped at
+  8 children per parent, and files nothing from free-form prose narrowing
+  alone — only from the two structured signals above.
+
+Copyable commands, one per workflow, each stopping where noted:
+
+```bash
+# Detailed staged plan: create phase children, stop (review/resume each child separately)
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode decompose-only
+
+# Same plan, but also implement phase 1 now; stops after phase 1's PR review loop
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode implement-by-phase
+
+# Discuss-mode split consensus: file generic linked children, stop (no implementation in discuss mode)
+agent-loop discuss 123 --repo OWNER/REPO --materialize-split-issues
+
+# Plan-only run whose deferred_stages should still be filed as generic children; stops after plan approval
+agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode plan-only --materialize-split-issues
+
+# Pick work back up on a child created by either path
+agent-loop issue <child-issue-number> --repo OWNER/REPO
+```
+
+Anti-example — do not run this; it duplicates children:
+
+```bash
+# WRONG: decompose-only already creates one child per phase; --materialize-split-issues
+# creates an unrelated, overlapping set of generic children for the same deferred work.
+agent-loop issue 123 --repo OWNER/REPO --plan-first \
+  --plan-execution-mode decompose-only --materialize-split-issues
+```
+
+Two worked examples:
+
+1. **Plan-first staged master issue.** Run `--plan-first` with reviewers
+   until the plan is approved, then run `--plan-execution-mode decompose-only`
+   to create the phase children. Continue with
+   `agent-loop issue <first-child>` per phase (or use `implement-by-phase`
+   instead of `decompose-only` to have phase 1 implemented in the same run).
+   `--materialize-split-issues` is not used anywhere in this flow — the phase
+   children already are the detailed decomposition.
+2. **Discuss-mode split consensus.** Run
+   `agent-loop discuss 123 --repo OWNER/REPO --materialize-split-issues` to
+   get a `split` consensus filed as generic linked child issues, then plan or
+   implement each child separately with `agent-loop issue <child>`. A later
+   `agent-loop issue 123 --repo OWNER/REPO --plan-first --implement-after-approval`
+   run on the parent resolves which specific child the approved plan covers
+   via a unique title match, or `--split-stage <child>` when the match is
+   ambiguous or missing.
+
+`--implement-after-approval` (the `implement-one-shot` alias) combined with
+`--materialize-split-issues` is not the failure mode above — it is the
+supported split-stage handoff flow described in [Split issue
+materialization](#split-issue-materialization) below. The warning here is
+scoped to `decompose-only` and `implement-by-phase` specifically, since only
+those two modes already create detailed per-phase children.
+
+Skill mode's `run-decompose` and `run-implement-by-phase` helper commands
+(see [`docs/skill_mode.md`](skill_mode.md)) drive the same
+`decompose-only` / `implement-by-phase` modes and are subject to the same
+rule.
 
 ### Split issue materialization
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -113,6 +113,11 @@ has already been approved:
   `decompose-only`.
 - `run-implement-by-phase` decomposes with mode `implement-by-phase`, then
   implements phase 1 only when that phase is `agent-pr`.
+
+Both helpers already create one detailed child issue per phase; do not also
+pass `--materialize-split-issues` for the same run. See [Phased decomposition
+versus split materialization](local_agent_loop.md#phased-decomposition-versus-split-materialization)
+for the decision rule and the duplicate-issue failure mode it prevents.
 - `run-pr-fix` addresses a settled blocking PR review for an externally opened
   PR. The target PR must be `OPEN`; `--reviewers` must exactly match the reviewer
   set used by the prior `run-pr-round`; and `--workdir` must be a clean,

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -474,7 +474,10 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "With --plan-first, choose what happens after approval: plan-only, "
             "decompose-only, implement-one-shot, or implement-by-phase. "
-            "Defaults to plan-only unless --implement-after-approval is used."
+            "Defaults to plan-only unless --implement-after-approval is used. "
+            "decompose-only/implement-by-phase already create one detailed child "
+            "issue per phase; do not also pass --materialize-split-issues for the "
+            "same run. See docs/local_agent_loop.md#phased-decomposition-versus-split-materialization."
         ),
     )
     issue.add_argument(
@@ -483,7 +486,10 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "File a linked child GitHub issue for each remaining discuss `split` proposal "
             "or plan `deferred_stages` entry instead of leaving them as unfiled text "
-            "(default: off, warning-only)."
+            "(default: off, warning-only). Do not combine with "
+            "--plan-execution-mode decompose-only or implement-by-phase, which already "
+            "create detailed child issues. See "
+            "docs/local_agent_loop.md#phased-decomposition-versus-split-materialization."
         ),
     )
     issue.add_argument(
@@ -618,7 +624,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "On a `split` consensus, file a linked child GitHub issue for each proposed "
-            "sub-issue instead of leaving them as unfiled text (default: off, warning-only)."
+            "sub-issue instead of leaving them as unfiled text (default: off, warning-only). "
+            "See docs/local_agent_loop.md#phased-decomposition-versus-split-materialization "
+            "for when to use this versus a plan-first decompose-only/implement-by-phase run."
         ),
     )
     add_common(discuss)

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -1,0 +1,77 @@
+import re
+from pathlib import Path
+
+from coding_review_agent_loop.cli import build_parser
+
+REPO_ROOT = Path(__file__).parent.parent
+LOCAL_AGENT_LOOP_DOC = REPO_ROOT / "docs" / "local_agent_loop.md"
+README = REPO_ROOT / "README.md"
+
+HEADING_TEXT = "Phased decomposition versus split materialization"
+
+
+def _github_anchor(heading_text: str) -> str:
+    """Approximate GitHub's markdown heading-to-anchor slug algorithm."""
+    slug = heading_text.lower()
+    slug = re.sub(r"[^\w\- ]", "", slug)
+    slug = slug.replace(" ", "-")
+    return slug
+
+
+def test_local_agent_loop_doc_has_decision_heading_and_table():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert f"### {HEADING_TEXT}" in text
+    assert "`--plan-execution-mode decompose-only`" in text
+    assert "`--plan-execution-mode implement-by-phase`" in text
+    assert "`--materialize-split-issues`" in text
+
+
+def test_local_agent_loop_doc_warns_about_combining_mechanisms():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    section_start = text.index(f"### {HEADING_TEXT}")
+    next_heading = text.index("### Split issue materialization", section_start)
+    section = text[section_start:next_heading]
+
+    assert "Do not combine" in section
+    assert "decompose-only" in section
+    assert "implement-by-phase" in section
+    assert "duplicate" in section.lower()
+
+
+def test_readme_links_to_decision_section_with_derived_anchor():
+    doc_text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert f"### {HEADING_TEXT}" in doc_text, "heading moved; update HEADING_TEXT"
+    expected_anchor = _github_anchor(HEADING_TEXT)
+
+    readme_text = README.read_text(encoding="utf-8")
+    normalized_readme_text = " ".join(readme_text.split())
+    assert f"docs/local_agent_loop.md#{expected_anchor}" in readme_text
+    assert "`--plan-execution-mode decompose-only`" in readme_text
+    assert "`--materialize-split-issues`" in readme_text
+    assert "duplicate children" in normalized_readme_text
+
+
+def test_cli_help_points_to_decision_section():
+    parser = build_parser()
+    issue_parser = None
+    discuss_parser = None
+    for action in parser._actions:
+        if hasattr(action, "choices") and isinstance(action.choices, dict):
+            issue_parser = action.choices.get("issue", issue_parser)
+            discuss_parser = action.choices.get("discuss", discuss_parser)
+    assert issue_parser is not None
+    assert discuss_parser is not None
+
+    def _help_for(subparser, option_string):
+        for sub_action in subparser._actions:
+            if option_string in getattr(sub_action, "option_strings", []):
+                return sub_action.help
+        raise AssertionError(f"{option_string} not found in parser")
+
+    plan_execution_mode_help = _help_for(issue_parser, "--plan-execution-mode")
+    issue_materialize_help = _help_for(issue_parser, "--materialize-split-issues")
+    discuss_materialize_help = _help_for(discuss_parser, "--materialize-split-issues")
+
+    anchor = "phased-decomposition-versus-split-materialization"
+    for help_text in (plan_execution_mode_help, issue_materialize_help, discuss_materialize_help):
+        assert anchor in help_text


### PR DESCRIPTION
## Summary

- Add a canonical `### Phased decomposition versus split materialization` section to `docs/local_agent_loop.md` (placed before `### Split issue materialization`) with the decision table, an explicit **do-not-combine** warning, per-mechanism stop points, copyable commands, an anti-example, and the two required worked examples (plan-first staged master issue; discuss-mode split consensus).
- Add a condensed `### Choosing a child-issue mechanism` mirror to `README.md` that links to the docs anchor, plus cross-links from the existing `--plan-execution-mode` mode list and split-materialization mentions in both files.
- Add a one-line pointer in `docs/skill_mode.md` near `run-decompose` / `run-implement-by-phase`, since skill mode drives the same modes.
- Extend CLI `--help` for `--plan-execution-mode` and both `--materialize-split-issues` flags (`issue` and `discuss` subcommands) with a short pointer to the new docs anchor. No flag, default, or validation behavior changes.
- Add `tests/test_docs_guidance.py`, which asserts the new heading/table/warning exist in `docs/local_agent_loop.md`, that `README.md` links to the docs section using an anchor derived from the actual heading (so the test fails on link rot, not a hardcoded anchor), and that `build_parser()`'s help strings for the three flags mention the docs anchor.

The documented rule matches current orchestrator behavior: `_handle_plan_first_split_scope` (which drives `--materialize-split-issues`) runs unconditionally before the `plan_execution_mode` dispatch in `orchestrator.py`, so combining `--materialize-split-issues` with `decompose-only`/`implement-by-phase` is not rejected by the CLI and produces two overlapping sets of child issues — the exact failure mode described in the issue.

Fixes #586

## Test plan

- [x] `PYTHONPATH=<repo> .venv/bin/python -m pytest tests/test_docs_guidance.py -q` — 4 passed
- [x] `PYTHONPATH=<repo> .venv/bin/python -m pytest tests/test_agent_loop.py -q` — 234 passed
- [x] `PYTHONPATH=<repo> .venv/bin/python -m pytest tests/ -q` — 1661 passed
- [x] Verified via `build_parser()` that the documented commands (including the anti-example) parse without CLI rejection, matching the "documentation-only, not enforced" framing

-- Anthropic Claude