### PR TITLE
Avoid indefinite coder waits on queued GitHub Actions checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,15 @@ reviewer rounds, and again after final reviewer approval before auto-merge. Add
 gate. The coder prompt also asks the coding agent to report the exact tests it
 ran, or explain why it could not run tests.
 
+A queued GitHub check that never starts a job (a hosted-runner capacity outage)
+or one cancelled before execution because a runner was unavailable is treated
+as external CI infrastructure blocking, not a code defect or actionable coder
+feedback: `--ci-queued-grace-seconds` (default 1200) bounds how long a queued
+check is treated as normal before the loop stops with a resumable message
+instead of a coder round waiting on it. See
+[External CI infrastructure stalls](docs/local_agent_loop.md#external-ci-infrastructure-stalls)
+for details.
+
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -345,6 +345,23 @@ python -m helpers.skill_runner run-task-round \
   `pending` > `blocking` > `incomplete` > `approved`.
 - **Merge is always a human decision.** The skill never runs CI-wait or
   auto-merge; every mode stops at "ready to merge."
+- **No unbounded CI waits.** Never run `gh run watch`, `gh pr checks --watch`,
+  or any other unbounded wait on a GitHub Actions check or workflow run —
+  including when fixing a reviewer-reported check failure as the host coder.
+  If you need to confirm CI status, take at most 3 status snapshots (`gh run
+  view <run-id> --json status,conclusion,startedAt` or `gh pr checks`), spaced
+  at least 30 seconds apart, for at most 120 seconds of total CI observation.
+  If a run is still `queued` past that bound, or was cancelled before any job
+  started (a GitHub-hosted-runner capacity outage), stop observing it and
+  report the round's result immediately, naming the affected check/run and
+  noting that work should resume once GitHub Actions runners recover — do not
+  treat this as a code defect. This does not apply to a check that is
+  actively running or that fails due to a real repository test failure; those
+  remain real work to fix. The `coding_review_agent_loop` CLI orchestrator
+  applies the equivalent bound and stall classification automatically (see
+  [External CI infrastructure stalls](docs/local_agent_loop.md#external-ci-infrastructure-stalls));
+  this bullet covers the skill-mode host-coder path, which drives its own
+  shell commands directly.
 
 ---
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1210,6 +1210,17 @@ When enabled, the tool waits for the configured GitHub check-run to pass before 
 
 Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps waiting for the configured check-run to resolve before merging, as before.
 
+### External CI infrastructure stalls
+
+GitHub-hosted runner capacity incidents can leave a check-run `queued` indefinitely with no job ever starting, or cause it to be cancelled before execution because a runner could not be acquired. Left unhandled, a coder round could otherwise run an unbounded `gh run watch` and consume an entire session without producing a result.
+
+Two independent, complementary mechanisms bound this instead:
+
+- **Detection and classification.** Every `get_pr_checks` fetch classifies each check-run against `--ci-queued-grace-seconds` (default 1200): a check still `queued`/`pending` with no job started past the grace period is `queued_too_long`; a check-run cancelled (or `startup_failure`) with no real start is `runner_unavailable`. A check is only ever treated as a full stop when the *whole* check board is wholly infrastructure-blocked — every failing/pending check is a classified stall, no required check is missing, and branch protection and the check query both succeeded. A single genuinely failing test, a never-reporting required check, or a partial API failure never takes this exit; it falls back to ordinary pending/failing handling instead. When the whole board is wholly blocked, the loop posts a comment explaining that no code change is required and no merge was attempted, and stops in a state that is safe to resume later — rerun the same command once GitHub Actions runners recover. With `--auto-merge`, the same predicate governs whether the CI wait loop exits early with that message instead of merging.
+- **Bounded coder observation policy.** Independent of classification, every coder prompt forbids `gh run watch`, `gh pr checks --watch`, or any other unbounded CI wait. A coder may take at most 3 status snapshots, spaced at least 30 seconds apart, for at most 120 seconds of total CI observation per turn; past that bound it must return its terminal blocking response immediately, naming the affected check/run and noting that work should resume once GitHub Actions runners recover. This applies even if a reviewer's finding is not recognized as a canonical stall-only item, so a coder round can never wait indefinitely on GitHub Actions infrastructure.
+
+Reviewers see the same classification (an "External CI infrastructure stalls" section in the PR checks context) and are instructed not to record a classified stall as a blocking code item; any other failing or never-reporting check remains ordinary review work.
+
 ## Agent Permission Flags
 
 By default, this standalone package does not pass permission-bypass flags to either agent. This is safer for open-source use, but some CLIs may prompt or fail in non-interactive mode unless you provide suitable flags.

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -185,6 +185,33 @@ repair pass. The original response is saved before recovery; `retry-validate`
 repair directories and PR-fix debug directories remain the final fallback for
 genuinely unrecoverable output.
 
+## No unbounded CI waits
+
+A queued GitHub check-run can sit indefinitely with no job started during a
+hosted-runner capacity incident, or be cancelled before execution because a
+runner could not be acquired. The orchestrating Claude session running this
+skill (the host coder) must not run `gh run watch`, `gh pr checks --watch`, or
+any other unbounded wait on such a check — including while fixing a
+reviewer-reported check failure. Take at most 3 bounded status snapshots
+(`gh run view <run-id> --json status,conclusion,startedAt` or `gh pr
+checks`), spaced at least 30 seconds apart, for at most 120 seconds of total
+CI observation, then stop with a resumable result instead of waiting further:
+name the affected check/run and note that work should resume once GitHub
+Actions runners recover, rather than treating the stall as a code defect. A
+check that is actively running, or that fails due to a real repository test
+failure, is unaffected — that remains real work to investigate and fix.
+
+The `coding_review_agent_loop` CLI orchestrator (used directly, outside skill
+mode) applies the equivalent bound automatically, plus board-wide stall
+classification driven by `--ci-queued-grace-seconds`; see [External CI
+infrastructure
+stalls](local_agent_loop.md#external-ci-infrastructure-stalls). Every coder
+prompt built by `coding_review_agent_loop.prompts` — including the ones
+`helpers/prompt_builders.py` reuses for skill mode's `run-pr-fix` — carries
+the same bounded-observation guidance, so this applies whether the coder turn
+runs through the CLI orchestrator or through the skill's own external-coder
+path.
+
 ## Session state
 
 Local session state is stored at:

--- a/src/coding_review_agent_loop/checks.py
+++ b/src/coding_review_agent_loop/checks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .ci_health import CiInfrastructureStall
 from .config import AgentLoopConfig
 from .github import PullRequestChecks
 from .logging import log
@@ -121,6 +122,50 @@ def _pr_check_details(pr_checks: PullRequestChecks) -> list[str]:
         )
     if pr_checks.branch_protection_note:
         details.append(pr_checks.branch_protection_note)
+    if pr_checks.infrastructure_stalls:
+        # Not code defects, and not necessarily the sole reason the state is
+        # failing/pending: annotate them so a coder round does not chase a
+        # check that is stalled on external GitHub Actions infrastructure.
+        details.append(
+            "External CI infrastructure stalls (not code defects): "
+            + "; ".join(stall.describe() for stall in pr_checks.infrastructure_stalls)
+        )
     if not details:
         details.append("No individual check names were available from the GitHub API.")
     return details
+
+
+def _ci_infrastructure_details(stall: CiInfrastructureStall) -> list[str]:
+    return [check.describe() for check in stall.checks]
+
+
+def _format_ci_infrastructure_comment(pr_number: int, stall: CiInfrastructureStall) -> str:
+    lines = [
+        f"External GitHub Actions infrastructure is blocking PR #{pr_number}.",
+        "",
+        "This is not a repository defect: no code change is required, and no merge was attempted.",
+        "",
+    ]
+    lines.extend(f"- {detail}" for detail in _ci_infrastructure_details(stall))
+    lines.extend(["", "-- coding-review-agent-loop"])
+    return "\n".join(lines)
+
+
+def _ci_infrastructure_stop_message(
+    pr_number: int,
+    stall: CiInfrastructureStall,
+    carried_items: list[str],
+) -> str:
+    lines = [
+        f"PR #{pr_number} is blocked on external GitHub Actions infrastructure, not a code defect.",
+        "",
+        "No code change is required and no merge was attempted. Rerun the same command once "
+        "GitHub Actions runners recover; the stalled check(s) should simply be rerun at that point.",
+        "",
+    ]
+    lines.extend(f"- {detail}" for detail in _ci_infrastructure_details(stall))
+    if carried_items:
+        lines.extend(["", "Reviewer items carried forward, still unresolved:"])
+        lines.extend(f"- {item}" for item in carried_items)
+    lines.extend(["", "-- coding-review-agent-loop"])
+    return "\n".join(lines)

--- a/src/coding_review_agent_loop/ci_health.py
+++ b/src/coding_review_agent_loop/ci_health.py
@@ -1,0 +1,337 @@
+"""CI infrastructure-stall detection.
+
+Owns the check data types (`PullRequestCheck`, `PullRequestChecks`) so this
+module has no dependency on `github.py`'s live API calls; `github.py` imports
+and re-exports these types instead. Everything here is pure classification
+over already-fetched data, so it only depends on stdlib.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal, Sequence
+
+
+@dataclass(frozen=True)
+class PullRequestCheck:
+    name: str
+    kind: Literal["check_run", "status_context"]
+    status: str
+    url: str | None = None
+    check_id: int | None = None
+    run_id: str | None = None
+    created_at: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+
+@dataclass(frozen=True)
+class StalledCheck:
+    name: str
+    kind: Literal["check_run", "status_context"]
+    reason: Literal["queued_too_long", "runner_unavailable"]
+    check_id: int | None
+    run_id: str | None
+    url: str | None
+    age_seconds: float | None
+
+    def describe(self) -> str:
+        location_parts: list[str] = []
+        if self.check_id is not None:
+            location_parts.append(f"check run {self.check_id}")
+        if self.run_id is not None:
+            location_parts.append(f"workflow run {self.run_id}")
+        if self.url:
+            location_parts.append(self.url)
+        location = f" ({', '.join(location_parts)})" if location_parts else ""
+        if self.reason == "queued_too_long":
+            detail = f"queued {_format_age(self.age_seconds)} without starting a job"
+        else:
+            detail = "cancelled before any job started (runner unavailable)"
+        return f"{self.name}{location} — {detail}"
+
+    def identifiers(self) -> tuple[str, ...]:
+        raw_ids = [self.name, self.run_id, str(self.check_id) if self.check_id is not None else None, self.url]
+        seen: list[str] = []
+        for raw_id in raw_ids:
+            if raw_id and raw_id not in seen:
+                seen.append(raw_id)
+        return tuple(seen)
+
+
+@dataclass(frozen=True)
+class PullRequestChecks:
+    state: Literal["passing", "failing", "pending", "no_checks", "unavailable"]
+    required_checks: tuple[str, ...]
+    passing: tuple[PullRequestCheck, ...]
+    pending: tuple[PullRequestCheck, ...]
+    failing: tuple[PullRequestCheck, ...]
+    missing_required: tuple[str, ...]
+    branch_protection_status: Literal["configured", "not_found", "forbidden", "unavailable"]
+    branch_protection_note: str | None = None
+    check_query_status: Literal["ok", "partial", "unavailable"] = "ok"
+    check_query_errors: tuple[str, ...] = ()
+    infrastructure_stalls: tuple[StalledCheck, ...] = field(default=())
+
+
+@dataclass(frozen=True)
+class CiInfrastructureStall:
+    checks: tuple[StalledCheck, ...]
+
+    @property
+    def is_stalled(self) -> bool:
+        return bool(self.checks)
+
+
+_RUN_ID_RE = re.compile(r"/actions/runs/(\d+)")
+
+
+def _extract_run_id(url: str | None) -> str | None:
+    if not url:
+        return None
+    match = _RUN_ID_RE.search(url)
+    return match.group(1) if match else None
+
+
+def _parse_timestamp(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if text.endswith("Z") or text.endswith("z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _age_seconds(created_at: str | None, *, now: datetime) -> float | None:
+    parsed = _parse_timestamp(created_at)
+    if parsed is None:
+        return None
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    delta = (now - parsed).total_seconds()
+    return max(0.0, delta)
+
+
+def _format_age(age_seconds: float | None) -> str:
+    if age_seconds is None:
+        return "for an unknown duration"
+    minutes = int(age_seconds // 60)
+    return f"{minutes}m"
+
+
+_QUEUED_LIKE_STATUSES = {"queued", "pending", "waiting", "requested"}
+_UNSTARTED_CANCEL_CONCLUSIONS = {"cancelled", "startup_failure"}
+
+
+def classify_ci_infrastructure_stall(
+    checks: Sequence[PullRequestCheck],
+    *,
+    now: datetime,
+    grace_seconds: int,
+) -> CiInfrastructureStall:
+    """Classify individual checks as external-infrastructure stalls.
+
+    Only ``check_run`` entries are eligible: commit-status contexts
+    (``status_context``) are set by arbitrary external systems, not GitHub
+    Actions runners, so they are never classified as an infrastructure stall.
+    """
+    stalled: list[StalledCheck] = []
+    for check in checks:
+        if check.kind != "check_run":
+            continue
+        status = (check.status or "").strip().lower()
+
+        if status in _UNSTARTED_CANCEL_CONCLUSIONS and (
+            check.started_at is None or check.started_at == check.completed_at
+        ):
+            stalled.append(
+                StalledCheck(
+                    name=check.name,
+                    kind=check.kind,
+                    reason="runner_unavailable",
+                    check_id=check.check_id,
+                    run_id=check.run_id,
+                    url=check.url,
+                    age_seconds=_age_seconds(check.created_at, now=now),
+                )
+            )
+            continue
+
+        if status in _QUEUED_LIKE_STATUSES and check.started_at is None:
+            age = _age_seconds(check.created_at, now=now)
+            if age is not None and age > grace_seconds:
+                stalled.append(
+                    StalledCheck(
+                        name=check.name,
+                        kind=check.kind,
+                        reason="queued_too_long",
+                        check_id=check.check_id,
+                        run_id=check.run_id,
+                        url=check.url,
+                        age_seconds=age,
+                    )
+                )
+
+    return CiInfrastructureStall(checks=tuple(stalled))
+
+
+def is_wholly_infrastructure_blocked(pr_checks: PullRequestChecks) -> bool:
+    """True only when every blocking/pending signal is an infrastructure stall.
+
+    This is the single gate for the orchestrator terminal stop, the reviewer
+    downgrade, and the auto-merge infrastructure outcome. A never-reporting
+    required check, unknown branch protection, a partial/unavailable check
+    query, or any genuinely failing/pending check makes this False.
+    """
+    if not pr_checks.infrastructure_stalls:
+        return False
+    if pr_checks.missing_required:
+        return False
+    if pr_checks.state == "unavailable":
+        return False
+    if pr_checks.branch_protection_status == "unavailable":
+        return False
+    if pr_checks.check_query_status != "ok":
+        return False
+    stalled_keys = {(stall.kind, stall.name) for stall in pr_checks.infrastructure_stalls}
+    for check in (*pr_checks.failing, *pr_checks.pending):
+        if (check.kind, check.name) not in stalled_keys:
+            return False
+    return True
+
+
+_IDENTIFIER_SENTINEL = "identsentinel"
+
+# Substring phrases whose presence signals stall semantics. Checked against the
+# normalized text after identifier substitution.
+_STALL_SEMANTIC_PHRASES: tuple[str, ...] = (
+    "runner unavailable",
+    "hosted runner",
+    "never started",
+    "did not start",
+    "no runner",
+    "before execution",
+    "runner acquisition",
+    "queued",
+    "cancelled",
+    "canceled",
+    "runner",
+    "capacity",
+)
+
+# Closed word-level vocabulary: every remaining token in a canonical stall-only
+# text must belong to this set (plus digits, the identifier sentinel, and
+# URLs) or the match fails. Kept intentionally small so an out-of-vocabulary
+# word (a filename, symbol, or code-defect noun) fails the match.
+_STALL_VOCABULARY_WORDS: frozenset[str] = frozenset(
+    {
+        "queued", "cancelled", "canceled", "runner", "runners", "hosted",
+        "never", "started", "starting", "start", "did", "no", "not",
+        "unavailable", "before", "execution", "capacity", "acquire",
+        "acquired", "acquisition", "recover", "recovers", "recovered",
+    }
+)
+
+_FUNCTION_WORDS: frozenset[str] = frozenset(
+    {
+        "a", "an", "the", "and", "or", "but", "is", "was", "were", "this",
+        "that", "these", "those", "for", "of", "to", "with", "without",
+        "than", "over", "past", "its", "it", "has", "have", "had", "been",
+        "being", "be", "still", "remains", "remained", "remain", "so",
+        "because", "due", "on", "in", "at", "as", "any", "job", "jobs",
+        "more", "external", "infrastructure", "issue", "since", "once",
+        "will", "should", "resume", "after", "work", "affected", "which",
+        "there", "not", "all", "one", "run", "runs", "runner",
+    }
+)
+
+_CI_NOUNS: frozenset[str] = frozenset(
+    {
+        "check", "checks", "workflow", "workflows", "run", "runs", "job",
+        "jobs", "github", "actions", "ci", "infrastructure", "external",
+    }
+)
+
+_TIME_UNITS: frozenset[str] = frozenset(
+    {
+        "m", "min", "mins", "minute", "minutes", "h", "hr", "hrs", "hour",
+        "hours", "s", "sec", "secs", "second", "seconds",
+    }
+)
+
+_CLOSED_VOCABULARY: frozenset[str] = (
+    _STALL_VOCABULARY_WORDS | _FUNCTION_WORDS | _CI_NOUNS | _TIME_UNITS
+)
+
+_URL_RE = re.compile(r"https?://\S+")
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_DIGIT_LETTER_BOUNDARY_RE = re.compile(r"(\d)([a-z])")
+_LETTER_DIGIT_BOUNDARY_RE = re.compile(r"([a-z])(\d)")
+_LEADING_MARKDOWN_RE = re.compile(r"^[\s\-\*•`'\"]+")
+
+_MAX_CANONICAL_TEXT_LENGTH = 400
+
+
+def is_canonical_stall_only_text(text: str, *, stalls: Sequence[StalledCheck]) -> bool:
+    """Whole-text, closed-vocabulary check for "this item is only a CI stall".
+
+    Fails closed: any token outside the closed vocabulary (a filename,
+    symbol, or code-defect noun) makes this return False, so a mixed item
+    naming a stalled run and then describing an unrelated code defect is
+    rejected in full.
+    """
+    if not text or not text.strip():
+        return False
+    if len(text) > _MAX_CANONICAL_TEXT_LENGTH:
+        return False
+
+    normalized = text.strip().lower()
+    normalized = _LEADING_MARKDOWN_RE.sub("", normalized)
+    normalized = normalized.strip("`'\" \t")
+    if not normalized:
+        return False
+
+    identifiers = sorted(
+        {identifier.lower() for stall in stalls for identifier in stall.identifiers() if identifier},
+        key=len,
+        reverse=True,
+    )
+
+    substituted = normalized
+    sentinel_count = 0
+    for identifier in identifiers:
+        if identifier and identifier in substituted:
+            sentinel_count += substituted.count(identifier)
+            substituted = substituted.replace(identifier, f" {_IDENTIFIER_SENTINEL} ")
+
+    if sentinel_count == 0:
+        return False
+
+    substituted = _URL_RE.sub(" url ", substituted)
+
+    if not any(phrase in substituted for phrase in _STALL_SEMANTIC_PHRASES):
+        return False
+
+    tokenizable = _DIGIT_LETTER_BOUNDARY_RE.sub(r"\1 \2", substituted)
+    tokenizable = _LETTER_DIGIT_BOUNDARY_RE.sub(r"\1 \2", tokenizable)
+
+    for token in _WORD_RE.findall(tokenizable):
+        if token == _IDENTIFIER_SENTINEL or token == "url":
+            continue
+        if token.isdigit():
+            continue
+        if token in _CLOSED_VOCABULARY:
+            continue
+        return False
+
+    return True

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -334,6 +334,16 @@ def build_parser() -> argparse.ArgumentParser:
             help="Polling interval for the CI check before auto-merge (default: 30).",
         )
         subparser.add_argument(
+            "--ci-queued-grace-seconds",
+            type=int,
+            default=1200,
+            help=(
+                "How long a check-run may sit queued with no job started before it is "
+                "treated as external GitHub Actions infrastructure blocking (for example "
+                "a hosted-runner capacity outage) rather than a normal wait (default: 1200)."
+            ),
+        )
+        subparser.add_argument(
             "--quiet",
             action="store_true",
             help="Suppress progress logs.",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -156,6 +156,10 @@ class AgentLoopConfig:
     # only; sequential stays the default. Distinct from --discuss-parallel
     # (#475), which covers discuss-mode debaters and is unaffected.
     review_parallel: bool = False
+    # How long a check-run may sit queued with no job started before it is
+    # treated as an external-CI-infrastructure stall rather than a normal
+    # wait (#602), e.g. a GitHub-hosted-runner capacity outage.
+    ci_queued_grace_seconds: int = 1200
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -826,6 +830,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         raise AgentLoopError("--ci-timeout-seconds must be greater than zero.")
     if args.ci_poll_interval_seconds <= 0:
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
+    if getattr(args, "ci_queued_grace_seconds", 1200) <= 0:
+        raise AgentLoopError("--ci-queued-grace-seconds must be greater than zero.")
     if args.progress_interval_seconds <= 0:
         raise AgentLoopError("--progress-interval-seconds must be greater than zero.")
     if args.agent_max_retries < 0:
@@ -907,6 +913,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ci_check_name=args.ci_check_name,
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
+        ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         quiet=args.quiet,
         log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
         progress_interval_seconds=args.progress_interval_seconds,

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import re
@@ -10,6 +11,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from .ci_health import (
+    CiInfrastructureStall,
+    PullRequestCheck,
+    PullRequestChecks,
+    StalledCheck,
+    _extract_run_id,
+    classify_ci_infrastructure_stall,
+    is_wholly_infrastructure_blocked,
+)
 from .errors import AgentLoopError
 from .logging import log
 from .protocol import parse_signed_human_requirement_body
@@ -18,6 +28,11 @@ from .workdirs import active_workdir
 
 if TYPE_CHECKING:
     from .config import AgentLoopConfig
+
+# PullRequestCheck/PullRequestChecks/StalledCheck/CiInfrastructureStall are
+# defined in ci_health.py (kept dependency-free of this module's live GitHub
+# API calls) and re-exported here for existing importers: checks.py,
+# orchestrator.py, prompts.py, and tests/agent_loop_helpers.py.
 
 
 @dataclass(frozen=True)
@@ -72,26 +87,6 @@ class PullRequestReviewContext:
     metadata: PullRequestMetadata
     comments: tuple[IssueComment, ...]
     human_requirements: tuple[HumanReviewRequirement, ...]
-
-
-@dataclass(frozen=True)
-class PullRequestCheck:
-    name: str
-    kind: Literal["check_run", "status_context"]
-    status: str
-    url: str | None = None
-
-
-@dataclass(frozen=True)
-class PullRequestChecks:
-    state: Literal["passing", "failing", "pending", "no_checks", "unavailable"]
-    required_checks: tuple[str, ...]
-    passing: tuple[PullRequestCheck, ...]
-    pending: tuple[PullRequestCheck, ...]
-    failing: tuple[PullRequestCheck, ...]
-    missing_required: tuple[str, ...]
-    branch_protection_status: Literal["configured", "not_found", "forbidden", "unavailable"]
-    branch_protection_note: str | None = None
 
 
 PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url,body"
@@ -526,6 +521,66 @@ def _dedupe_checks(checks: list[PullRequestCheck]) -> tuple[PullRequestCheck, ..
     return tuple(deduped.values())
 
 
+def _parse_check_runs_payload(payload: object) -> tuple[list[PullRequestCheck], list[str]]:
+    """Parse the `commits/{sha}/check-runs` response into `PullRequestCheck`s.
+
+    Shared by `get_pr_checks` (full board) and `get_check_record` (a single
+    configured check's full timestamped record for the auto-merge wait loop).
+    """
+    checks: list[PullRequestCheck] = []
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        errors.append("check-runs response was not a JSON object")
+        return checks, errors
+    for raw_check in payload.get("check_runs") or []:
+        if not isinstance(raw_check, dict):
+            continue
+        name = _optional_str(raw_check.get("name"))
+        if not name:
+            continue
+        url = _optional_str(raw_check.get("html_url") or raw_check.get("details_url"))
+        raw_id = raw_check.get("id")
+        checks.append(
+            PullRequestCheck(
+                name=name,
+                kind="check_run",
+                status=_normalize_check_run_status(raw_check),
+                url=url,
+                check_id=raw_id if isinstance(raw_id, int) else None,
+                run_id=_extract_run_id(url),
+                created_at=_optional_str(raw_check.get("created_at")),
+                started_at=_optional_str(raw_check.get("started_at")),
+                completed_at=_optional_str(raw_check.get("completed_at")),
+            )
+        )
+    return checks, errors
+
+
+def _parse_commit_statuses_payload(payload: object) -> tuple[list[PullRequestCheck], list[str]]:
+    checks: list[PullRequestCheck] = []
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        errors.append("commit-status response was not a JSON object")
+        return checks, errors
+    for raw_status in payload.get("statuses") or []:
+        if not isinstance(raw_status, dict):
+            continue
+        name = _optional_str(raw_status.get("context"))
+        if not name:
+            continue
+        checks.append(
+            PullRequestCheck(
+                name=name,
+                kind="status_context",
+                status=_optional_str(raw_status.get("state")) or "pending",
+                url=_optional_str(raw_status.get("target_url")),
+                created_at=_optional_str(raw_status.get("created_at")),
+                completed_at=_optional_str(raw_status.get("updated_at")),
+            )
+        )
+    return checks, errors
+
+
 def _fetch_branch_protection_required_checks(
     runner: Runner,
     *,
@@ -587,6 +642,7 @@ def get_pr_checks(
     *,
     config: AgentLoopConfig,
     metadata: PullRequestMetadata,
+    now: datetime.datetime | None = None,
 ) -> PullRequestChecks:
     if config.dry_run:
         return PullRequestChecks(
@@ -598,6 +654,8 @@ def get_pr_checks(
             missing_required=(),
             branch_protection_status="unavailable",
             branch_protection_note="Dry run mode does not query live GitHub PR checks.",
+            check_query_status="unavailable",
+            check_query_errors=("Dry run mode does not query live GitHub PR checks.",),
         )
 
     if not metadata.head_sha:
@@ -610,6 +668,8 @@ def get_pr_checks(
             missing_required=(),
             branch_protection_status="unavailable",
             branch_protection_note="PR head SHA is unavailable, so GitHub PR checks could not be queried.",
+            check_query_status="unavailable",
+            check_query_errors=("PR head SHA is unavailable.",),
         )
 
     branch_protection_status, required_checks, branch_protection_note = (
@@ -640,6 +700,8 @@ def get_pr_checks(
 
     check_errors: list[str] = []
     checks: list[PullRequestCheck] = []
+    check_runs_ok = False
+    statuses_ok = False
 
     if check_runs_result.returncode == 0:
         try:
@@ -647,20 +709,10 @@ def get_pr_checks(
         except json.JSONDecodeError:
             check_errors.append("check-runs response was not valid JSON")
         else:
-            for raw_check in payload.get("check_runs") or []:
-                if not isinstance(raw_check, dict):
-                    continue
-                name = _optional_str(raw_check.get("name"))
-                if not name:
-                    continue
-                checks.append(
-                    PullRequestCheck(
-                        name=name,
-                        kind="check_run",
-                        status=_normalize_check_run_status(raw_check),
-                        url=_optional_str(raw_check.get("html_url") or raw_check.get("details_url")),
-                    )
-                )
+            check_runs_ok = True
+            parsed_checks, parse_errors = _parse_check_runs_payload(payload)
+            checks.extend(parsed_checks)
+            check_errors.extend(parse_errors)
     else:
         check_errors.append("check-runs query failed")
 
@@ -670,22 +722,19 @@ def get_pr_checks(
         except json.JSONDecodeError:
             check_errors.append("commit-status response was not valid JSON")
         else:
-            for raw_status in payload.get("statuses") or []:
-                if not isinstance(raw_status, dict):
-                    continue
-                name = _optional_str(raw_status.get("context"))
-                if not name:
-                    continue
-                checks.append(
-                    PullRequestCheck(
-                        name=name,
-                        kind="status_context",
-                        status=_optional_str(raw_status.get("state")) or "pending",
-                        url=_optional_str(raw_status.get("target_url")),
-                    )
-                )
+            statuses_ok = True
+            parsed_statuses, parse_errors = _parse_commit_statuses_payload(payload)
+            checks.extend(parsed_statuses)
+            check_errors.extend(parse_errors)
     else:
         check_errors.append("commit-status query failed")
+
+    if check_runs_ok and statuses_ok:
+        check_query_status: Literal["ok", "partial", "unavailable"] = "ok"
+    elif check_runs_ok or statuses_ok:
+        check_query_status = "partial"
+    else:
+        check_query_status = "unavailable"
 
     deduped_checks = _dedupe_checks(checks)
     passing = tuple(check for check in deduped_checks if _classify_check_status(check.status) == "passing")
@@ -693,6 +742,11 @@ def get_pr_checks(
     failing = tuple(check for check in deduped_checks if _classify_check_status(check.status) == "failing")
     observed_names = {check.name for check in deduped_checks}
     missing_required = tuple(name for name in required_checks if name not in observed_names)
+    infrastructure_stalls = classify_ci_infrastructure_stall(
+        deduped_checks,
+        now=now or datetime.datetime.now(datetime.timezone.utc),
+        grace_seconds=config.ci_queued_grace_seconds,
+    ).checks
 
     state: Literal["passing", "failing", "pending", "no_checks", "unavailable"]
     if failing:
@@ -722,6 +776,9 @@ def get_pr_checks(
         missing_required=missing_required,
         branch_protection_status=branch_protection_status,
         branch_protection_note=branch_protection_note,
+        check_query_status=check_query_status,
+        check_query_errors=tuple(check_errors),
+        infrastructure_stalls=infrastructure_stalls,
     )
 
 
@@ -1105,24 +1162,55 @@ def get_pr_head_sha(runner: Runner, config: AgentLoopConfig, pr_number: int) -> 
     return sha
 
 
-def get_check_status(runner: Runner, config: AgentLoopConfig, head_sha: str) -> str:
+def get_check_record(runner: Runner, config: AgentLoopConfig, head_sha: str) -> PullRequestCheck | None:
+    """Full timestamped record for `config.ci_check_name`, or None if absent/unavailable."""
     result = runner.run(
-        [
-            config.gh_cmd,
-            "api",
-            f"repos/{config.repo}/commits/{head_sha}/check-runs",
-            "--jq",
-            (
-                f"[.check_runs[] | select(.name == {json.dumps(config.ci_check_name)})] | "
-                'if length == 0 then "pending" else .[0].conclusion // .[0].status end'
-            ),
-        ],
+        [config.gh_cmd, "api", f"repos/{config.repo}/commits/{head_sha}/check-runs"],
         cwd=active_workdir(config),
+        check=False,
     )
-    return result.stdout.strip() or "pending"
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    checks, _errors = _parse_check_runs_payload(payload)
+    for check in checks:
+        if check.name == config.ci_check_name:
+            return check
+    return None
 
 
-def wait_for_ci(runner: Runner, config: AgentLoopConfig, pr_number: int) -> None:
+def get_check_status(runner: Runner, config: AgentLoopConfig, head_sha: str) -> str:
+    record = get_check_record(runner, config, head_sha)
+    return record.status if record is not None else "pending"
+
+
+@dataclass(frozen=True)
+class CiWaitOutcome:
+    status: Literal["passed", "infrastructure_stall"]
+    stall: CiInfrastructureStall | None = None
+    pr_checks: PullRequestChecks | None = None
+
+
+def wait_for_ci(
+    runner: Runner,
+    config: AgentLoopConfig,
+    pr_number: int,
+    *,
+    metadata: PullRequestMetadata,
+) -> CiWaitOutcome:
+    """Poll the configured CI check before auto-merge.
+
+    A queued-too-long or pre-execution-cancelled check is not, by itself,
+    grounds to stop: a stall on the single configured check only ends the
+    wait once a full `get_pr_checks` snapshot confirms the whole PR check
+    board is wholly infrastructure-blocked (`is_wholly_infrastructure_blocked`).
+    Otherwise this keeps today's contract exactly: keep polling and ultimately
+    raise `AgentLoopError` on a genuine terminal failure or `ci_timeout_seconds`
+    expiry.
+    """
     log(config, f"Waiting for GitHub check '{config.ci_check_name}' before merge")
     head_sha = get_pr_head_sha(runner, config, pr_number)
     attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
@@ -1135,10 +1223,22 @@ def wait_for_ci(runner: Runner, config: AgentLoopConfig, pr_number: int) -> None
         "skipped",
     }
     for attempt in range(attempts):
-        status = get_check_status(runner, config, head_sha)
+        record = get_check_record(runner, config, head_sha)
+        status = record.status if record is not None else "pending"
         log(config, f"GitHub check '{config.ci_check_name}' status: {status}")
         if status == "success":
-            return
+            return CiWaitOutcome(status="passed")
+
+        stall = classify_ci_infrastructure_stall(
+            [record] if record is not None else [],
+            now=datetime.datetime.now(datetime.timezone.utc),
+            grace_seconds=config.ci_queued_grace_seconds,
+        )
+        if stall.is_stalled:
+            snapshot = get_pr_checks(runner, config=config, metadata=metadata)
+            if is_wholly_infrastructure_blocked(snapshot):
+                return CiWaitOutcome(status="infrastructure_stall", stall=stall, pr_checks=snapshot)
+
         if status in terminal_failures:
             raise AgentLoopError(f"CI check '{config.ci_check_name}' failed with status: {status}")
         if attempt < attempts - 1:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -201,7 +201,10 @@ from .workdir_guard import (
     validate_test_commands_within_workdir,
 )
 from .checks import (
+    _ci_infrastructure_details,
+    _format_ci_infrastructure_comment,
     _format_pr_checks_comment,
+    _ci_infrastructure_stop_message,
     _pending_ci_status_summary,
     _pending_ci_stop_guidance,
     _pending_ci_stop_message,
@@ -209,6 +212,12 @@ from .checks import (
     _pr_check_details,
     run_optional_tests,
     run_pre_review_tests,
+)
+from .ci_health import (
+    CiInfrastructureStall,
+    StalledCheck,
+    is_canonical_stall_only_text,
+    is_wholly_infrastructure_blocked,
 )
 from .comment_rendering import (
     DEFERRED_STAGES_MARKER_RE,
@@ -2942,6 +2951,65 @@ def _is_pending_ci_only_review(parsed_review: ParsedReview, pr_checks: PullReque
     return True
 
 
+def _coder_infrastructure_stall_notice(stalls: Sequence[StalledCheck]) -> str:
+    """Prepended to a coder follow-up review when checks are wholly
+    infrastructure-blocked (#602), so the coder never has to discover this
+    itself by waiting on the stalled check.
+    """
+    if not stalls:
+        return ""
+    bullets = "\n".join(f"- {stall.describe()}" for stall in stalls)
+    return (
+        "External CI infrastructure is currently blocking the following GitHub "
+        "checks; this is not a code defect and there is no fix for it in this PR:\n"
+        f"{bullets}\n\n"
+        "Do not wait for these checks to leave queued state and do not attempt to "
+        "retrigger them. Fix only the genuine review items below. If your terminal "
+        "response needs to mention CI status, name the affected check/run above and "
+        "say that work should resume once GitHub Actions runners recover.\n\n"
+    )
+
+
+_BOILERPLATE_REVIEW_SUMMARIES = {"Review complete.", "Plan review complete."}
+
+
+def _is_infrastructure_ci_only_review(parsed_review: ParsedReview, pr_checks: PullRequestChecks) -> bool:
+    """Detect a blocking review whose only content is a canonical restatement of
+    an external CI infrastructure stall (a queued check that never started a
+    job, or one cancelled before execution because a hosted runner was
+    unavailable), rather than an actionable code-level finding.
+
+    Unlike `_is_pending_ci_only_review`'s keyword heuristic, this requires the
+    whole check board to already be classified `is_wholly_infrastructure_blocked`
+    and every blocking item (and non-boilerplate summary) to pass the closed-
+    vocabulary `is_canonical_stall_only_text` check. Any failure aborts the
+    downgrade for the whole review, so a mixed item that names the stalled run
+    and then describes an unrelated code defect reaches the coder unchanged.
+    """
+    if not is_wholly_infrastructure_blocked(pr_checks):
+        return False
+    if parsed_review.followups.same_pr:
+        return False
+    if any(item.disposition in {"blocking", "same-pr"} for item in parsed_review.dispositions):
+        return False
+    candidate_texts = [
+        item.text for item in parsed_review.blocking_items if item.text and item.text.strip()
+    ]
+    if not candidate_texts:
+        return False
+    stalls = pr_checks.infrastructure_stalls
+    if not all(is_canonical_stall_only_text(text, stalls=stalls) for text in candidate_texts):
+        return False
+    summary = (parsed_review.summary or "").strip()
+    if (
+        summary
+        and summary not in _BOILERPLATE_REVIEW_SUMMARIES
+        and not is_canonical_stall_only_text(summary, stalls=stalls)
+    ):
+        return False
+    return True
+
+
 def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
     if not summary:
         return False
@@ -5621,6 +5689,20 @@ def run_pr_loop(
                     parsed_review = dataclasses_replace(parsed_review, state="approved", blocking_items=())
                     review_state = parsed_review.state
 
+                if (
+                    resumed_record is None
+                    and review_state == "blocking"
+                    and _is_infrastructure_ci_only_review(parsed_review, reviewer_pr_checks)
+                ):
+                    log(
+                        config,
+                        f"Round {round_number}: {reviewer_name} blocking review only restates "
+                        "an external CI infrastructure stall; treating as approved instead of "
+                        "starting a new coder follow-up round",
+                    )
+                    parsed_review = dataclasses_replace(parsed_review, state="approved", blocking_items=())
+                    review_state = parsed_review.state
+
                 if _is_incomplete_pr_review(parsed_review):
                     if len(configured_reviewers) == 1:
                         incomplete_pr_review_error = AgentLoopError(
@@ -5869,6 +5951,7 @@ def run_pr_loop(
                         f"disagreement.\n\nDisputed items still unresolved:\n{item_summaries}"
                     )
 
+            pr_checks: PullRequestChecks | None = None
             if not must_fix_items:
                 if human_requirements:
                     missing_acknowledgements = [
@@ -6029,6 +6112,47 @@ def run_pr_loop(
                     next_unresolved_item_number += 1
                     must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
                 pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+                if not must_fix_items and is_wholly_infrastructure_blocked(pr_checks):
+                    # Every remaining blocking/pending signal is external GitHub
+                    # Actions infrastructure (a queued check that never started a
+                    # job, or one cancelled before execution because a hosted
+                    # runner was unavailable): stop cleanly and resumably instead
+                    # of a synthetic blocking item, a coder round, or a merge.
+                    stall = CiInfrastructureStall(checks=pr_checks.infrastructure_stalls)
+                    _publish_approved_followups(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        head_sha=pr_metadata.head_sha,
+                        pr_comments=pr_comments,
+                        followups=future_followups,
+                    )
+                    post_pr_comment(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        body=_format_ci_infrastructure_comment(pr_number, stall),
+                    )
+                    post_pr_comment(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        body=_ci_infrastructure_stop_message(pr_number, stall, []),
+                    )
+                    log(
+                        config,
+                        f"Round {round_number}: reviewers approved PR #{pr_number}; GitHub checks "
+                        "are wholly blocked by external CI infrastructure; stopping without a "
+                        "coder follow-up round or merge",
+                    )
+                    print(
+                        f"PR #{pr_number} was approved by {format_agent_list(configured_reviewers)}, "
+                        "but external GitHub Actions infrastructure is blocking CI "
+                        f"({'; '.join(_ci_infrastructure_details(stall))}). No code change is "
+                        "required and no merge was attempted; rerun the same command once GitHub "
+                        "Actions runners recover."
+                    )
+                    return 0
                 if not must_fix_items:
                     if pr_checks.state in {"pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)
@@ -6113,7 +6237,35 @@ def run_pr_loop(
                     )
                     run_optional_tests(runner, config)
                     if config.auto_merge:
-                        wait_for_ci(runner, config, pr_number)
+                        wait_outcome = wait_for_ci(runner, config, pr_number, metadata=pr_metadata)
+                        if wait_outcome.status == "infrastructure_stall":
+                            assert wait_outcome.stall is not None
+                            post_pr_comment(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                body=_format_ci_infrastructure_comment(pr_number, wait_outcome.stall),
+                            )
+                            post_pr_comment(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                body=_ci_infrastructure_stop_message(pr_number, wait_outcome.stall, []),
+                            )
+                            log(
+                                config,
+                                f"Round {round_number}: PR #{pr_number} CI wait stopped on external "
+                                "infrastructure blocking; no merge attempted",
+                            )
+                            print(
+                                f"PR #{pr_number} was approved by "
+                                f"{format_agent_list(configured_reviewers)}, but external GitHub "
+                                "Actions infrastructure is blocking CI "
+                                f"({'; '.join(_ci_infrastructure_details(wait_outcome.stall))}). "
+                                "No merge was attempted; rerun the same command once GitHub Actions "
+                                "runners recover."
+                            )
+                            return 0
                         merge_pr(runner, config, pr_number)
                     print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
                     return 0
@@ -6123,10 +6275,26 @@ def run_pr_loop(
                     "human review required."
                 )
 
+            # Structural backstop (#602): even when the reviewer downgrade above
+            # correctly declines (a mixed item, a genuine defect alongside a
+            # stalled check), a coder round must never be able to wait
+            # indefinitely on external CI infrastructure. Always confirm the
+            # freshest check board before starting the round and, when it is
+            # wholly infrastructure-blocked, prepend the stall context so the
+            # coder fixes only the genuine items and returns a bounded terminal
+            # response instead of chasing the stalled check.
+            if pr_checks is None:
+                pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+            stall_context = (
+                _coder_infrastructure_stall_notice(pr_checks.infrastructure_stalls)
+                if is_wholly_infrastructure_blocked(pr_checks)
+                else ""
+            )
+
             same_pr_items = [item for item in unresolved_items if item.status == "same-pr"]
             blocking_items = [item for item in unresolved_items if item.status == "blocking"]
             if same_pr_items and not blocking_items:
-                combined_review = _format_same_pr_unresolved_items(same_pr_items)
+                combined_review = stall_context + _format_same_pr_unresolved_items(same_pr_items)
                 coder_human_requirements_context = render_coder_human_requirements_prompt_context(
                     human_requirements
                 )
@@ -6141,7 +6309,7 @@ def run_pr_loop(
                     human_requirements_context=coder_human_requirements_context,
                 )
             else:
-                combined_review = _format_unresolved_items_for_coder(unresolved_items)
+                combined_review = stall_context + _format_unresolved_items_for_coder(unresolved_items)
                 coder_human_requirements_context = render_coder_human_requirements_prompt_context(
                     human_requirements
                 )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -96,10 +96,40 @@ def _coder_test_reporting_guidance() -> str:
     )
 
 
+def _coder_ci_wait_guidance() -> str:
+    return (
+        "Do not run `gh run watch`, `gh pr checks --watch`, or any other unbounded wait "
+        "on a GitHub Actions check or workflow run. If you need to confirm CI status, take "
+        "at most 3 status snapshots (for example `gh run view <run-id> "
+        "--json status,conclusion,startedAt` or `gh pr checks`), spaced at least 30 seconds "
+        "apart, for at most 120 seconds of total CI observation in this turn. If a run is "
+        "still queued past that bound, or was cancelled before any job started, stop "
+        "observing it and return your terminal blocking response immediately: name the "
+        "affected check, run ID, and URL in `remaining_items`/`remaining_item_notes` (or the "
+        "equivalent prose for prompt shapes without that structured schema) and say work "
+        "should resume once GitHub Actions runners recover. This does not apply to a check "
+        "that is actively running or that fails due to a real repository test failure — "
+        "those remain real work to investigate and fix.\n"
+    )
+
+
 def _coder_documentation_guidance() -> str:
     return (
         "If your implementation adds or changes a user-facing subcommand, flag, "
         "or mode, update README.md and any relevant docs/ files as part of this PR.\n"
+    )
+
+
+def _reviewer_ci_infrastructure_guidance() -> str:
+    return (
+        "A check listed under \"External CI infrastructure stalls\" in the GitHub PR "
+        "checks block is external GitHub Actions infrastructure blocking (a queued check "
+        "that never started a job, or one cancelled before execution because a hosted "
+        "runner was unavailable), not a code-level finding. Do not record it as a "
+        "`blocking_items` entry or as the reason for a `blocking` review; mention it in "
+        "`summary` only if relevant. Any other failing check, or a required check that "
+        "never reports at all, remains ordinary review work and may still justify a "
+        "blocking review.\n"
     )
 
 
@@ -698,6 +728,17 @@ def format_pr_checks(checks: PullRequestChecks) -> str:
         lines.append(f"- Required checks not yet reporting: {', '.join(checks.missing_required)}")
     if checks.branch_protection_note:
         lines.append(f"- Branch protection: {checks.branch_protection_note}")
+    if checks.infrastructure_stalls:
+        lines.append("- External CI infrastructure stalls:")
+        for stall in checks.infrastructure_stalls:
+            lines.append(f"  - {stall.describe()}")
+        lines.append(
+            "  A check listed above is external GitHub Actions infrastructure blocking "
+            "(a queued check that never started a job, or one cancelled before execution "
+            "because a hosted runner was unavailable). Do not record it as a blocking "
+            "code item. Any other failing check, or a required check that never reports "
+            "at all, remains ordinary review work."
+        )
     return "\n".join(lines)
 
 
@@ -1016,7 +1057,7 @@ Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1611,7 +1652,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1654,7 +1695,7 @@ background, check on it or re-run it in the foreground now and wait for it to
 finish; do not launch anything new in the background. Then commit, push, and
 open the pull request if that is not already done, or continue exactly where
 you left off.
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
 
@@ -1679,7 +1720,7 @@ Use this local checkout as your workspace. Decide between two paths:
     {config.base}. Do not wait for {reviewer_name}; this local orchestrator
     will run {reviewer_name} after you create the PR.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 
 (b) If the task is genuinely ambiguous or missing information that would change
     the implementation, do NOT write code. Instead, ask focused clarifying
@@ -1727,7 +1768,7 @@ Clarification so far:
 Now proceed. Strongly prefer to implement the task and open a PR. Only ask
 again if a critical detail is still missing.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 
 {_agent_unavailable_guidance(coder_signature)}
 Do not place your signature before the AGENT_STATE or AGENT_CLARIFY marker.
@@ -1887,7 +1928,7 @@ Pending or unavailable GitHub checks are an external wait state: mention them
 only in `summary`, never in `blocking_items`, and never as the sole reason to
 return `state: "blocking"` — only failing checks or real code-level findings
 justify a blocking review.
-When the PR changes files under `alembic/versions/`, verify migration topology:
+{_reviewer_ci_infrastructure_guidance()}When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
 {_reviewer_documentation_check()}"""
@@ -2211,7 +2252,7 @@ Pending or unavailable GitHub checks are an external wait state: mention them
 only in `summary`, never in `blocking_items`, and never as the sole reason to
 return `state: "blocking"` — only failing checks or real code-level findings
 justify a blocking review.
-When the PR changes files under `alembic/versions/`, verify migration topology:
+{_reviewer_ci_infrastructure_guidance()}When the PR changes files under `alembic/versions/`, verify migration topology:
 new revisions should descend from the current head unless the PR intentionally
 adds a merge migration.
 {_reviewer_documentation_check()}{human_requirements_guidance}
@@ -2306,7 +2347,7 @@ needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}
@@ -2355,7 +2396,7 @@ current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead. The PR
 remains blocked pending another review round after this cleanup.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2589,6 +2589,62 @@ def test_config_rejects_non_positive_max_rounds(tmp_path, max_rounds):
         config_from_args(args, FakeRunner())
 
 
+def test_config_defaults_ci_queued_grace_seconds(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+    config = config_from_args(args, FakeRunner())
+
+    assert config.ci_queued_grace_seconds == 1200
+
+
+def test_config_parses_custom_ci_queued_grace_seconds(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--ci-queued-grace-seconds",
+        "600",
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+    config = config_from_args(args, FakeRunner())
+
+    assert config.ci_queued_grace_seconds == 600
+
+
+@pytest.mark.parametrize("ci_queued_grace_seconds", ["0", "-1"])
+def test_config_rejects_non_positive_ci_queued_grace_seconds(tmp_path, ci_queued_grace_seconds):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr",
+        "77",
+        "--repo",
+        "OWNER/REPO",
+        "--ci-queued-grace-seconds",
+        ci_queued_grace_seconds,
+        "--claude-dir",
+        str(tmp_path / "claude"),
+        "--codex-dir",
+        str(tmp_path / "codex"),
+    ])
+
+    with pytest.raises(AgentLoopError, match="--ci-queued-grace-seconds must be greater than zero"):
+        config_from_args(args, FakeRunner())
+
+
 def test_config_defaults_do_not_bypass_agent_permissions(tmp_path):
     parser = build_parser()
     args = parser.parse_args([

--- a/tests/test_ci_health.py
+++ b/tests/test_ci_health.py
@@ -1,0 +1,416 @@
+import datetime
+import json
+
+from coding_review_agent_loop.ci_health import (
+    CiInfrastructureStall,
+    PullRequestCheck,
+    PullRequestChecks,
+    StalledCheck,
+    _extract_run_id,
+    classify_ci_infrastructure_stall,
+    is_canonical_stall_only_text,
+    is_wholly_infrastructure_blocked,
+)
+import coding_review_agent_loop.github as github_module
+from coding_review_agent_loop.github import (
+    PullRequestCheck as GithubPullRequestCheck,
+    PullRequestChecks as GithubPullRequestChecks,
+    PullRequestMetadata,
+    get_check_record,
+    get_check_status,
+    get_pr_checks,
+)
+from coding_review_agent_loop.runner import CommandResult, Runner
+
+from agent_loop_helpers import make_config
+
+NOW = datetime.datetime(2026, 5, 23, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _check(**overrides):
+    defaults = dict(
+        name="test",
+        kind="check_run",
+        status="queued",
+        url=None,
+        check_id=None,
+        run_id=None,
+        created_at=None,
+        started_at=None,
+        completed_at=None,
+    )
+    defaults.update(overrides)
+    return PullRequestCheck(**defaults)
+
+
+# --- classify_ci_infrastructure_stall ---------------------------------------
+
+
+def test_queued_past_grace_is_stalled():
+    check = _check(status="queued", created_at="2026-05-23T11:00:00Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert stall.is_stalled
+    assert stall.checks[0].reason == "queued_too_long"
+    assert stall.checks[0].age_seconds == 3600.0
+
+
+def test_queued_within_grace_is_not_stalled():
+    check = _check(status="queued", created_at="2026-05-23T11:55:00Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert not stall.is_stalled
+
+
+def test_long_running_in_progress_is_not_stalled():
+    check = _check(status="in_progress", created_at="2026-05-23T09:00:00Z", started_at="2026-05-23T09:00:05Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert not stall.is_stalled
+
+
+def test_success_and_failure_are_not_stalled():
+    for status in ("success", "failure"):
+        check = _check(status=status, created_at="2026-05-23T09:00:00Z")
+        stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+        assert not stall.is_stalled
+
+
+def test_cancelled_with_no_start_is_runner_unavailable():
+    check = _check(status="cancelled", created_at="2026-05-23T11:58:00Z", started_at=None, completed_at="2026-05-23T11:59:00Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert stall.is_stalled
+    assert stall.checks[0].reason == "runner_unavailable"
+
+
+def test_cancelled_with_same_start_and_complete_is_runner_unavailable():
+    check = _check(status="cancelled", started_at="2026-05-23T11:59:00Z", completed_at="2026-05-23T11:59:00Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert stall.is_stalled
+    assert stall.checks[0].reason == "runner_unavailable"
+
+
+def test_cancelled_with_real_start_is_not_stalled():
+    check = _check(status="cancelled", started_at="2026-05-23T11:00:00Z", completed_at="2026-05-23T11:30:00Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert not stall.is_stalled
+
+
+def test_status_context_never_classified():
+    check = _check(kind="status_context", status="queued", created_at="2026-05-23T09:00:00Z")
+    stall = classify_ci_infrastructure_stall([check], now=NOW, grace_seconds=1200)
+    assert not stall.is_stalled
+
+
+def test_missing_malformed_and_future_timestamps_do_not_raise():
+    checks = [
+        _check(status="queued", created_at=None),
+        _check(status="queued", created_at="not-a-timestamp"),
+        _check(status="queued", created_at="2026-05-23T11:00:00Z"),
+        _check(status="queued", created_at="2099-01-01T00:00:00Z"),  # future
+    ]
+    stall = classify_ci_infrastructure_stall(checks, now=NOW, grace_seconds=1200)
+    # Only the genuinely-past-grace one should stall; none should raise.
+    assert len(stall.checks) == 1
+    assert stall.checks[0].age_seconds == 3600.0
+
+
+def test_z_suffixed_and_offset_timestamps_both_parse():
+    z_check = _check(status="queued", created_at="2026-05-23T11:00:00Z")
+    offset_check = _check(status="queued", created_at="2026-05-23T11:00:00+00:00")
+    stall = classify_ci_infrastructure_stall([z_check, offset_check], now=NOW, grace_seconds=1200)
+    assert len(stall.checks) == 2
+
+
+def test_extract_run_id_from_actions_url():
+    url = "https://github.com/OWNER/REPO/actions/runs/31123230205/job/12345"
+    assert _extract_run_id(url) == "31123230205"
+
+
+def test_extract_run_id_non_actions_url():
+    assert _extract_run_id("https://example.com/foo") is None
+
+
+def test_extract_run_id_none():
+    assert _extract_run_id(None) is None
+
+
+# --- is_wholly_infrastructure_blocked ---------------------------------------
+
+
+def _stalled_check(name="test", run_id="31123230205", check_id=998877, url=None):
+    return StalledCheck(
+        name=name,
+        kind="check_run",
+        reason="queued_too_long",
+        check_id=check_id,
+        run_id=run_id,
+        url=url or f"https://github.com/OWNER/REPO/actions/runs/{run_id}",
+        age_seconds=3600.0,
+    )
+
+
+def _pr_checks(**overrides):
+    defaults = dict(
+        state="pending",
+        required_checks=(),
+        passing=(),
+        pending=(_check(status="queued"),),
+        failing=(),
+        missing_required=(),
+        branch_protection_status="configured",
+        branch_protection_note=None,
+        check_query_status="ok",
+        check_query_errors=(),
+        infrastructure_stalls=(_stalled_check(),),
+    )
+    defaults.update(overrides)
+    return PullRequestChecks(**defaults)
+
+
+def test_wholly_blocked_when_all_stalled():
+    checks = _pr_checks()
+    assert is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_with_missing_required():
+    checks = _pr_checks(missing_required=("lint",))
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_with_genuine_failing_check():
+    checks = _pr_checks(failing=(_check(name="other", status="failure"),))
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_with_normal_running_check():
+    checks = _pr_checks(pending=(_check(status="queued"), _check(name="lint", status="in_progress")))
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_when_branch_protection_unavailable():
+    checks = _pr_checks(branch_protection_status="unavailable")
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_when_state_unavailable():
+    checks = _pr_checks(state="unavailable")
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_with_partial_check_query():
+    checks = _pr_checks(check_query_status="partial")
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_with_unavailable_check_query():
+    checks = _pr_checks(check_query_status="unavailable")
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+def test_not_wholly_blocked_with_no_stalls():
+    checks = _pr_checks(infrastructure_stalls=(), pending=())
+    assert not is_wholly_infrastructure_blocked(checks)
+
+
+# --- is_canonical_stall_only_text -------------------------------------------
+
+
+def test_canonical_stall_only_sentence_matches():
+    stalls = [_stalled_check(name="test", run_id="31123230205")]
+    text = (
+        "GitHub check `test` (workflow run 31123230205) has been queued for over "
+        "100 minutes because a hosted runner was unavailable; runner unavailable."
+    )
+    assert is_canonical_stall_only_text(text, stalls=stalls)
+
+
+def test_canonical_stall_text_plus_code_defect_fails():
+    stalls = [_stalled_check(name="test", run_id="31123230205")]
+    text = (
+        "GitHub check `test` (workflow run 31123230205) runner unavailable, and "
+        "models.py has a null pointer bug that crashes on empty input."
+    )
+    assert not is_canonical_stall_only_text(text, stalls=stalls)
+
+
+def test_stall_wording_without_identifier_fails():
+    stalls = [_stalled_check(name="test", run_id="31123230205")]
+    text = "The check is queued and the runner is unavailable."
+    assert not is_canonical_stall_only_text(text, stalls=stalls)
+
+
+def test_identifier_without_stall_semantics_fails():
+    stalls = [_stalled_check(name="test", run_id="31123230205")]
+    text = "GitHub check `test` (workflow run 31123230205) looks fine to me."
+    assert not is_canonical_stall_only_text(text, stalls=stalls)
+
+
+def test_generic_ci_keywords_only_fails():
+    stalls = [_stalled_check(name="test", run_id="31123230205")]
+    text = "CI infrastructure failed for this PR."
+    assert not is_canonical_stall_only_text(text, stalls=stalls)
+
+
+def test_overlength_text_fails():
+    stalls = [_stalled_check(name="test", run_id="31123230205")]
+    text = "GitHub check `test` (workflow run 31123230205) runner unavailable. " + ("queued " * 100)
+    assert not is_canonical_stall_only_text(text, stalls=stalls)
+
+
+def test_empty_text_fails():
+    assert not is_canonical_stall_only_text("", stalls=[_stalled_check()])
+
+
+# --- get_pr_checks -----------------------------------------------------------
+
+
+class _StubGhRunner(Runner):
+    def __init__(
+        self,
+        *,
+        check_runs_payload=None,
+        check_runs_returncode=0,
+        check_runs_stdout=None,
+        status_payload=None,
+        status_returncode=0,
+        branch_protection_payload=None,
+        branch_protection_returncode=0,
+    ):
+        super().__init__(dry_run=False)
+        self._check_runs_stdout = (
+            check_runs_stdout if check_runs_stdout is not None else json.dumps(check_runs_payload or {"check_runs": []})
+        )
+        self._check_runs_returncode = check_runs_returncode
+        self._status_stdout = json.dumps(status_payload or {"state": "success", "statuses": []})
+        self._status_returncode = status_returncode
+        self._branch_protection_stdout = json.dumps(branch_protection_payload or {"contexts": []})
+        self._branch_protection_returncode = branch_protection_returncode
+
+    def run(self, args, *, cwd, input_text=None, check=True, env=None):
+        cmd = [str(a) for a in args]
+        if cmd[:2] == ["gh", "api"] and "protection/required_status_checks" in cmd[2]:
+            return CommandResult(cmd, cwd, self._branch_protection_stdout, "", self._branch_protection_returncode)
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs"):
+            return CommandResult(cmd, cwd, self._check_runs_stdout, "", self._check_runs_returncode)
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/status"):
+            return CommandResult(cmd, cwd, self._status_stdout, "", self._status_returncode)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+
+def _metadata():
+    return PullRequestMetadata(
+        number=77,
+        repo="OWNER/REPO",
+        title="Title",
+        head_branch="feature",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/77",
+    )
+
+
+def test_get_pr_checks_populates_new_fields(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubGhRunner(
+        check_runs_payload={
+            "check_runs": [
+                {
+                    "id": 555,
+                    "name": "test",
+                    "status": "queued",
+                    "conclusion": None,
+                    "html_url": "https://github.com/OWNER/REPO/actions/runs/31123230205/job/1",
+                    "created_at": "2026-05-23T11:00:00Z",
+                    "started_at": None,
+                    "completed_at": None,
+                }
+            ]
+        },
+        branch_protection_payload={"contexts": ["test"]},
+    )
+
+    pr_checks = get_pr_checks(runner, config=config, metadata=_metadata(), now=NOW)
+
+    assert pr_checks.check_query_status == "ok"
+    assert pr_checks.check_query_errors == ()
+    check = pr_checks.pending[0]
+    assert check.check_id == 555
+    assert check.run_id == "31123230205"
+    assert check.created_at == "2026-05-23T11:00:00Z"
+    assert len(pr_checks.infrastructure_stalls) == 1
+    assert pr_checks.infrastructure_stalls[0].reason == "queued_too_long"
+
+
+def test_get_pr_checks_partial_query_failure(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubGhRunner(
+        check_runs_payload={"check_runs": [{"id": 1, "name": "test", "status": "completed", "conclusion": "success"}]},
+        status_returncode=1,
+        branch_protection_payload={"contexts": ["test"]},
+    )
+
+    pr_checks = get_pr_checks(runner, config=config, metadata=_metadata(), now=NOW)
+
+    assert pr_checks.check_query_status == "partial"
+    assert "commit-status query failed" in pr_checks.check_query_errors
+
+
+def test_get_pr_checks_malformed_json_is_partial(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubGhRunner(
+        check_runs_stdout="not json",
+        status_payload={"state": "success", "statuses": []},
+        branch_protection_payload={"contexts": []},
+    )
+
+    pr_checks = get_pr_checks(runner, config=config, metadata=_metadata(), now=NOW)
+
+    assert pr_checks.check_query_status == "partial"
+    assert "check-runs response was not valid JSON" in pr_checks.check_query_errors
+
+
+def test_get_pr_checks_both_queries_fail_is_unavailable(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubGhRunner(check_runs_returncode=1, status_returncode=1)
+
+    pr_checks = get_pr_checks(runner, config=config, metadata=_metadata(), now=NOW)
+
+    assert pr_checks.check_query_status == "unavailable"
+
+
+def test_reexported_names_import_from_github_module():
+    assert github_module.PullRequestCheck is PullRequestCheck
+    assert github_module.PullRequestChecks is PullRequestChecks
+    assert GithubPullRequestCheck is PullRequestCheck
+    assert GithubPullRequestChecks is PullRequestChecks
+
+
+def test_get_check_record_returns_full_record(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubGhRunner(
+        check_runs_payload={
+            "check_runs": [
+                {
+                    "id": 42,
+                    "name": "test",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "started_at": "2026-05-23T11:00:00Z",
+                    "completed_at": "2026-05-23T11:05:00Z",
+                }
+            ]
+        }
+    )
+
+    record = get_check_record(runner, config, "abc123")
+
+    assert record is not None
+    assert record.check_id == 42
+    assert record.status == "success"
+    assert get_check_status(runner, config, "abc123") == "success"
+
+
+def test_get_check_record_missing_check_returns_none(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubGhRunner(check_runs_payload={"check_runs": []})
+
+    assert get_check_record(runner, config, "abc123") is None
+    assert get_check_status(runner, config, "abc123") == "pending"

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -8,6 +8,7 @@ LOCAL_AGENT_LOOP_DOC = REPO_ROOT / "docs" / "local_agent_loop.md"
 README = REPO_ROOT / "README.md"
 
 HEADING_TEXT = "Phased decomposition versus split materialization"
+CI_STALL_HEADING_TEXT = "External CI infrastructure stalls"
 
 
 def _github_anchor(heading_text: str) -> str:
@@ -75,3 +76,37 @@ def test_cli_help_points_to_decision_section():
     anchor = "phased-decomposition-versus-split-materialization"
     for help_text in (plan_execution_mode_help, issue_materialize_help, discuss_materialize_help):
         assert anchor in help_text
+
+
+def test_local_agent_loop_doc_has_ci_infrastructure_stall_section():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert f"### {CI_STALL_HEADING_TEXT}" in text
+    assert "`--ci-queued-grace-seconds`" in text
+    assert "queued_too_long" in text
+    assert "runner_unavailable" in text
+
+
+def test_readme_links_to_ci_infrastructure_stall_section():
+    doc_text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert f"### {CI_STALL_HEADING_TEXT}" in doc_text, "heading moved; update CI_STALL_HEADING_TEXT"
+    expected_anchor = _github_anchor(CI_STALL_HEADING_TEXT)
+
+    readme_text = README.read_text(encoding="utf-8")
+    assert f"docs/local_agent_loop.md#{expected_anchor}" in readme_text
+    assert "`--ci-queued-grace-seconds`" in readme_text
+
+
+def test_cli_help_documents_ci_queued_grace_seconds():
+    parser = build_parser()
+    pr_parser = None
+    for action in parser._actions:
+        if hasattr(action, "choices") and isinstance(action.choices, dict):
+            pr_parser = action.choices.get("pr", pr_parser)
+    assert pr_parser is not None
+
+    help_text = None
+    for sub_action in pr_parser._actions:
+        if "--ci-queued-grace-seconds" in getattr(sub_action, "option_strings", []):
+            help_text = sub_action.help
+    assert help_text is not None
+    assert "1200" in help_text

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1042,7 +1042,15 @@ def test_pr_loop_downgrades_pending_ci_only_blocking_review_with_auto_merge(tmp_
                 blocking_items=["GitHub check `test` is still pending/in_progress."],
             )
         ],
-        pr_check_runs_payload={"check_runs": []},
+        # "test" (the configured auto-merge check) is already green; "lint" is
+        # still running so the overall board is `pending` (driving the
+        # downgrade) without leaving the auto-merge wait polling forever.
+        pr_check_runs_payload={
+            "check_runs": [
+                {"name": "test", "status": "completed", "conclusion": "success"},
+                {"name": "lint", "status": "in_progress"},
+            ]
+        },
         pr_status_payload={"state": "pending", "statuses": []},
         pr_branch_protection_payload={"contexts": ["test"]},
     )
@@ -1123,6 +1131,358 @@ def test_pr_loop_stops_gracefully_when_github_checks_pending_without_auto_merge(
         in captured.out
     )
     _assert_pending_ci_stop_guidance(captured.out)
+
+_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD = {
+    "check_runs": [
+        {
+            "id": 111,
+            "name": "test",
+            "status": "queued",
+            "conclusion": None,
+            "html_url": "https://github.com/OWNER/REPO/actions/runs/31123230205/job/1",
+            "created_at": "2020-01-01T00:00:00Z",
+            "started_at": None,
+            "completed_at": None,
+        }
+    ]
+}
+
+_RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD = {
+    "check_runs": [
+        {
+            "id": 222,
+            "name": "test",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "html_url": "https://github.com/OWNER/REPO/actions/runs/31123230206/job/1",
+            "created_at": "2020-01-01T00:00:00Z",
+            "started_at": None,
+            "completed_at": "2020-01-01T00:05:00Z",
+        }
+    ]
+}
+
+
+def test_pr_loop_infrastructure_stall_canonical_blocking_item_downgrades(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Review complete.",
+                blocking_items=[
+                    "GitHub check `test` (workflow run 31123230206) was cancelled before "
+                    "execution because a hosted runner was unavailable; runner unavailable.",
+                ],
+            )
+        ],
+        pr_check_runs_payload=_RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    infra_comment = next(
+        comment for comment in runner.comments
+        if comment.startswith("External GitHub Actions infrastructure is blocking PR #77.")
+    )
+    assert "runner unavailable" in infra_comment.lower()
+    stop_comment = runner.comments[-1]
+    assert stop_comment.startswith(
+        "PR #77 is blocked on external GitHub Actions infrastructure, not a code defect."
+    )
+
+
+def test_pr_loop_infrastructure_stall_queued_too_long_on_approval(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert any(
+        comment.startswith("External GitHub Actions infrastructure is blocking PR #77.")
+        for comment in runner.comments
+    )
+    assert any("queued" in comment.lower() for comment in runner.comments)
+
+
+def test_pr_loop_infrastructure_stall_pre_execution_cancel_no_synthetic_item(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert not any("GitHub PR checks are failing" in comment for comment in runner.comments)
+
+
+def test_pr_loop_genuine_failure_alongside_stall_not_downgraded(tmp_path):
+    mixed_payload = {
+        "check_runs": [
+            {
+                "id": 111,
+                "name": "test",
+                "status": "completed",
+                "conclusion": "failure",
+                "html_url": "https://github.com/OWNER/REPO/actions/runs/1/job/1",
+            },
+            _RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD["check_runs"][0] | {"name": "lint"},
+        ]
+    }
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Missing null check in models.py causing a crash on empty input.",
+                blocking_items=["Missing null check in models.py causing a crash on empty input."],
+            ),
+        ],
+        pr_check_runs_payload=mixed_payload,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, max_rounds=1)
+
+    with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+
+def test_pr_loop_mixed_single_item_stall_plus_defect_not_downgraded(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Review complete.",
+                blocking_items=[
+                    "GitHub check `test` (workflow run 31123230206) runner unavailable, and "
+                    "models.py is missing a null check that crashes on empty input.",
+                ],
+            ),
+        ],
+        pr_check_runs_payload=_RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, max_rounds=1)
+
+    with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+
+def test_pr_loop_generic_ci_keyword_item_not_downgraded(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Review complete.",
+                blocking_items=["CI infrastructure failed for this PR."],
+            ),
+        ],
+        pr_check_runs_payload=_RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, max_rounds=1)
+
+    with pytest.raises(AgentLoopError, match="blocking issues after round 1"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+
+def test_pr_loop_stall_plus_missing_required_no_infra_stop(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test", "lint"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(
+        comment.startswith("External GitHub Actions infrastructure is blocking")
+        for comment in runner.comments
+    )
+    assert any(
+        comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+        for comment in runner.comments
+    )
+
+
+def test_pr_loop_stall_plus_partial_query_no_infra_stop(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_status_returncode=1,
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(
+        comment.startswith("External GitHub Actions infrastructure is blocking")
+        for comment in runner.comments
+    )
+    assert any(
+        comment.startswith("Reviewers approved PR #77, but GitHub check status is unavailable.")
+        or comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+        for comment in runner.comments
+    )
+
+
+def test_pr_loop_actively_running_check_unchanged_pending_behavior(tmp_path, capsys):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload={
+            "check_runs": [
+                {
+                    "id": 333,
+                    "name": "test",
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "created_at": "2020-01-01T00:00:00Z",
+                    "started_at": "2020-01-01T00:00:05Z",
+                }
+            ]
+        },
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(
+        comment.startswith("External GitHub Actions infrastructure is blocking")
+        for comment in runner.comments
+    )
+    stop_comment = runner.comments[-1]
+    assert stop_comment.startswith("Reviewers approved PR #77, but GitHub checks are still pending.")
+
+
+def test_pr_loop_coder_round_gets_stall_backstop_context(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking",
+                summary="Missing null check in models.py causing a crash on empty input.",
+                blocking_items=["Missing null check in models.py causing a crash on empty input."],
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Codex final approval.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Added the missing null check.",
+                addressed_items=["item-1"],
+                remaining_items=[],
+            ),
+        ],
+        pr_check_runs_payload={
+            "check_runs": [
+                _RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD["check_runs"][0],
+            ]
+        },
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    followup_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "External CI infrastructure is currently blocking" in followup_prompt
+    assert "31123230206" in followup_prompt
+    assert "Do not wait for these checks" in followup_prompt
+
+
+def test_pr_loop_auto_merge_queued_too_long_stops_without_merge(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1200, ci_poll_interval_seconds=30)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+    assert any(
+        comment.startswith("External GitHub Actions infrastructure is blocking")
+        for comment in runner.comments
+    )
+    sleep_commands = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]
+    assert len(sleep_commands) == 0
+
+
+def test_pr_loop_auto_merge_pre_execution_cancel_stops_without_merge(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_RUNNER_UNAVAILABLE_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1200, ci_poll_interval_seconds=30)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+    assert any(
+        comment.startswith("External GitHub Actions infrastructure is blocking")
+        for comment in runner.comments
+    )
+
+
+def test_pr_loop_auto_merge_stall_plus_missing_required_keeps_waiting(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": ["test", "lint"]},
+    )
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=60, ci_poll_interval_seconds=30)
+
+    with pytest.raises(AgentLoopError, match="did not pass within"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+
+
+def test_pr_loop_auto_merge_stall_plus_partial_query_keeps_waiting(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="LGTM.")],
+        pr_check_runs_payload=_QUEUED_TOO_LONG_CHECK_RUNS_PAYLOAD,
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_status_returncode=1,
+        pr_branch_protection_payload={"contexts": ["test"]},
+    )
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=60, ci_poll_interval_seconds=30)
+
+    with pytest.raises(AgentLoopError, match="did not pass within"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+
 
 def test_pr_loop_summarizes_approved_followups_before_pending_check_stop(tmp_path):
     runner = FakeRunner(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,7 +2,7 @@ import pytest
 
 from agent_loop_helpers import *  # noqa: F403
 from coding_review_agent_loop.github import PullRequestCheck, PullRequestChecks
-from coding_review_agent_loop.prompts import format_pr_checks
+from coding_review_agent_loop.prompts import build_task_clarification_prompt, format_pr_checks
 
 _EXPECTED_UNRESOLVED_ITEMS_GUIDANCE = """Prior unresolved items are present. Disposition every listed
 item in the JSON `prior_item_dispositions` array — do not add a separate prose section
@@ -1614,6 +1614,74 @@ def test_format_pr_checks_renders_failure_url_when_available_without_empty_link(
         assert f"— {url}" in rendered
     else:
         assert "—" not in rendered
+
+def test_format_pr_checks_renders_external_infrastructure_stall_section():
+    from coding_review_agent_loop.ci_health import StalledCheck
+
+    stall = StalledCheck(
+        name="test",
+        kind="check_run",
+        reason="queued_too_long",
+        check_id=111,
+        run_id="31123230205",
+        url="https://github.com/OWNER/REPO/actions/runs/31123230205/job/1",
+        age_seconds=6240.0,
+    )
+    checks = PullRequestChecks(
+        state="pending",
+        required_checks=("test",),
+        passing=(),
+        pending=(PullRequestCheck(name="test", kind="check_run", status="queued"),),
+        failing=(),
+        missing_required=(),
+        branch_protection_status="configured",
+        infrastructure_stalls=(stall,),
+    )
+
+    rendered = format_pr_checks(checks)
+
+    assert "External CI infrastructure stalls:" in rendered
+    assert "31123230205" in rendered
+    assert "Do not record it as a blocking code item" in rendered
+    assert "remains ordinary review work" in rendered
+
+
+@pytest.mark.parametrize("compact_context", [False, True])
+def test_review_prompt_includes_external_ci_infrastructure_reviewer_guidance(
+    tmp_path, compact_context
+):
+    config = make_config(tmp_path)
+    prompt = build_review_prompt(77, 1, config, reviewer="codex", compact_context=compact_context)
+    assert "External CI infrastructure stalls" in prompt
+    assert "not a code-level finding" in prompt
+    assert "Do not record it as a" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda config: build_issue_prompt(56, config),
+        lambda config: build_issue_implementation_prompt(56, "1. Fix it.", config),
+        lambda config: build_completion_recovery_prompt(config),
+        lambda config: build_task_prompt("Fix the bug.", config),
+        lambda config: build_task_clarification_prompt("Fix the bug.", [], config),
+        lambda config: build_followup_prompt(77, 1, "Needs tests.", config),
+        lambda config: build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+    ],
+)
+def test_coder_prompts_forbid_unbounded_ci_waits_with_exact_bound(tmp_path, builder):
+    config = make_config(tmp_path)
+    prompt = builder(config)
+
+    assert "gh run watch" in prompt
+    assert "gh pr checks --watch" in prompt
+    assert "at most 3" in prompt
+    assert "30 seconds" in prompt
+    assert "120 seconds" in prompt
+    assert "return your terminal blocking response immediately" in prompt
+    assert "resume once GitHub Actions runners recover" in prompt
+    assert "actively running" in prompt
+
 
 @pytest.mark.parametrize("compact_context", [False, True])
 def test_review_prompt_distinguishes_failing_from_pending_check_blocking_policy(

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1565,6 +1565,33 @@ class TestPromptCheckoutPath:
         assert wd in prompt
         assert self._no_bare_skill_runner(prompt) == 0
 
+    def test_pr_fix_prompt_carries_no_unbounded_ci_wait_guidance(self) -> None:
+        # #602: helpers/prompt_builders.py's run-pr-fix prompt delegates to
+        # coding_review_agent_loop.prompts.build_followup_prompt, which must
+        # carry the same bounded CI-observation policy as the CLI orchestrator
+        # so the skill's external-coder path can't wait indefinitely either.
+        from helpers.prompt_builders import build_pr_fix_prompt_for_skill
+        wd = "/tmp/coding-review-agent-loop/skill-runner-codex"
+        prompt = build_pr_fix_prompt_for_skill(
+            295,
+            [{
+                "item_id": "item-1",
+                "reviewer": "codex",
+                "source_round": 1,
+                "text": "Fix the bug.",
+                "status": "blocking",
+            }],
+            1,
+            repo="wwind123/coding-review-agent-loop",
+            coder="codex",
+            reviewers=["gemini"],
+            workdir=wd,
+        )
+        assert "gh run watch" in prompt
+        assert "at most 3" in prompt
+        assert "120 seconds" in prompt
+        assert "resume once GitHub Actions runners recover" in prompt
+
 
 # ---------------------------------------------------------------------------
 # helpers/skill_runner.py  _run_test_gate (#296, increment 2)


### PR DESCRIPTION
## Summary

- Classify a GitHub check-run that is queued past a grace period (`--ci-queued-grace-seconds`, default 1200) or cancelled before execution because a hosted runner was unavailable, as external CI infrastructure blocking — not a code defect.
- The new `ci_health` module owns `PullRequestCheck`/`PullRequestChecks` and a single whole-check-state gate, `is_wholly_infrastructure_blocked`, that governs the orchestrator terminal stop, the reviewer downgrade, and the `--auto-merge` wait outcome. A genuinely failing/never-reporting check, a missing required check, or a partial/unavailable check query never takes the infrastructure exit.
- Reviewer blocking items are only downgraded when a closed-vocabulary canonical-text matcher (`is_canonical_stall_only_text`) accepts every blocking item and the summary — a mixed item naming a stalled run and then describing a real defect still reaches the coder unchanged.
- As a structural backstop, every coder prompt (issue, implementation, task, followup, etc.) now forbids unbounded `gh run watch`/`gh pr checks --watch` and caps CI observation to at most 3 status snapshots over 120 seconds, so a coder round can never wait indefinitely even when the downgrade correctly declines to fire.
- `--auto-merge`'s `wait_for_ci` only exits early on a full `get_pr_checks` snapshot confirming the whole board is wholly infrastructure-blocked; otherwise it keeps the existing poll/timeout/raise contract unchanged.
- Documented the new flag and behavior in `README.md`, `docs/local_agent_loop.md`, `SKILL.md`, and `docs/skill_mode.md` (including the skill-mode host-coder path, which drives its own shell commands).

Fixes #602

## Test plan

- [x] `pytest tests/test_ci_health.py -q` (new: classifier, whole-board gate, canonical-text matcher, `get_pr_checks` field/parsing coverage)
- [x] `pytest tests/test_orchestrator_pr.py -q` (existing coverage plus 15 new infrastructure-stall scenarios: canonical downgrade, queued-too-long/pre-execution-cancel approval stops, genuine-defect and mixed-item non-downgrades, missing-required/partial-query exclusions, unchanged running-check behavior, coder backstop context, and `--auto-merge` stop/keep-waiting cases)
- [x] `pytest tests/test_prompts.py tests/test_agent_loop.py tests/test_skill_helpers.py tests/test_docs_guidance.py -q`
- [x] Full suite: `pytest tests/ -q` → 1806 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)