### PR TITLE
Enable CI watch by default with auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,16 +624,17 @@ still-computing (`UNKNOWN`) GitHub mergeability result is re-checked before
 being treated as unresolved. See
 [Merge conflicts](docs/local_agent_loop.md#merge-conflicts) for details.
 
-Use `--watch-pending-ci` to opt into a foreground post-approval watcher. It
-polls the complete check board with `--ci-timeout-seconds` and
+With `--auto-merge`, agent-loop foreground-polls the complete check board after
+approval with
+`--ci-timeout-seconds` and
 `--ci-poll-interval-seconds`, without invoking agents while checks are pending.
 Failure resumes the coder with the failed-check details; a successful/no-check
-board is reported as merge-ready (or merged with `--auto-merge`). The watcher
-is synchronous and interruptible: Ctrl-C leaves no worker behind, and a rerun
-starts from fresh PR state. On timeout the local terminal prints a shell-quoted
-rerun command; PR comments intentionally contain no captured command arguments.
-Without this flag, existing pending-CI and legacy `--ci-check-name` behavior is
-unchanged.
+board is merged. The watcher is synchronous and interruptible: Ctrl-C leaves
+no worker behind, and a rerun starts from fresh PR state. On timeout the local
+terminal prints a shell-quoted rerun command; PR comments intentionally contain
+no captured command arguments. Use `--no-watch-pending-ci` with `--auto-merge`
+to retain the previous behavior. Without `--auto-merge`, agent-loop reports an
+approved PR as merge-ready and does not wait for CI.
 
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 

--- a/README.md
+++ b/README.md
@@ -634,7 +634,9 @@ no worker behind, and a rerun starts from fresh PR state. On timeout the local
 terminal prints a shell-quoted rerun command; PR comments intentionally contain
 no captured command arguments. Use `--no-watch-pending-ci` with `--auto-merge`
 to retain the previous behavior. Without `--auto-merge`, agent-loop reports an
-approved PR as merge-ready and does not wait for CI.
+approved PR as merge-ready and does not wait for CI, unless `--watch-pending-ci`
+is passed explicitly, in which case it still watches the check board and
+reports merge-ready without merging.
 
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1206,26 +1206,40 @@ agent-loop pr 123 \
   --ci-check-name test
 ```
 
-When enabled, the tool waits for the configured GitHub check-run to pass before merging. Local `--test-command` is an additional local gate, not a replacement for CI. By default, `--test-command` also runs after coder-created or coder-updated changes before reviewer rounds, so reviewers are less likely to spend rounds on code that already fails the configured local test command. Use `--no-pre-review-tests` to keep `--test-command` as a post-approval gate only.
+When enabled with the full-board watcher (the default — see "Watch pending CI"
+below), the tool foreground-polls the whole PR check board before merging.
+With `--no-watch-pending-ci`, it instead waits for the single configured
+`--ci-check-name` check-run to pass before merging, as in earlier releases.
+Local `--test-command` is an additional local gate, not a replacement for CI.
+By default, `--test-command` also runs after coder-created or coder-updated
+changes before reviewer rounds, so reviewers are less likely to spend rounds
+on code that already fails the configured local test command. Use
+`--no-pre-review-tests` to keep `--test-command` as a post-approval gate only.
 
-Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps waiting for the configured check-run to resolve before merging, as before.
+Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps watching until checks resolve before merging.
 
 ### Watch pending CI
 
-`--watch-pending-ci` is an opt-in alternative after approval. It foreground-polls
-the full PR check/status/required-check board using the existing timeout and poll
-interval controls. It does not call reviewers or the coder while checks remain
-pending. A completed actionable failure resumes the normal coder loop with the
-check name, conclusion, and URL; success or a reliable no-check board is
-merge-ready, or merges directly with `--auto-merge` (the legacy single
-`--ci-check-name` waiter is not used in this mode). A new head is re-reviewed,
-and the final-round CI-failure path receives one bounded extra round.
+`--watch-pending-ci` is enabled by default whenever `--auto-merge` is set;
+pass `--no-watch-pending-ci` to fall back to the legacy single
+`--ci-check-name` waiter described above. It can also be passed explicitly
+without `--auto-merge`, in which case it watches checks after approval and
+reports merge-ready without merging.
+
+When active, it foreground-polls the full PR check/status/required-check board
+using the existing timeout and poll interval controls. It does not call
+reviewers or the coder while checks remain pending. A completed actionable
+failure resumes the normal coder loop with the check name, conclusion, and
+URL; success or a reliable no-check board is merge-ready, or merges directly
+with `--auto-merge`. A new head is re-reviewed, and the final-round
+CI-failure path receives one bounded extra round.
 
 The watch runs synchronously with interruptible `sleep` subprocesses, so Ctrl-C
 and restarts leave no hidden worker. Timeout and transient API snapshots remain
 bounded and print a shell-quoted rerun command only locally; GitHub comments do
 not repeat invocation arguments. Dry-run previews the watch without polling,
-sleeping, resuming agents, or merging. Disabled mode retains the behavior above.
+sleeping, resuming agents, or merging. `--no-watch-pending-ci` retains the
+legacy named-check-only behavior described above.
 
 ### External CI infrastructure stalls
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -335,7 +335,6 @@ def build_parser() -> argparse.ArgumentParser:
         )
         subparser.add_argument(
             "--watch-pending-ci",
-            "--no-watch-pending-ci",
             action=argparse.BooleanOptionalAction,
             dest="watch_pending_ci",
             default=None,

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -335,10 +335,13 @@ def build_parser() -> argparse.ArgumentParser:
         )
         subparser.add_argument(
             "--watch-pending-ci",
-            action="store_true",
+            "--no-watch-pending-ci",
+            action=argparse.BooleanOptionalAction,
+            dest="watch_pending_ci",
+            default=None,
             help=(
-                "After approval, foreground-poll the full GitHub check board and resume "
-                "the coder if CI fails. Disabled by default."
+                "With --auto-merge, foreground-poll the full GitHub check board after approval "
+                "and resume the coder if CI fails (enabled by default with --auto-merge)."
             ),
         )
         subparser.add_argument(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -165,8 +165,9 @@ class AgentLoopConfig:
     # from a confirmed conflict, which is never re-polled here (#606).
     mergeability_poll_attempts: int = 3
     mergeability_poll_interval_seconds: int = 5
-    # Opt-in foreground full-board CI watch after reviewer approval (#587).
-    # These are defaulted to keep direct AgentLoopConfig constructors compatible.
+    # Foreground full-board CI watch after reviewer approval (#587). CLI
+    # invocations enable this automatically with --auto-merge; direct config
+    # constructions remain conservative unless they set it explicitly.
     watch_pending_ci: bool = False
     invocation_argv: tuple[str, ...] = ()
 
@@ -938,7 +939,12 @@ def config_from_args(
         ci_check_name=args.ci_check_name,
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
-        watch_pending_ci=getattr(args, "watch_pending_ci", False),
+        watch_pending_ci=(
+            bool(getattr(args, "auto_merge", False))
+            if getattr(args, "watch_pending_ci", None) is None
+            else bool(getattr(args, "auto_merge", False))
+            and bool(args.watch_pending_ci)
+        ),
         invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -942,8 +942,7 @@ def config_from_args(
         watch_pending_ci=(
             bool(getattr(args, "auto_merge", False))
             if getattr(args, "watch_pending_ci", None) is None
-            else bool(getattr(args, "auto_merge", False))
-            and bool(args.watch_pending_ci)
+            else bool(args.watch_pending_ci)
         ),
         invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1284,6 +1284,18 @@ def test_config_allows_disabling_auto_merge_ci_watch(tmp_path):
     assert config.watch_pending_ci is False
 
 
+def test_config_honors_explicit_ci_watch_without_auto_merge(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "77", "--repo", "OWNER/REPO", "--watch-pending-ci",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.watch_pending_ci is True
+    assert config.auto_merge is False
+
+
 @pytest.mark.parametrize(
     ("coder", "reviewer", "missing_command", "override_flag"),
     [

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1248,20 +1248,40 @@ def test_omitted_agent_dirs_default_to_repo_scoped_temp_checkouts(monkeypatch, t
     ).resolve()
 
 
-def test_config_captures_watch_invocation_without_rebuilding_antigravity_model(tmp_path):
+def test_config_enables_ci_watch_with_auto_merge_without_rebuilding_antigravity_model(tmp_path):
     parser = build_parser()
     args = parser.parse_args([
-        "pr", "77", "--repo", "OWNER/REPO", "--antigravity-model", "Gemini 3.1 Pro (High)",
-        "--watch-pending-ci",
+        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge",
+        "--antigravity-model", "Gemini 3.1 Pro (High)",
     ])
     config = config_from_args(
         args,
         FakeRunner(),
-        invocation_argv=("agent-loop", "pr", "77", "--watch-pending-ci"),
+        invocation_argv=("agent-loop", "pr", "77"),
     )
     assert config.watch_pending_ci is True
-    assert config.invocation_argv[-1] == "--watch-pending-ci"
+    assert config.invocation_argv[-1] == "77"
     assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
+
+
+def test_config_does_not_enable_ci_watch_without_auto_merge(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args(["pr", "77", "--repo", "OWNER/REPO"])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.watch_pending_ci is False
+
+
+def test_config_allows_disabling_auto_merge_ci_watch(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge", "--no-watch-pending-ci",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.watch_pending_ci is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Enable the post-approval full GitHub CI watcher automatically for `--auto-merge` runs.

When an approved PR's check fails, agent-loop now returns the PR to the coder with the failed-check details rather than exiting after the CI wait. Attended runs without `--auto-merge` remain unchanged and do not wait for CI.

`--no-watch-pending-ci` preserves the old auto-merge behavior for callers that need it. The existing `--watch-pending-ci` spelling remains accepted.

## Verification

- `pytest tests/test_agent_loop.py -q` (`242 passed`)
- `pytest tests/test_ci_watch.py tests/test_orchestrator_pr.py -q` (`168 passed`)
