### PR TITLE
Watch pending CI and resume review loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,17 @@ still-computing (`UNKNOWN`) GitHub mergeability result is re-checked before
 being treated as unresolved. See
 [Merge conflicts](docs/local_agent_loop.md#merge-conflicts) for details.
 
+Use `--watch-pending-ci` to opt into a foreground post-approval watcher. It
+polls the complete check board with `--ci-timeout-seconds` and
+`--ci-poll-interval-seconds`, without invoking agents while checks are pending.
+Failure resumes the coder with the failed-check details; a successful/no-check
+board is reported as merge-ready (or merged with `--auto-merge`). The watcher
+is synchronous and interruptible: Ctrl-C leaves no worker behind, and a rerun
+starts from fresh PR state. On timeout the local terminal prints a shell-quoted
+rerun command; PR comments intentionally contain no captured command arguments.
+Without this flag, existing pending-CI and legacy `--ci-check-name` behavior is
+unchanged.
+
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1210,6 +1210,23 @@ When enabled, the tool waits for the configured GitHub check-run to pass before 
 
 Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps waiting for the configured check-run to resolve before merging, as before.
 
+### Watch pending CI
+
+`--watch-pending-ci` is an opt-in alternative after approval. It foreground-polls
+the full PR check/status/required-check board using the existing timeout and poll
+interval controls. It does not call reviewers or the coder while checks remain
+pending. A completed actionable failure resumes the normal coder loop with the
+check name, conclusion, and URL; success or a reliable no-check board is
+merge-ready, or merges directly with `--auto-merge` (the legacy single
+`--ci-check-name` waiter is not used in this mode). A new head is re-reviewed,
+and the final-round CI-failure path receives one bounded extra round.
+
+The watch runs synchronously with interruptible `sleep` subprocesses, so Ctrl-C
+and restarts leave no hidden worker. Timeout and transient API snapshots remain
+bounded and print a shell-quoted rerun command only locally; GitHub comments do
+not repeat invocation arguments. Dry-run previews the watch without polling,
+sleeping, resuming agents, or merging. Disabled mode retains the behavior above.
+
 ### External CI infrastructure stalls
 
 GitHub-hosted runner capacity incidents can leave a check-run `queued` indefinitely with no job ever starting, or cause it to be cancelled before execution because a runner could not be acquired. Left unhandled, a coder round could otherwise run an unbounded `gh run watch` and consume an entire session without producing a result.

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -695,11 +695,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     runner = Runner(dry_run=args.dry_run)
     try:
-        config = config_from_args(args, runner)
         # Preserve tokens (rather than a rendered command) so timeout guidance can
         # be safely shell-quoted locally. Programmatic callers have no sys.argv.
         invocation = tuple([sys.argv[0], *sys.argv[1:]]) if argv is None else tuple(["agent-loop", *argv])
-        config = AgentLoopConfig(**{**config.__dict__, "invocation_argv": invocation})
+        config = config_from_args(args, runner, invocation_argv=invocation)
         implementation_override_requested = (
             args.implementation_coder is not None
             or args.implementation_coder_model

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -334,6 +334,14 @@ def build_parser() -> argparse.ArgumentParser:
             help="Polling interval for the CI check before auto-merge (default: 30).",
         )
         subparser.add_argument(
+            "--watch-pending-ci",
+            action="store_true",
+            help=(
+                "After approval, foreground-poll the full GitHub check board and resume "
+                "the coder if CI fails. Disabled by default."
+            ),
+        )
+        subparser.add_argument(
             "--ci-queued-grace-seconds",
             type=int,
             default=1200,
@@ -688,6 +696,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     runner = Runner(dry_run=args.dry_run)
     try:
         config = config_from_args(args, runner)
+        # Preserve tokens (rather than a rendered command) so timeout guidance can
+        # be safely shell-quoted locally. Programmatic callers have no sys.argv.
+        invocation = tuple([sys.argv[0], *sys.argv[1:]]) if argv is None else tuple(["agent-loop", *argv])
+        config = AgentLoopConfig(**{**config.__dict__, "invocation_argv": invocation})
         implementation_override_requested = (
             args.implementation_coder is not None
             or args.implementation_coder_model

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -165,6 +165,10 @@ class AgentLoopConfig:
     # from a confirmed conflict, which is never re-polled here (#606).
     mergeability_poll_attempts: int = 3
     mergeability_poll_interval_seconds: int = 5
+    # Opt-in foreground full-board CI watch after reviewer approval (#587).
+    # These are defaulted to keep direct AgentLoopConfig constructors compatible.
+    watch_pending_ci: bool = False
+    invocation_argv: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -922,6 +926,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ci_check_name=args.ci_check_name,
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
+        watch_pending_ci=getattr(args, "watch_pending_ci", False),
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),
         mergeability_poll_interval_seconds=getattr(args, "mergeability_poll_interval_seconds", 5),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -173,7 +173,14 @@ class AgentLoopConfig:
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
             object.__setattr__(self, "reviewer", (self.reviewer,))
-        if self.antigravity_model is not None and self.antigravity_models:
+        # Reconstructing a normalized frozen config (for example to add an
+        # invocation token list) feeds the legacy single model back as its
+        # equivalent one-item chain.  Treat that representation as idempotent.
+        if (
+            self.antigravity_model is not None
+            and self.antigravity_models
+            and self.antigravity_models != (self.antigravity_model,)
+        ):
             raise AgentLoopError("Cannot specify both antigravity_model and a custom antigravity_models chain.")
         if self.antigravity_model is not None:
             object.__setattr__(self, "antigravity_models", (self.antigravity_model,))
@@ -788,7 +795,12 @@ def preflight_agent_commands(
         runner.remember_agent_command(command, resolved, override_flag)
 
 
-def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfig:
+def config_from_args(
+    args: argparse.Namespace,
+    runner: Runner,
+    *,
+    invocation_argv: tuple[str, ...] = (),
+) -> AgentLoopConfig:
     configured_reviewers = tuple(args.reviewer or ["codex"])
     if len(set(configured_reviewers)) != len(configured_reviewers):
         raise AgentLoopError("--reviewer cannot include the same agent more than once.")
@@ -927,6 +939,7 @@ def config_from_args(args: argparse.Namespace, runner: Runner) -> AgentLoopConfi
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
         watch_pending_ci=getattr(args, "watch_pending_ci", False),
+        invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),
         mergeability_poll_interval_seconds=getattr(args, "mergeability_poll_interval_seconds", 5),

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -1314,6 +1314,58 @@ class CiWaitOutcome:
     mergeability: PullRequestMergeability | None = None
 
 
+@dataclass(frozen=True)
+class CiWatchOutcome:
+    """Terminal result from the opt-in full-board post-approval watcher."""
+
+    status: Literal["passed", "no_checks", "failed", "timeout", "infrastructure_stall", "merge_conflict", "head_changed", "dry_run"]
+    pr_checks: PullRequestChecks | None = None
+    failed_checks: tuple[PullRequestCheck, ...] = ()
+    mergeability: PullRequestMergeability | None = None
+    head_sha: str | None = None
+
+
+def watch_pr_checks(
+    runner: Runner,
+    config: AgentLoopConfig,
+    pr_number: int,
+    *,
+    metadata: PullRequestMetadata,
+    attempts: int | None = None,
+) -> CiWatchOutcome:
+    """Synchronously watch the complete current-head check board.
+
+    This deliberately sits beside the legacy single-check ``wait_for_ci``.
+    It has no worker or persisted process; interrupting the foreground runner
+    stops it immediately and a later invocation simply fetches fresh state.
+    """
+    if config.dry_run:
+        return CiWatchOutcome(status="dry_run", head_sha=metadata.head_sha)
+    limit = attempts if attempts is not None else max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
+    latest: PullRequestChecks | None = None
+    for attempt in range(limit):
+        current_head = get_pr_head_sha(runner, config, pr_number)
+        if metadata.head_sha and current_head != metadata.head_sha:
+            return CiWatchOutcome(status="head_changed", pr_checks=latest, head_sha=current_head)
+        mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
+        if mergeability.state == "conflicted":
+            return CiWatchOutcome(status="merge_conflict", pr_checks=latest, mergeability=mergeability, head_sha=current_head)
+        snapshot = get_pr_checks(runner, config=config, metadata=metadata)
+        latest = snapshot
+        if is_wholly_infrastructure_blocked(snapshot):
+            return CiWatchOutcome(status="infrastructure_stall", pr_checks=snapshot, head_sha=current_head)
+        if snapshot.state == "failing":
+            return CiWatchOutcome(status="failed", pr_checks=snapshot, failed_checks=snapshot.failing, head_sha=current_head)
+        reliable = snapshot.check_query_status == "ok" and snapshot.branch_protection_status in {"configured", "not_found"}
+        if snapshot.state == "passing" and reliable and not snapshot.pending and not snapshot.missing_required:
+            return CiWatchOutcome(status="passed", pr_checks=snapshot, head_sha=current_head)
+        if snapshot.state == "no_checks" and reliable and not snapshot.missing_required:
+            return CiWatchOutcome(status="no_checks", pr_checks=snapshot, head_sha=current_head)
+        if attempt < limit - 1:
+            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
+    return CiWatchOutcome(status="timeout", pr_checks=latest, head_sha=metadata.head_sha)
+
+
 def wait_for_ci(
     runner: Runner,
     config: AgentLoopConfig,

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -1320,8 +1320,14 @@ class CiWatchOutcome:
     """Terminal result from the opt-in full-board post-approval watcher."""
 
     status: Literal[
-        "passed", "no_checks", "failed", "timeout", "infrastructure_stall",
-        "merge_conflict", "head_changed", "dry_run",
+        "passed",
+        "no_checks",
+        "failed",
+        "timeout",
+        "infrastructure_stall",
+        "merge_conflict",
+        "head_changed",
+        "dry_run",
     ]
     pr_checks: PullRequestChecks | None = None
     failed_checks: tuple[PullRequestCheck, ...] = ()

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -1318,11 +1319,16 @@ class CiWaitOutcome:
 class CiWatchOutcome:
     """Terminal result from the opt-in full-board post-approval watcher."""
 
-    status: Literal["passed", "no_checks", "failed", "timeout", "infrastructure_stall", "merge_conflict", "head_changed", "dry_run"]
+    status: Literal[
+        "passed", "no_checks", "failed", "timeout", "infrastructure_stall",
+        "merge_conflict", "head_changed", "dry_run",
+    ]
     pr_checks: PullRequestChecks | None = None
     failed_checks: tuple[PullRequestCheck, ...] = ()
     mergeability: PullRequestMergeability | None = None
     head_sha: str | None = None
+    stall: CiInfrastructureStall | None = None
+    attempts_used: int = 0
 
 
 def watch_pr_checks(
@@ -1331,6 +1337,7 @@ def watch_pr_checks(
     pr_number: int,
     *,
     metadata: PullRequestMetadata,
+    deadline: float | None = None,
     attempts: int | None = None,
 ) -> CiWatchOutcome:
     """Synchronously watch the complete current-head check board.
@@ -1341,29 +1348,65 @@ def watch_pr_checks(
     """
     if config.dry_run:
         return CiWatchOutcome(status="dry_run", head_sha=metadata.head_sha)
-    limit = attempts if attempts is not None else max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
+    deadline = deadline if deadline is not None else time.monotonic() + config.ci_timeout_seconds
+    limit = attempts if attempts is not None else max(
+        1, config.ci_timeout_seconds // config.ci_poll_interval_seconds
+    )
     latest: PullRequestChecks | None = None
     for attempt in range(limit):
-        current_head = get_pr_head_sha(runner, config, pr_number)
+        # A flaky head probe is diagnostic only.  The full-board and
+        # mergeability probes already degrade transient API failures safely.
+        try:
+            current_head = get_pr_head_sha(runner, config, pr_number)
+        except AgentLoopError as error:
+            log(config, f"PR #{pr_number}: head probe failed while watching ({error}); retrying")
+            current_head = metadata.head_sha
         if metadata.head_sha and current_head != metadata.head_sha:
-            return CiWatchOutcome(status="head_changed", pr_checks=latest, head_sha=current_head)
+            return CiWatchOutcome(
+                status="head_changed", pr_checks=latest, head_sha=current_head,
+                attempts_used=attempt + 1,
+            )
         mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
         if mergeability.state == "conflicted":
-            return CiWatchOutcome(status="merge_conflict", pr_checks=latest, mergeability=mergeability, head_sha=current_head)
+            return CiWatchOutcome(
+                status="merge_conflict", pr_checks=latest, mergeability=mergeability,
+                head_sha=current_head, attempts_used=attempt + 1,
+            )
         snapshot = get_pr_checks(runner, config=config, metadata=metadata)
         latest = snapshot
         if is_wholly_infrastructure_blocked(snapshot):
-            return CiWatchOutcome(status="infrastructure_stall", pr_checks=snapshot, head_sha=current_head)
+            return CiWatchOutcome(
+                status="infrastructure_stall",
+                pr_checks=snapshot,
+                head_sha=current_head,
+                stall=CiInfrastructureStall(checks=snapshot.infrastructure_stalls),
+                attempts_used=attempt + 1,
+            )
         if snapshot.state == "failing":
-            return CiWatchOutcome(status="failed", pr_checks=snapshot, failed_checks=snapshot.failing, head_sha=current_head)
-        reliable = snapshot.check_query_status == "ok" and snapshot.branch_protection_status in {"configured", "not_found"}
+            return CiWatchOutcome(
+                status="failed", pr_checks=snapshot, failed_checks=snapshot.failing,
+                head_sha=current_head, attempts_used=attempt + 1,
+            )
+        reliable = snapshot.check_query_status == "ok" and snapshot.branch_protection_status in {
+            "configured", "not_found", "forbidden",
+        }
         if snapshot.state == "passing" and reliable and not snapshot.pending and not snapshot.missing_required:
-            return CiWatchOutcome(status="passed", pr_checks=snapshot, head_sha=current_head)
+            return CiWatchOutcome(
+                status="passed", pr_checks=snapshot, head_sha=current_head,
+                attempts_used=attempt + 1,
+            )
         if snapshot.state == "no_checks" and reliable and not snapshot.missing_required:
-            return CiWatchOutcome(status="no_checks", pr_checks=snapshot, head_sha=current_head)
-        if attempt < limit - 1:
-            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
-    return CiWatchOutcome(status="timeout", pr_checks=latest, head_sha=metadata.head_sha)
+            return CiWatchOutcome(
+                status="no_checks", pr_checks=snapshot, head_sha=current_head,
+                attempts_used=attempt + 1,
+            )
+        if time.monotonic() >= deadline or attempt == limit - 1:
+            return CiWatchOutcome(
+                status="timeout", pr_checks=latest, head_sha=current_head,
+                attempts_used=attempt + 1,
+            )
+        runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
+    raise AssertionError("CI watch loop must return a terminal outcome")
 
 
 def wait_for_ci(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -8,6 +8,7 @@ import json
 import re
 import shlex
 import sys
+import time
 import zoneinfo
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -46,6 +47,7 @@ from .errors import (
     UnknownPriorItemDispositionError,
 )
 from .github import (
+    CiWatchOutcome,
     IssueContext,
     PullRequestChecks,
     PullRequestMergeability,
@@ -5289,6 +5291,9 @@ def run_pr_loop(
             start_round_number = resumed_round.round_number
             log(config, f"PR #{pr_number}: resuming round {start_round_number}")
         watch_failure_extension_used = False
+        watch_head_extension_used = False
+        watch_deadline: float | None = None
+        watch_attempts_remaining: int | None = None
         # One extra slot is only activated by a watcher-discovered failure on
         # the configured final round; ordinary review failures retain the cap.
         allowed_rounds = config.max_rounds
@@ -6258,8 +6263,37 @@ def run_pr_loop(
                     )
                     return 0
                 if not must_fix_items and config.watch_pending_ci:
-                    log(config, f"Round {round_number}: watching GitHub checks for PR #{pr_number} in the foreground")
-                    watch_outcome = watch_pr_checks(runner, config, pr_number, metadata=pr_metadata)
+                    if watch_deadline is None:
+                        watch_deadline = time.monotonic() + config.ci_timeout_seconds
+                        watch_attempts_remaining = max(
+                            1,
+                            config.ci_timeout_seconds // config.ci_poll_interval_seconds,
+                        )
+                    watching_message = (
+                        f"Reviewers approved PR #{pr_number}; watching GitHub checks "
+                        "in the foreground. "
+                        "No coder or reviewer agents will run while checks remain pending."
+                    )
+                    log(config, f"Round {round_number}: {watching_message}")
+                    post_pr_comment(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        body=watching_message + "\n\n-- coding-review-agent-loop",
+                    )
+                    assert watch_attempts_remaining is not None
+                    if watch_attempts_remaining <= 0:
+                        watch_outcome = CiWatchOutcome(status="timeout")
+                    else:
+                        watch_outcome = watch_pr_checks(
+                            runner,
+                            config,
+                            pr_number,
+                            metadata=pr_metadata,
+                            deadline=watch_deadline,
+                            attempts=watch_attempts_remaining,
+                        )
+                    watch_attempts_remaining -= watch_outcome.attempts_used
                     if watch_outcome.status == "dry_run":
                         print(f"PR #{pr_number} approval found; dry-run preview did not perform live CI watching.")
                         return 0
@@ -6272,27 +6306,74 @@ def run_pr_loop(
                         else:
                             print(f"PR #{pr_number} is merge-ready after CI watch completed.")
                         return 0
-                    if watch_outcome.status in {"timeout", "infrastructure_stall"}:
-                        _publish_approved_followups(runner, config=config, pr_number=pr_number, head_sha=pr_metadata.head_sha, pr_comments=pr_comments, followups=future_followups)
+                    if watch_outcome.status == "infrastructure_stall":
+                        _publish_approved_followups(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=future_followups,
+                        )
+                        assert watch_outcome.stall is not None
+                        post_pr_comment(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            body=_format_ci_infrastructure_comment(
+                                pr_number, watch_outcome.stall
+                            ),
+                        )
+                        post_pr_comment(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            body=_ci_infrastructure_stop_message(
+                                pr_number, watch_outcome.stall, []
+                            ),
+                        )
+                        print(f"PR #{pr_number} CI watch stopped: external CI infrastructure is stalled.")
+                        return 0
+                    if watch_outcome.status == "timeout":
+                        _publish_approved_followups(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=future_followups,
+                        )
                         details = (
                             _pr_check_details(watch_outcome.pr_checks)
                             if watch_outcome.pr_checks
                             else ["No reliable check snapshot was available."]
                         )
-                        post_pr_comment(runner, config=config, pr_number=pr_number, body=_pending_ci_stop_message(pr_number, "pending", details))
+                        post_pr_comment(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            body=_pending_ci_stop_message(pr_number, "pending", details),
+                        )
                         rerun = shlex.join(config.invocation_argv) if config.invocation_argv else f"agent-loop pr {pr_number} --watch-pending-ci"
                         note = "" if config.invocation_argv else " (deterministic fallback; original invocation unavailable)"
                         print(
-                            f"PR #{pr_number} CI watch timed out or stalled: {'; '.join(details)}. "
+                            f"PR #{pr_number} CI watch timed out: {'; '.join(details)}. "
                             f"Rerun: {rerun}{note}"
                         )
                         return 0
                     if watch_outcome.status == "head_changed":
                         log(config, f"PR #{pr_number} head changed while watching; re-review is required")
-                        # Fresh state is fetched by the next normal round. Do not
-                        # publish approved follow-ups for the obsolete head.
-                        unresolved_items.append(_next_unresolved_item(item_number=next_unresolved_item_number, reviewer="GitHub PR checks", source_round=round_number, text="PR head changed while CI was being watched; re-review the new head.", status="blocking"))
-                        next_unresolved_item_number += 1
+                        # Consume a fresh review round without dispatching the
+                        # coder: prior-head approvals and resume state are stale.
+                        if round_number == allowed_rounds and not watch_head_extension_used:
+                            allowed_rounds += 1
+                            watch_head_extension_used = True
+                        resumed_round = None
+                        current_resume = None
+                        prefetched_pr_context = get_pr_review_context(
+                            runner, config=config, pr_number=pr_number
+                        )
+                        continue
                     elif watch_outcome.status == "merge_conflict":
                         unresolved_items = _reconcile_merge_conflict_item(unresolved_items, mergeability=watch_outcome.mergeability, source_round=round_number, current_head_sha=pr_metadata.head_sha)
                     elif watch_outcome.status == "failed":
@@ -6302,7 +6383,23 @@ def run_pr_loop(
                             else ["GitHub checks failed."]
                         )
                         log(config, f"Round {round_number}: CI watch failed; resuming coder")
-                        unresolved_items.append(_next_unresolved_item(item_number=next_unresolved_item_number, reviewer="GitHub PR checks", source_round=round_number, text=_pr_check_blocking_review(pr_number, "failing", details), status="blocking"))
+                        post_pr_comment(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            body=_format_pr_checks_comment(pr_number, "failing", details),
+                        )
+                        unresolved_items.append(
+                            _next_unresolved_item(
+                                item_number=next_unresolved_item_number,
+                                reviewer="GitHub PR checks",
+                                source_round=round_number,
+                                text=_pr_check_blocking_review(
+                                    pr_number, "failing", details
+                                ),
+                                status="blocking",
+                            )
+                        )
                         next_unresolved_item_number += 1
                         if round_number == config.max_rounds and not watch_failure_extension_used:
                             allowed_rounds += 1
@@ -6444,7 +6541,7 @@ def run_pr_loop(
                     if not must_fix_items:
                         print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
                         return 0
-            if round_number == config.max_rounds:
+            if round_number == allowed_rounds:
                 raise AgentLoopError(
                     f"One or more reviewers still reported blocking issues after round {round_number}; "
                     "human review required."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6426,7 +6426,7 @@ def run_pr_loop(
                             )
                         )
                         next_unresolved_item_number += 1
-                        if round_number == config.max_rounds and not watch_failure_extension_used:
+                        if round_number == allowed_rounds and not watch_failure_extension_used:
                             allowed_rounds += 1
                             watch_failure_extension_used = True
                     must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5297,7 +5297,12 @@ def run_pr_loop(
         # One extra slot is only activated by a watcher-discovered failure on
         # the configured final round; ordinary review failures retain the cap.
         allowed_rounds = config.max_rounds
-        for round_number in range(start_round_number, config.max_rounds + 2):
+        # The two independent one-shot watcher allowances below can extend the
+        # effective ceiling by two rounds in one invocation. Keep the static
+        # range large enough to reach both; ``allowed_rounds`` remains the
+        # authoritative guard and prevents either slot from being used unless
+        # its corresponding watcher transition grants it.
+        for round_number in range(start_round_number, config.max_rounds + 3):
             if round_number > allowed_rounds:
                 raise AgentLoopError(
                     f"One or more reviewers still reported blocking issues after round {allowed_rounds}; human review required."
@@ -6298,7 +6303,14 @@ def run_pr_loop(
                         print(f"PR #{pr_number} approval found; dry-run preview did not perform live CI watching.")
                         return 0
                     if watch_outcome.status in {"passed", "no_checks"}:
-                        _publish_approved_followups(runner, config=config, pr_number=pr_number, head_sha=pr_metadata.head_sha, pr_comments=pr_comments, followups=future_followups)
+                        _publish_approved_followups(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=future_followups,
+                        )
                         run_optional_tests(runner, config)
                         if config.auto_merge:
                             merge_pr(runner, config, pr_number)
@@ -6354,8 +6366,16 @@ def run_pr_loop(
                             pr_number=pr_number,
                             body=_pending_ci_stop_message(pr_number, "pending", details),
                         )
-                        rerun = shlex.join(config.invocation_argv) if config.invocation_argv else f"agent-loop pr {pr_number} --watch-pending-ci"
-                        note = "" if config.invocation_argv else " (deterministic fallback; original invocation unavailable)"
+                        rerun = (
+                            shlex.join(config.invocation_argv)
+                            if config.invocation_argv
+                            else f"agent-loop pr {pr_number} --watch-pending-ci"
+                        )
+                        note = (
+                            ""
+                            if config.invocation_argv
+                            else " (deterministic fallback; original invocation unavailable)"
+                        )
                         print(
                             f"PR #{pr_number} CI watch timed out: {'; '.join(details)}. "
                             f"Rerun: {rerun}{note}"
@@ -6375,7 +6395,12 @@ def run_pr_loop(
                         )
                         continue
                     elif watch_outcome.status == "merge_conflict":
-                        unresolved_items = _reconcile_merge_conflict_item(unresolved_items, mergeability=watch_outcome.mergeability, source_round=round_number, current_head_sha=pr_metadata.head_sha)
+                        unresolved_items = _reconcile_merge_conflict_item(
+                            unresolved_items,
+                            mergeability=watch_outcome.mergeability,
+                            source_round=round_number,
+                            current_head_sha=pr_metadata.head_sha,
+                        )
                     elif watch_outcome.status == "failed":
                         details = (
                             _pr_check_details(watch_outcome.pr_checks)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6,6 +6,7 @@ import datetime
 import hashlib
 import json
 import re
+import shlex
 import sys
 import zoneinfo
 from collections.abc import Callable, Mapping, Sequence
@@ -63,6 +64,7 @@ from .github import (
     validate_pr_body_does_not_close_issue,
     validate_pr_references_issue,
     wait_for_ci,
+    watch_pr_checks,
 )
 from .issue_pr_handoff import (
     post_issue_pr_handoff_comment,
@@ -5286,7 +5288,15 @@ def run_pr_loop(
             next_unresolved_item_number = resumed_round.next_unresolved_item_number
             start_round_number = resumed_round.round_number
             log(config, f"PR #{pr_number}: resuming round {start_round_number}")
-        for round_number in range(start_round_number, config.max_rounds + 1):
+        watch_failure_extension_used = False
+        # One extra slot is only activated by a watcher-discovered failure on
+        # the configured final round; ordinary review failures retain the cap.
+        allowed_rounds = config.max_rounds
+        for round_number in range(start_round_number, config.max_rounds + 2):
+            if round_number > allowed_rounds:
+                raise AgentLoopError(
+                    f"One or more reviewers still reported blocking issues after round {allowed_rounds}; human review required."
+                )
             coder_name = agent_display_name(config.coder)
             if pre_review_test_pending:
                 run_pre_review_tests(runner, config)
@@ -6247,6 +6257,57 @@ def run_pr_loop(
                         "Actions runners recover."
                     )
                     return 0
+                if not must_fix_items and config.watch_pending_ci:
+                    log(config, f"Round {round_number}: watching GitHub checks for PR #{pr_number} in the foreground")
+                    watch_outcome = watch_pr_checks(runner, config, pr_number, metadata=pr_metadata)
+                    if watch_outcome.status == "dry_run":
+                        print(f"PR #{pr_number} approval found; dry-run preview did not perform live CI watching.")
+                        return 0
+                    if watch_outcome.status in {"passed", "no_checks"}:
+                        _publish_approved_followups(runner, config=config, pr_number=pr_number, head_sha=pr_metadata.head_sha, pr_comments=pr_comments, followups=future_followups)
+                        run_optional_tests(runner, config)
+                        if config.auto_merge:
+                            merge_pr(runner, config, pr_number)
+                            print(f"PR #{pr_number} merged after CI watch completed.")
+                        else:
+                            print(f"PR #{pr_number} is merge-ready after CI watch completed.")
+                        return 0
+                    if watch_outcome.status in {"timeout", "infrastructure_stall"}:
+                        _publish_approved_followups(runner, config=config, pr_number=pr_number, head_sha=pr_metadata.head_sha, pr_comments=pr_comments, followups=future_followups)
+                        details = (
+                            _pr_check_details(watch_outcome.pr_checks)
+                            if watch_outcome.pr_checks
+                            else ["No reliable check snapshot was available."]
+                        )
+                        post_pr_comment(runner, config=config, pr_number=pr_number, body=_pending_ci_stop_message(pr_number, "pending", details))
+                        rerun = shlex.join(config.invocation_argv) if config.invocation_argv else f"agent-loop pr {pr_number} --watch-pending-ci"
+                        note = "" if config.invocation_argv else " (deterministic fallback; original invocation unavailable)"
+                        print(
+                            f"PR #{pr_number} CI watch timed out or stalled: {'; '.join(details)}. "
+                            f"Rerun: {rerun}{note}"
+                        )
+                        return 0
+                    if watch_outcome.status == "head_changed":
+                        log(config, f"PR #{pr_number} head changed while watching; re-review is required")
+                        # Fresh state is fetched by the next normal round. Do not
+                        # publish approved follow-ups for the obsolete head.
+                        unresolved_items.append(_next_unresolved_item(item_number=next_unresolved_item_number, reviewer="GitHub PR checks", source_round=round_number, text="PR head changed while CI was being watched; re-review the new head.", status="blocking"))
+                        next_unresolved_item_number += 1
+                    elif watch_outcome.status == "merge_conflict":
+                        unresolved_items = _reconcile_merge_conflict_item(unresolved_items, mergeability=watch_outcome.mergeability, source_round=round_number, current_head_sha=pr_metadata.head_sha)
+                    elif watch_outcome.status == "failed":
+                        details = (
+                            _pr_check_details(watch_outcome.pr_checks)
+                            if watch_outcome.pr_checks
+                            else ["GitHub checks failed."]
+                        )
+                        log(config, f"Round {round_number}: CI watch failed; resuming coder")
+                        unresolved_items.append(_next_unresolved_item(item_number=next_unresolved_item_number, reviewer="GitHub PR checks", source_round=round_number, text=_pr_check_blocking_review(pr_number, "failing", details), status="blocking"))
+                        next_unresolved_item_number += 1
+                        if round_number == config.max_rounds and not watch_failure_extension_used:
+                            allowed_rounds += 1
+                            watch_failure_extension_used = True
+                    must_fix_items = [item for item in unresolved_items if item.status in {"blocking", "same-pr"}]
                 if not must_fix_items:
                     if pr_checks.state in {"pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1248,6 +1248,22 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, t
     ).resolve()
 
 
+def test_config_captures_watch_invocation_without_rebuilding_antigravity_model(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "77", "--repo", "OWNER/REPO", "--antigravity-model", "Gemini 3.1 Pro (High)",
+        "--watch-pending-ci",
+    ])
+    config = config_from_args(
+        args,
+        FakeRunner(),
+        invocation_argv=("agent-loop", "pr", "77", "--watch-pending-ci"),
+    )
+    assert config.watch_pending_ci is True
+    assert config.invocation_argv[-1] == "--watch-pending-ci"
+    assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
+
+
 @pytest.mark.parametrize(
     ("coder", "reviewer", "missing_command", "override_flag"),
     [

--- a/tests/test_ci_watch.py
+++ b/tests/test_ci_watch.py
@@ -1,0 +1,69 @@
+"""Focused tests for the opt-in full-board post-approval CI watcher (#587)."""
+
+from unittest.mock import patch
+
+from coding_review_agent_loop.ci_health import PullRequestCheck, PullRequestChecks
+from coding_review_agent_loop.github import PullRequestMetadata, PullRequestMergeability, watch_pr_checks
+from coding_review_agent_loop.runner import CommandResult, Runner
+
+from agent_loop_helpers import make_config
+
+
+class _Runner(Runner):
+    def __init__(self):
+        super().__init__(dry_run=False)
+        self.commands = []
+
+    def run(self, args, *, cwd, input_text=None, check=True, env=None):
+        self.commands.append(list(args))
+        return CommandResult(list(args), cwd, "", "", 0)
+
+
+def _metadata():
+    return PullRequestMetadata(7, "OWNER/REPO", "title", "head", "main", "sha", "url")
+
+
+def _checks(state, *, failing=(), pending=(), query="ok", protection="configured"):
+    return PullRequestChecks(
+        state=state, required_checks=(), passing=(), pending=pending, failing=failing,
+        missing_required=(), branch_protection_status=protection, branch_protection_note=None,
+        check_query_status=query, check_query_errors=(), infrastructure_stalls=(),
+    )
+
+
+def _mergeability():
+    return PullRequestMergeability("mergeable", "MERGEABLE", "CLEAN", "sha", "main")
+
+
+def test_watch_pending_to_failure_reports_failed_records_and_sleeps(tmp_path):
+    runner = _Runner()
+    failed = PullRequestCheck("test", "completed", "failure", "https://checks/1", None, None)
+    with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \
+         patch("coding_review_agent_loop.github.get_pr_mergeability", return_value=_mergeability()), \
+         patch("coding_review_agent_loop.github.get_pr_checks", side_effect=[_checks("pending"), _checks("failing", failing=(failed,))]):
+        outcome = watch_pr_checks(runner, make_config(tmp_path, watch_pending_ci=True, ci_timeout_seconds=60, ci_poll_interval_seconds=30), 7, metadata=_metadata())
+    assert outcome.status == "failed"
+    assert outcome.failed_checks == (failed,)
+    assert [command[0] for command in runner.commands] == ["sleep"]
+
+
+def test_watch_success_and_head_change_are_terminal(tmp_path):
+    runner = _Runner()
+    with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \
+         patch("coding_review_agent_loop.github.get_pr_mergeability", return_value=_mergeability()), \
+         patch("coding_review_agent_loop.github.get_pr_checks", return_value=_checks("passing")):
+        assert watch_pr_checks(runner, make_config(tmp_path, watch_pending_ci=True), 7, metadata=_metadata()).status == "passed"
+    with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="new-sha"):
+        assert watch_pr_checks(runner, make_config(tmp_path, watch_pending_ci=True), 7, metadata=_metadata()).status == "head_changed"
+
+
+def test_watch_timeout_retries_transient_snapshots_and_dry_run_does_not_poll(tmp_path):
+    runner = _Runner()
+    with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \
+         patch("coding_review_agent_loop.github.get_pr_mergeability", return_value=_mergeability()), \
+         patch("coding_review_agent_loop.github.get_pr_checks", return_value=_checks("unavailable", query="unavailable", protection="unavailable")):
+        outcome = watch_pr_checks(runner, make_config(tmp_path, watch_pending_ci=True, ci_timeout_seconds=60, ci_poll_interval_seconds=30), 7, metadata=_metadata())
+    assert outcome.status == "timeout"
+    assert len(runner.commands) == 1
+    dry = make_config(tmp_path, watch_pending_ci=True, dry_run=True)
+    assert watch_pr_checks(_Runner(), dry, 7, metadata=_metadata()).status == "dry_run"

--- a/tests/test_ci_watch.py
+++ b/tests/test_ci_watch.py
@@ -38,7 +38,12 @@ def _mergeability():
 
 def test_watch_pending_to_failure_reports_failed_records_and_sleeps(tmp_path):
     runner = _Runner()
-    failed = PullRequestCheck("test", "completed", "failure", "https://checks/1", None, None)
+    failed = PullRequestCheck(
+        name="test",
+        kind="check_run",
+        status="failure",
+        url="https://checks/1",
+    )
     with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \
          patch("coding_review_agent_loop.github.get_pr_mergeability", return_value=_mergeability()), \
          patch("coding_review_agent_loop.github.get_pr_checks", side_effect=[_checks("pending"), _checks("failing", failing=(failed,))]):

--- a/tests/test_ci_watch.py
+++ b/tests/test_ci_watch.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from coding_review_agent_loop.ci_health import PullRequestCheck, PullRequestChecks
+from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import PullRequestMetadata, PullRequestMergeability, watch_pr_checks
 from coding_review_agent_loop.runner import CommandResult, Runner
 
@@ -67,3 +68,30 @@ def test_watch_timeout_retries_transient_snapshots_and_dry_run_does_not_poll(tmp
     assert len(runner.commands) == 1
     dry = make_config(tmp_path, watch_pending_ci=True, dry_run=True)
     assert watch_pr_checks(_Runner(), dry, 7, metadata=_metadata()).status == "dry_run"
+
+
+def test_watch_accepts_forbidden_branch_protection_and_retries_flaky_head_probe(tmp_path):
+    runner = _Runner()
+    with patch(
+        "coding_review_agent_loop.github.get_pr_head_sha",
+        side_effect=[AgentLoopError("temporary gh failure"), "sha"],
+    ), patch(
+        "coding_review_agent_loop.github.get_pr_mergeability",
+        return_value=_mergeability(),
+    ), patch(
+        "coding_review_agent_loop.github.get_pr_checks",
+        side_effect=[_checks("pending"), _checks("passing", protection="forbidden")],
+    ):
+        outcome = watch_pr_checks(
+            runner,
+            make_config(
+                tmp_path,
+                watch_pending_ci=True,
+                ci_timeout_seconds=60,
+                ci_poll_interval_seconds=30,
+            ),
+            7,
+            metadata=_metadata(),
+        )
+    assert outcome.status == "passed"
+    assert [command[0] for command in runner.commands] == ["sleep"]

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -14,6 +14,7 @@ from coding_review_agent_loop.comment_rendering import (
 from coding_review_agent_loop.errors import QuotaResetExceededError
 from coding_review_agent_loop.followups import MAX_APPROVED_FOLLOWUP_ISSUES, reconcile_approved_followups
 from coding_review_agent_loop.github import (
+    CiWatchOutcome,
     HumanReviewRequirement,
     IssueComment,
     IssueContext,
@@ -877,6 +878,23 @@ def test_pr_loop_routes_failing_github_checks_through_coder_followup(tmp_path, m
     assert "Failing checks: tests/test_security.py (failure)" in followup_prompt
     assert "https://github.com/OWNER/REPO/actions/runs/555" in followup_prompt
     assert "Do not claim global test success unless GitHub PR checks are green." in followup_prompt
+
+
+def test_watch_mode_success_skips_legacy_wait_for_ci(tmp_path, monkeypatch):
+    runner = FakeRunner(codex_outputs=[structured_pr_review(state="approved", summary="Approved.")])
+    config = make_config(tmp_path, watch_pending_ci=True, auto_merge=False)
+    monkeypatch.setattr(
+        orchestrator,
+        "watch_pr_checks",
+        lambda *args, **kwargs: CiWatchOutcome(status="passed", attempts_used=1),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_ci",
+        lambda *args, **kwargs: pytest.fail("legacy CI waiter must not run in watch mode"),
+    )
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert any("watching GitHub checks" in comment for comment in runner.comments)
 
 
 def test_pr_loop_refreshes_checks_between_reviewers_and_before_coder(tmp_path, monkeypatch):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -14,10 +14,13 @@ from coding_review_agent_loop.comment_rendering import (
 from coding_review_agent_loop.errors import QuotaResetExceededError
 from coding_review_agent_loop.followups import MAX_APPROVED_FOLLOWUP_ISSUES, reconcile_approved_followups
 from coding_review_agent_loop.github import (
+    CiWaitOutcome,
     CiWatchOutcome,
     HumanReviewRequirement,
     IssueComment,
     IssueContext,
+    PullRequestCheck,
+    PullRequestChecks,
     PullRequestMetadata,
     PullRequestReviewContext,
     get_pr_checks,
@@ -880,9 +883,33 @@ def test_pr_loop_routes_failing_github_checks_through_coder_followup(tmp_path, m
     assert "Do not claim global test success unless GitHub PR checks are green." in followup_prompt
 
 
-def test_watch_mode_success_skips_legacy_wait_for_ci(tmp_path, monkeypatch):
+def _watch_check_board(
+    state,
+    *,
+    failing=(),
+    pending=(),
+    missing_required=(),
+    errors=(),
+):
+    return PullRequestChecks(
+        state=state,
+        required_checks=("test",),
+        passing=(),
+        pending=tuple(pending),
+        failing=tuple(failing),
+        missing_required=tuple(missing_required),
+        branch_protection_status="configured",
+        check_query_status="partial" if errors else "ok",
+        check_query_errors=tuple(errors),
+    )
+
+
+@pytest.mark.parametrize("auto_merge", [False, True])
+def test_watch_mode_success_skips_legacy_wait_for_ci(
+    tmp_path, monkeypatch, auto_merge
+):
     runner = FakeRunner(codex_outputs=[structured_pr_review(state="approved", summary="Approved.")])
-    config = make_config(tmp_path, watch_pending_ci=True, auto_merge=False)
+    config = make_config(tmp_path, watch_pending_ci=True, auto_merge=auto_merge)
     monkeypatch.setattr(
         orchestrator,
         "watch_pr_checks",
@@ -895,6 +922,338 @@ def test_watch_mode_success_skips_legacy_wait_for_ci(tmp_path, monkeypatch):
     )
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
     assert any("watching GitHub checks" in comment for comment in runner.comments)
+    merge_commands = [
+        cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "pr", "merge"]
+    ]
+    assert bool(merge_commands) is auto_merge
+
+
+def test_watch_failure_on_final_round_dispatches_coder_with_check_diagnostic(
+    tmp_path, monkeypatch
+):
+    failure_url = "https://github.com/OWNER/REPO/actions/runs/555"
+    failed_check = PullRequestCheck(
+        name="test",
+        kind="check_run",
+        status="failure",
+        url=failure_url,
+    )
+    outcomes = iter(
+        [
+            CiWatchOutcome(
+                status="failed",
+                pr_checks=_watch_check_board("failing", failing=(failed_check,)),
+                failed_checks=(failed_check,),
+                attempts_used=1,
+            ),
+            CiWatchOutcome(status="passed", attempts_used=1),
+        ]
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Approved."),
+            structured_pr_review(
+                state="approved",
+                summary="Approved after CI fix.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"}
+                ],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Fixed the CI failure.",
+                addressed_items=["item-1"],
+            )
+        ],
+    )
+    config = make_config(tmp_path, watch_pending_ci=True, max_rounds=1)
+    monkeypatch.setattr(
+        orchestrator, "watch_pr_checks", lambda *args, **kwargs: next(outcomes)
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    coder_prompts = [cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(coder_prompts) == 1
+    assert "GitHub PR checks unresolved blocking item [item-1] from round 1" in coder_prompts[0]
+    assert "Failing checks: test (failure)" in coder_prompts[0]
+    assert failure_url in coder_prompts[0]
+    assert any(
+        comment.startswith("GitHub PR checks are failing for PR #77.")
+        and failure_url in comment
+        for comment in runner.comments
+    )
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 2
+
+
+def test_watch_head_change_re_reviews_without_coder_and_preserves_budget(
+    tmp_path, monkeypatch
+):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Old head approved."),
+            structured_pr_review(state="approved", summary="New head approved."),
+        ]
+    )
+    config = make_config(
+        tmp_path,
+        watch_pending_ci=True,
+        max_rounds=1,
+        ci_timeout_seconds=60,
+        ci_poll_interval_seconds=10,
+    )
+    watch_calls = []
+
+    def watch(*args, **kwargs):
+        watch_calls.append((kwargs["deadline"], kwargs["attempts"]))
+        if len(watch_calls) == 1:
+            runner.pr_payload["headRefOid"] = "new-head"
+            return CiWatchOutcome(
+                status="head_changed", head_sha="new-head", attempts_used=2
+            )
+        return CiWatchOutcome(status="passed", head_sha="new-head", attempts_used=1)
+
+    monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 2
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert watch_calls[0][0] == watch_calls[1][0]
+    assert [attempts for _deadline, attempts in watch_calls] == [6, 4]
+
+
+def test_watch_combined_failure_and_head_change_can_use_both_extensions(
+    tmp_path, monkeypatch
+):
+    failed_check = PullRequestCheck(
+        name="test", kind="check_run", status="failure", url="https://example.test/run"
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Round one approved."),
+            structured_pr_review(
+                state="approved",
+                summary="Round two approved.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"}
+                ],
+            ),
+            structured_pr_review(state="approved", summary="Round three approved."),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Fixed CI.",
+                addressed_items=["item-1"],
+            )
+        ],
+    )
+    config = make_config(tmp_path, watch_pending_ci=True, max_rounds=1)
+    call_count = 0
+
+    def watch(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return CiWatchOutcome(
+                status="failed",
+                pr_checks=_watch_check_board("failing", failing=(failed_check,)),
+                failed_checks=(failed_check,),
+                attempts_used=1,
+            )
+        if call_count == 2:
+            runner.pr_payload["headRefOid"] = "newer-head"
+            return CiWatchOutcome(
+                status="head_changed", head_sha="newer-head", attempts_used=1
+            )
+        return CiWatchOutcome(status="passed", head_sha="newer-head", attempts_used=1)
+
+    monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert call_count == 3
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 3
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 1
+
+
+@pytest.mark.parametrize(
+    ("invocation_argv", "expected_rerun", "expected_note"),
+    [
+        (
+            ("agent-loop", "pr", "77", "--claude-arg", "token value"),
+            "agent-loop pr 77 --claude-arg 'token value'",
+            "",
+        ),
+        (
+            (),
+            "agent-loop pr 77 --watch-pending-ci",
+            "deterministic fallback; original invocation unavailable",
+        ),
+    ],
+)
+def test_watch_timeout_renders_local_rerun_without_leaking_it_to_comment(
+    tmp_path, monkeypatch, capsys, invocation_argv, expected_rerun, expected_note
+):
+    pending_check = PullRequestCheck(
+        name="test", kind="check_run", status="in_progress"
+    )
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]
+    )
+    config = make_config(
+        tmp_path,
+        watch_pending_ci=True,
+        invocation_argv=invocation_argv,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "watch_pr_checks",
+        lambda *args, **kwargs: CiWatchOutcome(
+            status="timeout",
+            pr_checks=_watch_check_board(
+                "pending",
+                pending=(pending_check,),
+                errors=("transient check-runs API failure",),
+            ),
+            attempts_used=1,
+        ),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    output = capsys.readouterr().out
+    assert expected_rerun in output
+    assert expected_note in output
+    assert "Pending checks: test (in_progress)" in output
+    assert all(expected_rerun not in comment for comment in runner.comments)
+    assert all("token value" not in comment for comment in runner.comments)
+
+
+def test_watch_dry_run_previews_without_poll_sleep_coder_or_merge(tmp_path, capsys):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]
+    )
+    config = make_config(
+        tmp_path,
+        watch_pending_ci=True,
+        auto_merge=True,
+        dry_run=True,
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    commands = [cmd for cmd, _cwd in runner.commands]
+    assert not any(cmd[:1] == ["sleep"] for cmd in commands)
+    assert not any(cmd[:1] == ["claude"] for cmd in commands)
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd in commands)
+    assert "dry-run preview did not perform live CI watching" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("auto_merge", [False, True])
+def test_disabled_watch_mode_preserves_legacy_pending_and_auto_merge_paths(
+    tmp_path, monkeypatch, auto_merge
+):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")],
+        pr_check_runs_payload={
+            "check_runs": [
+                {"name": "test", "status": "in_progress", "conclusion": None}
+            ]
+        },
+    )
+    config = make_config(tmp_path, watch_pending_ci=False, auto_merge=auto_merge)
+    monkeypatch.setattr(
+        orchestrator,
+        "watch_pr_checks",
+        lambda *args, **kwargs: pytest.fail("disabled watch mode must not invoke watcher"),
+    )
+    wait_calls = []
+
+    def legacy_wait(*args, **kwargs):
+        wait_calls.append((args, kwargs))
+        return CiWaitOutcome(status="passed")
+
+    monkeypatch.setattr(orchestrator, "wait_for_ci", legacy_wait)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert bool(wait_calls) is auto_merge
+    merge_commands = [
+        cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "pr", "merge"]
+    ]
+    assert bool(merge_commands) is auto_merge
+    if not auto_merge:
+        assert any("checks are still pending" in comment for comment in runner.comments)
+
+
+def test_watch_publishes_approved_followups_only_after_terminal_success(
+    tmp_path, monkeypatch
+):
+    failed_check = PullRequestCheck(
+        name="test", kind="check_run", status="failure", url="https://example.test/run"
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="approved",
+                summary="Approved with follow-up.",
+                future_followups=["Document the optional tuning knob."],
+            ),
+            structured_pr_review(
+                state="approved",
+                summary="Approved after CI fix.",
+                future_followups=["Document the optional tuning knob."],
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "future"},
+                    {"item_id": "item-2", "disposition": "resolved"}
+                ],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Fixed CI.",
+                addressed_items=["item-2"],
+            )
+        ],
+    )
+    config = make_config(
+        tmp_path,
+        watch_pending_ci=True,
+        max_rounds=1,
+        approved_followups="summarize",
+    )
+    call_count = 0
+
+    def watch(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        assert not any(
+            comment.startswith("Approved-review future follow-ups")
+            for comment in runner.comments
+        )
+        if call_count == 1:
+            return CiWatchOutcome(
+                status="failed",
+                pr_checks=_watch_check_board("failing", failing=(failed_check,)),
+                failed_checks=(failed_check,),
+                attempts_used=1,
+            )
+        return CiWatchOutcome(status="passed", attempts_used=1)
+
+    monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    followup_comments = [
+        comment
+        for comment in runner.comments
+        if comment.startswith("Approved-review future follow-ups")
+    ]
+    assert len(followup_comments) == 1
+    assert "Document the optional tuning knob." in followup_comments[0]
 
 
 def test_pr_loop_refreshes_checks_between_reviewers_and_before_coder(tmp_path, monkeypatch):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1079,6 +1079,60 @@ def test_watch_combined_failure_and_head_change_can_use_both_extensions(
     assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 1
 
 
+def test_watch_combined_head_change_and_failure_can_use_both_extensions(
+    tmp_path, monkeypatch
+):
+    failed_check = PullRequestCheck(
+        name="test", kind="check_run", status="failure", url="https://example.test/run"
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Round one approved."),
+            structured_pr_review(state="approved", summary="Round two approved."),
+            structured_pr_review(
+                state="approved",
+                summary="Round three approved.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"}
+                ],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Fixed CI.",
+                addressed_items=["item-1"],
+            )
+        ],
+    )
+    config = make_config(tmp_path, watch_pending_ci=True, max_rounds=1)
+    call_count = 0
+
+    def watch(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            runner.pr_payload["headRefOid"] = "newer-head"
+            return CiWatchOutcome(
+                status="head_changed", head_sha="newer-head", attempts_used=1
+            )
+        if call_count == 2:
+            return CiWatchOutcome(
+                status="failed",
+                pr_checks=_watch_check_board("failing", failing=(failed_check,)),
+                failed_checks=(failed_check,),
+                attempts_used=1,
+            )
+        return CiWatchOutcome(status="passed", head_sha="newer-head", attempts_used=1)
+
+    monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert call_count == 3
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 3
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 1
+
+
 @pytest.mark.parametrize(
     ("invocation_argv", "expected_rerun", "expected_note"),
     [


### PR DESCRIPTION
## Summary
- add opt-in foreground full-board CI watching after PR approval
- resume the coder on actionable CI failures and retain legacy wait behavior when disabled
- document watch-mode behavior and cover watcher transitions

Fixes #587

## Tests
- ........................................................................ [ 39%]
........................................................................ [ 79%]
......................................                                   [100%]
182 passed in 3.22s