### PR TITLE
Fix timeout wrapper command parsing

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1084,11 +1084,12 @@ executable in *program position* -- for example `/usr/bin/python3`, a venv's
 treated as a test location, and neither is the value of a narrow set of
 interpreter-valued flags/env-vars (`--python`, `PYTHONPATH=`, and similar).
 The supported wrappers are parsed only far enough to locate their nested
-program: `timeout`, `sudo`, `nice`, `stdbuf`, `env`, and `xargs`. GNU `timeout`
-consumes one duration after its options (including bare, suffixed, and
-fractional values); value-taking wrapper options are likewise consumed only
-for their defined options such as `timeout -k`/`-s`, `sudo -u`/`-g`, `nice -n`,
-`stdbuf -i`/`-o`/`-e`, `env -u`/`-C`, and `xargs -n`/`-P`/`-I`. These exemptions
+program: `timeout`, `sudo`, `nohup`, `nice`, `time`, `stdbuf`, `command`,
+`env`, and `xargs`. GNU `timeout` consumes one duration after its options
+(including bare, suffixed, and fractional values); value-taking wrapper options
+are likewise consumed only for their defined options such as `timeout -k`/`-s`,
+`sudo -u`/`-g`, `nice -n`, `stdbuf -i`/`-o`/`-e`, `env -u`/`-C`, and
+`xargs -n`/`-P`/`-I`. These exemptions
 are gated on command position or on a specific interpreter-valued construct,
 not on path components: wrapper operands, option values, workdirs,
 test/script targets, outputs, remote targets, malformed commands, and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1083,10 +1083,18 @@ executable in *program position* -- for example `/usr/bin/python3`, a venv's
 `.venv/bin/pytest`, or a wrapper like `sudo`/`env` in front of one -- is not
 treated as a test location, and neither is the value of a narrow set of
 interpreter-valued flags/env-vars (`--python`, `PYTHONPATH=`, and similar).
-These exemptions are gated on command position or on a specific
-interpreter-valued construct, not on path components, so a toolchain-shaped
-path used as an ordinary argument (`pytest /outside/bin/tests/test_foo.py`)
-still fails containment. Package acquisition (`pip install ...`, including the
+The supported wrappers are parsed only far enough to locate their nested
+program: `timeout`, `sudo`, `nice`, `stdbuf`, `env`, and `xargs`. GNU `timeout`
+consumes one duration after its options (including bare, suffixed, and
+fractional values); value-taking wrapper options are likewise consumed only
+for their defined options such as `timeout -k`/`-s`, `sudo -u`/`-g`, `nice -n`,
+`stdbuf -i`/`-o`/`-e`, `env -u`/`-C`, and `xargs -n`/`-P`/`-I`. These exemptions
+are gated on command position or on a specific interpreter-valued construct,
+not on path components: wrapper operands, option values, workdirs,
+test/script targets, outputs, remote targets, malformed commands, and
+arbitrary `/tmp` paths receive no blanket exemption, so a toolchain-shaped path
+used as an ordinary argument (`pytest /outside/bin/tests/test_foo.py`) still
+fails containment. Package acquisition (`pip install ...`, including the
 `python -m pip install ...` form) is exempted from the separate live-target
 check described below, but never from path containment.
 A URL is rejected as a live remote target when it appears in command syntax

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -566,7 +566,7 @@ def _is_command_clause(clause: _Clause) -> bool:
         return True
     tokens = clause.tokens
     traversal = _wrapper_traversal(tokens)
-    if traversal.recognized_prefix:
+    if traversal.recognized_prefix and traversal.effective_head_index is None:
         # A malformed recognized wrapper remains command syntax.  It gets no
         # nested-program exemption, but must not hide live URLs as prose.
         return True

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -214,30 +214,109 @@ def _is_windows_toolchain_executable(token: str) -> bool:
     return any(pattern.search(parent) for pattern in _WINDOWS_TOOLCHAIN_PARENT_RES)
 
 
-def _program_position_indices(tokens: Sequence[str]) -> tuple[set[int], int]:
-    """Indices occupied by wrapper programs plus the final effective head index."""
+_WRAPPER_VALUE_OPTIONS = {
+    "timeout": {"-k", "--kill-after", "-s", "--signal"},
+    "sudo": {"-u", "-g"},
+    "nice": {"-n"},
+    "stdbuf": {"-i", "-o", "-e"},
+    "env": {"-u", "-C"},
+    "xargs": {"-n", "-P", "-I"},
+}
+_TIMEOUT_DURATION_RE = re.compile(r"(?:\d+(?:\.\d*)?|\.\d+)(?:[smhd])?$")
+
+
+@dataclass(frozen=True)
+class _WrapperTraversal:
+    """Wrapper-prefix recognition is deliberately distinct from a valid head."""
+
+    recognized_prefix: bool
+    program_positions: set[int]
+    effective_head_index: int | None
+
+
+def _program_basename(token: str) -> str:
+    """Return a platform-neutral executable basename without treating /foo as an option."""
+    return _strip_wrap(token).rstrip(".,;:!?").replace("\\", "/").rsplit("/", 1)[-1].lower()
+
+
+def _consume_wrapper_options(tokens: Sequence[str], start: int, wrapper: str) -> int | None:
+    """Consume GNU-style wrapper options, preserving unknown options as valueless."""
+    i = start
+    value_options = _WRAPPER_VALUE_OPTIONS.get(wrapper, set())
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "--":
+            return i + 1
+        # Deliberately do not recognize slash-prefixed Windows tokens as options.
+        if not token.startswith("-") or _is_path_like_token(token):
+            return i
+        option, sep, _value = token.partition("=")
+        if option in value_options:
+            if sep:
+                i += 1
+                continue
+            # Attached short values, such as -k10s or -n10, are valid.
+            if option.startswith("-") and not option.startswith("--") and len(token) > len(option):
+                i += 1
+                continue
+            if i + 1 >= len(tokens):
+                return None
+            i += 2
+            continue
+        if token.startswith("-") and not token.startswith("--"):
+            attached_option = next(
+                (known for known in value_options if token.startswith(known) and len(token) > len(known)),
+                None,
+            )
+            if attached_option is not None:
+                i += 1
+                continue
+        # Every other dash-prefixed option remains a no-value option.
+        i += 1
+    return i
+
+
+def _parse_wrapper(tokens: Sequence[str], index: int, wrapper: str) -> int | None:
+    next_index = _consume_wrapper_options(tokens, index + 1, wrapper)
+    if next_index is None:
+        return None
+    if wrapper == "timeout":
+        if next_index >= len(tokens) or not _TIMEOUT_DURATION_RE.fullmatch(tokens[next_index]):
+            return None
+        next_index += 1
+    if next_index >= len(tokens):
+        return None
+    return next_index
+
+
+def _wrapper_traversal(tokens: Sequence[str]) -> _WrapperTraversal:
     positions: set[int] = set()
     i = 0
-    n = len(tokens)
-    while i < n:
+    recognized_prefix = False
+    while i < len(tokens):
         if VAR_ASSIGNMENT_RE.match(tokens[i]):
             i += 1
             continue
-        if Path(_strip_wrap(tokens[i])).name in WRAPPER_PROGRAMS:
+        wrapper = _program_basename(tokens[i])
+        if wrapper not in WRAPPER_PROGRAMS:
             positions.add(i)
-            i += 1
-            while i < n and tokens[i].startswith("-") and not _is_path_like_token(tokens[i]):
-                i += 1
-            continue
-        break
-    if i < n:
+            return _WrapperTraversal(recognized_prefix, positions, i)
+        recognized_prefix = True
         positions.add(i)
-    return positions, i
+        next_index = _parse_wrapper(tokens, i, wrapper)
+        if next_index is None:
+            return _WrapperTraversal(True, positions, None)
+        i = next_index
+    return _WrapperTraversal(recognized_prefix, positions, None)
 
 
-def _effective_head_index(tokens: Sequence[str]) -> int:
-    _, head_index = _program_position_indices(tokens)
-    return head_index
+def _program_position_indices(tokens: Sequence[str]) -> tuple[set[int], int | None]:
+    traversal = _wrapper_traversal(tokens)
+    return traversal.program_positions, traversal.effective_head_index
+
+
+def _effective_head_index(tokens: Sequence[str]) -> int | None:
+    return _wrapper_traversal(tokens).effective_head_index
 
 
 # ---------------------------------------------------------------------------
@@ -421,20 +500,8 @@ def _windows_path_is_exempt(command: str, raw_windows: str, origin: Origin) -> b
         idx = next((i for i, t in enumerate(tokens) if t.strip("`'\".,") == raw_windows), None)
         if idx is None:
             continue
-        i = 0
-        n = len(tokens)
-        while i < n:
-            tok = tokens[i]
-            if VAR_ASSIGNMENT_RE.match(tok):
-                i += 1
-                continue
-            if tok in WRAPPER_PROGRAMS:
-                i += 1
-                while i < n and tokens[i].startswith("-"):
-                    i += 1
-                continue
-            break
-        if idx != i:
+        traversal = _wrapper_traversal(tokens)
+        if traversal.effective_head_index != idx:
             return False
         if idx > 0 and tokens[idx - 1] in WORKDIR_FLAGS:
             return False
@@ -451,7 +518,7 @@ def _acquisition_exempt(clause: _Clause) -> bool:
     tokens = clause.tokens
     n = len(tokens)
     idx = _effective_head_index(tokens)
-    if idx >= n:
+    if idx is None or idx >= n:
         return False
     head = tokens[idx]
     head_name = Path(_strip_wrap(head)).name
@@ -498,8 +565,13 @@ def _is_command_clause(clause: _Clause) -> bool:
     if clause.mode == "structured" and clause.command_by_contract:
         return True
     tokens = clause.tokens
-    idx = _effective_head_index(tokens)
-    if idx >= len(tokens):
+    traversal = _wrapper_traversal(tokens)
+    if traversal.recognized_prefix:
+        # A malformed recognized wrapper remains command syntax.  It gets no
+        # nested-program exemption, but must not hide live URLs as prose.
+        return True
+    idx = traversal.effective_head_index
+    if idx is None or idx >= len(tokens):
         return False
     return _is_command_shaped(tokens[idx])
 
@@ -559,7 +631,7 @@ def _head_opened_span_targets(clause: _Clause) -> list[str]:
     tokens = clause.tokens
     n = len(tokens)
     head_idx = _effective_head_index(tokens)
-    if head_idx >= n:
+    if head_idx is None or head_idx >= n:
         return []
     return _walk_span(tokens, head_idx, n)
 

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -168,6 +168,101 @@ def test_accepts_windows_interpreter_absolute_path(tmp_path):
     validate_test_commands_within_workdir((command,), assigned_workdir=assigned)
 
 
+# ---------------------------------------------------------------------------
+# Issue #616: operand-aware wrapper traversal.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command", [
+    "timeout 180s /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "timeout 180s /other/checkout/.venv/bin/pytest tests/test_foo.py",
+    "timeout -k 10s -s TERM 180s /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "timeout -k10s -sTERM 180s /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "timeout --kill-after=10s --signal=TERM 180 /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "timeout -- 0.5 /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "timeout --foreground 1h /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "timeout 180s env VAR=1 /other/checkout/.venv/bin/python -m pytest tests/test_foo.py",
+    "sudo -u root /usr/bin/python3 -m pytest tests/test_foo.py",
+    "sudo -E /usr/bin/python3 -m pytest tests/test_foo.py",
+    "nice -n 10 /usr/bin/python3 -m pytest tests/test_foo.py",
+    "nice -10 /usr/bin/python3 -m pytest tests/test_foo.py",
+    "stdbuf -o L /usr/bin/python3 -m pytest tests/test_foo.py",
+    "env -i /usr/bin/python3 -m pytest tests/test_foo.py",
+    "xargs -n 1 /usr/bin/python3 -m pytest tests/test_foo.py",
+])
+def test_accepts_operand_aware_wrapper_interpreters(tmp_path, command):
+    validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+def test_accepts_gnu_timeout_windows_interpreter(tmp_path):
+    validate_test_commands_within_workdir(
+        (r"timeout 180s C:\Python311\python.exe -m pytest tests\test_foo.py",),
+        assigned_workdir=_assigned(tmp_path),
+    )
+
+
+@pytest.mark.parametrize("command", [
+    "timeout 180s /outside/checkout/run_tests.sh",
+    "timeout 180s pytest /outside/checkout/tests/test_foo.py",
+    "timeout 180s cd /outside/checkout && pytest tests/test_foo.py",
+    "timeout 180s pytest --rootdir /outside/checkout tests/test_foo.py",
+    "timeout 180s pytest tests/test_foo.py > /outside/results.log",
+    "timeout -k /outside/value 180s /usr/bin/python3 -m pytest tests/test_foo.py",
+    "timeout /outside/checkout/run_tests.sh",
+])
+def test_rejects_timeout_wrapped_outside_paths(tmp_path, command):
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+@pytest.mark.parametrize("command", [
+    "timeout curl https://live.example",
+    "timeout badduration curl https://live.example",
+    "timeout -k",
+    "timeout 180s",
+    "sudo -u",
+])
+def test_malformed_wrappers_do_not_grant_exemptions(tmp_path, command):
+    assigned = _assigned(tmp_path)
+    if "https://" in command:
+        with pytest.raises(AgentLoopError, match="live remote target"):
+            validate_test_commands_within_workdir((command,), assigned_workdir=assigned)
+    else:
+        validate_test_commands_within_workdir((command,), assigned_workdir=assigned)
+
+
+def test_rejects_windows_native_timeout_option(tmp_path):
+    with pytest.raises(AgentLoopError, match="cannot be validated"):
+        validate_test_commands_within_workdir(
+            (r"timeout /t 180 C:\Python311\python.exe -m pytest tests\test_foo.py",),
+            assigned_workdir=_assigned(tmp_path),
+        )
+
+
+def test_timeout_wrapped_urls_in_response_are_command_classified(tmp_path):
+    assigned = _assigned(tmp_path)
+    for command in (
+        "timeout 180s curl https://live.example",
+        "timeout curl https://live.example",
+        "timeout badduration curl https://live.example",
+    ):
+        with pytest.raises(AgentLoopError, match="live remote target"):
+            validate_response_tests_within_workdir(f"Tests: `{command}`", assigned_workdir=assigned)
+
+
+def test_timeout_wrapped_package_acquisition_keeps_path_checks(tmp_path):
+    assigned = _assigned(tmp_path)
+    validate_test_commands_within_workdir(
+        ("timeout 180s python -m pip install https://packages.example/pkg.whl",),
+        assigned_workdir=assigned,
+    )
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        validate_test_commands_within_workdir(
+            ("timeout 180s python -m pip install --target /outside/site https://packages.example/pkg.whl",),
+            assigned_workdir=assigned,
+        )
+
+
 def test_accepts_ran_absolute_interpreter_through_response_path(tmp_path):
     assigned = _assigned(tmp_path)
     text = "Tests: ran /usr/bin/python3 -m pytest tests/test_foo.py - 12 passed."

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -250,6 +250,15 @@ def test_timeout_wrapped_urls_in_response_are_command_classified(tmp_path):
             validate_response_tests_within_workdir(f"Tests: `{command}`", assigned_workdir=assigned)
 
 
+@pytest.mark.parametrize("text", [
+    "Tests: time constraints meant we relied on the report at https://ci.example/123",
+    "Tests: env variables are documented at https://ci.example/123",
+    "Tests: Command output was saved to https://ci.example/123",
+])
+def test_accepts_wrapper_word_narrative_with_unattached_url(tmp_path, text):
+    validate_response_tests_within_workdir(text, assigned_workdir=_assigned(tmp_path))
+
+
 def test_timeout_wrapped_package_acquisition_keeps_path_checks(tmp_path):
     assigned = _assigned(tmp_path)
     validate_test_commands_within_workdir(


### PR DESCRIPTION
## Summary
- parse GNU timeout durations and supported wrapper operands before finding nested programs
- retain strict path validation and command classification when wrapper parsing is malformed
- add wrapper, Windows GNU timeout, containment, URL, and acquisition regressions

## Testing
- `timeout 300s python3 -m pytest tests/test_workdir_guard.py` (125 passed)
- attempted `timeout 900s python3 -m pytest -q`; the execution transport stopped around 30 seconds before pytest produced a terminal summary

Fixes #616