### PR TITLE
Detect PR merge conflicts and route resolution through the coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,15 @@ instead of a coder round waiting on it. See
 [External CI infrastructure stalls](docs/local_agent_loop.md#external-ci-infrastructure-stalls)
 for details.
 
+A confirmed GitHub merge conflict (`mergeStateStatus: DIRTY` or `mergeable:
+CONFLICTING`) is checked before every reviewer round and again before CI
+checks/auto-merge, and routes the PR to the coder to resolve instead of
+waiting on CI or attempting a merge; `--mergeability-poll-attempts` (default
+3) and `--mergeability-poll-interval-seconds` (default 5) bound how long a
+still-computing (`UNKNOWN`) GitHub mergeability result is re-checked before
+being treated as unresolved. See
+[Merge conflicts](docs/local_agent_loop.md#merge-conflicts) for details.
+
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -345,6 +345,16 @@ python -m helpers.skill_runner run-task-round \
   `pending` > `blocking` > `incomplete` > `approved`.
 - **Merge is always a human decision.** The skill never runs CI-wait or
   auto-merge; every mode stops at "ready to merge."
+- **Merge conflicts route to the coder, not CI-wait.** The `coding_review_agent_loop`
+  CLI orchestrator checks GitHub's own mergeability (`mergeStateStatus`/`mergeable`)
+  before each review round and again before CI checks/auto-merge; a confirmed
+  `dirty`/`CONFLICTING` state skips reviewers and any CI wait or merge attempt
+  and routes the PR to the assigned coder to sync, resolve, and push instead
+  (see [Merge conflicts](docs/local_agent_loop.md#merge-conflicts)). In
+  skill-mode, if you find `gh pr view` reporting `mergeable: false` /
+  `mergeStateStatus: DIRTY`, treat that the same way: resolve the conflict as
+  the host coder before continuing review, rather than waiting on CI for the
+  current head.
 - **No unbounded CI waits.** Never run `gh run watch`, `gh pr checks --watch`,
   or any other unbounded wait on a GitHub Actions check or workflow run —
   including when fixing a reviewer-reported check failure as the host coder.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1221,6 +1221,46 @@ Two independent, complementary mechanisms bound this instead:
 
 Reviewers see the same classification (an "External CI infrastructure stalls" section in the PR checks context) and are instructed not to record a classified stall as a blocking code item; any other failing or never-reporting check remains ordinary review work.
 
+### Merge conflicts
+
+GitHub's own mergeability computation, not just the current-head CI check, is
+evaluated before spending reviewer time or an auto-merge CI wait: a PR whose
+branch has drifted out of sync with its base can otherwise pass every
+reviewer round only to fail to merge, or run CI against a head that stops
+being relevant the moment the base advances.
+
+- **When it's checked.** The loop probes `gh pr view --json
+  mergeable,mergeStateStatus,headRefOid,baseRefName` at the start of every
+  review round (before any reviewer is invoked) and again right before
+  fetching GitHub PR checks / attempting `--auto-merge` (the "merge gate").
+  `--auto-merge`'s CI wait also re-checks mergeability on every poll, so a
+  conflict that appears mid-wait stops the wait immediately instead of
+  polling a check on a head that can no longer merge.
+- **Classification.** A `mergeStateStatus` of `DIRTY` or a `mergeable` of
+  `CONFLICTING` is a confirmed conflict, checked first so it wins even if the
+  other field is null. A `mergeable` of `MERGEABLE` is mergeable. Everything
+  else — including GitHub's own `UNKNOWN` (still computing), a non-zero `gh`
+  exit, or unparsable output — is `unknown` and is treated exactly like
+  `mergeable`: it never triggers a coder round on its own. An explicit
+  `UNKNOWN` is retried up to `--mergeability-poll-attempts` times (default 3),
+  `--mergeability-poll-interval-seconds` apart (default 5), before settling as
+  `unknown`.
+- **What happens on a confirmed conflict.** Reviewers are skipped for that
+  round, no GitHub PR checks are fetched, and no CI wait or `gh pr merge` is
+  attempted. The coder is dispatched with a dedicated prompt naming the
+  observed base branch and head SHA, instructed to sync the branch, merge
+  `origin/<base>`, resolve every conflict, run relevant tests, commit, and
+  push to the same PR — never opening a new PR, never waiting on CI, and
+  never force-pushing over unrelated work. Any other genuinely unresolved
+  reviewer items are carried into the same round.
+- **After a resolution push.** The next round re-probes mergeability from
+  scratch; once GitHub reports `mergeable` (or `unknown`), the synthetic
+  conflict item clears itself and normal reviewer/CI flow resumes against the
+  new head — prior approvals and checks from the old head are never reused
+  for merging. If the head is still unchanged the next time a conflict round
+  would be dispatched (the coder made no progress), the loop stops cleanly
+  with an explanatory comment instead of looping.
+
 ### Focused, bounded local test selection
 
 A same-PR follow-up scoped to a wording correction in two files does not

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -344,6 +344,21 @@ def build_parser() -> argparse.ArgumentParser:
             ),
         )
         subparser.add_argument(
+            "--mergeability-poll-attempts",
+            type=int,
+            default=3,
+            help=(
+                "How many times to re-check GitHub mergeability while it reports "
+                "'UNKNOWN' before treating it as unresolved (default: 3)."
+            ),
+        )
+        subparser.add_argument(
+            "--mergeability-poll-interval-seconds",
+            type=int,
+            default=5,
+            help="Delay between mergeability re-checks while GitHub reports 'UNKNOWN' (default: 5).",
+        )
+        subparser.add_argument(
             "--quiet",
             action="store_true",
             help="Suppress progress logs.",

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -34,7 +34,7 @@ from .protocol import (
     UnresolvedReviewItem,
     review_freeform_summary_text,
 )
-from .unresolved_items import HUMAN_REQUIREMENTS_ACK_ITEM_ID
+from .unresolved_items import HUMAN_REQUIREMENTS_ACK_ITEM_ID, MERGE_CONFLICT_ITEM_ID
 
 if TYPE_CHECKING:
     from .agents.base import AgentName
@@ -125,6 +125,8 @@ def _format_unresolved_item_label(
     status = _item_label_status(item)
     if item.item_id == HUMAN_REQUIREMENTS_ACK_ITEM_ID:
         return f"Human-requirements acknowledgement item, round {item.source_round}: {summary}"
+    if item.item_id == MERGE_CONFLICT_ITEM_ID:
+        return f"Merge conflict item, round {item.source_round}: {summary}"
     phrases = {
         "blocking": "Blocking issue",
         "same-pr": "Same-PR follow-up",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -160,6 +160,11 @@ class AgentLoopConfig:
     # treated as an external-CI-infrastructure stall rather than a normal
     # wait (#602), e.g. a GitHub-hosted-runner capacity outage.
     ci_queued_grace_seconds: int = 1200
+    # Bounded re-poll for a GitHub mergeability computation still in progress
+    # (`mergeable: "UNKNOWN"`), and the interval between attempts. Distinct
+    # from a confirmed conflict, which is never re-polled here (#606).
+    mergeability_poll_attempts: int = 3
+    mergeability_poll_interval_seconds: int = 5
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -832,6 +837,10 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
     if getattr(args, "ci_queued_grace_seconds", 1200) <= 0:
         raise AgentLoopError("--ci-queued-grace-seconds must be greater than zero.")
+    if getattr(args, "mergeability_poll_attempts", 3) <= 0:
+        raise AgentLoopError("--mergeability-poll-attempts must be greater than zero.")
+    if getattr(args, "mergeability_poll_interval_seconds", 5) <= 0:
+        raise AgentLoopError("--mergeability-poll-interval-seconds must be greater than zero.")
     if args.progress_interval_seconds <= 0:
         raise AgentLoopError("--progress-interval-seconds must be greater than zero.")
     if args.agent_max_retries < 0:
@@ -914,6 +923,8 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
+        mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),
+        mergeability_poll_interval_seconds=getattr(args, "mergeability_poll_interval_seconds", 5),
         quiet=args.quiet,
         log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
         progress_interval_seconds=args.progress_interval_seconds,

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -89,6 +89,15 @@ class PullRequestReviewContext:
     human_requirements: tuple[HumanReviewRequirement, ...]
 
 
+@dataclass(frozen=True)
+class PullRequestMergeability:
+    state: Literal["mergeable", "conflicted", "unknown"]
+    mergeable_raw: str | None
+    merge_state_raw: str | None
+    head_sha: str | None
+    base_branch: str | None
+
+
 PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url,body"
 PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
 ISSUE_REFERENCE_RE_TEMPLATE = r"(?:#%d\b|/issues/%d\b)"
@@ -467,6 +476,116 @@ def get_pr_review_context(
         metadata=_parse_pr_metadata(data, config=config, pr_number=pr_number),
         comments=comments,
         human_requirements=_parse_pr_human_requirements(data),
+    )
+
+
+def _classify_mergeability(
+    *, mergeable_raw: str | None, merge_state_raw: str | None
+) -> Literal["mergeable", "conflicted", "unknown"]:
+    # Explicit conflict evidence wins first, even when the other field is
+    # null/missing: a DIRTY merge state or a CONFLICTING mergeable value both
+    # mean GitHub cannot merge the branch as-is.
+    if merge_state_raw == "DIRTY" or mergeable_raw == "CONFLICTING":
+        return "conflicted"
+    if mergeable_raw == "MERGEABLE":
+        return "mergeable"
+    return "unknown"
+
+
+def get_pr_mergeability(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    cwd: Path | None = None,
+) -> PullRequestMergeability:
+    """Probe GitHub's computed mergeability for `pr_number`.
+
+    A confirmed `mergeable`/`conflicted` state is authoritative. Anything
+    else -- a non-zero `gh` exit, unparsable JSON, a null/missing `mergeable`
+    with no conflict evidence, or an explicit `"UNKNOWN"` (GitHub is still
+    computing it) -- settles as `unknown` so an old `gh`, a token without
+    `mergeStateStatus` access, or a transient computation window is never
+    mistaken for a real conflict. Only the explicit `"UNKNOWN"` case is worth
+    a bounded re-poll, since it is the one case GitHub says will resolve on
+    its own shortly.
+    """
+    if config.dry_run:
+        return PullRequestMergeability(
+            state="unknown",
+            mergeable_raw=None,
+            merge_state_raw=None,
+            head_sha=None,
+            base_branch=None,
+        )
+
+    resolved_cwd = cwd or active_workdir(config)
+    attempts = max(1, config.mergeability_poll_attempts)
+    for attempt in range(attempts):
+        result = runner.run(
+            [
+                config.gh_cmd,
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                config.repo,
+                "--json",
+                "mergeable,mergeStateStatus,headRefOid,baseRefName",
+            ],
+            cwd=resolved_cwd,
+            check=False,
+        )
+        if result.returncode != 0:
+            log(config, f"PR #{pr_number}: mergeability probe failed (gh exit {result.returncode}); treating as unknown")
+            return PullRequestMergeability(
+                state="unknown",
+                mergeable_raw=None,
+                merge_state_raw=None,
+                head_sha=None,
+                base_branch=None,
+            )
+        try:
+            data = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            log(config, f"PR #{pr_number}: mergeability probe returned invalid JSON; treating as unknown")
+            return PullRequestMergeability(
+                state="unknown",
+                mergeable_raw=None,
+                merge_state_raw=None,
+                head_sha=None,
+                base_branch=None,
+            )
+        mergeable_raw = _optional_str(data.get("mergeable"))
+        merge_state_raw = _optional_str(data.get("mergeStateStatus"))
+        head_sha = _optional_str(data.get("headRefOid"))
+        base_branch = _optional_str(data.get("baseRefName"))
+        state = _classify_mergeability(mergeable_raw=mergeable_raw, merge_state_raw=merge_state_raw)
+        if state != "unknown" or mergeable_raw != "UNKNOWN":
+            return PullRequestMergeability(
+                state=state,
+                mergeable_raw=mergeable_raw,
+                merge_state_raw=merge_state_raw,
+                head_sha=head_sha,
+                base_branch=base_branch,
+            )
+        if attempt < attempts - 1:
+            log(
+                config,
+                f"PR #{pr_number}: GitHub is still computing mergeability (UNKNOWN); "
+                f"retrying in {config.mergeability_poll_interval_seconds}s "
+                f"({attempt + 1}/{attempts})",
+            )
+            runner.run(
+                ["sleep", str(config.mergeability_poll_interval_seconds)],
+                cwd=resolved_cwd,
+            )
+    return PullRequestMergeability(
+        state="unknown",
+        mergeable_raw="UNKNOWN",
+        merge_state_raw=merge_state_raw,
+        head_sha=head_sha,
+        base_branch=base_branch,
     )
 
 
@@ -1189,9 +1308,10 @@ def get_check_status(runner: Runner, config: AgentLoopConfig, head_sha: str) -> 
 
 @dataclass(frozen=True)
 class CiWaitOutcome:
-    status: Literal["passed", "infrastructure_stall"]
+    status: Literal["passed", "infrastructure_stall", "merge_conflict"]
     stall: CiInfrastructureStall | None = None
     pr_checks: PullRequestChecks | None = None
+    mergeability: PullRequestMergeability | None = None
 
 
 def wait_for_ci(
@@ -1210,6 +1330,11 @@ def wait_for_ci(
     Otherwise this keeps today's contract exactly: keep polling and ultimately
     raise `AgentLoopError` on a genuine terminal failure or `ci_timeout_seconds`
     expiry.
+
+    Each poll also re-checks GitHub mergeability first (#606): once the base
+    advances or a rebase-required situation appears, the PR's current-head CI
+    is no longer a reliable merge signal, so a confirmed conflict ends the
+    wait immediately without attempting a merge.
     """
     log(config, f"Waiting for GitHub check '{config.ci_check_name}' before merge")
     head_sha = get_pr_head_sha(runner, config, pr_number)
@@ -1223,6 +1348,11 @@ def wait_for_ci(
         "skipped",
     }
     for attempt in range(attempts):
+        mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
+        if mergeability.state == "conflicted":
+            log(config, f"PR #{pr_number}: GitHub reports a merge conflict; stopping CI wait")
+            return CiWaitOutcome(status="merge_conflict", mergeability=mergeability)
+
         record = get_check_record(runner, config, head_sha)
         status = record.status if record is not None else "pending"
         log(config, f"GitHub check '{config.ci_check_name}' status: {status}")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -47,8 +47,10 @@ from .errors import (
 from .github import (
     IssueContext,
     PullRequestChecks,
+    PullRequestMergeability,
     PullRequestReviewContext,
     get_issue_context,
+    get_pr_mergeability,
     parse_linked_issue_numbers,
     get_pr_checks,
     get_pr_review_context,
@@ -110,6 +112,7 @@ from .prompts import (
     build_plan_decomposition_prompt,
     build_plan_review_prompt,
     build_plan_revision_prompt,
+    build_merge_conflict_prompt,
     build_review_prompt,
     build_same_pr_followup_prompt,
     build_task_clarification_prompt,
@@ -292,16 +295,19 @@ from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
     CODER_DISPUTE_NOTE_PREFIX,
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+    MERGE_CONFLICT_ITEM_ID,
     _apply_dispute_evidence,
     _apply_unresolved_item_dispositions,
     _collect_prior_compact_summaries,
     _clear_human_requirements_ack_item,
+    _clear_merge_conflict_item,
     _format_same_pr_unresolved_items,
     _format_unresolved_items_for_coder,
     _is_disputed_item,
     _maybe_fill_resolved_dispositions_from_prose,
     _next_unresolved_item,
     _normalize_disposition_section_prose,
+    _reconcile_merge_conflict_item,
     _record_prior_item_disposition,
     _reconcile_human_requirements_ack_item,
     _upsert_human_requirements_ack_item,
@@ -5262,6 +5268,12 @@ def run_pr_loop(
             # pass one reviewer session, so attach it to the first configured reviewer.
             reviewer_session_ids[configured_reviewers[0]] = reviewer_session_id
         prefetched_pr_context: PullRequestReviewContext | None = None
+        # Bounded-progress guard for merge-conflict rounds (#606): if the coder
+        # is dispatched to resolve a conflict and the PR head is still exactly
+        # the same head the next time a conflict dispatch is about to happen,
+        # the coder round made no progress -- stop cleanly instead of looping.
+        conflict_dispatch_head_sha: str | None = None
+        latest_mergeability: PullRequestMergeability | None = None
         resumed_round = _resume_pr_round(
             initial_pr_context.comments,
             head_sha=initial_pr_context.metadata.head_sha,
@@ -5297,6 +5309,27 @@ def run_pr_loop(
                 human_requirements=human_requirements,
                 source_round=round_number,
             )
+            # GitHub mergeability gate (#606): fetch and evaluate before starting
+            # a review round so a confirmed conflict routes straight to the coder
+            # instead of spending reviewer time (or later a full CI wait) on a
+            # branch that cannot merge. `unknown` is left alone here so a
+            # transient GitHub mergeability computation window never triggers an
+            # unnecessary coder round.
+            round_start_mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
+            latest_mergeability = round_start_mergeability
+            unresolved_items = _reconcile_merge_conflict_item(
+                unresolved_items,
+                mergeability=round_start_mergeability,
+                source_round=round_number,
+            )
+            conflict_pending = round_start_mergeability.state == "conflicted"
+            if conflict_pending:
+                log(
+                    config,
+                    f"Round {round_number}: PR #{pr_number} has a merge conflict with "
+                    f"{round_start_mergeability.base_branch or config.base or 'the base branch'}; "
+                    f"skipping reviewers and routing to {agent_display_name(config.coder)}",
+                )
             prior_unresolved_items = tuple(unresolved_items)
             prior_dispositions: dict[str, list[ReviewItemDisposition]] = {
                 item.item_id: [] for item in prior_unresolved_items
@@ -5348,6 +5381,7 @@ def run_pr_loop(
                     "without current-head coder metadata; routing recovered prior items "
                     f"through {coder_name} before review",
                 )
+            skip_reviewers_this_round = skip_reviewers_for_recovery or conflict_pending
 
             pr_fatal_errors: list[tuple[str, AgentLoopError]] = []
             pr_prep_failures: dict[AgentName, AgentLoopError] = {}
@@ -5380,7 +5414,7 @@ def run_pr_loop(
                     return "carried"
                 return "turn"
 
-            if config.review_parallel and not skip_reviewers_for_recovery:
+            if config.review_parallel and not skip_reviewers_this_round:
                 pending_pr_reviewers = [
                     reviewer for reviewer in configured_reviewers
                     if _pr_reviewer_prelaunch_kind(reviewer) == "turn"
@@ -5503,7 +5537,7 @@ def run_pr_loop(
                             "PR sync; nothing to launch in parallel this round",
                         )
 
-            for reviewer in (() if skip_reviewers_for_recovery else configured_reviewers):
+            for reviewer in (() if skip_reviewers_this_round else configured_reviewers):
                 reviewer_name = agent_display_name(reviewer)
                 if reviewer in unavailable_reviewer_failures:
                     log(
@@ -6136,8 +6170,30 @@ def run_pr_loop(
                     )
                     next_unresolved_item_number += 1
                     must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
-                pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
-                if not must_fix_items and is_wholly_infrastructure_blocked(pr_checks):
+
+                # Re-evaluate mergeability before CI checks / merge (#606): reviews
+                # can take a while, so the branch may have gone conflicted since
+                # the round-start probe. A confirmed conflict here skips the checks
+                # fetch entirely and blocks the merge branch below via must_fix_items.
+                merge_gate_mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
+                latest_mergeability = merge_gate_mergeability
+                unresolved_items = _reconcile_merge_conflict_item(
+                    unresolved_items,
+                    mergeability=merge_gate_mergeability,
+                    source_round=round_number,
+                )
+                must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
+                if merge_gate_mergeability.state == "conflicted":
+                    log(
+                        config,
+                        f"Round {round_number}: PR #{pr_number} became conflicted with "
+                        f"{merge_gate_mergeability.base_branch or config.base or 'the base branch'} "
+                        "before merge; skipping CI checks and merge this round",
+                    )
+                    pr_checks = None
+                else:
+                    pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+                if pr_checks is not None and not must_fix_items and is_wholly_infrastructure_blocked(pr_checks):
                     # Every remaining blocking/pending signal is external GitHub
                     # Actions infrastructure (a queued check that never started a
                     # job, or one cancelled before execution because a hosted
@@ -6291,14 +6347,76 @@ def run_pr_loop(
                                 "runners recover."
                             )
                             return 0
-                        merge_pr(runner, config, pr_number)
-                    print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
-                    return 0
+                        if wait_outcome.status == "merge_conflict":
+                            assert wait_outcome.mergeability is not None
+                            latest_mergeability = wait_outcome.mergeability
+                            unresolved_items = _reconcile_merge_conflict_item(
+                                unresolved_items,
+                                mergeability=wait_outcome.mergeability,
+                                source_round=round_number,
+                            )
+                            must_fix_items = [
+                                item for item in unresolved_items if item.status in {"blocking", "same-pr"}
+                            ]
+                            log(
+                                config,
+                                f"Round {round_number}: PR #{pr_number} became conflicted with "
+                                f"{wait_outcome.mergeability.base_branch or config.base or 'the base branch'} "
+                                "during the CI wait; no merge attempted",
+                            )
+                        else:
+                            merge_pr(runner, config, pr_number)
+                    if not must_fix_items:
+                        print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
+                        return 0
             if round_number == config.max_rounds:
                 raise AgentLoopError(
                     f"One or more reviewers still reported blocking issues after round {round_number}; "
                     "human review required."
                 )
+
+            has_merge_conflict_item = any(
+                item.item_id == MERGE_CONFLICT_ITEM_ID for item in unresolved_items
+            )
+
+            if has_merge_conflict_item:
+                if (
+                    conflict_dispatch_head_sha is not None
+                    and conflict_dispatch_head_sha == (pr_metadata.head_sha or "")
+                ):
+                    # The previous conflict-resolution round was dispatched from
+                    # this exact head and the head still has not moved: another
+                    # coder round would just repeat the same conflict. Stop
+                    # cleanly and resumably instead of looping (#606).
+                    conflict_base = (
+                        (latest_mergeability.base_branch if latest_mergeability else None)
+                        or pr_metadata.base_branch
+                        or config.base
+                        or "its base branch"
+                    )
+                    post_pr_comment(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        body=(
+                            f"PR #{pr_number} is still conflicted with `{conflict_base}` and the head "
+                            f"did not change after the last conflict-resolution round. Push a resolved "
+                            "head to continue, then rerun the same command.\n\n"
+                            f"<!-- AGENT_STATE: blocking -->\n-- Orchestrator"
+                        ),
+                    )
+                    log(
+                        config,
+                        f"Round {round_number}: PR #{pr_number} is still conflicted with "
+                        f"`{conflict_base}` and the head did not advance; stopping cleanly",
+                    )
+                    print(
+                        f"PR #{pr_number} is still conflicted with `{conflict_base}` and the head "
+                        "did not change after the last conflict-resolution round. Push a resolved "
+                        "head to continue, then rerun the same command."
+                    )
+                    return 0
+                conflict_dispatch_head_sha = pr_metadata.head_sha or ""
 
             # Structural backstop (#602): even when the reviewer downgrade above
             # correctly declines (a mixed item, a genuine defect alongside a
@@ -6307,18 +6425,57 @@ def run_pr_loop(
             # freshest check board before starting the round and, when it is
             # wholly infrastructure-blocked, prepend the stall context so the
             # coder fixes only the genuine items and returns a bounded terminal
-            # response instead of chasing the stalled check.
-            if pr_checks is None:
+            # response instead of chasing the stalled check. Skipped entirely
+            # while conflicted (#606): a conflicted branch must not generate any
+            # check-run, commit-status, or branch-protection API calls.
+            if pr_checks is None and not has_merge_conflict_item:
                 pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
             stall_context = (
                 _coder_infrastructure_stall_notice(pr_checks.infrastructure_stalls)
-                if is_wholly_infrastructure_blocked(pr_checks)
+                if pr_checks is not None and is_wholly_infrastructure_blocked(pr_checks)
                 else ""
             )
 
             same_pr_items = [item for item in unresolved_items if item.status == "same-pr"]
             blocking_items = [item for item in unresolved_items if item.status == "blocking"]
-            if same_pr_items and not blocking_items:
+            if has_merge_conflict_item:
+                other_items = [
+                    item for item in unresolved_items if item.item_id != MERGE_CONFLICT_ITEM_ID
+                ]
+                combined_review = _format_unresolved_items_for_coder(other_items)
+                coder_human_requirements_context = render_coder_human_requirements_prompt_context(
+                    human_requirements
+                )
+                resolved_base_branch = (
+                    (latest_mergeability.base_branch if latest_mergeability else None)
+                    or pr_metadata.base_branch
+                    or config.base
+                    or "the base branch"
+                )
+                resolved_head_sha = (
+                    (latest_mergeability.head_sha if latest_mergeability else None) or pr_metadata.head_sha
+                )
+                merge_state_detail = (
+                    f"mergeable={latest_mergeability.mergeable_raw or 'unknown'}, "
+                    f"mergeStateStatus={latest_mergeability.merge_state_raw or 'unknown'}"
+                    if latest_mergeability is not None
+                    else "mergeable=unknown, mergeStateStatus=unknown"
+                )
+                followup_prompt = build_merge_conflict_prompt(
+                    pr_number,
+                    round_number,
+                    combined_review,
+                    config,
+                    memory,
+                    issue_context=issue_context,
+                    human_requirements=human_requirements,
+                    base_branch=resolved_base_branch,
+                    head_sha=resolved_head_sha,
+                    merge_state_detail=merge_state_detail,
+                    human_requirements_context=coder_human_requirements_context,
+                )
+                log(config, f"Round {round_number}: {coder_name} resolving merge conflict")
+            elif same_pr_items and not blocking_items:
                 combined_review = stall_context + _format_same_pr_unresolved_items(same_pr_items)
                 coder_human_requirements_context = render_coder_human_requirements_prompt_context(
                     human_requirements
@@ -6333,6 +6490,7 @@ def run_pr_loop(
                     human_requirements=human_requirements,
                     human_requirements_context=coder_human_requirements_context,
                 )
+                log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
             else:
                 combined_review = stall_context + _format_unresolved_items_for_coder(unresolved_items)
                 coder_human_requirements_context = render_coder_human_requirements_prompt_context(
@@ -6348,11 +6506,11 @@ def run_pr_loop(
                     human_requirements=human_requirements,
                     human_requirements_context=coder_human_requirements_context,
                 )
-            log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
+                log(config, f"Round {round_number}: {coder_name} addressing reviewer feedback")
             repair_unresolved_item_ids = tuple(
                 item.item_id
                 for item in unresolved_items
-                if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+                if item.item_id not in {HUMAN_REQUIREMENTS_ACK_ITEM_ID, MERGE_CONFLICT_ITEM_ID}
             )
             coder_response = _run_validated_agent(
                 runner,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5321,8 +5321,17 @@ def run_pr_loop(
                 unresolved_items,
                 mergeability=round_start_mergeability,
                 source_round=round_number,
+                current_head_sha=pr_metadata.head_sha,
             )
-            conflict_pending = round_start_mergeability.state == "conflicted"
+            # A confirmed conflict from this probe is pending; so is a
+            # preserved blocker from an earlier confirmed conflict that this
+            # probe merely returned `unknown` for on the same head (a probe
+            # hiccup, not evidence the conflict resolved) -- checking the
+            # ledger, not the raw probe state, is what keeps the coder from
+            # being bypassed by a transient GitHub mergeability failure.
+            conflict_pending = any(
+                item.item_id == MERGE_CONFLICT_ITEM_ID for item in unresolved_items
+            )
             if conflict_pending:
                 log(
                     config,
@@ -6181,9 +6190,13 @@ def run_pr_loop(
                     unresolved_items,
                     mergeability=merge_gate_mergeability,
                     source_round=round_number,
+                    current_head_sha=pr_metadata.head_sha,
                 )
                 must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
-                if merge_gate_mergeability.state == "conflicted":
+                merge_gate_conflict_pending = any(
+                    item.item_id == MERGE_CONFLICT_ITEM_ID for item in unresolved_items
+                )
+                if merge_gate_conflict_pending:
                     log(
                         config,
                         f"Round {round_number}: PR #{pr_number} became conflicted with "
@@ -6354,6 +6367,7 @@ def run_pr_loop(
                                 unresolved_items,
                                 mergeability=wait_outcome.mergeability,
                                 source_round=round_number,
+                                current_head_sha=pr_metadata.head_sha,
                             )
                             must_fix_items = [
                                 item for item in unresolved_items if item.status in {"blocking", "same-pr"}

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -2495,6 +2495,61 @@ the AGENT_STATE footer. Your response must end with, in this exact order:
 """
 
 
+def build_merge_conflict_prompt(
+    pr_number: int,
+    round_number: int,
+    review: str,
+    config: AgentLoopConfig,
+    memory: AgentMemoryContext | None = None,
+    issue_context: IssueContext | None = None,
+    human_requirements: Sequence[HumanReviewRequirement] | None = None,
+    *,
+    base_branch: str,
+    head_sha: str | None,
+    merge_state_detail: str,
+    human_requirements_context: CoderHumanRequirementsPromptContext | None = None,
+) -> str:
+    reviewer_name = format_agent_list(reviewers(config))
+    coder_signature = agent_signature(config.coder, config)
+    if human_requirements_context is None:
+        human_requirements_context = render_coder_human_requirements_prompt_context(human_requirements)
+    head_description = f"`{head_sha}`" if head_sha else "the current PR head"
+    return f"""GitHub reports that pull request #{pr_number} in {config.repo} has a merge conflict \
+with its base branch `{base_branch}` ({merge_state_detail}) at {head_description}.
+
+Resolve this conflict in this local checkout before any further review or merge \
+can happen. Pull/sync the PR branch, merge `origin/{base_branch}` into it, resolve \
+every conflict, run relevant tests, commit, and push to the same PR branch. Do not \
+open a new PR and do not force-push over commits that are not part of this \
+conflict resolution or the listed follow-up items below. Do not check CI status \
+or wait for CI runs in this round -- CI and reviews are re-evaluated automatically \
+against the new head after your push.
+{_coder_workdir_guidance(config)}
+{_scratch_file_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(structured=True)}{_coder_documentation_guidance()}
+{_issue_context_block(issue_context)}
+{human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
+{_memory_block(memory)}
+
+Other unresolved reviewer items carried into this round (address them in the same \
+push if practical, alongside the conflict resolution):
+
+{review}
+
+{_structured_coder_followup_guidance(
+    reviewer_name=reviewer_name,
+    human_requirements_context=human_requirements_context,
+    coder_signature=coder_signature,
+)}This is round {round_number}. Use blocking to hand the resolved PR back for review.
+If you cannot safely resolve the conflict, explain why and still use the blocking
+marker so a human can intervene. Do not place your signature before the
+AGENT_STATE footer. Your response must end with, in this exact order:
+
+<!-- AGENT_STATE: blocking -->
+-- {coder_signature}
+"""
+
+
 def _render_discuss_agenda_prompt_block(agenda: ParsedDiscussAgenda) -> list[str]:
     lines: list[str] = []
     if agenda.consensus:

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -6,6 +6,7 @@ import re
 from collections.abc import Sequence
 
 from .errors import AgentLoopError, UnknownPriorItemDispositionError
+from .github import PullRequestMergeability
 from .prompts import render_coder_human_requirements_prompt_context
 from .protocol import (
     ParsedPlanReview,
@@ -22,6 +23,7 @@ from .protocol import (
 )
 
 HUMAN_REQUIREMENTS_ACK_ITEM_ID = "item-human-requirements-acknowledgement"
+MERGE_CONFLICT_ITEM_ID = "item-merge-conflict"
 CODER_DISPUTE_NOTE_PREFIX = "Coder disputes this item"
 ALL_RESOLVED_PROSE_RE = re.compile(
     r"^all (?:prior items|listed items|carried-forward items) are resolved\.?$"
@@ -265,13 +267,67 @@ def _reconcile_human_requirements_ack_item(
     return _clear_human_requirements_ack_item(unresolved_items)
 
 
+def _upsert_merge_conflict_item(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    *,
+    source_round: int,
+    text: str,
+) -> list[UnresolvedReviewItem]:
+    retained = [item for item in unresolved_items if item.item_id != MERGE_CONFLICT_ITEM_ID]
+    retained.append(
+        UnresolvedReviewItem(
+            item_id=MERGE_CONFLICT_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=source_round,
+            text=text,
+            status="blocking",
+            source_status="blocking",
+        )
+    )
+    return retained
+
+
+def _clear_merge_conflict_item(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+) -> list[UnresolvedReviewItem]:
+    return [item for item in unresolved_items if item.item_id != MERGE_CONFLICT_ITEM_ID]
+
+
+def _reconcile_merge_conflict_item(
+    unresolved_items: Sequence[UnresolvedReviewItem],
+    *,
+    mergeability: PullRequestMergeability,
+    source_round: int,
+) -> list[UnresolvedReviewItem]:
+    """Keep the synthetic conflict item in sync with the latest GitHub probe.
+
+    A confirmed `conflicted` state (re-)adds the blocking item; `mergeable`
+    or `unknown` clears it -- `unknown` is deliberately treated the same as
+    `mergeable` here so a transient GitHub mergeability computation window
+    does not leave a stale blocking item in the ledger (#606).
+    """
+    if mergeability.state != "conflicted":
+        return _clear_merge_conflict_item(unresolved_items)
+    base = mergeability.base_branch or "the base branch"
+    head = mergeability.head_sha or "the current head"
+    text = (
+        f"PR branch has a merge conflict with `{base}` (GitHub reports "
+        f"mergeable={mergeability.mergeable_raw or 'unknown'}, "
+        f"mergeStateStatus={mergeability.merge_state_raw or 'unknown'}) at head `{head}`. "
+        "Merge or rebase onto the current base and resolve the conflict before this "
+        "PR can be reviewed or merged."
+    )
+    return _upsert_merge_conflict_item(unresolved_items, source_round=source_round, text=text)
+
+
 def _validate_structured_coder_followup_items(
     parsed: StructuredCoderFollowup,
     *,
     unresolved_items: Sequence[UnresolvedReviewItem],
 ) -> None:
+    excluded_synthetic_ids = {HUMAN_REQUIREMENTS_ACK_ITEM_ID, MERGE_CONFLICT_ITEM_ID}
     allowed_ids = [
-        item.item_id for item in unresolved_items if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID
+        item.item_id for item in unresolved_items if item.item_id not in excluded_synthetic_ids
     ]
     # Future follow-ups are informational carry-forwards, not actionable this round --
     # they are not shown in the same-PR-only follow-up prompt, so the coder cannot
@@ -280,7 +336,7 @@ def _validate_structured_coder_followup_items(
     required_ids = [
         item.item_id
         for item in unresolved_items
-        if item.item_id != HUMAN_REQUIREMENTS_ACK_ITEM_ID and item.status != "future"
+        if item.item_id not in excluded_synthetic_ids and item.status != "future"
     ]
     listed_ids = [*parsed.addressed_items, *parsed.remaining_items, *parsed.disputed_items]
     duplicates = sorted({item_id for item_id in listed_ids if listed_ids.count(item_id) > 1})

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -267,13 +267,22 @@ def _reconcile_human_requirements_ack_item(
     return _clear_human_requirements_ack_item(unresolved_items)
 
 
+_CONFIRMED_CONFLICT_HEAD_NOTE_PREFIX = "confirmed-head:"
+
+
 def _upsert_merge_conflict_item(
     unresolved_items: Sequence[UnresolvedReviewItem],
     *,
     source_round: int,
     text: str,
+    confirmed_head_sha: str | None,
 ) -> list[UnresolvedReviewItem]:
     retained = [item for item in unresolved_items if item.item_id != MERGE_CONFLICT_ITEM_ID]
+    notes = (
+        (f"{_CONFIRMED_CONFLICT_HEAD_NOTE_PREFIX}{confirmed_head_sha}",)
+        if confirmed_head_sha
+        else ()
+    )
     retained.append(
         UnresolvedReviewItem(
             item_id=MERGE_CONFLICT_ITEM_ID,
@@ -282,6 +291,7 @@ def _upsert_merge_conflict_item(
             text=text,
             status="blocking",
             source_status="blocking",
+            notes=notes,
         )
     )
     return retained
@@ -293,31 +303,62 @@ def _clear_merge_conflict_item(
     return [item for item in unresolved_items if item.item_id != MERGE_CONFLICT_ITEM_ID]
 
 
+def _confirmed_conflict_head(item: UnresolvedReviewItem) -> str | None:
+    for note in item.notes:
+        if note.startswith(_CONFIRMED_CONFLICT_HEAD_NOTE_PREFIX):
+            return note[len(_CONFIRMED_CONFLICT_HEAD_NOTE_PREFIX):]
+    return None
+
+
 def _reconcile_merge_conflict_item(
     unresolved_items: Sequence[UnresolvedReviewItem],
     *,
     mergeability: PullRequestMergeability,
     source_round: int,
+    current_head_sha: str | None,
 ) -> list[UnresolvedReviewItem]:
     """Keep the synthetic conflict item in sync with the latest GitHub probe.
 
-    A confirmed `conflicted` state (re-)adds the blocking item; `mergeable`
-    or `unknown` clears it -- `unknown` is deliberately treated the same as
-    `mergeable` here so a transient GitHub mergeability computation window
-    does not leave a stale blocking item in the ledger (#606).
+    A confirmed `conflicted` state (re-)adds the blocking item, recording the
+    head it was confirmed against. A positively `mergeable` result clears it.
+    `unknown` clears it too -- but only when there was no previously
+    confirmed conflict, or the head has since advanced -- so a transient
+    GitHub mergeability computation window never creates a spurious blocker
+    (#606). If a conflict was already confirmed and `current_head_sha` is
+    unchanged, a later `unknown` (a probe hiccup, not new information) must
+    not silently drop the blocker: doing so would let reviewers, checks, or
+    a merge proceed against a branch GitHub last told us is still conflicted.
     """
-    if mergeability.state != "conflicted":
+    if mergeability.state == "conflicted":
+        base = mergeability.base_branch or "the base branch"
+        head = mergeability.head_sha or current_head_sha or "the current head"
+        text = (
+            f"PR branch has a merge conflict with `{base}` (GitHub reports "
+            f"mergeable={mergeability.mergeable_raw or 'unknown'}, "
+            f"mergeStateStatus={mergeability.merge_state_raw or 'unknown'}) at head `{head}`. "
+            "Merge or rebase onto the current base and resolve the conflict before this "
+            "PR can be reviewed or merged."
+        )
+        return _upsert_merge_conflict_item(
+            unresolved_items,
+            source_round=source_round,
+            text=text,
+            confirmed_head_sha=mergeability.head_sha or current_head_sha,
+        )
+    if mergeability.state == "mergeable":
         return _clear_merge_conflict_item(unresolved_items)
-    base = mergeability.base_branch or "the base branch"
-    head = mergeability.head_sha or "the current head"
-    text = (
-        f"PR branch has a merge conflict with `{base}` (GitHub reports "
-        f"mergeable={mergeability.mergeable_raw or 'unknown'}, "
-        f"mergeStateStatus={mergeability.merge_state_raw or 'unknown'}) at head `{head}`. "
-        "Merge or rebase onto the current base and resolve the conflict before this "
-        "PR can be reviewed or merged."
+
+    # mergeability.state == "unknown"
+    existing = next(
+        (item for item in unresolved_items if item.item_id == MERGE_CONFLICT_ITEM_ID), None
     )
-    return _upsert_merge_conflict_item(unresolved_items, source_round=source_round, text=text)
+    if existing is None:
+        return list(unresolved_items)
+    if _confirmed_conflict_head(existing) == current_head_sha:
+        # Same head the conflict was confirmed against; preserve the blocker
+        # until GitHub positively reports `mergeable` or the head advances.
+        return list(unresolved_items)
+    return _clear_merge_conflict_item(unresolved_items)
 
 
 def _validate_structured_coder_followup_items(

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -143,6 +143,7 @@ from coding_review_agent_loop.prompts import (
     build_issue_implementation_prompt,
     build_issue_plan_prompt,
     build_issue_prompt,
+    build_merge_conflict_prompt,
     build_task_prompt,
     build_same_pr_followup_prompt,
     build_plan_review_prompt,
@@ -240,6 +241,7 @@ class FakeRunner(Runner):
         advance_pr_head_on_coder_followup=True,
         search_issues_payload=None,
         open_prs_payload=None,
+        mergeability_payloads=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -331,6 +333,18 @@ class FakeRunner(Runner):
         # number/body keys; defaults to no open PRs found.
         self.open_prs_payload = open_prs_payload if open_prs_payload is not None else []
         self.open_prs_calls = 0
+        # Scripted responses for `get_pr_mergeability`'s dedicated `gh pr view
+        # --json mergeable,mergeStateStatus,headRefOid,baseRefName` probe
+        # (#606), consumed one call at a time. Each entry is a dict with any of
+        # mergeable/mergeStateStatus/headRefOid/baseRefName; missing keys are
+        # None. When exhausted (or unset), falls back to those same keys read
+        # from `pr_payload`, which is None/None by default -- unknown, no-op
+        # for tests that never set mergeability -- so existing suites are
+        # unaffected.
+        self.mergeability_payloads = (
+            list(mergeability_payloads) if mergeability_payloads is not None else None
+        )
+        self.mergeability_calls = 0
         self._agent_pr_counter = 0
         self._agent_command_seen = False
         # Parallel discuss debaters (#475) call run_with_log from worker
@@ -734,6 +748,23 @@ class FakeRunner(Runner):
         if cmd[:3] == ["gh", "pr", "list"]:
             self.open_prs_calls += 1
             return CommandResult(cmd, cwd_path, json_dumps(self.open_prs_payload), "", 0)
+
+        if (
+            cmd[:3] == ["gh", "pr", "view"]
+            and "--json" in cmd
+            and cmd[cmd.index("--json") + 1] == "mergeable,mergeStateStatus,headRefOid,baseRefName"
+        ):
+            self.mergeability_calls += 1
+            if self.mergeability_payloads:
+                payload = self.mergeability_payloads.pop(0)
+            else:
+                payload = {
+                    "mergeable": self.pr_payload.get("mergeable"),
+                    "mergeStateStatus": self.pr_payload.get("mergeStateStatus"),
+                    "headRefOid": self.pr_payload.get("headRefOid"),
+                    "baseRefName": self.pr_payload.get("baseRefName"),
+                }
+            return CommandResult(cmd, cwd_path, json_dumps(payload), "", 0)
 
         if cmd[:3] == ["gh", "pr", "view"]:
             if "--jq" in cmd and ".headRefOid" in cmd:

--- a/tests/test_merge_conflict.py
+++ b/tests/test_merge_conflict.py
@@ -1,0 +1,176 @@
+"""Orchestrator-level tests for GitHub merge-conflict detection and routing (#606)."""
+from unittest.mock import patch
+
+import coding_review_agent_loop.orchestrator as orchestrator
+from coding_review_agent_loop.cli import run_pr_loop
+
+from agent_loop_helpers import FakeRunner, command_index, make_config
+
+
+def _codex_exec_commands(runner):
+    return [cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]
+
+
+def _claude_commands(runner):
+    return [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+
+
+def _check_runs_commands(runner):
+    return [
+        cmd
+        for cmd, _cwd in runner.commands
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs")
+    ]
+
+
+def _merge_commands(runner):
+    return [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "pr", "merge"]]
+
+
+def test_conflict_at_round_start_skips_reviewers_and_routes_to_coder(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Resolved the conflict.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        mergeability_payloads=[
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+        ],
+    )
+    config = make_config(tmp_path)
+
+    result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    # No reviewer invocation and no CI checks fetch happened before the coder
+    # resolved the conflict: only one codex call (round 2's review, after the
+    # conflict was resolved) and it comes after the single claude call.
+    assert len(_codex_exec_commands(runner)) == 1
+    assert len(_claude_commands(runner)) == 1
+    claude_index = command_index(runner.commands, ["claude"])
+    codex_index = command_index(runner.commands, ["codex", "exec"])
+    assert claude_index < codex_index
+    # Zero check-run/status/branch-protection calls happened before the coder
+    # was dispatched to resolve the conflict.
+    check_runs_index_before_claude = [
+        cmd for cmd, _cwd in runner.commands[:claude_index]
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs")
+    ]
+    assert check_runs_index_before_claude == []
+
+
+def test_conflict_after_review_before_merge_blocks_ci_wait_and_merge(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Resolved the conflict.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        mergeability_payloads=[
+            {
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+        ],
+    )
+    config = make_config(tmp_path, auto_merge=True)
+
+    with patch(
+        "coding_review_agent_loop.orchestrator.wait_for_ci", wraps=orchestrator.wait_for_ci
+    ) as wait_spy, patch("coding_review_agent_loop.orchestrator.merge_pr") as merge_spy:
+        result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    # The merge-gate probe (right before CI checks) caught the conflict, so
+    # CI was never polled and the merge was never attempted in round 1;
+    # both only happen after the coder resolves and round 2 re-approves.
+    assert wait_spy.call_count == 1
+    assert merge_spy.call_count == 1
+    assert len(_codex_exec_commands(runner)) == 2
+    assert len(_claude_commands(runner)) == 1
+
+
+def test_unknown_mergeability_does_not_block_normal_flow(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+    )
+    config = make_config(tmp_path, auto_merge=True, mergeability_poll_attempts=1)
+
+    result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    assert len(_merge_commands(runner)) == 1
+    assert not any("conflict" in comment.lower() for comment in runner.comments)
+
+
+def test_persistent_conflict_with_unchanged_head_stops_cleanly(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=["Tried to resolve.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        mergeability_payloads=[
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+        ],
+        advance_pr_head_on_coder_followup=False,
+    )
+    config = make_config(tmp_path)
+
+    result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    # Only one coder round was dispatched; the second round detected the
+    # unchanged head and stopped cleanly instead of dispatching again.
+    assert len(_claude_commands(runner)) == 1
+    assert any("still conflicted" in comment for comment in runner.comments)
+
+
+def test_conflict_resolution_requires_fresh_ci_and_review(tmp_path):
+    """A resolution push is treated as code-changing: stale approvals/checks
+    are not reused, and the new head goes through a full reviewer + CI cycle
+    before merge."""
+    runner = FakeRunner(
+        claude_outputs=["Resolved the conflict.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        mergeability_payloads=[
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+        ],
+    )
+    config = make_config(tmp_path, auto_merge=True)
+
+    result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    assert len(_codex_exec_commands(runner)) == 1
+    assert len(_merge_commands(runner)) == 1
+    merge_index = command_index(runner.commands, ["gh", "pr", "merge"])
+    codex_index = command_index(runner.commands, ["codex", "exec"])
+    claude_index = command_index(runner.commands, ["claude"])
+    assert claude_index < codex_index < merge_index

--- a/tests/test_merge_conflict.py
+++ b/tests/test_merge_conflict.py
@@ -145,6 +145,42 @@ def test_persistent_conflict_with_unchanged_head_stops_cleanly(tmp_path):
     assert any("still conflicted" in comment for comment in runner.comments)
 
 
+def test_confirmed_conflict_survives_transient_unknown_reprobe_on_same_head(tmp_path):
+    """Regression (#609 review): DIRTY at round start, the coder is
+    dispatched but does not push (head unchanged), and the next round's probe
+    comes back `UNKNOWN` (a transient GitHub failure) for that same head. The
+    confirmed conflict must be preserved rather than silently cleared -- which
+    would otherwise let reviewers run, GitHub checks be fetched, and (with
+    auto-merge) a merge be attempted against a branch GitHub last told us was
+    still conflicted. Instead, the unchanged-head bounded-progress guard
+    should fire: no second coder round, no reviewer, no checks fetch, no
+    merge."""
+    runner = FakeRunner(
+        claude_outputs=["Tried to resolve.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        mergeability_payloads=[
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+        ],
+        advance_pr_head_on_coder_followup=False,
+    )
+    config = make_config(tmp_path, auto_merge=True, mergeability_poll_attempts=1)
+
+    result = run_pr_loop(runner, pr_number=77, config=config)
+
+    assert result == 0
+    assert len(_claude_commands(runner)) == 1
+    assert _codex_exec_commands(runner) == []
+    assert _check_runs_commands(runner) == []
+    assert _merge_commands(runner) == []
+    assert any("still conflicted" in comment for comment in runner.comments)
+
+
 def test_conflict_resolution_requires_fresh_ci_and_review(tmp_path):
     """A resolution push is treated as code-changing: stale approvals/checks
     are not reused, and the new head goes through a full reviewer + CI cycle

--- a/tests/test_mergeability.py
+++ b/tests/test_mergeability.py
@@ -1,0 +1,391 @@
+"""Tests for GitHub mergeability probing and its use in wait_for_ci (#606)."""
+import json
+
+from coding_review_agent_loop.comment_rendering import _format_unresolved_item_label
+from coding_review_agent_loop.github import (
+    PullRequestMergeability,
+    PullRequestMetadata,
+    get_pr_mergeability,
+    wait_for_ci,
+)
+from coding_review_agent_loop.protocol import UnresolvedReviewItem, validate_structured_coder_followup
+from coding_review_agent_loop.runner import CommandResult, Runner
+from coding_review_agent_loop.unresolved_items import (
+    MERGE_CONFLICT_ITEM_ID,
+    _reconcile_merge_conflict_item,
+    _validate_structured_coder_followup_items,
+)
+
+from agent_loop_helpers import make_config, structured_coder_followup
+
+
+class _StubMergeabilityRunner(Runner):
+    def __init__(self, *, mergeability_responses=None, check_runs_responses=None):
+        super().__init__(dry_run=False)
+        self.mergeability_responses = list(mergeability_responses or [])
+        self.check_runs_responses = list(
+            check_runs_responses
+            or [{"check_runs": [{"name": "test", "status": "completed", "conclusion": "success"}]}]
+        )
+        self.sleep_calls: list[str] = []
+        self.commands: list[list[str]] = []
+
+    def run(self, args, *, cwd, input_text=None, check=True, env=None):
+        cmd = [str(a) for a in args]
+        self.commands.append(cmd)
+        if cmd[:1] == ["sleep"]:
+            self.sleep_calls.append(cmd[1])
+            return CommandResult(cmd, cwd, "", "", 0)
+        if (
+            cmd[:3] == ["gh", "pr", "view"]
+            and "--json" in cmd
+            and cmd[cmd.index("--json") + 1] == "mergeable,mergeStateStatus,headRefOid,baseRefName"
+        ):
+            if not self.mergeability_responses:
+                raise AssertionError("no more scripted mergeability responses")
+            response = self.mergeability_responses.pop(0)
+            payload, returncode = response if isinstance(response, tuple) else (response, 0)
+            stdout = payload if isinstance(payload, str) else json.dumps(payload)
+            return CommandResult(cmd, cwd, stdout, "", returncode)
+        if cmd[:3] == ["gh", "pr", "view"] and "--jq" in cmd and ".headRefOid" in cmd:
+            return CommandResult(cmd, cwd, "headsha1\n", "", 0)
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs"):
+            payload = self.check_runs_responses.pop(0) if self.check_runs_responses else {"check_runs": []}
+            return CommandResult(cmd, cwd, json.dumps(payload), "", 0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+
+def _metadata(**overrides):
+    fields = dict(
+        number=77,
+        repo="OWNER/REPO",
+        title="Title",
+        head_branch="feature",
+        base_branch="main",
+        head_sha="headsha1",
+        url="https://github.com/OWNER/REPO/pull/77",
+    )
+    fields.update(overrides)
+    return PullRequestMetadata(**fields)
+
+
+# --- get_pr_mergeability precedence -----------------------------------------
+
+
+def test_conflicting_mergeable_is_conflicted(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY", "headRefOid": "h1", "baseRefName": "main"}
+        ]
+    )
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "conflicted"
+    assert result.mergeable_raw == "CONFLICTING"
+    assert result.merge_state_raw == "DIRTY"
+    assert result.head_sha == "h1"
+    assert result.base_branch == "main"
+
+
+def test_dirty_with_null_mergeable_is_conflicted(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": None, "mergeStateStatus": "DIRTY", "headRefOid": "h1", "baseRefName": "main"}
+        ]
+    )
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "conflicted"
+
+
+def test_mergeable_state(tmp_path):
+    config = make_config(tmp_path)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "headRefOid": "h1", "baseRefName": "main"}
+        ]
+    )
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "mergeable"
+
+
+def test_explicit_unknown_bounded_repoll_then_settles_unknown(tmp_path):
+    config = make_config(tmp_path, mergeability_poll_attempts=3, mergeability_poll_interval_seconds=7)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+        ]
+    )
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "unknown"
+    assert result.mergeable_raw == "UNKNOWN"
+    assert runner.sleep_calls == ["7", "7"]
+
+
+def test_explicit_unknown_resolves_within_budget(tmp_path):
+    config = make_config(tmp_path, mergeability_poll_attempts=3, mergeability_poll_interval_seconds=2)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+            {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "headRefOid": "h1", "baseRefName": "main"},
+        ]
+    )
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "mergeable"
+    assert runner.sleep_calls == ["2"]
+
+
+def test_null_missing_mergeable_no_conflict_evidence_is_unknown_without_polling(tmp_path):
+    config = make_config(tmp_path, mergeability_poll_attempts=3)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[{"mergeable": None, "mergeStateStatus": "BEHIND"}]
+    )
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "unknown"
+    assert runner.sleep_calls == []
+
+
+def test_gh_exit_failure_is_unknown(tmp_path):
+    config = make_config(tmp_path, mergeability_poll_attempts=3)
+    runner = _StubMergeabilityRunner(mergeability_responses=[({}, 1)])
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "unknown"
+    assert runner.sleep_calls == []
+
+
+def test_invalid_json_is_unknown(tmp_path):
+    config = make_config(tmp_path, mergeability_poll_attempts=3)
+    runner = _StubMergeabilityRunner(mergeability_responses=["not json"])
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "unknown"
+    assert runner.sleep_calls == []
+
+
+def test_dry_run_never_calls_gh(tmp_path):
+    config = make_config(tmp_path, dry_run=True)
+    runner = _StubMergeabilityRunner()
+
+    result = get_pr_mergeability(runner, config=config, pr_number=77)
+
+    assert result.state == "unknown"
+    assert runner.commands == []
+
+
+# --- wait_for_ci merge_conflict outcome -------------------------------------
+
+
+def test_wait_for_ci_returns_merge_conflict_on_first_poll(tmp_path):
+    config = make_config(tmp_path, ci_timeout_seconds=120, ci_poll_interval_seconds=10)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY", "headRefOid": "h1", "baseRefName": "main"}
+        ],
+    )
+
+    outcome = wait_for_ci(runner, config, 77, metadata=_metadata())
+
+    assert outcome.status == "merge_conflict"
+    assert outcome.mergeability is not None
+    assert outcome.mergeability.state == "conflicted"
+    # The conflict is checked before any check-run poll or sleep this attempt.
+    assert runner.check_runs_responses  # untouched
+    assert runner.sleep_calls == []
+
+
+def test_wait_for_ci_passes_when_not_conflicted(tmp_path):
+    config = make_config(tmp_path, ci_timeout_seconds=120, ci_poll_interval_seconds=10)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "headRefOid": "h1", "baseRefName": "main"}
+        ],
+    )
+
+    outcome = wait_for_ci(runner, config, 77, metadata=_metadata())
+
+    assert outcome.status == "passed"
+    assert outcome.mergeability is None
+
+
+def test_wait_for_ci_reprobes_conflict_on_later_poll(tmp_path):
+    config = make_config(tmp_path, ci_timeout_seconds=120, ci_poll_interval_seconds=10)
+    runner = _StubMergeabilityRunner(
+        mergeability_responses=[
+            {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "headRefOid": "h1", "baseRefName": "main"},
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY", "headRefOid": "h1", "baseRefName": "main"},
+        ],
+        check_runs_responses=[
+            {"check_runs": [{"name": "test", "status": "in_progress", "conclusion": None}]},
+        ],
+    )
+
+    outcome = wait_for_ci(runner, config, 77, metadata=_metadata())
+
+    assert outcome.status == "merge_conflict"
+    assert outcome.mergeability is not None
+    assert outcome.mergeability.state == "conflicted"
+
+
+# --- _reconcile_merge_conflict_item ------------------------------------------
+
+
+def test_reconcile_adds_blocking_item_when_conflicted():
+    mergeability = PullRequestMergeability(
+        state="conflicted",
+        mergeable_raw="CONFLICTING",
+        merge_state_raw="DIRTY",
+        head_sha="abc123",
+        base_branch="main",
+    )
+
+    items = _reconcile_merge_conflict_item([], mergeability=mergeability, source_round=1)
+
+    assert len(items) == 1
+    assert items[0].item_id == MERGE_CONFLICT_ITEM_ID
+    assert items[0].status == "blocking"
+    assert "main" in items[0].text
+    assert "abc123" in items[0].text
+
+
+def test_reconcile_clears_item_when_mergeable():
+    prior = [
+        UnresolvedReviewItem(
+            item_id=MERGE_CONFLICT_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=1,
+            text="stale conflict text",
+            status="blocking",
+            source_status="blocking",
+        )
+    ]
+    mergeability = PullRequestMergeability(
+        state="mergeable", mergeable_raw="MERGEABLE", merge_state_raw="CLEAN", head_sha="h2", base_branch="main"
+    )
+
+    items = _reconcile_merge_conflict_item(prior, mergeability=mergeability, source_round=2)
+
+    assert items == []
+
+
+def test_reconcile_clears_item_when_unknown():
+    prior = [
+        UnresolvedReviewItem(
+            item_id=MERGE_CONFLICT_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=1,
+            text="stale conflict text",
+            status="blocking",
+            source_status="blocking",
+        )
+    ]
+    mergeability = PullRequestMergeability(
+        state="unknown", mergeable_raw=None, merge_state_raw=None, head_sha=None, base_branch=None
+    )
+
+    items = _reconcile_merge_conflict_item(prior, mergeability=mergeability, source_round=2)
+
+    assert items == []
+
+
+def test_reconcile_preserves_other_items():
+    other_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Fix the null check.",
+        status="blocking",
+        source_status="blocking",
+    )
+    mergeability = PullRequestMergeability(
+        state="conflicted", mergeable_raw="CONFLICTING", merge_state_raw="DIRTY", head_sha="h1", base_branch="main"
+    )
+
+    items = _reconcile_merge_conflict_item([other_item], mergeability=mergeability, source_round=2)
+
+    assert other_item in items
+    assert any(item.item_id == MERGE_CONFLICT_ITEM_ID for item in items)
+
+
+# --- structured coder followup validation excludes the synthetic item -------
+
+
+def test_structured_followup_excludes_merge_conflict_item_from_allowed_ids():
+    conflict_item = UnresolvedReviewItem(
+        item_id=MERGE_CONFLICT_ITEM_ID,
+        reviewer="Orchestrator",
+        source_round=1,
+        text="conflict",
+        status="blocking",
+        source_status="blocking",
+    )
+    other_item = UnresolvedReviewItem(
+        item_id="item-1",
+        reviewer="OpenAI Codex",
+        source_round=1,
+        text="Fix the null check.",
+        status="blocking",
+        source_status="blocking",
+    )
+    text = structured_coder_followup(addressed_items=["item-1"])
+    parsed = validate_structured_coder_followup(text)
+
+    # Does not raise: item-1 is classified and the synthetic conflict item is
+    # neither required nor referenced.
+    _validate_structured_coder_followup_items(
+        parsed, unresolved_items=[conflict_item, other_item]
+    )
+
+
+def test_structured_followup_rejects_merge_conflict_item_reference():
+    conflict_item = UnresolvedReviewItem(
+        item_id=MERGE_CONFLICT_ITEM_ID,
+        reviewer="Orchestrator",
+        source_round=1,
+        text="conflict",
+        status="blocking",
+        source_status="blocking",
+    )
+    text = structured_coder_followup(addressed_items=[MERGE_CONFLICT_ITEM_ID])
+    parsed = validate_structured_coder_followup(text)
+
+    try:
+        _validate_structured_coder_followup_items(parsed, unresolved_items=[conflict_item])
+    except Exception as exc:  # AgentLoopError
+        assert "unknown" in str(exc).lower()
+    else:
+        raise AssertionError("expected an error for referencing the synthetic conflict item")
+
+
+# --- comment rendering label --------------------------------------------------
+
+
+def test_merge_conflict_item_label():
+    item = UnresolvedReviewItem(
+        item_id=MERGE_CONFLICT_ITEM_ID,
+        reviewer="Orchestrator",
+        source_round=3,
+        text="PR branch has a merge conflict with `main`.",
+        status="blocking",
+        source_status="blocking",
+    )
+
+    label = _format_unresolved_item_label(item)
+
+    assert "Merge conflict item, round 3" in label

--- a/tests/test_mergeability.py
+++ b/tests/test_mergeability.py
@@ -255,13 +255,18 @@ def test_reconcile_adds_blocking_item_when_conflicted():
         base_branch="main",
     )
 
-    items = _reconcile_merge_conflict_item([], mergeability=mergeability, source_round=1)
+    items = _reconcile_merge_conflict_item(
+        [], mergeability=mergeability, source_round=1, current_head_sha="abc123"
+    )
 
     assert len(items) == 1
     assert items[0].item_id == MERGE_CONFLICT_ITEM_ID
     assert items[0].status == "blocking"
     assert "main" in items[0].text
     assert "abc123" in items[0].text
+    # The confirmed head is recorded so a later transient `unknown` probe on
+    # the same head can be told apart from a genuinely resolved conflict.
+    assert any("abc123" in note for note in items[0].notes)
 
 
 def test_reconcile_clears_item_when_mergeable():
@@ -273,33 +278,90 @@ def test_reconcile_clears_item_when_mergeable():
             text="stale conflict text",
             status="blocking",
             source_status="blocking",
+            notes=("confirmed-head:h1",),
         )
     ]
     mergeability = PullRequestMergeability(
         state="mergeable", mergeable_raw="MERGEABLE", merge_state_raw="CLEAN", head_sha="h2", base_branch="main"
     )
 
-    items = _reconcile_merge_conflict_item(prior, mergeability=mergeability, source_round=2)
+    items = _reconcile_merge_conflict_item(
+        prior, mergeability=mergeability, source_round=2, current_head_sha="h2"
+    )
 
     assert items == []
 
 
-def test_reconcile_clears_item_when_unknown():
+def test_reconcile_no_op_when_unknown_without_prior_conflict():
+    """A fresh `unknown` with nothing previously confirmed must never create
+    a blocker -- a transient GitHub mergeability computation window must not
+    trigger an unnecessary coder round."""
+    mergeability = PullRequestMergeability(
+        state="unknown", mergeable_raw=None, merge_state_raw=None, head_sha=None, base_branch=None
+    )
+
+    items = _reconcile_merge_conflict_item(
+        [], mergeability=mergeability, source_round=2, current_head_sha="h1"
+    )
+
+    assert items == []
+
+
+def test_reconcile_preserves_confirmed_conflict_when_unknown_on_same_head():
+    """Regression (#609 review): once a conflict is confirmed on a head, a
+    later probe returning `unknown` for that *same* head (a probe hiccup, not
+    new information -- e.g. the coder round made no push) must not silently
+    clear the blocker. Clearing it would let reviewers, checks, or a merge
+    proceed against a branch GitHub last told us is still conflicted, and
+    would bypass the unchanged-head bounded-progress guard, which only fires
+    while the synthetic item remains present."""
     prior = [
         UnresolvedReviewItem(
             item_id=MERGE_CONFLICT_ITEM_ID,
             reviewer="Orchestrator",
             source_round=1,
-            text="stale conflict text",
+            text="PR branch has a merge conflict with `main`.",
             status="blocking",
             source_status="blocking",
+            notes=("confirmed-head:abc123",),
         )
     ]
     mergeability = PullRequestMergeability(
         state="unknown", mergeable_raw=None, merge_state_raw=None, head_sha=None, base_branch=None
     )
 
-    items = _reconcile_merge_conflict_item(prior, mergeability=mergeability, source_round=2)
+    items = _reconcile_merge_conflict_item(
+        prior, mergeability=mergeability, source_round=2, current_head_sha="abc123"
+    )
+
+    assert len(items) == 1
+    assert items[0].item_id == MERGE_CONFLICT_ITEM_ID
+    assert items[0].status == "blocking"
+
+
+def test_reconcile_clears_item_when_unknown_after_head_advanced():
+    """Once the head genuinely changes (a resolution attempt happened), a
+    fresh `unknown` for that new commit is ordinary -- not a hiccup on the
+    known-conflicted head -- so it clears normally and lets the round
+    re-evaluate the new head."""
+    prior = [
+        UnresolvedReviewItem(
+            item_id=MERGE_CONFLICT_ITEM_ID,
+            reviewer="Orchestrator",
+            source_round=1,
+            text="PR branch has a merge conflict with `main`.",
+            status="blocking",
+            source_status="blocking",
+            notes=("confirmed-head:abc123",),
+        )
+    ]
+    mergeability = PullRequestMergeability(
+        state="unknown", mergeable_raw=None, merge_state_raw=None, head_sha=None, base_branch=None
+    )
+
+    items = _reconcile_merge_conflict_item(
+        prior, mergeability=mergeability, source_round=2, current_head_sha="def456"
+    )
 
     assert items == []
 
@@ -317,7 +379,9 @@ def test_reconcile_preserves_other_items():
         state="conflicted", mergeable_raw="CONFLICTING", merge_state_raw="DIRTY", head_sha="h1", base_branch="main"
     )
 
-    items = _reconcile_merge_conflict_item([other_item], mergeability=mergeability, source_round=2)
+    items = _reconcile_merge_conflict_item(
+        [other_item], mergeability=mergeability, source_round=2, current_head_sha="h1"
+    )
 
     assert other_item in items
     assert any(item.item_id == MERGE_CONFLICT_ITEM_ID for item in items)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -118,6 +118,50 @@ def test_coder_prompts_include_assigned_workdir_rule(tmp_path):
         assert "`pwd` and `git status --branch --short`" in prompt
 
 
+def test_build_merge_conflict_prompt_content(tmp_path):
+    config = make_config(tmp_path)
+
+    prompt = build_merge_conflict_prompt(
+        77,
+        2,
+        "Codex unresolved blocking item [item-1] from round 1:\n- Fix the null check.",
+        config,
+        base_branch="release-2",
+        head_sha="deadbeef",
+        merge_state_detail="mergeable=CONFLICTING, mergeStateStatus=DIRTY",
+    )
+
+    assert "merge conflict" in prompt
+    assert "`release-2`" in prompt
+    assert "mergeable=CONFLICTING, mergeStateStatus=DIRTY" in prompt
+    assert "`deadbeef`" in prompt
+    assert "merge `origin/release-2`" in prompt
+    assert "push to the same PR branch" in prompt
+    assert "Do not open a new PR" in prompt
+    assert "Do not check CI status or wait for CI runs" in prompt
+    assert "run relevant tests" in prompt
+    assert "[item-1]" in prompt
+    assert '"kind": "coder_followup"' in prompt
+    assert "This is round 2." in prompt
+    assert "<!-- AGENT_STATE: blocking -->" in prompt
+
+
+def test_build_merge_conflict_prompt_head_sha_optional(tmp_path):
+    config = make_config(tmp_path)
+
+    prompt = build_merge_conflict_prompt(
+        77,
+        1,
+        "",
+        config,
+        base_branch="main",
+        head_sha=None,
+        merge_state_detail="mergeable=unknown, mergeStateStatus=unknown",
+    )
+
+    assert "the current PR head" in prompt
+
+
 def test_coder_test_reporting_guidance_forbids_background_completion_work(tmp_path):
     config = make_config(tmp_path)
 


### PR DESCRIPTION
## Summary

- Probe GitHub mergeability (`gh pr view --json mergeable,mergeStateStatus,headRefOid,baseRefName`) before each PR review round and again before fetching GitHub checks / attempting `--auto-merge`; a confirmed `DIRTY`/`CONFLICTING` state skips reviewers and any CI wait or merge attempt for that round.
- `wait_for_ci` re-probes mergeability on every poll and returns a new `merge_conflict` outcome, so a conflict that appears mid-wait stops the wait immediately instead of continuing to poll a check on a head that can no longer merge.
- A confirmed conflict routes the PR to the coder via a dedicated `build_merge_conflict_prompt`, naming the observed base branch, head SHA, and merge state, instructing it to sync, merge `origin/<base>`, resolve conflicts, run tests, commit, and push to the same PR (never opening a new PR or waiting on CI). Any other genuinely unresolved reviewer items are carried into the same round via a synthetic `item-merge-conflict` ledger entry (excluded from the coder's required/allowed structured item IDs, like the human-requirements-acknowledgement item).
- A resolution push is treated as code-changing: the next round re-probes mergeability from scratch, clears the synthetic item once GitHub reports `mergeable` or `unknown`, and re-runs reviewers and CI against the new head before any merge — stale approvals/checks from the old head are never reused.
- `mergeable: "UNKNOWN"` (GitHub still computing) is kept distinct from a confirmed conflict: it's bounded-retried (`--mergeability-poll-attempts`, default 3; `--mergeability-poll-interval-seconds`, default 5) and never triggers an unnecessary coder round.
- A conflict round that makes no head progress (the coder round pushed nothing, or GitHub still reports the same conflicted head) stops cleanly with an explanatory PR comment instead of dispatching the coder again.

## Test plan

- [x] `python -m pytest tests/test_mergeability.py tests/test_merge_conflict.py tests/test_prompts.py tests/test_orchestrator_pr.py tests/test_agent_loop.py tests/test_ci_health.py tests/test_comment_rendering.py tests/test_antigravity.py tests/test_backends.py -q`
- [x] `python -m pytest tests/ -q` (full suite, 1855 passed)
- [x] Manual: `agent-loop pr --help` shows the new `--mergeability-poll-attempts` / `--mergeability-poll-interval-seconds` flags

Fixes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)