### PR TITLE
Bound coder local test selection and forbid background test polling

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -362,6 +362,25 @@ python -m helpers.skill_runner run-task-round \
   [External CI infrastructure stalls](docs/local_agent_loop.md#external-ci-infrastructure-stalls));
   this bullet covers the skill-mode host-coder path, which drives its own
   shell commands directly.
+- **Focused, bounded local tests.** Select tests proportionate to the files
+  actually changed and the reviewer item being addressed; prefer the
+  repository's verified focused test command over a broad suite when one
+  covers the change, and give a one-line rationale tying each selected test
+  module to a changed file or reviewer item. Do not run the whole `tests/`
+  suite, an `--ignore` list that amounts to the whole suite, or broad
+  server/database/integration/end-to-end suites unless the change actually
+  touches those surfaces, focused tests demonstrably do not cover it, or a
+  human or the issue explicitly asked for full-suite verification. Run
+  required completion tests in the foreground with visible output under an
+  explicit bounded timeout; never launch pytest (or any required test) in the
+  background, and never spawn a shell loop that polls a process ID, `ps`/
+  `kill -0`/`wait`, or a task-output file to learn whether it finished. If a
+  required test exceeds its bound, terminate it and report the blocker
+  immediately, naming the exact command and the timeout, rather than waiting
+  silently or retrying with a broader selection. The `coding_review_agent_loop`
+  CLI orchestrator's coder prompts carry the same policy; this bullet covers
+  the skill-mode host-coder path, which drives its own shell commands and
+  chooses its own test scope directly.
 
 ---
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1221,6 +1221,58 @@ Two independent, complementary mechanisms bound this instead:
 
 Reviewers see the same classification (an "External CI infrastructure stalls" section in the PR checks context) and are instructed not to record a classified stall as a blocking code item; any other failing or never-reporting check remains ordinary review work.
 
+### Focused, bounded local test selection
+
+A same-PR follow-up scoped to a wording correction in two files does not
+justify pulling in a `tests/test_server.py`-class suite (hundreds of
+unmarked FastAPI/database/SSE tests) or a `pytest tests/ --ignore=...` list
+that amounts to nearly the whole repository. A coder that does this and then
+backgrounds the run and polls it — via a shell loop watching a process ID or
+a task-output file — consumes the session for many minutes with no visible
+progress and leaves manual interruption as the practical recovery path. This
+is distinct from [External CI infrastructure
+stalls](#external-ci-infrastructure-stalls): that section bounds waiting on
+*GitHub Actions* infrastructure; this one bounds the *local* test command a
+coder chooses to run and how it runs it.
+
+Every coder prompt built by `coding_review_agent_loop.prompts` requires:
+
+- **Proportionate selection.** Tests must be chosen for the files actually
+  changed and the reviewer item being addressed, preferring the repository's
+  verified focused test command from the execution profile when one covers
+  the change. When the change is narrow, the coder must give a one-line
+  rationale for each selected test module tying it to a changed file or
+  reviewer item.
+- **A breadth prohibition with an escape hatch.** No whole-`tests/` run, no
+  `--ignore` list that is effectively the whole suite, and no broad
+  server/database/integration/end-to-end suite — unless the change actually
+  touches those surfaces, focused tests demonstrably do not cover it, or a
+  human or the issue explicitly asked for full-suite verification. Normal
+  full-suite verification for a genuinely broad change stays available; only
+  the unnecessary or mis-targeted case is prohibited.
+- **Foreground execution under a bounded timeout.** Required completion
+  tests run in the foreground with visible output and a concrete stated cap
+  (at most 900 seconds per required test command). Coders must not launch
+  pytest in the background or spawn auxiliary shell loops that poll process
+  IDs, `ps`/`kill -0`/`wait`, or task-output files to learn whether a test
+  finished.
+- **A valid terminal path on timeout.** If a required test exceeds its
+  bound, the coder terminates the run and returns a valid terminal response
+  immediately, naming the exact command and the timeout, rather than
+  silently waiting or retrying with a broader selection. `build_task_prompt`
+  and `build_task_clarification_prompt` document a no-PR `AGENT_STATE:
+  blocking` result for exactly this case, so a free-form task turn that must
+  stop after a bounded timeout has an ordinary terminal path instead of
+  being forced into an `agent_unavailable` report reserved for genuine
+  environment/tooling failure.
+
+The completion-recovery prompt (sent once, when a prior implementation turn
+ended without a valid terminal marker and its text suggested deferring to
+background work) instructs the coder not to poll or wait on that old job —
+no PID watching, no `ps`/`kill -0`/`wait` loop, no tailing its log or
+task-output file — but to terminate a known process once if needed and
+re-run the command it actually needs in the foreground under the bound.
+
 ## Agent Permission Flags
 
 By default, this standalone package does not pass permission-bypass flags to either agent. This is safer for open-source use, but some CLIs may prompt or fail in non-interactive mode unless you provide suitable flags.

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -212,6 +212,32 @@ the same bounded-observation guidance, so this applies whether the coder turn
 runs through the CLI orchestrator or through the skill's own external-coder
 path.
 
+## Focused, bounded local test runs
+
+A same-PR follow-up or reviewer item scoped to a couple of files does not
+justify running the whole `tests/` suite, an `--ignore` list that amounts to
+the whole suite, or a broad server/database/integration suite — those add
+minutes of runtime and hide progress when they are launched in the background
+and polled from an auxiliary shell loop. The host coder must select tests
+proportionate to the files actually changed and the reviewer item being
+addressed, prefer the repository's verified focused test command when one
+covers the change, and give a one-line rationale tying each selected test
+module to a changed file or reviewer item. Broad suites remain available when
+the change genuinely touches those surfaces, focused tests demonstrably do
+not cover it, or a human or the issue explicitly asked for full-suite
+verification. Required completion tests must run in the foreground with
+visible output under an explicit bounded timeout; never launch pytest in the
+background or poll a process ID, `ps`/`kill -0`/`wait`, or a task-output file
+to learn whether it finished. If a required test exceeds its bound, terminate
+it and report the blocker immediately, naming the exact command and the
+timeout, instead of waiting silently or retrying with a broader selection.
+
+Every coder prompt built by `coding_review_agent_loop.prompts` — including the
+ones `helpers/prompt_builders.py` reuses for skill mode's `run-pr-fix` —
+carries this policy, but the skill's host coder drives its own shell commands
+directly and is not itself constrained by the CLI orchestrator's test
+plumbing, so this section states the policy explicitly for that path.
+
 ## Session state
 
 Local session state is stored at:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2735,6 +2735,25 @@ def _require_pr_number_or_clarification(text: str) -> int | str:
     )
 
 
+def _require_task_implementation_result(text: str) -> int | str | _TerminalNoPrImplementation:
+    """Accept a positive PR, a clarification request, or a terminal no-PR blocking result (#604)."""
+    pr_number = parse_pr_number(text)
+    if pr_number is not None:
+        return pr_number
+    if is_clarification_request(text):
+        return "clarification"
+    try:
+        state = parse_agent_state(text)
+    except AgentLoopError:
+        state = None
+    if state == "blocking":
+        return _TerminalNoPrImplementation("blocking")
+    raise AgentLoopError(
+        "Agent response did not include a PR marker, PR URL, clarification marker, "
+        "or a terminal blocking marker."
+    )
+
+
 def _require_plan_state_or_clarification(text: str) -> StructuredPlanState | str:
     if is_clarification_request(text):
         return "clarification"
@@ -5058,8 +5077,8 @@ def run_task_loop(
                 config=config,
                 prompt=prompt,
                 session_id=session_id,
-                marker_description="<!-- AGENT_PR: <number> -->, PR URL, or <!-- AGENT_CLARIFY -->",
-                validate=_require_pr_number_or_clarification,
+                marker_description="<!-- AGENT_PR: <number> -->, PR URL, blocking, or <!-- AGENT_CLARIFY -->",
+                validate=_require_task_implementation_result,
                 usage_context=usage_context,
                 salvage_context=SalvageContext(
                     repo=config.repo,
@@ -5072,6 +5091,12 @@ def run_task_loop(
             )
             coder_output = coder_response.text
             session_id = coder_response.session_id
+
+            if isinstance(coder_response.marker_value, _TerminalNoPrImplementation):
+                raise AgentLoopError(
+                    "Coder did not create a valid PR; task implementation is "
+                    f"{coder_response.marker_value.state}.\n\n{coder_output}"
+                )
 
             if isinstance(coder_response.marker_value, int):
                 pr_number = coder_response.marker_value

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -82,17 +82,76 @@ def _scratch_file_guidance() -> str:
     )
 
 
-def _coder_test_reporting_guidance() -> str:
+def _coder_test_reporting_guidance(*, structured: bool = False) -> str:
+    if structured:
+        reporting = (
+            "Before opening or updating the PR, run the relevant tests you can run "
+            "locally. Report the exact commands you ran in `tests_run` as "
+            "machine-readable strings only — no pass/fail prose or rationale "
+            "there. If you cannot run tests, say why in `summary`."
+        )
+    else:
+        reporting = (
+            "Before opening or updating the PR, run the relevant tests you can run "
+            "locally. In your final response, include a short `Tests:` line listing "
+            "the exact commands run and whether they passed. If you cannot run tests, "
+            "explain why in that `Tests:` line."
+        )
     return (
-        "Before opening or updating the PR, run the relevant tests you can run "
-        "locally. In your final response, include a short `Tests:` line listing "
-        "the exact commands run and whether they passed. If you cannot run tests, "
-        "explain why in that `Tests:` line. Run tests and any other required "
+        f"{reporting} Run tests and any other required "
         "completion work (builds, commits, pushes, PR creation) in the "
         "foreground and wait for them to finish before ending this turn. Do not "
         "launch them in the background and end the turn saying you will wait for "
         "them; a turn that ends without a real terminal marker because required "
         "work is still running in the background cannot be validated.\n"
+    )
+
+
+def _coder_local_test_scope_guidance(*, structured: bool = False) -> str:
+    if structured:
+        rationale = (
+            "When the change is narrow, give a one-line rationale for each "
+            "selected test module tying it to a changed file or reviewer item — "
+            "put that rationale in `addressed_item_notes` for the item those "
+            "tests cover, or in `summary` when no single item-scoped note fits. "
+            "`tests_run` itself holds only the exact commands, never rationale "
+            "or a `Tests:` line."
+        )
+        broad_reason_location = "the same `addressed_item_notes`/`summary` field you used for the rationale"
+    else:
+        rationale = (
+            "When the change is narrow, give a one-line rationale for each "
+            "selected test module tying it to a changed file or reviewer item, "
+            "next to the exact commands in the `Tests:` line."
+        )
+        broad_reason_location = "that same `Tests:` line"
+    return (
+        "Select tests proportionate to the files you actually changed and to "
+        "the reviewer item you are addressing; prefer the repository's verified "
+        "focused test command from the execution profile when one covers the "
+        f"change. {rationale} Do not run the whole `tests/` suite, an "
+        "`--ignore` list that is effectively the whole suite, or broad "
+        "server/database/integration/end-to-end suites unless the change "
+        "actually touches those surfaces, focused tests demonstrably do not "
+        "cover it, or a human or the issue explicitly asked for full-suite "
+        f"verification — and when a broad run is justified, state that reason in {broad_reason_location}. "
+        "Run required completion tests in the foreground with visible output "
+        "and an explicit bounded timeout (a concrete stated cap, at most 900 "
+        "seconds per required test command). Never launch pytest in the "
+        "background (`&`, `nohup`, background task/tool invocations) and never "
+        "spawn auxiliary shell loops that poll process IDs, `ps`/`kill -0`/"
+        "`wait`, or task-output files to learn whether it finished. If a "
+        "required test exceeds its bound, terminate the run and return a valid "
+        "terminal response immediately, naming the exact command and the "
+        "timeout, rather than silently waiting or retrying with a broader "
+        "selection"
+        + (
+            " (use `remaining_items`/`remaining_item_notes` for this)"
+            if structured
+            else " (use the prose blocking result for this)"
+        )
+        + ". Reserve agent-unavailable for a genuine environment/tooling "
+        "failure, not an ordinary slow test.\n"
     )
 
 
@@ -1057,7 +1116,7 @@ Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_pr_reference_guidance(issue_number)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1652,7 +1711,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1690,12 +1749,14 @@ the orchestrator will not send another one after this turn.
 
 Inspect the existing checkout now (`git status`, `git diff`, `git log`) to see
 what you already did. Do not restart the implementation from scratch. Finish
-only foreground work from here: if you started tests or a build in the
-background, check on it or re-run it in the foreground now and wait for it to
-finish; do not launch anything new in the background. Then commit, push, and
-open the pull request if that is not already done, or continue exactly where
-you left off.
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+only foreground work from here: do not poll or wait on that old background job
+— no PID watching, no `ps`/`kill -0`/`wait` loop, and no tailing its log or
+task-output file. If you know its process ID, terminate it once (a single
+`kill <pid>`, not a loop) and then re-run the command you actually need in the
+foreground under the bounded timeout below, waiting for it to finish; launch
+nothing new in the background. Then commit, push, and open the pull request if
+that is not already done, or continue exactly where you left off.
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
 
@@ -1720,7 +1781,7 @@ Use this local checkout as your workspace. Decide between two paths:
     {config.base}. Do not wait for {reviewer_name}; this local orchestrator
     will run {reviewer_name} after you create the PR.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 
 (b) If the task is genuinely ambiguous or missing information that would change
     the implementation, do NOT write code. Instead, ask focused clarifying
@@ -1728,16 +1789,23 @@ Use this local checkout as your workspace. Decide between two paths:
 
 {_agent_unavailable_guidance(coder_signature)}
 Prefer (a) when reasonable assumptions can be documented in the PR description;
-choose (b) only for material ambiguity. Do not place your signature before the
-AGENT_STATE or AGENT_CLARIFY marker. Your response must end with, in this exact
-order — for (a):
+choose (b) only for material ambiguity. If you cannot safely proceed and
+cannot create a PR — for example after a bounded local test run exceeded its
+timeout — explain the blocker, naming the exact command and the timeout, and
+end with `AGENT_STATE: blocking` without an `AGENT_PR` marker instead of
+inventing a placeholder like `AGENT_PR: 0`. Do not place your signature before
+the AGENT_STATE or AGENT_CLARIFY marker. Your response must end with, in this
+exact order — for a completed implementation:
 
 <!-- AGENT_PR: <number> -->
 <!-- AGENT_STATE: blocking -->
 -- {coder_signature}
 
-or for (b):
+For a no-PR blocking result:
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
 
+For clarification:
 <!-- AGENT_CLARIFY -->
 -- {coder_signature}
 """
@@ -1768,14 +1836,22 @@ Clarification so far:
 Now proceed. Strongly prefer to implement the task and open a PR. Only ask
 again if a critical detail is still missing.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 
 {_agent_unavailable_guidance(coder_signature)}
-Do not place your signature before the AGENT_STATE or AGENT_CLARIFY marker.
-Your response must end with, in this exact order:
+If you cannot safely proceed and cannot create a PR — for example after a
+bounded local test run exceeded its timeout — explain the blocker, naming the
+exact command and the timeout, and end with `AGENT_STATE: blocking` without an
+`AGENT_PR` marker instead of inventing a placeholder like `AGENT_PR: 0`. Do not
+place your signature before the AGENT_STATE or AGENT_CLARIFY marker. Your
+response must end with, in this exact order:
 
 For implementation:
 <!-- AGENT_PR: <number> -->
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+
+For a no-PR blocking result:
 <!-- AGENT_STATE: blocking -->
 -- {coder_signature}
 
@@ -2347,7 +2423,7 @@ needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}
@@ -2396,7 +2472,7 @@ current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead. The PR
 remains blocked pending another review round after this cleanup.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance()}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory)}

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -9,6 +9,7 @@ README = REPO_ROOT / "README.md"
 
 HEADING_TEXT = "Phased decomposition versus split materialization"
 CI_STALL_HEADING_TEXT = "External CI infrastructure stalls"
+LOCAL_TEST_SCOPE_HEADING_TEXT = "Focused, bounded local test selection"
 
 
 def _github_anchor(heading_text: str) -> str:
@@ -94,6 +95,25 @@ def test_readme_links_to_ci_infrastructure_stall_section():
     readme_text = README.read_text(encoding="utf-8")
     assert f"docs/local_agent_loop.md#{expected_anchor}" in readme_text
     assert "`--ci-queued-grace-seconds`" in readme_text
+
+
+def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert f"### {LOCAL_TEST_SCOPE_HEADING_TEXT}" in text
+    section_start = text.index(f"### {LOCAL_TEST_SCOPE_HEADING_TEXT}")
+    next_heading = text.index("## Agent Permission Flags", section_start)
+    section = " ".join(text[section_start:next_heading].split())
+
+    assert "External CI infrastructure" in section
+    assert "distinct from" in section
+    assert "900 seconds" in section
+    assert "must not launch pytest in the background" in section
+    assert "poll process" in section
+    assert "`ps`/`kill -0`/`wait`" in section
+    assert "task-output files" in section
+    assert "a human or the issue explicitly asked for full-suite" in section
+    assert "no-PR `AGENT_STATE: blocking`" in section
+    assert "agent_unavailable" in section
 
 
 def test_cli_help_documents_ci_queued_grace_seconds():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -154,7 +154,11 @@ def test_completion_recovery_prompt_instructs_foreground_only_continuation(tmp_p
     assert "one-time, bounded continuation" in prompt
     assert "will not send another one after this turn" in prompt
     assert "Do not restart the implementation from scratch" in prompt
-    assert "do not launch anything new in the background" in prompt
+    assert "do not poll or wait on that old background job" in prompt
+    assert "no PID watching, no `ps`/`kill -0`/`wait` loop" in prompt
+    assert "no tailing its log or\ntask-output file" in prompt
+    assert "terminate it once (a single\n`kill <pid>`, not a loop)" in prompt
+    assert "nothing new in the background" in prompt
     assert "Inspect the existing checkout now" in prompt
 
 
@@ -1681,6 +1685,103 @@ def test_coder_prompts_forbid_unbounded_ci_waits_with_exact_bound(tmp_path, buil
     assert "return your terminal blocking response immediately" in prompt
     assert "resume once GitHub Actions runners recover" in prompt
     assert "actively running" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda config: build_issue_prompt(56, config),
+        lambda config: build_issue_implementation_prompt(56, "1. Fix it.", config),
+        lambda config: build_completion_recovery_prompt(config),
+        lambda config: build_task_prompt("Fix the bug.", config),
+        lambda config: build_task_clarification_prompt("Fix the bug.", [], config),
+        lambda config: build_followup_prompt(77, 1, "Needs tests.", config),
+        lambda config: build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+    ],
+)
+def test_coder_prompts_require_focused_bounded_local_tests(tmp_path, builder):
+    config = make_config(tmp_path)
+    prompt = " ".join(builder(config).split())
+
+    assert "proportionate to the files you actually changed" in prompt
+    assert "prefer the repository's verified focused test command" in prompt
+    assert "one-line rationale for each" in prompt
+    assert "Do not run the whole `tests/` suite" in prompt
+    assert "broad server/database/integration/end-to-end suites" in prompt
+    assert "at most 900" in prompt
+    assert "Never launch pytest in the background" in prompt
+    assert "poll process IDs" in prompt
+    assert "`ps`/`kill -0`/`wait`" in prompt
+    assert "task-output files" in prompt
+    assert "terminate the run and return a valid" in prompt
+    assert "naming the exact command and the timeout" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda config: build_issue_prompt(56, config),
+        lambda config: build_issue_implementation_prompt(56, "1. Fix it.", config),
+        lambda config: build_completion_recovery_prompt(config),
+        lambda config: build_task_prompt("Fix the bug.", config),
+        lambda config: build_task_clarification_prompt("Fix the bug.", [], config),
+    ],
+)
+def test_free_form_coder_prompts_report_tests_via_tests_line(tmp_path, builder):
+    config = make_config(tmp_path)
+    prompt = " ".join(builder(config).split())
+
+    assert "include a short `Tests:` line" in prompt
+    assert "next to the exact commands in the `Tests:` line" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda config: build_followup_prompt(77, 1, "Needs tests.", config),
+        lambda config: build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+    ],
+)
+def test_structured_coder_prompts_route_test_rationale_to_json_fields(tmp_path, builder):
+    config = make_config(tmp_path)
+    prompt = " ".join(builder(config).split())
+
+    assert "include a short `Tests:` line" not in prompt
+    assert "`tests_run` as machine-readable strings only" in prompt
+    assert "`addressed_item_notes` for the item those" in prompt
+    assert "or in `summary` when no single item-scoped note fits" in prompt
+    assert "never rationale or a `Tests:` line" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda config: build_issue_prompt(56, config),
+        lambda config: build_completion_recovery_prompt(config),
+        lambda config: build_task_prompt("Fix the bug.", config),
+        lambda config: build_followup_prompt(77, 1, "Needs tests.", config),
+        lambda config: build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+    ],
+)
+def test_coder_prompts_preserve_full_suite_escape_hatch(tmp_path, builder):
+    config = make_config(tmp_path)
+    prompt = " ".join(builder(config).split())
+
+    assert "actually touches those surfaces" in prompt
+    assert "a human or the issue explicitly asked for full-suite" in prompt
+
+
+def test_task_prompts_document_no_pr_blocking_branch(tmp_path):
+    config = make_config(tmp_path)
+
+    task_prompt = " ".join(build_task_prompt("Fix the bug.", config).split())
+    clarification_prompt = " ".join(
+        build_task_clarification_prompt("Fix the bug.", [], config).split()
+    )
+
+    for prompt in (task_prompt, clarification_prompt):
+        assert "For a no-PR blocking result:" in prompt
+        assert "without an `AGENT_PR` marker" in prompt
 
 
 @pytest.mark.parametrize("compact_context", [False, True])

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1592,6 +1592,37 @@ class TestPromptCheckoutPath:
         assert "120 seconds" in prompt
         assert "resume once GitHub Actions runners recover" in prompt
 
+    def test_pr_fix_prompt_carries_focused_local_test_guidance(self) -> None:
+        # #604: the run-pr-fix prompt delegates to build_followup_prompt, which
+        # must carry the same proportionate/bounded local-test policy as the
+        # CLI orchestrator so the skill's external-coder path can't pull in an
+        # unnecessarily broad suite or poll a backgrounded test run either.
+        from helpers.prompt_builders import build_pr_fix_prompt_for_skill
+        wd = "/tmp/coding-review-agent-loop/skill-runner-codex"
+        prompt = " ".join(
+            build_pr_fix_prompt_for_skill(
+                295,
+                [{
+                    "item_id": "item-1",
+                    "reviewer": "codex",
+                    "source_round": 1,
+                    "text": "Fix the bug.",
+                    "status": "blocking",
+                }],
+                1,
+                repo="wwind123/coding-review-agent-loop",
+                coder="codex",
+                reviewers=["gemini"],
+                workdir=wd,
+            ).split()
+        )
+        assert "proportionate to the files you actually changed" in prompt
+        assert "Do not run the whole `tests/` suite" in prompt
+        assert "Never launch pytest in the background" in prompt
+        assert "poll process IDs" in prompt
+        assert "`tests_run` as machine-readable strings only" in prompt
+        assert "include a short `Tests:` line" not in prompt
+
 
 # ---------------------------------------------------------------------------
 # helpers/skill_runner.py  _run_test_gate (#296, increment 2)

--- a/tests/test_task_loop.py
+++ b/tests/test_task_loop.py
@@ -175,6 +175,24 @@ def test_task_loop_requires_pr_or_clarification_marker(tmp_path):
     with pytest.raises(AgentLoopError, match="PR marker"):
         run_task_loop(runner, task_text="Do something", config=config)
 
+
+def test_task_loop_terminates_on_no_pr_blocking_result(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Local test `python -m pytest tests/test_foo.py -q` exceeded its "
+            "900 second bound; terminated and did not open a PR.\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="task implementation is blocking") as exc_info:
+        run_task_loop(runner, task_text="Do something", config=config)
+
+    assert "exceeded its" in str(exc_info.value)
+    assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
+    assert runner.comments == []
+
 def test_codex_task_loop_creates_pr_then_claude_approves(tmp_path):
     runner = FakeRunner(
         codex_outputs=[


### PR DESCRIPTION
## Summary

Coder prompts previously left local test-command scope unbounded: a narrow same-PR follow-up could pull in an unmarked whole-suite run (e.g. `tests/test_server.py`-class FastAPI/database/SSE tests), or nearly the whole `tests/` directory via a long `--ignore` list, then get launched in the background and "recovered" by polling a PID or task-output file from an auxiliary shell loop. That hides progress and consumes the coder session with manual interruption as the practical recovery path.

- Added `_coder_local_test_scope_guidance(*, structured: bool)` in `prompts.py`, interpolated into all seven coder-facing builders (`build_issue_prompt`, `build_issue_implementation_prompt`, `build_completion_recovery_prompt`, `build_task_prompt`, `build_task_clarification_prompt`, `build_followup_prompt`, `build_same_pr_followup_prompt`). It requires: test selection proportionate to the changed files/reviewer item, preference for the repo's verified focused test command, a one-line rationale per selected test module when the change is narrow, a prohibition on whole-suite/broad server-database-integration suites (with an explicit escape hatch for genuinely broad changes or explicit human/issue request), foreground execution under a stated bounded timeout (≤900s), and a ban on background pytest launches or PID/`ps`/`kill -0`/`wait`/task-file polling loops.
- `_coder_test_reporting_guidance()` now takes the same `structured` switch: free-form builders keep the `Tests:` prose line; the two structured `coder_followup` builders route reporting to `tests_run` (exact commands only) and the rationale to `addressed_item_notes`/`summary`, since `validate_structured_coder_followup` enforces an exact key set.
- `build_task_prompt` and `build_task_clarification_prompt` gain a `For a no-PR blocking result:` branch (`AGENT_STATE: blocking` with no `AGENT_PR` marker), and the orchestrator gets a matching `_require_task_implementation_result` validator wired into `run_task_loop`, so a bounded-timeout stop has an ordinary terminal path instead of being forced into `agent_unavailable`.
- `build_completion_recovery_prompt`'s "check on it [in the background]" prose is rewritten: never poll the old job (no PID watch, no `ps`/`kill -0`/`wait` loop, no tailing its log/task-output file); terminate it once if needed, then re-run the needed command in the foreground under the bound.
- Docs: new `**Focused, bounded local tests.**` bullet in `SKILL.md`, `## Focused, bounded local test runs` in `docs/skill_mode.md`, and `### Focused, bounded local test selection` in `docs/local_agent_loop.md` (distinguishing this from #602's GitHub Actions infrastructure-stall bound).

Fixes #604

## Test plan
- [x] `python -m pytest tests/test_prompts.py tests/test_task_loop.py tests/test_completion_recovery.py tests/test_skill_helpers.py tests/test_docs_guidance.py -q` — 358 passed
- [x] `python -m pytest tests/ -q` — 1829 passed (full suite; entirely fast in-process unit tests, no server/db/network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)