### PR TITLE
Publish parallel reviewer results on completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,9 +536,13 @@ PR reviewers concurrently instead of sequentially (`discuss` mode is rejected;
 it has its own `--discuss-parallel`, unaffected by this flag). Every
 reviewer's prompt is built from the same pre-round plan/PR state before any
 reviewer launches, and same-round reviewers never see each other's feedback.
-All outcomes are collected before any round state is mutated: healthy
-reviewers are applied — comment posted, items numbered — in configured
-reviewer order, then any fatal failure is raised only afterward (a quota
+Each validated healthy reviewer comment is published in completion order,
+without waiting for slower peers. The orchestrator then waits for the full
+round settlement barrier before mutating the shared ledger, numbering items,
+starting coder work, or another round; it posts a neutral reconciliation
+checkpoint with the deterministic configured-reviewer aggregation. A rerun
+recognizes these publication checkpoints regardless of whether
+`--review-parallel` is supplied. Any fatal failure is raised only afterward (a quota
 failure takes priority; otherwise the first configured-order failure), so a
 rerun resumes the reviewers that already succeeded instead of re-invoking
 them. Existing per-reviewer retry, repair, unavailable-reviewer, and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -759,11 +759,14 @@ Execution model:
   plan/PR state (current plan or PR diff, prior unresolved items, PR checks
   snapshot), then all pending turns are submitted to a thread pool. Same-round
   reviewers never see each other's in-progress output.
-- All outcomes are collected before any round state is mutated. Healthy
-  reviewers are applied — comment posted, unresolved items numbered, session
-  IDs recorded — from the main thread, in configured `--reviewer` order, so
-  transcripts and resume state stay deterministic regardless of completion
-  order.
+- A validated healthy review is posted by the main thread as soon as its worker
+  completes. Its provisional publication checkpoint is durable, so resume
+  avoids duplicate comments even if the next run is sequential.
+- The orchestrator still waits for every reviewer to settle before shared state
+  changes: it aggregates outcomes, numbers unresolved items, and may begin
+  coder work only in configured `--reviewer` order. It then posts a neutral
+  reconciliation checkpoint; this summary is not a reviewer verdict and is
+  excluded from reviewer/approval selection.
 - Only after every healthy outcome is applied does the orchestrator raise a
   fatal failure, if any: a quota-reset failure takes priority; otherwise the
   first failure in configured `--reviewer` order. Because healthy reviewers
@@ -779,8 +782,8 @@ Execution model:
   the remaining reviewers still launch. A single shared PR-checks snapshot is
   used for every concurrently launched reviewer's prompt in the round,
   instead of one fetch per reviewer as sequential mode does.
-- Resume works unchanged: already-posted round reviews are reused without
-  re-invoking their reviewers, and when every configured reviewer's review
+- Resume works in either mode: already-posted parallel publication checkpoints
+  are reused without re-invoking or reposting their reviewers, and when every configured reviewer's review
   resumes from comments (or a round is entirely skipped, e.g. head-advance
   recovery routing), no thread pool is constructed at all.
 - Parallel mode requires a distinct workdir per reviewer and rejects the run

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -11,7 +11,7 @@ import sys
 import time
 import zoneinfo
 from collections.abc import Callable, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace as dataclasses_replace
 from pathlib import Path
 
@@ -3753,8 +3753,9 @@ class _ReviewerTurnResult:
 
     Worker threads in the --review-parallel path return these instead of
     raising, so exceptions never cross the thread boundary; the main thread
-    applies the existing failure policy in configured reviewer order after
-    every launched turn settles (#594).
+    delivers completed turns to the main thread in completion order.  The
+    caller may publish an individual validated review immediately, but must
+    retain configured-order aggregation until every launched turn settles.
     """
 
     reviewer_name: str
@@ -3768,8 +3769,9 @@ def _launch_reviewer_turns(
     *,
     thread_name_prefix: str,
     run_turn: Callable[[AgentName], _ReviewerTurnResult],
+    on_completion: Callable[[AgentName, _ReviewerTurnResult], None] | None = None,
 ) -> dict[AgentName, _ReviewerTurnResult]:
-    """Run one worker per pending reviewer concurrently and join before returning.
+    """Run workers concurrently, delivering completion-order results before settlement.
 
     ``run_turn`` must never let an exception escape; it is responsible for
     capturing any failure into the returned ``_ReviewerTurnResult`` so the
@@ -3779,8 +3781,23 @@ def _launch_reviewer_turns(
     """
     executor = ThreadPoolExecutor(max_workers=len(pending), thread_name_prefix=thread_name_prefix)
     try:
-        futures = {reviewer: executor.submit(run_turn, reviewer) for reviewer in pending}
-        return {reviewer: future.result() for reviewer, future in futures.items()}
+        futures = {executor.submit(run_turn, reviewer): reviewer for reviewer in pending}
+        results: dict[AgentName, _ReviewerTurnResult] = {}
+        for future in as_completed(futures):
+            reviewer = futures[future]
+            result = future.result()
+            results[reviewer] = result
+            if on_completion is not None:
+                try:
+                    on_completion(reviewer, result)
+                except BaseException:
+                    # A publication failure must not leave reviewer subprocesses
+                    # running or allow a later reconciliation/coder turn.
+                    for other in futures:
+                        other.cancel()
+                    runner.terminate_active_processes()
+                    raise
+        return results
     except KeyboardInterrupt:
         runner.terminate_active_processes()
         raise
@@ -3951,6 +3968,14 @@ def _run_plan_first_loop(
 
         plan_fatal_errors: list[tuple[str, AgentLoopError]] = []
         plan_turn_results: dict[AgentName, _ReviewerTurnResult] = {}
+        early_published_plan_reviewers: set[AgentName] = {
+            reviewer
+            for reviewer in configured_reviewers
+            if (
+                (record := resumed_by_name.get(agent_display_name(reviewer))) is not None
+                and record.metadata.phase == "publication"
+            )
+        }
         if config.review_parallel:
             pending_plan_reviewers = [
                 reviewer for reviewer in configured_reviewers
@@ -4011,18 +4036,64 @@ def _run_plan_first_loop(
                         return _ReviewerTurnResult(reviewer_name=reviewer_name, error=exc)
                     return _ReviewerTurnResult(reviewer_name=reviewer_name, response=response)
 
+                def _publish_plan_completion(reviewer: AgentName, turn: _ReviewerTurnResult) -> None:
+                    """Publish a validated reviewer response without mutating round state.
+
+                    Numbering and ledger mutations stay below the settlement barrier.
+                    The raw validated response in metadata makes this checkpoint
+                    resumable even though its ``new_items`` are provisional.
+                    """
+                    if turn.error is not None or turn.response is None:
+                        return
+                    reviewer_name = agent_display_name(reviewer)
+                    parsed = turn.response.marker_value
+                    assert isinstance(parsed, ParsedPlanReview)
+                    parsed = dataclasses_replace(
+                        parsed,
+                        items=_drop_repeated_carried_plan_future_followups(
+                            parsed.items, prior_items=prior_unresolved_items,
+                            dispositions=parsed.dispositions,
+                        ),
+                    )
+                    if _is_incomplete_plan_review(parsed):
+                        return
+                    post_issue_comment(
+                        runner, config=config, issue_number=issue_number,
+                        body=_attach_round_metadata(
+                            render_public_agent_comment(
+                                kind="plan_review", parsed=parsed, agent=reviewer_name,
+                                prior_items=prior_unresolved_items,
+                                dispositions=parsed.dispositions,
+                                human_requirements_resolved_flag=human_requirements_resolved(turn.response.text),
+                                config=config, model_used=turn.response.model_used,
+                            ),
+                            PostedRoundMetadata(
+                                flow="plan", role="reviewer", agent=reviewer_name,
+                                round_number=round_number, subject=_plan_subject(current_plan),
+                                prior_items=prior_unresolved_items,
+                                dispositions=parsed.dispositions, state=parsed.state,
+                                compact_prior_summaries=tuple(compact_prior_summaries),
+                                model_used=turn.response.model_used, phase="publication",
+                                canonical_reviewer_response=turn.response.text,
+                                publication_identity=f"plan:{_plan_subject(current_plan)}:{round_number}:{reviewer_name}",
+                            ),
+                        ),
+                    )
+                    early_published_plan_reviewers.add(reviewer)
+
                 plan_turn_results = _launch_reviewer_turns(
                     runner,
                     pending_plan_reviewers,
                     thread_name_prefix=f"plan-review-r{round_number}",
                     run_turn=_plan_reviewer_worker,
+                    on_completion=_publish_plan_completion,
                 )
 
         for reviewer in configured_reviewers:
             reviewer_name = agent_display_name(reviewer)
             resumed_record = resumed_by_name.get(reviewer_name)
             if resumed_record is not None:
-                review_output = resumed_record.body
+                review_output = resumed_record.metadata.canonical_reviewer_response or resumed_record.body
                 review_model_used = resumed_record.metadata.model_used
                 structured_review = parse_structured_plan_review(
                     review_output,
@@ -4161,7 +4232,7 @@ def _run_plan_first_loop(
                 blocking_reviews.append((reviewer_name, review_output))
             else:
                 approved_review_outputs.append((reviewer_name, review_output))
-            if resumed_record is None:
+            if resumed_record is None or resumed_record.metadata.phase == "publication":
                 for item in parsed_review.items.blocking:
                     tracked_item = _next_unresolved_item(
                         item_number=next_unresolved_item_number,
@@ -4195,7 +4266,8 @@ def _run_plan_first_loop(
                     round_new_unresolved_items.append(tracked_item)
                     reviewer_new_unresolved_items.append(tracked_item)
                     next_unresolved_item_number += 1
-                post_issue_comment(
+                if reviewer not in early_published_plan_reviewers:
+                    post_issue_comment(
                     runner,
                     config=config,
                     issue_number=issue_number,
@@ -4226,9 +4298,26 @@ def _run_plan_first_loop(
                             model_used=review_model_used,
                         ),
                     ),
-                )
+                    )
             else:
                 round_new_unresolved_items.extend(reviewer_new_unresolved_items)
+
+        if config.review_parallel and not (current_resume is not None and current_resume.reconciled):
+            settled = ", ".join(agent_display_name(reviewer) for reviewer in configured_reviewers)
+            post_issue_comment(
+                runner, config=config, issue_number=issue_number,
+                body=_attach_round_metadata(
+                    f"Plan review round {round_number} reconciliation: settled reviewers: {settled or 'none'}. "
+                    f"Finalization {'stops' if plan_fatal_errors else 'continues'} after reconciliation.",
+                    PostedRoundMetadata(
+                        flow="plan", role="summary", agent="Orchestrator", round_number=round_number,
+                        subject=_plan_subject(current_plan), prior_items=prior_unresolved_items,
+                        dispositions=tuple(
+                            disposition for values in prior_dispositions.values() for disposition in values
+                        ), new_items=tuple(round_new_unresolved_items), phase="reconciliation",
+                    ),
+                ),
+            )
 
         if plan_fatal_errors:
             # Every healthy reviewer above was already applied (comment
@@ -5415,6 +5504,7 @@ def run_pr_loop(
             pr_fatal_errors: list[tuple[str, AgentLoopError]] = []
             pr_prep_failures: dict[AgentName, AgentLoopError] = {}
             pr_turn_results: dict[AgentName, _ReviewerTurnResult] = {}
+            early_published_pr_reviewers: set[AgentName] = set()
             shared_reviewer_pr_checks: PullRequestChecks | None = None
 
             def _pr_reviewer_prelaunch_kind(reviewer: AgentName) -> str:
@@ -5553,11 +5643,54 @@ def run_pr_loop(
                                 return _ReviewerTurnResult(reviewer_name=reviewer_name, error=exc)
                             return _ReviewerTurnResult(reviewer_name=reviewer_name, response=response)
 
+                        def _publish_pr_completion(reviewer: AgentName, turn: _ReviewerTurnResult) -> None:
+                            """Publish a completion-order PR review; settlement remains below."""
+                            if turn.error is not None or turn.response is None:
+                                return
+                            reviewer_name = agent_display_name(reviewer)
+                            parsed = turn.response.marker_value
+                            assert isinstance(parsed, ParsedReview)
+                            parsed = dataclasses_replace(
+                                parsed,
+                                followups=_drop_repeated_carried_future_followups(
+                                    parsed.followups, prior_items=prior_unresolved_items,
+                                    dispositions=parsed.dispositions,
+                                ),
+                            )
+                            if parsed.state == "blocking" and _is_pending_ci_only_review(parsed, shared_reviewer_pr_checks):
+                                parsed = dataclasses_replace(parsed, state="approved", blocking_items=())
+                            if parsed.state == "blocking" and _is_infrastructure_ci_only_review(parsed, shared_reviewer_pr_checks):
+                                parsed = dataclasses_replace(parsed, state="approved", blocking_items=())
+                            if _is_incomplete_pr_review(parsed):
+                                return
+                            post_pr_comment(
+                                runner, config=config, pr_number=pr_number,
+                                body=_attach_round_metadata(
+                                    render_public_agent_comment(
+                                        kind="pr_review", parsed=parsed, agent=reviewer_name,
+                                        human_requirements_resolved_flag=human_requirements_resolved(turn.response.text),
+                                        prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
+                                        config=config, model_used=turn.response.model_used,
+                                    ),
+                                    PostedRoundMetadata(
+                                        flow="pr", role="reviewer", agent=reviewer_name,
+                                        round_number=round_number, subject=current_pr_subject,
+                                        prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
+                                        state=parsed.state, model_used=turn.response.model_used,
+                                        surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
+                                        phase="publication", canonical_reviewer_response=turn.response.text,
+                                        publication_identity=f"pr:{current_pr_subject}:{round_number}:{reviewer_name}",
+                                    ),
+                                ),
+                            )
+                            early_published_pr_reviewers.add(reviewer)
+
                         pr_turn_results = _launch_reviewer_turns(
                             runner,
                             launchable_pr_reviewers,
                             thread_name_prefix=f"pr-review-r{round_number}",
                             run_turn=_pr_reviewer_worker,
+                            on_completion=_publish_pr_completion,
                         )
                     else:
                         log(
@@ -5578,7 +5711,7 @@ def run_pr_loop(
                 resumed_record = resumed_by_name.get(reviewer_name)
                 carried_approval_record: PostedRoundRecord | None = None
                 if resumed_record is not None:
-                    review_output = resumed_record.body
+                    review_output = resumed_record.metadata.canonical_reviewer_response or resumed_record.body
                     review_model_used = resumed_record.metadata.model_used
                     reparsed_review = parse_review(review_output, reviewer=reviewer_name)
                     parsed_review = ParsedReview(
@@ -5840,7 +5973,11 @@ def run_pr_loop(
                     f"{_describe_pr_review_outcome(parsed_review, has_blocking_summary=has_blocking_summary)}",
                 )
                 if review_state == "blocking":
-                    if resumed_record is None and carried_approval_record is None:
+                    if (
+                        resumed_record is None
+                        and carried_approval_record is None
+                        and reviewer not in early_published_pr_reviewers
+                    ):
                         if parsed_review.blocking_items:
                             for blocking_item in parsed_review.blocking_items:
                                 tracked_item = _next_unresolved_item(
@@ -5934,7 +6071,11 @@ def run_pr_loop(
                     continue
 
                 approved_review_outputs.append((reviewer_name, review_output))
-                if resumed_record is None and carried_approval_record is None:
+                if (
+                    resumed_record is None
+                    and carried_approval_record is None
+                    and reviewer not in early_published_pr_reviewers
+                ):
                     if config.approved_followups != "ignore":
                         for followup in parsed_review.followups.future:
                             tracked_item = _next_unresolved_item(
@@ -5982,6 +6123,27 @@ def run_pr_loop(
                 else:
                     if resumed_record is not None:
                         round_new_unresolved_items.extend(reviewer_new_unresolved_items)
+
+            if (
+                config.review_parallel
+                and not skip_reviewers_this_round
+                and not (current_resume is not None and current_resume.reconciled)
+            ):
+                settled = ", ".join(agent_display_name(reviewer) for reviewer in configured_reviewers)
+                post_pr_comment(
+                    runner, config=config, pr_number=pr_number,
+                    body=_attach_round_metadata(
+                        f"PR review round {round_number} reconciliation: settled reviewers: {settled or 'none'}. "
+                        f"Finalization {'stops' if pr_fatal_errors else 'continues'} after reconciliation.",
+                        PostedRoundMetadata(
+                            flow="pr", role="summary", agent="Orchestrator", round_number=round_number,
+                            subject=current_pr_subject, prior_items=prior_unresolved_items,
+                            dispositions=tuple(
+                                disposition for values in prior_dispositions.values() for disposition in values
+                            ), new_items=tuple(round_new_unresolved_items), phase="reconciliation",
+                        ),
+                    ),
+                )
 
             if pr_fatal_errors:
                 # Every healthy reviewer above was already applied (comment

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3976,6 +3976,38 @@ def _run_plan_first_loop(
                 and record.metadata.phase == "publication"
             )
         }
+
+        def _post_plan_reviewer_comment(
+            reviewer_name: str,
+            parsed: ParsedPlanReview,
+            *,
+            review_output: str,
+            model_used: str | None,
+            new_items: tuple[UnresolvedReviewItem, ...] = (),
+            phase: str = "authoritative",
+        ) -> None:
+            """Post one plan review using the same rendering and durable record."""
+            post_issue_comment(
+                runner, config=config, issue_number=issue_number,
+                body=_attach_round_metadata(
+                    render_public_agent_comment(
+                        kind="plan_review", parsed=parsed, agent=reviewer_name,
+                        prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
+                        human_requirements_resolved_flag=human_requirements_resolved(review_output),
+                        config=config, model_used=model_used,
+                    ),
+                    PostedRoundMetadata(
+                        flow="plan", role="reviewer", agent=reviewer_name,
+                        round_number=round_number, subject=_plan_subject(current_plan),
+                        prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
+                        new_items=new_items, state=parsed.state,
+                        compact_prior_summaries=tuple(compact_prior_summaries),
+                        model_used=model_used, phase=phase,
+                        canonical_reviewer_response=(review_output if phase == "publication" else None),
+                    ),
+                ),
+            )
+
         if config.review_parallel:
             pending_plan_reviewers = [
                 reviewer for reviewer in configured_reviewers
@@ -4057,27 +4089,9 @@ def _run_plan_first_loop(
                     )
                     if _is_incomplete_plan_review(parsed):
                         return
-                    post_issue_comment(
-                        runner, config=config, issue_number=issue_number,
-                        body=_attach_round_metadata(
-                            render_public_agent_comment(
-                                kind="plan_review", parsed=parsed, agent=reviewer_name,
-                                prior_items=prior_unresolved_items,
-                                dispositions=parsed.dispositions,
-                                human_requirements_resolved_flag=human_requirements_resolved(turn.response.text),
-                                config=config, model_used=turn.response.model_used,
-                            ),
-                            PostedRoundMetadata(
-                                flow="plan", role="reviewer", agent=reviewer_name,
-                                round_number=round_number, subject=_plan_subject(current_plan),
-                                prior_items=prior_unresolved_items,
-                                dispositions=parsed.dispositions, state=parsed.state,
-                                compact_prior_summaries=tuple(compact_prior_summaries),
-                                model_used=turn.response.model_used, phase="publication",
-                                canonical_reviewer_response=turn.response.text,
-                                publication_identity=f"plan:{_plan_subject(current_plan)}:{round_number}:{reviewer_name}",
-                            ),
-                        ),
+                    _post_plan_reviewer_comment(
+                        reviewer_name, parsed, review_output=turn.response.text,
+                        model_used=turn.response.model_used, phase="publication",
                     )
                     early_published_plan_reviewers.add(reviewer)
 
@@ -4267,37 +4281,10 @@ def _run_plan_first_loop(
                     reviewer_new_unresolved_items.append(tracked_item)
                     next_unresolved_item_number += 1
                 if reviewer not in early_published_plan_reviewers:
-                    post_issue_comment(
-                    runner,
-                    config=config,
-                    issue_number=issue_number,
-                    body=_attach_round_metadata(
-                        render_public_agent_comment(
-                            kind="plan_review",
-                            parsed=parsed_review,
-                            agent=reviewer_name,
-                            prior_items=prior_unresolved_items,
-                            dispositions=parsed_review.dispositions,
-                            human_requirements_resolved_flag=human_requirements_resolved(
-                                review_output
-                            ),
-                            config=config,
-                            model_used=review_model_used,
-                        ),
-                        PostedRoundMetadata(
-                            flow="plan",
-                            role="reviewer",
-                            agent=reviewer_name,
-                            round_number=round_number,
-                            subject=_plan_subject(current_plan),
-                            prior_items=prior_unresolved_items,
-                            dispositions=parsed_review.dispositions,
-                            new_items=tuple(reviewer_new_unresolved_items),
-                            state=review_state,
-                            compact_prior_summaries=tuple(compact_prior_summaries),
-                            model_used=review_model_used,
-                        ),
-                    ),
+                    _post_plan_reviewer_comment(
+                        reviewer_name, parsed_review, review_output=review_output,
+                        model_used=review_model_used,
+                        new_items=tuple(reviewer_new_unresolved_items),
                     )
             else:
                 round_new_unresolved_items.extend(reviewer_new_unresolved_items)
@@ -5504,8 +5491,46 @@ def run_pr_loop(
             pr_fatal_errors: list[tuple[str, AgentLoopError]] = []
             pr_prep_failures: dict[AgentName, AgentLoopError] = {}
             pr_turn_results: dict[AgentName, _ReviewerTurnResult] = {}
-            early_published_pr_reviewers: set[AgentName] = set()
+            early_published_pr_reviewers: set[AgentName] = {
+                reviewer
+                for reviewer in configured_reviewers
+                if (
+                    (record := resumed_by_name.get(agent_display_name(reviewer))) is not None
+                    and record.metadata.phase == "publication"
+                )
+            }
             shared_reviewer_pr_checks: PullRequestChecks | None = None
+
+            def _post_pr_reviewer_comment(
+                reviewer_name: str,
+                parsed: ParsedReview,
+                *,
+                review_output: str,
+                model_used: str | None,
+                new_items: tuple[UnresolvedReviewItem, ...] = (),
+                phase: str = "authoritative",
+            ) -> None:
+                """Post one PR review using the same rendering and durable record."""
+                post_pr_comment(
+                    runner, config=config, pr_number=pr_number,
+                    body=_attach_round_metadata(
+                        render_public_agent_comment(
+                            kind="pr_review", parsed=parsed, agent=reviewer_name,
+                            human_requirements_resolved_flag=human_requirements_resolved(review_output),
+                            prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
+                            config=config, model_used=model_used,
+                        ),
+                        PostedRoundMetadata(
+                            flow="pr", role="reviewer", agent=reviewer_name,
+                            round_number=round_number, subject=current_pr_subject,
+                            prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
+                            new_items=new_items, state=parsed.state, model_used=model_used,
+                            surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
+                            phase=phase,
+                            canonical_reviewer_response=(review_output if phase == "publication" else None),
+                        ),
+                    ),
+                )
 
             def _pr_reviewer_prelaunch_kind(reviewer: AgentName) -> str:
                 # Pure classification, no agent calls: mirrors the resumed/
@@ -5663,25 +5688,9 @@ def run_pr_loop(
                                 parsed = dataclasses_replace(parsed, state="approved", blocking_items=())
                             if _is_incomplete_pr_review(parsed):
                                 return
-                            post_pr_comment(
-                                runner, config=config, pr_number=pr_number,
-                                body=_attach_round_metadata(
-                                    render_public_agent_comment(
-                                        kind="pr_review", parsed=parsed, agent=reviewer_name,
-                                        human_requirements_resolved_flag=human_requirements_resolved(turn.response.text),
-                                        prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
-                                        config=config, model_used=turn.response.model_used,
-                                    ),
-                                    PostedRoundMetadata(
-                                        flow="pr", role="reviewer", agent=reviewer_name,
-                                        round_number=round_number, subject=current_pr_subject,
-                                        prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
-                                        state=parsed.state, model_used=turn.response.model_used,
-                                        surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
-                                        phase="publication", canonical_reviewer_response=turn.response.text,
-                                        publication_identity=f"pr:{current_pr_subject}:{round_number}:{reviewer_name}",
-                                    ),
-                                ),
+                            _post_pr_reviewer_comment(
+                                reviewer_name, parsed, review_output=turn.response.text,
+                                model_used=turn.response.model_used, phase="publication",
                             )
                             early_published_pr_reviewers.add(reviewer)
 
@@ -5974,9 +5983,8 @@ def run_pr_loop(
                 )
                 if review_state == "blocking":
                     if (
-                        resumed_record is None
+                        (resumed_record is None or resumed_record.metadata.phase == "publication")
                         and carried_approval_record is None
-                        and reviewer not in early_published_pr_reviewers
                     ):
                         if parsed_review.blocking_items:
                             for blocking_item in parsed_review.blocking_items:
@@ -6033,38 +6041,12 @@ def run_pr_loop(
                                 round_new_unresolved_items.append(tracked_item)
                                 reviewer_new_unresolved_items.append(tracked_item)
                                 next_unresolved_item_number += 1
-                        post_pr_comment(
-                            runner,
-                            config=config,
-                            pr_number=pr_number,
-                            body=_attach_round_metadata(
-                                render_public_agent_comment(
-                                    kind="pr_review",
-                                    parsed=parsed_review,
-                                    agent=reviewer_name,
-                                    human_requirements_resolved_flag=human_requirements_resolved(
-                                        review_output
-                                    ),
-                                    prior_items=prior_unresolved_items,
-                                    dispositions=parsed_review.dispositions,
-                                    config=config,
-                                    model_used=review_model_used,
-                                ),
-                                PostedRoundMetadata(
-                                    flow="pr",
-                                    role="reviewer",
-                                    agent=reviewer_name,
-                                    round_number=round_number,
-                                    subject=current_pr_subject,
-                                    prior_items=prior_unresolved_items,
-                                    dispositions=parsed_review.dispositions,
-                                    new_items=tuple(reviewer_new_unresolved_items),
-                                    state=review_state,
-                                    model_used=review_model_used,
-                                    surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
-                                ),
-                            ),
-                        )
+                        if reviewer not in early_published_pr_reviewers:
+                            _post_pr_reviewer_comment(
+                                reviewer_name, parsed_review, review_output=review_output,
+                                model_used=review_model_used,
+                                new_items=tuple(reviewer_new_unresolved_items),
+                            )
                     else:
                         if resumed_record is not None:
                             round_new_unresolved_items.extend(reviewer_new_unresolved_items)
@@ -6072,9 +6054,8 @@ def run_pr_loop(
 
                 approved_review_outputs.append((reviewer_name, review_output))
                 if (
-                    resumed_record is None
+                    (resumed_record is None or resumed_record.metadata.phase == "publication")
                     and carried_approval_record is None
-                    and reviewer not in early_published_pr_reviewers
                 ):
                     if config.approved_followups != "ignore":
                         for followup in parsed_review.followups.future:
@@ -6088,38 +6069,12 @@ def run_pr_loop(
                             round_new_unresolved_items.append(tracked_item)
                             reviewer_new_unresolved_items.append(tracked_item)
                             next_unresolved_item_number += 1
-                    post_pr_comment(
-                        runner,
-                        config=config,
-                        pr_number=pr_number,
-                        body=_attach_round_metadata(
-                            render_public_agent_comment(
-                                kind="pr_review",
-                                parsed=parsed_review,
-                                agent=reviewer_name,
-                                human_requirements_resolved_flag=human_requirements_resolved(
-                                    review_output
-                                ),
-                                prior_items=prior_unresolved_items,
-                                dispositions=parsed_review.dispositions,
-                                config=config,
-                                model_used=review_model_used,
-                            ),
-                            PostedRoundMetadata(
-                                flow="pr",
-                                role="reviewer",
-                                agent=reviewer_name,
-                                round_number=round_number,
-                                    subject=current_pr_subject,
-                                prior_items=prior_unresolved_items,
-                                dispositions=parsed_review.dispositions,
-                                new_items=tuple(reviewer_new_unresolved_items),
-                                state=review_state,
-                                model_used=review_model_used,
-                                surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
-                            ),
-                        ),
-                    )
+                    if reviewer not in early_published_pr_reviewers:
+                        _post_pr_reviewer_comment(
+                            reviewer_name, parsed_review, review_output=review_output,
+                            model_used=review_model_used,
+                            new_items=tuple(reviewer_new_unresolved_items),
+                        )
                 else:
                     if resumed_record is not None:
                         round_new_unresolved_items.extend(reviewer_new_unresolved_items)

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -82,6 +82,11 @@ class PostedRoundMetadata:
     # the current signed requirements from one made before new requirements
     # were surfaced for the same immutable PR head.
     surfaced_reviewer_requirement_ids: tuple[str, ...] = ()
+    # Parallel reviewers publish a durable provisional checkpoint before the
+    # configured-order settlement barrier.  Legacy records are authoritative.
+    phase: str = "authoritative"
+    canonical_reviewer_response: str | None = None
+    publication_identity: str | None = None
 
 
 @dataclass(frozen=True)
@@ -107,6 +112,7 @@ class ResumedReviewRound:
     ledger_may_be_incomplete: bool = False
     compact_prior_summaries: tuple[str, ...] = ()
     unrecorded_head_advance: bool = False
+    reconciled: bool = False
 
 
 def _serialize_unresolved_item(item: UnresolvedReviewItem) -> dict[str, object]:
@@ -184,6 +190,9 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "result_mode": metadata.result_mode,
         "evidence_reconciliation": metadata.evidence_reconciliation,
         "surfaced_reviewer_requirement_ids": list(metadata.surfaced_reviewer_requirement_ids),
+        "phase": metadata.phase,
+        "canonical_reviewer_response": metadata.canonical_reviewer_response,
+        "publication_identity": metadata.publication_identity,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -254,6 +263,15 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             ),
             surfaced_reviewer_requirement_ids=tuple(
                 str(item) for item in payload.get("surfaced_reviewer_requirement_ids", [])
+            ),
+            phase=str(payload.get("phase", "authoritative")),
+            canonical_reviewer_response=(
+                str(payload["canonical_reviewer_response"])
+                if payload.get("canonical_reviewer_response") is not None else None
+            ),
+            publication_identity=(
+                str(payload["publication_identity"])
+                if payload.get("publication_identity") is not None else None
             ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
@@ -602,6 +620,7 @@ def _resume_pr_round(
             if latest_coder_record is not None
             else ()
         ),
+        reconciled=any(record.metadata.role == "summary" for record in current_round_records),
     )
 
 
@@ -652,6 +671,7 @@ def _resume_plan_round(
             + 1,
             ledger_may_be_incomplete=ledger_may_be_incomplete,
             compact_prior_summaries=latest_coder_record.metadata.compact_prior_summaries,
+            reconciled=any(record.metadata.role == "summary" for record in current_round_records),
         ),
     )
 

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -86,7 +86,6 @@ class PostedRoundMetadata:
     # configured-order settlement barrier.  Legacy records are authoritative.
     phase: str = "authoritative"
     canonical_reviewer_response: str | None = None
-    publication_identity: str | None = None
 
 
 @dataclass(frozen=True)
@@ -192,7 +191,6 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "surfaced_reviewer_requirement_ids": list(metadata.surfaced_reviewer_requirement_ids),
         "phase": metadata.phase,
         "canonical_reviewer_response": metadata.canonical_reviewer_response,
-        "publication_identity": metadata.publication_identity,
     }
     encoded = base64.urlsafe_b64encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -268,10 +266,6 @@ def _decode_round_metadata(encoded: str) -> PostedRoundMetadata:
             canonical_reviewer_response=(
                 str(payload["canonical_reviewer_response"])
                 if payload.get("canonical_reviewer_response") is not None else None
-            ),
-            publication_identity=(
-                str(payload["publication_identity"])
-                if payload.get("publication_identity") is not None else None
             ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -471,8 +471,19 @@ def _recover_unrecorded_pr_head_advance(
         if record.metadata.role == "reviewer"
         and (latest_coder_record is None or record.index > latest_coder_record.index)
     )
+    new_item_records_after_coder = tuple(
+        record
+        for record in current_round_records
+        if record.metadata.role in {"reviewer", "summary"}
+        and (latest_coder_record is None or record.index > latest_coder_record.index)
+    )
     all_reviewer_records = tuple(
         record for record in current_round_records if record.metadata.role == "reviewer"
+    )
+    all_new_item_records = tuple(
+        record
+        for record in current_round_records
+        if record.metadata.role in {"reviewer", "summary"}
     )
 
     if latest_coder_record is not None and not reviewer_records_after_coder:
@@ -488,7 +499,7 @@ def _recover_unrecorded_pr_head_advance(
             retain_future=False,
         )
         recovered_items = _active_pr_items(recovered_items)
-        _append_active_pr_new_items(recovered_items, reviewer_records_after_coder)
+        _append_active_pr_new_items(recovered_items, new_item_records_after_coder)
         coder_output = latest_coder_record.metadata.raw_structured_coder_response or latest_coder_record.body
         compact_prior_summaries = latest_coder_record.metadata.compact_prior_summaries
     elif all_reviewer_records:
@@ -499,7 +510,7 @@ def _recover_unrecorded_pr_head_advance(
             retain_future=False,
         )
         recovered_items = _active_pr_items(recovered_items)
-        _append_active_pr_new_items(recovered_items, all_reviewer_records)
+        _append_active_pr_new_items(recovered_items, all_new_item_records)
         coder_output = None
         compact_prior_summaries = ()
     else:

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -3924,6 +3924,62 @@ def test_resume_pr_round_recovers_unrecorded_head_advance_reviewer_new_item():
     assert [item.item_id for item in resumed.prior_items] == ["item-2"]
     assert resumed.next_unresolved_item_number == 3
 
+
+def test_resume_pr_round_recovers_parallel_reconciliation_new_items_after_head_advance():
+    """Parallel publication checkpoints omit items; reconciliation owns the ledger."""
+    active_items = (
+        UnresolvedReviewItem(
+            item_id="item-1",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Preserve the first reconciled blocker.",
+            status="blocking",
+        ),
+        UnresolvedReviewItem(
+            item_id="item-2",
+            reviewer="OpenAI Codex",
+            source_round=1,
+            text="Preserve the second reconciled blocker.",
+            status="same-pr",
+        ),
+    )
+    coder_comment = _attach_round_metadata(
+        "Initial PR handoff.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        PostedRoundMetadata(
+            flow="pr", role="coder", agent="Claude", round_number=1,
+            subject="old-sha", prior_items=(),
+        ),
+    )
+    publication_comment = _attach_round_metadata(
+        "Blocked.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr", role="reviewer", agent="Codex", round_number=1,
+            subject="old-sha", prior_items=(), state="blocking", phase="publication",
+        ),
+    )
+    reconciliation_comment = _attach_round_metadata(
+        "Reconciliation.\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
+        PostedRoundMetadata(
+            flow="pr", role="summary", agent="Review reconciliation", round_number=1,
+            subject="old-sha", prior_items=(), new_items=active_items, state="blocking",
+        ),
+    )
+
+    resumed = _resume_pr_round(
+        [
+            IssueComment(author="bot", created_at="2026-05-25T00:00:00Z", body=coder_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:01:00Z", body=publication_comment),
+            IssueComment(author="bot", created_at="2026-05-25T00:02:00Z", body=reconciliation_comment),
+        ],
+        head_sha="new-sha",
+        configured_reviewers=("codex",),
+    )
+
+    assert resumed is not None
+    assert resumed.unrecorded_head_advance is True
+    assert [item.item_id for item in resumed.prior_items] == ["item-1", "item-2"]
+    assert resumed.next_unresolved_item_number == 3
+
 def test_resume_pr_round_recovers_coder_only_unrecorded_head_advance():
     carried_item = UnresolvedReviewItem(
         item_id="item-1",

--- a/tests/test_review_parallel.py
+++ b/tests/test_review_parallel.py
@@ -189,6 +189,8 @@ class _EarlyPublicationBarrierRunner(FakeRunner):
 
     def run_with_log(self, args, *, cwd, **kwargs):
         cmd = [str(arg) for arg in args]
+        if cmd[:1] == ["claude"] and not self.gemini_finished.is_set():
+            self.coder_started_before_gemini_finished = True
         if cmd[:1] == ["gemini"]:
             time.sleep(0.15)
             result = super().run_with_log(args, cwd=cwd, **kwargs)
@@ -198,8 +200,6 @@ class _EarlyPublicationBarrierRunner(FakeRunner):
 
     def run(self, args, *, cwd, **kwargs):
         cmd = [str(arg) for arg in args]
-        if cmd[:1] == ["claude"] and not self.gemini_finished.is_set():
-            self.coder_started_before_gemini_finished = True
         if cmd[:3] == ["gh", "pr", "comment"] and not self.gemini_finished.is_set():
             self.codex_published_before_gemini_finished = True
         return super().run(args, cwd=cwd, **kwargs)

--- a/tests/test_review_parallel.py
+++ b/tests/test_review_parallel.py
@@ -85,10 +85,9 @@ def test_plan_first_parallel_runs_same_round_reviewers_concurrently(tmp_path):
     assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
 
     assert runner.overlap_confirmed, "same-round plan reviewers did not run concurrently"
-    assert "Codex plan review complete." in runner.comments[1]
-    assert "-- OpenAI Codex" in runner.comments[1]
-    assert "Gemini plan review complete." in runner.comments[2]
-    assert "-- Google Gemini" in runner.comments[2]
+    assert any("Codex plan review complete." in comment for comment in runner.comments)
+    assert any("Gemini plan review complete." in comment for comment in runner.comments)
+    assert any("reconciliation" in comment for comment in runner.comments)
 
 
 def test_pr_loop_parallel_runs_same_round_reviewers_concurrently(tmp_path):
@@ -103,10 +102,9 @@ def test_pr_loop_parallel_runs_same_round_reviewers_concurrently(tmp_path):
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
     assert runner.overlap_confirmed, "same-round PR reviewers did not run concurrently"
-    assert "Codex PR review complete." in runner.comments[0]
-    assert "-- OpenAI Codex" in runner.comments[0]
-    assert "Gemini PR review complete." in runner.comments[1]
-    assert "-- Google Gemini" in runner.comments[1]
+    assert any("Codex PR review complete." in comment for comment in runner.comments)
+    assert any("Gemini PR review complete." in comment for comment in runner.comments)
+    assert "reconciliation" in runner.comments[-1]
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +141,10 @@ def test_plan_first_parallel_matches_sequential_comments(tmp_path):
     assert run_issue_loop(sequential_runner, issue_number=56, config=sequential_config, plan_first=True) == 0
     assert run_issue_loop(parallel_runner, issue_number=56, config=parallel_config, plan_first=True) == 0
 
-    assert parallel_runner.comments == sequential_runner.comments
+    assert all(any(summary in comment for comment in parallel_runner.comments) for summary in (
+        "Codex approves the plan.", "Gemini approves the plan.",
+    ))
+    assert "reconciliation" in parallel_runner.comments[-2]
 
 
 def test_pr_loop_parallel_matches_sequential_comments(tmp_path):
@@ -167,7 +168,10 @@ def test_pr_loop_parallel_matches_sequential_comments(tmp_path):
     assert run_pr_loop(sequential_runner, pr_number=77, config=sequential_config) == 0
     assert run_pr_loop(parallel_runner, pr_number=77, config=parallel_config) == 0
 
-    assert parallel_runner.comments == sequential_runner.comments
+    assert all(any(summary in comment for comment in parallel_runner.comments) for summary in (
+        "Codex approves the PR.", "Gemini approves the PR.",
+    ))
+    assert "reconciliation" in parallel_runner.comments[-1]
 
 
 # ---------------------------------------------------------------------------
@@ -194,8 +198,8 @@ def test_plan_first_parallel_collects_healthy_review_before_raising_then_resumes
 
     # Gemini's healthy review is posted (comment[0] is the coder's plan) even
     # though Codex's failure aborts the round afterward.
-    assert len(runner.comments) == 2
-    assert "Gemini approves the plan." in runner.comments[1]
+    assert len(runner.comments) == 3
+    assert any("Gemini approves the plan." in comment for comment in runner.comments)
 
     # A rerun resumes Gemini's posted review instead of re-invoking it.
     commands_before_rerun = len(runner.commands)
@@ -222,8 +226,8 @@ def test_pr_loop_parallel_collects_healthy_review_before_raising_then_resumes(tm
     with pytest.raises(AgentLoopError, match="Codex"):
         run_pr_loop(runner, pr_number=77, config=config)
 
-    assert len(runner.comments) == 1
-    assert "Gemini approves the PR." in runner.comments[0]
+    assert len(runner.comments) == 2
+    assert any("Gemini approves the PR." in comment for comment in runner.comments)
 
     commands_before_rerun = len(runner.commands)
     runner.codex_outputs.append(structured_pr_review(summary="Codex approves after rerun."))
@@ -257,8 +261,8 @@ def test_pr_loop_parallel_sync_failure_isolated_from_healthy_reviewer(tmp_path):
             run_pr_loop(runner, pr_number=77, config=config)
 
     assert not any(cmd[:2] == ["codex", "exec"] for cmd, _cwd in runner.commands)
-    assert len(runner.comments) == 1
-    assert "Gemini approves the PR." in runner.comments[0]
+    assert len(runner.comments) == 2
+    assert any("Gemini approves the PR." in comment for comment in runner.comments)
 
 
 # ---------------------------------------------------------------------------
@@ -469,5 +473,5 @@ def test_plan_first_parallel_repair_isolated_between_reviewers(tmp_path):
         assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
 
     assert len(repair_calls) == 1
-    assert "Codex approves after repair." in runner.comments[1]
-    assert "Gemini approves the plan." in runner.comments[2]
+    assert any("Codex approves after repair." in comment for comment in runner.comments)
+    assert any("Gemini approves the plan." in comment for comment in runner.comments)

--- a/tests/test_review_parallel.py
+++ b/tests/test_review_parallel.py
@@ -1,5 +1,6 @@
 """Tests for opt-in parallel plan/PR reviewer execution (#594)."""
 import threading
+import time
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ from coding_review_agent_loop.errors import QuotaResetExceededError
 from agent_loop_helpers import (
     FakeRunner,
     make_config,
+    structured_coder_followup,
     structured_plan_review,
     structured_plan_state,
     structured_pr_review,
@@ -141,9 +143,10 @@ def test_plan_first_parallel_matches_sequential_comments(tmp_path):
     assert run_issue_loop(sequential_runner, issue_number=56, config=sequential_config, plan_first=True) == 0
     assert run_issue_loop(parallel_runner, issue_number=56, config=parallel_config, plan_first=True) == 0
 
-    assert all(any(summary in comment for comment in parallel_runner.comments) for summary in (
-        "Codex approves the plan.", "Gemini approves the plan.",
-    ))
+    reviewer_comments = lambda runner: {
+        comment for comment in runner.comments if comment.startswith("**Review verdict:")
+    }
+    assert reviewer_comments(parallel_runner) == reviewer_comments(sequential_runner)
     assert "reconciliation" in parallel_runner.comments[-2]
 
 
@@ -168,10 +171,122 @@ def test_pr_loop_parallel_matches_sequential_comments(tmp_path):
     assert run_pr_loop(sequential_runner, pr_number=77, config=sequential_config) == 0
     assert run_pr_loop(parallel_runner, pr_number=77, config=parallel_config) == 0
 
-    assert all(any(summary in comment for comment in parallel_runner.comments) for summary in (
-        "Codex approves the PR.", "Gemini approves the PR.",
-    ))
+    reviewer_comments = lambda runner: {
+        comment for comment in runner.comments if comment.startswith("**Review verdict:")
+    }
+    assert reviewer_comments(parallel_runner) == reviewer_comments(sequential_runner)
     assert "reconciliation" in parallel_runner.comments[-1]
+
+
+class _EarlyPublicationBarrierRunner(FakeRunner):
+    """Makes Gemini slow enough to observe completion-order publication."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.gemini_finished = threading.Event()
+        self.codex_published_before_gemini_finished = False
+        self.coder_started_before_gemini_finished = False
+
+    def run_with_log(self, args, *, cwd, **kwargs):
+        cmd = [str(arg) for arg in args]
+        if cmd[:1] == ["gemini"]:
+            time.sleep(0.15)
+            result = super().run_with_log(args, cwd=cwd, **kwargs)
+            self.gemini_finished.set()
+            return result
+        return super().run_with_log(args, cwd=cwd, **kwargs)
+
+    def run(self, args, *, cwd, **kwargs):
+        cmd = [str(arg) for arg in args]
+        if cmd[:1] == ["claude"] and not self.gemini_finished.is_set():
+            self.coder_started_before_gemini_finished = True
+        if cmd[:3] == ["gh", "pr", "comment"] and not self.gemini_finished.is_set():
+            self.codex_published_before_gemini_finished = True
+        return super().run(args, cwd=cwd, **kwargs)
+
+
+def test_pr_parallel_publishes_fast_review_before_settlement_and_coder_followup(tmp_path):
+    runner = _EarlyPublicationBarrierRunner(
+        codex_outputs=[structured_pr_review(
+            state="blocking", summary="Codex found two blockers.",
+            blocking_items=["First blocker.", "Second blocker."],
+        ), structured_pr_review(
+            summary="Codex approves after the fix.",
+            prior_item_dispositions=[
+                {"item_id": "item-1", "disposition": "resolved"},
+                {"item_id": "item-2", "disposition": "resolved"},
+            ],
+        )],
+        gemini_outputs=[structured_pr_review(summary="Gemini approves.", reviewer="Google Gemini"),
+                        structured_pr_review(
+                            summary="Gemini approves after the fix.", reviewer="Google Gemini",
+                            prior_item_dispositions=[
+                                {"item_id": "item-1", "disposition": "resolved"},
+                                {"item_id": "item-2", "disposition": "resolved"},
+                            ],
+                        )],
+        claude_outputs=[structured_coder_followup(
+            summary="Fixed both blockers.", addressed_items=["item-1", "item-2"]
+        )],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert runner.codex_published_before_gemini_finished
+    assert not runner.coder_started_before_gemini_finished
+    coder_prompt = next("\n".join(cmd) for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "[item-1]" in coder_prompt and "[item-2]" in coder_prompt
+
+
+def test_pr_parallel_resume_after_publication_does_not_duplicate_or_lose_items(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking", summary="Codex found a blocker.", blocking_items=["Persist this item."]
+            ),
+            structured_pr_review(
+                summary="Codex approves after the fix.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        gemini_outputs=[
+            structured_pr_review(summary="Gemini approves.", reviewer="Google Gemini"),
+            structured_pr_review(
+                summary="Gemini approves after the fix.", reviewer="Google Gemini",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+        claude_outputs=[structured_coder_followup(
+            summary="Fixed the persisted item.", addressed_items=["item-1"]
+        )],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True)
+    real_post = orchestrator.post_pr_comment
+
+    def interrupt_before_reconciliation(*args, **kwargs):
+        if "reconciliation" in kwargs["body"]:
+            raise KeyboardInterrupt
+        return real_post(*args, **kwargs)
+
+    with patch.object(orchestrator, "post_pr_comment", side_effect=interrupt_before_reconciliation):
+        with pytest.raises(KeyboardInterrupt):
+            run_pr_loop(runner, pr_number=77, config=config)
+
+    codex_publications = lambda: sum(
+        (metadata := orchestrator._decode_round_metadata(
+            orchestrator.ROUND_RESUME_MARKER_RE.search(comment["body"])["payload"]
+        )).agent == "Codex"
+        and metadata.phase == "publication"
+        and metadata.round_number == 1
+        for comment in runner.pr_payload["comments"]
+        if orchestrator.ROUND_RESUME_MARKER_RE.search(comment["body"])
+    )
+    assert codex_publications() == 1
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert codex_publications() == 1
+    coder_prompt = next("\n".join(cmd) for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "[item-1]" in coder_prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #615

Publishes validated parallel plan and PR reviewer comments as workers complete while retaining the settlement barrier for deterministic aggregation and coder work. Adds durable publication/reconciliation metadata and documents mode-independent resume behavior.