### PR TITLE
Reduce Antigravity print timeout to 10 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ guidance. Notes: Antigravity turns are single-shot (no cross-round session
 resume) and report estimated token usage (`agy` emits no token counts).
 
 Each `agy --print` invocation is run with `--print-timeout` set from
-`--antigravity-print-timeout-seconds` (default 3600, i.e. one hour), which
+`--antigravity-print-timeout-seconds` (default 600, i.e. ten minutes), which
 overrides `agy`'s own five-minute print-mode default so long coder/reviewer
 turns are not cut short. Raise or lower it with, for example,
 `--antigravity-print-timeout-seconds 1800`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -87,7 +87,7 @@ override or `--antigravity-models MODEL [MODEL ...]` for a custom ordered chain;
 the two model options are mutually exclusive. Customize fallback detection with
 `--antigravity-quota-signatures SIGNATURE [SIGNATURE ...]`. Each `agy --print`
 call passes `--print-timeout` from `--antigravity-print-timeout-seconds`
-(default `3600`, i.e. one hour, matching the `agent-loop` CLI), overriding
+(default `600`, i.e. ten minutes, matching the `agent-loop` CLI), overriding
 `agy`'s own five-minute print-mode default so long turns are not cut short.
 These options are available on every skill command that can invoke an
 external agent.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -16,7 +16,7 @@ The default coder is Claude and the default reviewer is Codex. Reverse the direc
 Gemini CLI consumer access (free / Google AI Pro / Ultra) is retiring on June 18, 2026; personal-account `gemini` users should migrate to the Antigravity CLI (`agy`) with `--coder antigravity` / `--reviewer antigravity` (pick the model via `--antigravity-model`, default `Gemini 3.1 Pro (High)`). Enterprise / API-key Gemini CLI paths may remain available for organizations that still have access, so the `gemini` backend is retained for those users. Direct Gemini CLI support is best-effort: maintainers without enterprise Gemini CLI access need reporter-provided `.agent-loop-logs/*gemini.log` output, response-file contents, CLI version, and any sharable account/access context to debug live `gemini` failures. Antigravity turns are single-shot (no cross-round session resume) and report estimated usage.
 
 Every `agy --print` call passes `--print-timeout` from
-`--antigravity-print-timeout-seconds` (default `3600`, i.e. one hour), which
+`--antigravity-print-timeout-seconds` (default `600`, i.e. ten minutes), which
 overrides `agy`'s own five-minute print-mode default so long turns are not
 cut short. Override it per run, e.g. `--antigravity-print-timeout-seconds
 1800`.

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -93,7 +93,7 @@ legacy single-model override or `--antigravity-models MODEL [MODEL ...]` for a
 custom ordered chain; these options are mutually exclusive. Use
 `--antigravity-quota-signatures SIGNATURE [SIGNATURE ...]` to customize the
 output signatures that trigger fallback. Use
-`--antigravity-print-timeout-seconds SECONDS` (default `3600`, matching the
+`--antigravity-print-timeout-seconds SECONDS` (default `600`, matching the
 `agent-loop` CLI) to override the `--print-timeout` passed to each `agy
 --print` call, which otherwise falls back to `agy`'s own five-minute
 print-mode default. These options are available on plan, task, PR-review,

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -146,7 +146,7 @@ def main() -> None:
         type=int,
         default=None,
         metavar="SECONDS",
-        help="Maximum wait for each agy --print invocation (default: 3600, "
+        help="Maximum wait for each agy --print invocation (default: 600, "
              "matching the agent-loop CLI). Overrides agy's five-minute "
              "print-mode default.",
     )

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -583,7 +583,7 @@ def _add_antigravity_options(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=None,
         metavar="SECONDS",
-        help="Maximum wait for each agy --print invocation (default: 3600, "
+        help="Maximum wait for each agy --print invocation (default: 600, "
              "matching the agent-loop CLI). Overrides agy's five-minute "
              "print-mode default.",
     )

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -168,7 +168,7 @@ def build_parser() -> argparse.ArgumentParser:
             default=DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT_SECONDS,
             metavar="SECONDS",
             help=(
-                "Maximum wait for each agy --print invocation (default: 3600). "
+                "Maximum wait for each agy --print invocation (default: 600). "
                 "Overrides agy's five-minute print-mode default."
             ),
         )

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -39,7 +39,7 @@ DEFAULT_ANTIGRAVITY_MODELS: tuple[str, ...] = (
 )
 # `agy --print` otherwise defaults to five minutes, which is too short for
 # complex reviews and causes it to exit with "timeout waiting for response".
-DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT_SECONDS = 60 * 60
+DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT_SECONDS = 10 * 60
 DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3.5 Flash (Medium)",)
 
 # Discuss-mode research policy values (#477). The CLI flag choices, the config

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -20,7 +20,7 @@ def test_antigravity_backend_command_and_prefers_response_file(tmp_path):
     cmd = runner.commands[-1][0]
     assert cmd[0] == "agy"
     assert cmd[cmd.index("--model") + 1] == "Gemini 3.1 Pro (High)"
-    assert cmd[cmd.index("--print-timeout") + 1] == "3600s"
+    assert cmd[cmd.index("--print-timeout") + 1] == "600s"
     assert "--dangerously-skip-permissions" in cmd
     # The prompt is the value of --print and must be the last argument (agy's
     # --print/--prompt consumes the next token, not a trailing positional).
@@ -442,7 +442,7 @@ def test_config_from_args_antigravity_defaults(tmp_path):
     assert config.antigravity_cmd == "agy"
     assert config.antigravity_model is None
     assert config.antigravity_models == ("Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)")
-    assert config.antigravity_print_timeout_seconds == 3600
+    assert config.antigravity_print_timeout_seconds == 600
     assert config.antigravity_quota_signatures == ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")
     assert config.antigravity_args == ("--dangerously-skip-permissions",)
     assert config.antigravity_dir == default_agent_workdir("OWNER/REPO", "antigravity").resolve()

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -3917,7 +3917,7 @@ class TestAntigravitySkill:
     @pytest.mark.parametrize(
         ("extra_args", "expected_timeout"),
         [
-            ((), 3600),
+            ((), 600),
             (("--antigravity-print-timeout-seconds", "900"), 900),
         ],
     )


### PR DESCRIPTION
## Summary

- Change the default Agy `--print-timeout` from 60 minutes to 10 minutes.
- Keep the existing `--antigravity-print-timeout-seconds` override and synchronized skill-mode helper behavior.
- Update the CLI help, documentation, and default assertions to `600` seconds.

This retains enough headroom beyond Agy's native five-minute default for legitimate reviews, while bounding a silent no-progress Agy hang much more tightly than one hour.

## Verification

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_antigravity.py tests/test_skill_helpers.py -q`

-- OpenAI Codex
