### PR TITLE
Treat Antigravity capacity failures as retryable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ auth/quota error near or after the cutoff, the tool surfaces this migration
 guidance. Notes: Antigravity turns are single-shot (no cross-round session
 resume) and report estimated token usage (`agy` emits no token counts).
 
-Provider-framed high-traffic, rate-limit, resource-exhausted, overload, and
+Provider capacity diagnostics for high-traffic, rate-limit, resource-exhausted, overload, and
 no-capacity errors retry the active model before advancing through this chain.
 `--agent-max-retries` is shared across the chain, so a run makes at most
 `models + retries` calls. Custom `--antigravity-quota-signatures` replace the

--- a/README.md
+++ b/README.md
@@ -119,11 +119,18 @@ agent-loop task "Fix the flaky test" --repo OWNER/REPO --coder antigravity --rev
 
 Pick the model with `--antigravity-model "<name>"` (as listed by `agy models`),
 or supply an ordered fallback chain with `--antigravity-models "<name>" ["<name>" ...]`
-(tried in order on quota exhaustion; default `Gemini 3.6 Flash (High)` →
+(tried in order after provider-framed capacity exhaustion; default `Gemini 3.6 Flash (High)` →
 `Gemini 3.5 Flash (High)` → `Gemini 3.1 Pro (High)`). When a `gemini` invocation fails with an
 auth/quota error near or after the cutoff, the tool surfaces this migration
 guidance. Notes: Antigravity turns are single-shot (no cross-round session
 resume) and report estimated token usage (`agy` emits no token counts).
+
+Provider-framed high-traffic, rate-limit, resource-exhausted, overload, and
+no-capacity errors retry the active model before advancing through this chain.
+`--agent-max-retries` is shared across the chain, so a run makes at most
+`models + retries` calls. Custom `--antigravity-quota-signatures` replace the
+defaults and control fallback eligibility. Invalid settings, unsupported models,
+timeouts, and schema-invalid responses remain deterministic and do not fall back.
 
 Each `agy --print` invocation is run with `--print-timeout` set from
 `--antigravity-print-timeout-seconds` (default 600, i.e. ten minutes), which

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,10 @@ the two model options are mutually exclusive. Customize fallback detection with
 call passes `--print-timeout` from `--antigravity-print-timeout-seconds`
 (default `600`, i.e. ten minutes, matching the `agent-loop` CLI), overriding
 `agy`'s own five-minute print-mode default so long turns are not cut short.
+Provider-framed capacity failures retry the active model before fallback; the
+`--max-retries` allowance is shared across the chain, capping calls at
+`models + retries`. Custom quota signatures control eligibility, while settings,
+model, timeout, and schema failures remain deterministic.
 These options are available on every skill command that can invoke an
 external agent.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,7 +89,7 @@ the two model options are mutually exclusive. Customize fallback detection with
 call passes `--print-timeout` from `--antigravity-print-timeout-seconds`
 (default `600`, i.e. ten minutes, matching the `agent-loop` CLI), overriding
 `agy`'s own five-minute print-mode default so long turns are not cut short.
-Provider-framed capacity failures retry the active model before fallback; the
+Provider capacity failures retry the active model before fallback; the
 `--max-retries` allowance is shared across the chain, capping calls at
 `models + retries`. Custom quota signatures control eligibility, while settings,
 model, timeout, and schema failures remain deterministic.

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -101,7 +101,7 @@ implementation, decomposition, phased implementation, and PR-fix commands.
 Antigravity turns are single-shot (no cross-round session resume) and report
 estimated token usage.
 
-Provider-framed high-traffic and capacity failures retry the active model before
+Provider high-traffic and capacity failures retry the active model before
 the ordered fallback chain advances. `--max-retries` is shared across the chain,
 which caps a run at `models + retries` calls; custom quota signatures decide which
 diagnostics qualify. Invalid settings, unsupported models, timeouts, and malformed

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -101,6 +101,12 @@ implementation, decomposition, phased implementation, and PR-fix commands.
 Antigravity turns are single-shot (no cross-round session resume) and report
 estimated token usage.
 
+Provider-framed high-traffic and capacity failures retry the active model before
+the ordered fallback chain advances. `--max-retries` is shared across the chain,
+which caps a run at `models + retries` calls; custom quota signatures decide which
+diagnostics qualify. Invalid settings, unsupported models, timeouts, and malformed
+responses do not retry or fall back.
+
 ## Approved-plan execution helpers
 
 Skill mode also exposes the external-coder execution helpers used after a plan

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -260,7 +260,7 @@ def main() -> None:
     workdir = Path(args.workdir)
 
     # Import backends lazily to avoid heavy import in dry-run path
-    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    from coding_review_agent_loop.agents.antigravity import AntigravityAttemptState, AntigravityBackend
     from coding_review_agent_loop.agents.codex import CodexBackend
     from coding_review_agent_loop.agents.gemini import GeminiBackend
     from coding_review_agent_loop.config import (
@@ -272,7 +272,7 @@ def main() -> None:
         sync_checkout_to_pr,
     )
     from coding_review_agent_loop.github import PullRequestMetadata
-    from coding_review_agent_loop.transient import is_transient_agent_output
+    from coding_review_agent_loop.transient import classify_antigravity_capacity, is_transient_agent_output
     from coding_review_agent_loop.usage import estimate_usage
 
     agent_name: AgentName = args.agent
@@ -374,17 +374,33 @@ def main() -> None:
     else:
         backend = GeminiBackend()
 
-    # Retry transient agent failures (429 / overloaded / timeout / capacity).
+    # Retry transient agent failures. Antigravity shares its retry allowance
+    # across the ordered model chain and only capacity diagnostics may advance it.
     # The primary failure path is a *returned* AgentResult with a non-zero
     # returncode whose raw_output (merged stdout+stderr) carries the signal;
     # a raised exception is the secondary path (its message embeds the captured
     # output tail for AgentLoopError from run_with_log).
-    max_attempts = args.max_retries + 1
+    antigravity_attempts = (
+        AntigravityAttemptState.from_config(config, args.max_retries)
+        if agent_name == "antigravity"
+        else None
+    )
+    max_attempts = (
+        len(config.antigravity_models) + args.max_retries
+        if antigravity_attempts is not None
+        else args.max_retries + 1
+    )
     backoff = args.retry_backoff_seconds
     result = None
     for attempt in range(1, max_attempts + 1):
+        candidate = None
         try:
-            candidate = backend.run(runner, config, prompt)
+            candidate = backend.run(
+                runner,
+                antigravity_attempts.singleton_config(config)
+                if antigravity_attempts is not None else config,
+                prompt,
+            )
         except Exception as exc:  # noqa: BLE001
             failure_text = str(exc)
         else:
@@ -395,7 +411,20 @@ def main() -> None:
                 break
 
         transient = is_transient_agent_output(failure_text or "")
-        if attempt < max_attempts and transient:
+        capacity = classify_antigravity_capacity(
+            failure_text or "",
+            returncode=(candidate.returncode if candidate is not None else 1),
+            empty_response=bool(candidate is not None and candidate.returncode == 0 and not candidate.text.strip()),
+            signatures=config.antigravity_quota_signatures,
+        ) if agent_name == "antigravity" else None
+        if capacity is not None and capacity.is_capacity:
+            transient = True
+        transition = (
+            antigravity_attempts.next_after_failure(
+                retryable=transient, provider_capacity=bool(capacity and capacity.is_capacity)
+            ) if antigravity_attempts is not None else ("retry" if transient and attempt < max_attempts else "stop")
+        )
+        if transition == "retry":
             delay = backoff[min(attempt - 1, len(backoff) - 1)] if backoff else 1
             print(
                 f"run_external: transient failure (attempt {attempt}/{max_attempts}), "
@@ -403,6 +432,9 @@ def main() -> None:
                 file=sys.stderr,
             )
             time.sleep(delay)
+            continue
+        if transition == "fallback":
+            print("run_external: provider capacity; trying next Antigravity model", file=sys.stderr)
             continue
         reason = "retries exhausted" if transient else "non-transient failure"
         print(

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -23,7 +23,7 @@ emits no token usage (usage falls back to the estimated path).
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 import tempfile
 from typing import TYPE_CHECKING
@@ -44,6 +44,34 @@ from ..runner import Runner, strip_ansi
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
+
+
+@dataclass
+class AntigravityAttemptState:
+    """Shared retry-before-fallback policy for normal Antigravity invocations."""
+
+    models: tuple[str, ...]
+    retries_remaining: int
+    model_index: int = 0
+    attempts: int = 0
+
+    @classmethod
+    def from_config(cls, config: "AgentLoopConfig", retries: int) -> "AntigravityAttemptState":
+        return cls(config.antigravity_models, retries)
+
+    def singleton_config(self, config: "AgentLoopConfig") -> "AgentLoopConfig":
+        return replace(config, antigravity_model=None, antigravity_models=(self.models[self.model_index],))
+
+    def next_after_failure(self, *, retryable: bool, provider_capacity: bool) -> str:
+        """Return retry, fallback, or stop; retries are chain-wide."""
+        self.attempts += 1
+        if retryable and self.retries_remaining:
+            self.retries_remaining -= 1
+            return "retry"
+        if provider_capacity and self.model_index + 1 < len(self.models):
+            self.model_index += 1
+            return "fallback"
+        return "stop"
 
 
 def _git_lock_path(workdir: Path) -> Path:
@@ -206,8 +234,11 @@ class AntigravityBackend:
         log_path_override: Path | None = None,
     ) -> AgentResult:
         import json, fcntl  # Unix-only (fcntl); imported here so the module loads on Windows
-        for i, model in enumerate(config.antigravity_models):
+        # Model traversal belongs to AntigravityAttemptState, owned by the
+        # caller.  This backend deliberately executes exactly one model.
+        for model in config.antigravity_models[:1]:
             response_path = public_response_path(config, "antigravity")
+            response_path.unlink(missing_ok=True)
             prompt_text = _with_public_response_marker_instruction(
                 with_public_response_file_instruction(prompt, response_path)
             )
@@ -398,13 +429,6 @@ class AntigravityBackend:
                 fcntl.flock(settings_lock, fcntl.LOCK_UN)
                 settings_lock.close()
             log(config, f"Antigravity ({model}) finished; log: {log_path}")
-
-            if result.returncode != 0:
-                stdout_lower = result.stdout.lower()
-                if any(sig.lower() in stdout_lower for sig in config.antigravity_quota_signatures):
-                    if i + 1 < len(config.antigravity_models):
-                        log(config, f"Antigravity ({model}) hit quota exhaustion, falling back to next model.")
-                        continue
 
             # Prefer the public response file the prompt asks the agent to write; else
             # keep only what follows the public-response marker in stdout; else stdout.

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -449,11 +449,11 @@ class AntigravityBackend:
             returncode=result.returncode,
             usage=None,
             raw_usage=None,
-            # The model we requested is the model that ran (single-shot, no
-            # server-side substitution); the signature stamps it (#332). #333's
-            # fallback chain will override this with the model that answered.
+            # This single-model backend reports the model it requested; the
+            # caller's attempt state advances to a fallback model if needed.
             model_used=model,
         )
+
     def run_repair(
         self,
         runner: Runner,

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -236,160 +236,112 @@ class AntigravityBackend:
         import json, fcntl  # Unix-only (fcntl); imported here so the module loads on Windows
         # Model traversal belongs to AntigravityAttemptState, owned by the
         # caller.  This backend deliberately executes exactly one model.
-        for model in config.antigravity_models[:1]:
-            response_path = public_response_path(config, "antigravity")
-            response_path.unlink(missing_ok=True)
-            prompt_text = _with_public_response_marker_instruction(
-                with_public_response_file_instruction(prompt, response_path)
+        model = config.antigravity_models[0]
+        response_path = public_response_path(config, "antigravity")
+        response_path.unlink(missing_ok=True)
+        prompt_text = _with_public_response_marker_instruction(
+            with_public_response_file_instruction(prompt, response_path)
+        )
+        oversized_prompt = len(prompt_text.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES
+        args = [
+            config.antigravity_cmd,
+            "--model",
+            model,
+            "--print-timeout",
+            f"{config.antigravity_print_timeout_seconds}s",
+            *config.antigravity_args,
+        ]
+        if role in {"reviewer", "repair"}:
+            args = [a for a in args if a != "--dangerously-skip-permissions"]
+        # agy resumes by conversation id (not gemini's --resume). agy --print does
+        # not surface a conversation id in plain output, so in practice session_id
+        # is None and turns are single-shot; honor it if a caller ever supplies one.
+        if session_id:
+            args += ["--conversation", session_id]
+        # The prompt is the value of --print (must be last), not a positional.
+        args += ["--print", _OVERSIZED_PROMPT_DIRECTIVE if oversized_prompt else prompt_text]
+        log_path = log_path_override or agent_log_path(
+            config, "antigravity", run_id=run_id, label=label
+        )
+        log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
+        # agy reads GEMINI.md from the workdir as high-priority system context before
+        # the model sees the prompt. Injecting a single-shot session rule prevents
+        # agy from spawning background execution tasks (which cause it to end the
+        # --print turn without a response). Cleanup strips only the injected prefix
+        # rather than restoring a snapshot, so file changes made during a coder turn
+        # are preserved. An exclusive flock on the lock file (resolved by
+        # _git_lock_path into git metadata, not the worktree) serializes the entire
+        # inject→run→strip sequence across concurrent processes sharing the same
+        # default per-repo workdir.
+        gemini_md_path = config.antigravity_dir / "GEMINI.md"
+        gemini_lock_path = (
+            config.antigravity_dir.parent / f".{config.antigravity_dir.name}.GEMINI.md.lock"
+            if role == "repair"
+            else _git_lock_path(config.antigravity_dir)
+        )
+        if role == "repair":
+            single_shot_instruction = _REPAIR_GEMINI_MD
+        else:
+            resolved_base = (config.base or "").strip()
+            diff_cmd = (
+                f"`git diff {resolved_base}...HEAD`"
+                if resolved_base
+                else "`git diff <base>...HEAD` (replace `<base>` with the resolved base branch)"
             )
-            oversized_prompt = len(prompt_text.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES
-            args = [
-                config.antigravity_cmd,
-                "--model",
-                model,
-                "--print-timeout",
-                f"{config.antigravity_print_timeout_seconds}s",
-                *config.antigravity_args,
-            ]
+            single_shot_instruction = (
+                "# Agent Loop Single-Shot Session\n\n"
+                "You are running in a single-shot, non-interactive `agy --print` session"
+                " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
+                "**Do NOT spawn background execution tasks or subagents under any"
+                " circumstances.**\n\n"
+                "**For code review tasks: DO NOT run tests, builds, compilation,"
+                " mutation, commits, background work, or unrelated discovery commands.**"
+                f" You may use only the strict allow-listed read-only commands to inspect"
+                " the assigned checkout and local PR diff. Prefer "
+                f"{diff_cmd}, `git show`, `git status`, `git log`, `rg`, `sed`, and"
+                " direct file reads over web search. Do not fetch, checkout, reset, clean,"
+                " or write files. Tests are CI's responsibility; your job is to read code"
+                " and identify issues. If you find yourself about to run `pytest`, `npm"
+                " test`, `go test`, or any build command, stop and write your review from"
+                " code inspection alone.\n\n"
+                "For non-review tasks that require shell commands, run them synchronously"
+                " in this same turn before writing your response.\n\n"
+                "---\n\n"
+            )
+        injected_gemini_prefix = single_shot_instruction
+        if oversized_prompt:
+            injected_gemini_prefix += (
+                "# Agent Loop Task\n\n"
+                f"{prompt_text}\n\n"
+                "---\n\n"
+            )
+        settings_path = _antigravity_settings_path()
+        settings_lock_path = settings_path.with_suffix(".json.lock")
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_lock = settings_lock_path.open("a+")
+        try:
+            fcntl.flock(settings_lock, fcntl.LOCK_EX)
             if role in {"reviewer", "repair"}:
-                args = [a for a in args if a != "--dangerously-skip-permissions"]
-            # agy resumes by conversation id (not gemini's --resume). agy --print does
-            # not surface a conversation id in plain output, so in practice session_id
-            # is None and turns are single-shot; honor it if a caller ever supplies one.
-            if session_id:
-                args += ["--conversation", session_id]
-            # The prompt is the value of --print (must be last), not a positional.
-            args += ["--print", _OVERSIZED_PROMPT_DIRECTIVE if oversized_prompt else prompt_text]
-            log_path = log_path_override or agent_log_path(
-                config, "antigravity", run_id=run_id, label=label
-            )
-            log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
-            # agy reads GEMINI.md from the workdir as high-priority system context before
-            # the model sees the prompt. Injecting a single-shot session rule prevents
-            # agy from spawning background execution tasks (which cause it to end the
-            # --print turn without a response). Cleanup strips only the injected prefix
-            # rather than restoring a snapshot, so file changes made during a coder turn
-            # are preserved. An exclusive flock on the lock file (resolved by
-            # _git_lock_path into git metadata, not the worktree) serializes the entire
-            # inject→run→strip sequence across concurrent processes sharing the same
-            # default per-repo workdir.
-            gemini_md_path = config.antigravity_dir / "GEMINI.md"
-            gemini_lock_path = (
-                config.antigravity_dir.parent / f".{config.antigravity_dir.name}.GEMINI.md.lock"
-                if role == "repair"
-                else _git_lock_path(config.antigravity_dir)
-            )
-            if role == "repair":
-                single_shot_instruction = _REPAIR_GEMINI_MD
-            else:
-                resolved_base = (config.base or "").strip()
-                diff_cmd = (
-                    f"`git diff {resolved_base}...HEAD`"
-                    if resolved_base
-                    else "`git diff <base>...HEAD` (replace `<base>` with the resolved base branch)"
-                )
-                single_shot_instruction = (
-                    "# Agent Loop Single-Shot Session\n\n"
-                    "You are running in a single-shot, non-interactive `agy --print` session"
-                    " invoked by an automated orchestrator. There will be no follow-up turns.\n\n"
-                    "**Do NOT spawn background execution tasks or subagents under any"
-                    " circumstances.**\n\n"
-                    "**For code review tasks: DO NOT run tests, builds, compilation,"
-                    " mutation, commits, background work, or unrelated discovery commands.**"
-                    f" You may use only the strict allow-listed read-only commands to inspect"
-                    " the assigned checkout and local PR diff. Prefer "
-                    f"{diff_cmd}, `git show`, `git status`, `git log`, `rg`, `sed`, and"
-                    " direct file reads over web search. Do not fetch, checkout, reset, clean,"
-                    " or write files. Tests are CI's responsibility; your job is to read code"
-                    " and identify issues. If you find yourself about to run `pytest`, `npm"
-                    " test`, `go test`, or any build command, stop and write your review from"
-                    " code inspection alone.\n\n"
-                    "For non-review tasks that require shell commands, run them synchronously"
-                    " in this same turn before writing your response.\n\n"
-                    "---\n\n"
-                )
-            injected_gemini_prefix = single_shot_instruction
-            if oversized_prompt:
-                injected_gemini_prefix += (
-                    "# Agent Loop Task\n\n"
-                    f"{prompt_text}\n\n"
-                    "---\n\n"
-                )
-            settings_path = _antigravity_settings_path()
-            settings_lock_path = settings_path.with_suffix(".json.lock")
-            settings_path.parent.mkdir(parents=True, exist_ok=True)
-            settings_lock = settings_lock_path.open("a+")
-            try:
-                fcntl.flock(settings_lock, fcntl.LOCK_EX)
-                if role in {"reviewer", "repair"}:
+                try:
+                    original_settings_text = settings_path.read_text(encoding="utf-8")
                     try:
-                        original_settings_text = settings_path.read_text(encoding="utf-8")
-                        try:
-                            existing_settings = json.loads(original_settings_text)
-                        except json.JSONDecodeError as exc:
-                            raise AgentLoopError(f"settings.json malformed: {exc}") from exc
-                        if not isinstance(existing_settings, dict):
-                            raise AgentLoopError("settings.json root is not a JSON object")
-                    except FileNotFoundError:
-                        original_settings_text = None
-                        existing_settings = {}
-                    try:
-                        injection = (
-                            _REPAIR_SETTINGS_INJECTION
-                            if role == "repair"
-                            else _REVIEWER_SETTINGS_INJECTION
-                        )
-                        injected = {**existing_settings, **injection}
-                        settings_path.write_text(json.dumps(injected, indent=2), encoding="utf-8")
-                        # Inner: GEMINI.md lock
-                        gemini_lock_file = gemini_lock_path.open("a+")
-                        try:
-                            fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
-                            try:
-                                existing_gemini = gemini_md_path.read_text(encoding="utf-8")
-                            except FileNotFoundError:
-                                existing_gemini = None
-                            gemini_md_path.write_text(
-                                injected_gemini_prefix + (existing_gemini or ""),
-                                encoding="utf-8",
-                            )
-                            try:
-                                result = runner.run_with_log(
-                                    args,
-                                    cwd=config.antigravity_dir,
-                                    log_path=log_path,
-                                    label=f"Antigravity ({model})",
-                                    progress_interval_seconds=config.progress_interval_seconds,
-                                    check=False,
-                                    env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
-                                    use_pty=True,
-                                    timeout_seconds=(
-                                        config.repair_timeout_seconds
-                                        if role == "repair"
-                                        else timeout_seconds
-                                    ),
-                                )
-                            finally:
-                                if gemini_md_path.exists():
-                                    current = gemini_md_path.read_text(encoding="utf-8")
-                                    if current.startswith(injected_gemini_prefix):
-                                        remainder = current[len(injected_gemini_prefix):]
-                                        if remainder:
-                                            gemini_md_path.write_text(remainder, encoding="utf-8")
-                                        else:
-                                            gemini_md_path.unlink()
-                        finally:
-                            fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
-                            gemini_lock_file.close()
-                            if role == "repair":
-                                gemini_lock_path.unlink(missing_ok=True)
-                    finally:
-                        if original_settings_text is None:
-                            settings_path.unlink(missing_ok=True)
-                        else:
-                            settings_path.write_text(original_settings_text, encoding="utf-8")
-                else:
-                    # Coder path: hold settings lock without modifying settings.json
+                        existing_settings = json.loads(original_settings_text)
+                    except json.JSONDecodeError as exc:
+                        raise AgentLoopError(f"settings.json malformed: {exc}") from exc
+                    if not isinstance(existing_settings, dict):
+                        raise AgentLoopError("settings.json root is not a JSON object")
+                except FileNotFoundError:
+                    original_settings_text = None
+                    existing_settings = {}
+                try:
+                    injection = (
+                        _REPAIR_SETTINGS_INJECTION
+                        if role == "repair"
+                        else _REVIEWER_SETTINGS_INJECTION
+                    )
+                    injected = {**existing_settings, **injection}
+                    settings_path.write_text(json.dumps(injected, indent=2), encoding="utf-8")
+                    # Inner: GEMINI.md lock
                     gemini_lock_file = gemini_lock_path.open("a+")
                     try:
                         fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
@@ -411,7 +363,11 @@ class AntigravityBackend:
                                 check=False,
                                 env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
                                 use_pty=True,
-                                timeout_seconds=timeout_seconds,
+                                timeout_seconds=(
+                                    config.repair_timeout_seconds
+                                    if role == "repair"
+                                    else timeout_seconds
+                                ),
                             )
                         finally:
                             if gemini_md_path.exists():
@@ -425,39 +381,79 @@ class AntigravityBackend:
                     finally:
                         fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
                         gemini_lock_file.close()
-            finally:
-                fcntl.flock(settings_lock, fcntl.LOCK_UN)
-                settings_lock.close()
-            log(config, f"Antigravity ({model}) finished; log: {log_path}")
-
-            # Prefer the public response file the prompt asks the agent to write; else
-            # keep only what follows the public-response marker in stdout; else stdout.
-            response_file_text = read_public_response_file(response_path)
-            if response_file_text is not None:
-                message_text, text_source = response_file_text, "response_file"
+                        if role == "repair":
+                            gemini_lock_path.unlink(missing_ok=True)
+                finally:
+                    if original_settings_text is None:
+                        settings_path.unlink(missing_ok=True)
+                    else:
+                        settings_path.write_text(original_settings_text, encoding="utf-8")
             else:
-                message_text, text_source = _strip_public_response_marker(result.stdout)
-            return AgentResult(
-                text=message_text,
-                raw_output=result.stdout,
-                text_source=text_source,
-                response_file_text=response_file_text,
-                response_file_path=response_path,
-                message_text=message_text,
-                session_id=None,
-                log_path=log_path,
-                returncode=result.returncode,
-                usage=None,
-                raw_usage=None,
-                # The model we requested is the model that ran (single-shot, no
-                # server-side substitution); the signature stamps it (#332). #333's
-                # fallback chain will override this with the model that answered.
-                model_used=model,
-            )
-        
-        # This point should not be reached since antigravity_models cannot be empty
-        raise RuntimeError("No antigravity models available to run.")
+                # Coder path: hold settings lock without modifying settings.json
+                gemini_lock_file = gemini_lock_path.open("a+")
+                try:
+                    fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
+                    try:
+                        existing_gemini = gemini_md_path.read_text(encoding="utf-8")
+                    except FileNotFoundError:
+                        existing_gemini = None
+                    gemini_md_path.write_text(
+                        injected_gemini_prefix + (existing_gemini or ""),
+                        encoding="utf-8",
+                    )
+                    try:
+                        result = runner.run_with_log(
+                            args,
+                            cwd=config.antigravity_dir,
+                            log_path=log_path,
+                            label=f"Antigravity ({model})",
+                            progress_interval_seconds=config.progress_interval_seconds,
+                            check=False,
+                            env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+                            use_pty=True,
+                            timeout_seconds=timeout_seconds,
+                        )
+                    finally:
+                        if gemini_md_path.exists():
+                            current = gemini_md_path.read_text(encoding="utf-8")
+                            if current.startswith(injected_gemini_prefix):
+                                remainder = current[len(injected_gemini_prefix):]
+                                if remainder:
+                                    gemini_md_path.write_text(remainder, encoding="utf-8")
+                                else:
+                                    gemini_md_path.unlink()
+                finally:
+                    fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
+                    gemini_lock_file.close()
+        finally:
+            fcntl.flock(settings_lock, fcntl.LOCK_UN)
+            settings_lock.close()
+        log(config, f"Antigravity ({model}) finished; log: {log_path}")
 
+        # Prefer the public response file the prompt asks the agent to write; else
+        # keep only what follows the public-response marker in stdout; else stdout.
+        response_file_text = read_public_response_file(response_path)
+        if response_file_text is not None:
+            message_text, text_source = response_file_text, "response_file"
+        else:
+            message_text, text_source = _strip_public_response_marker(result.stdout)
+        return AgentResult(
+            text=message_text,
+            raw_output=result.stdout,
+            text_source=text_source,
+            response_file_text=response_file_text,
+            response_file_path=response_path,
+            message_text=message_text,
+            session_id=None,
+            log_path=log_path,
+            returncode=result.returncode,
+            usage=None,
+            raw_usage=None,
+            # The model we requested is the model that ran (single-shot, no
+            # server-side substitution); the signature stamps it (#332). #333's
+            # fallback chain will override this with the model that answered.
+            model_used=model,
+        )
     def run_repair(
         self,
         runner: Runner,

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -209,13 +209,13 @@ def build_parser() -> argparse.ArgumentParser:
             "--antigravity-models",
             nargs="+",
             default=None,
-            help="Ordered chain of Antigravity models to try on quota exhaustion. Mutually exclusive with --antigravity-model.",
+            help="Ordered Antigravity fallback chain after provider capacity retries. Mutually exclusive with --antigravity-model.",
         )
         subparser.add_argument(
             "--antigravity-quota-signatures",
             nargs="+",
             default=list(DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES),
-            help="Output substrings that trigger model fallback (default: quota, rate limit, etc).",
+            help="Provider error substrings that permit Antigravity fallback (default: quota, high traffic, etc).",
         )
         subparser.add_argument(
             "--codex-model",
@@ -389,7 +389,7 @@ def build_parser() -> argparse.ArgumentParser:
             "--agent-max-retries",
             type=int,
             default=2,
-            help="Maximum retries for narrow transient agent/model failures (default: 2).",
+            help="Maximum transient retries; shared across the Antigravity fallback chain (default: 2).",
         )
         subparser.add_argument(
             "--agent-retry-backoff-seconds",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -25,9 +25,15 @@ from .workdirs import active_workdir, agent_workdir
 DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES: tuple[str, ...] = (
     "quota",
     "rate limit",
+    "too many requests",
     "resource exhausted",
     "RESOURCE_EXHAUSTED",
     "429",
+    "high traffic",
+    "try again in a minute",
+    "overload",
+    "no capacity",
+    "temporarily at capacity",
 )
 
 # Default Antigravity model fallback chain, applied in __post_init__ when neither a

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, replace as dataclasses_replace
 from pathlib import Path
 
 from .agents.base import AgentName, AgentResult
+from .agents.antigravity import AntigravityAttemptState
 from .agents.registry import agent_display_name, agent_signature, get_backend, run_agent_result
 from .config import (
     AgentLoopConfig,
@@ -196,6 +197,7 @@ from .salvage import (
 from .transient import (
     NON_RETRYABLE_AGENT_OUTPUT_RE,
     TRANSIENT_AGENT_OUTPUT_RE,
+    classify_antigravity_capacity,
     is_transient_agent_output,
     looks_like_backgrounded_completion,
 )
@@ -2076,7 +2078,17 @@ def _run_validated_agent(
         marker_description=marker_description,
     )
     log_paths: list[object] = []
-    max_attempts = config.agent_max_retries + 1
+    antigravity_attempts = (
+        AntigravityAttemptState.from_config(config, config.agent_max_retries)
+        if agent == "antigravity" and not use_repair
+        else None
+    )
+    # Each fallback retains an initial attempt; retry allowance is shared.
+    max_attempts = (
+        len(config.antigravity_models) + config.agent_max_retries
+        if antigravity_attempts is not None
+        else config.agent_max_retries + 1
+    )
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
     last_classification_text = ""
@@ -2090,10 +2102,15 @@ def _run_validated_agent(
     completion_recovery_attempted = False
 
     for attempt in range(1, max_attempts + 1):
+        attempt_config = (
+            antigravity_attempts.singleton_config(config)
+            if antigravity_attempts is not None
+            else config
+        )
         result = run_agent_result(
             runner,
             agent=agent,
-            config=config,
+            config=attempt_config,
             prompt=prompt,
             session_id=session_id,
             run_id=usage_context.run_id if usage_context is not None else None,
@@ -2117,6 +2134,7 @@ def _run_validated_agent(
             )
 
         should_retry = False
+        provider_capacity = False
         if result.returncode is None:
             # Timed out (returncode=None from Runner.run_with_log). Detected
             # before transient classification: a kill deadline is not a
@@ -2133,12 +2151,32 @@ def _run_validated_agent(
             last_classification_text = classification_text
             should_retry = _is_transient_agent_output(classification_text)
             last_failure_category = _failure_category(classification_text)
+            capacity = classify_antigravity_capacity(
+                classification_text,
+                returncode=result.returncode,
+                empty_response=False,
+                signatures=config.antigravity_quota_signatures,
+            ) if agent == "antigravity" else None
+            provider_capacity = bool(capacity and capacity.is_capacity)
+            if provider_capacity:
+                should_retry = True
+                last_failure_category = "transient"
         elif not text.strip():
             last_error = "agent response was empty"
             classification_text = _agent_failure_classification_text(result, phase="empty")
             last_classification_text = classification_text
             should_retry = _is_transient_agent_output(classification_text)
             last_failure_category = _failure_category(classification_text)
+            capacity = classify_antigravity_capacity(
+                classification_text,
+                returncode=result.returncode,
+                empty_response=True,
+                signatures=config.antigravity_quota_signatures,
+            ) if agent == "antigravity" else None
+            provider_capacity = bool(capacity and capacity.is_capacity)
+            if provider_capacity:
+                should_retry = True
+                last_failure_category = "transient"
         else:
             response_file_pre_status = (
                 _response_file_structured_status(result.response_file_text)
@@ -2626,7 +2664,14 @@ def _run_validated_agent(
                     )
                     message += diagnostics.format_for_error()
                     raise QuotaResetExceededError(message)
-            if attempt < max_attempts:
+            transition = (
+                antigravity_attempts.next_after_failure(
+                    retryable=should_retry, provider_capacity=provider_capacity
+                )
+                if antigravity_attempts is not None
+                else ("retry" if attempt < max_attempts else "stop")
+            )
+            if transition == "retry":
                 delay = _retry_delay(config, attempt)
                 category = last_failure_category
                 log(
@@ -2635,6 +2680,14 @@ def _run_validated_agent(
                     f"retrying in {delay}s (attempt {attempt + 1}/{max_attempts})",
                 )
                 runner.run(("sleep", str(delay)), cwd=active_workdir(config))
+                continue
+            if transition == "fallback":
+                log(
+                    config,
+                    f"{agent_name}: provider capacity exhausted for "
+                    f"{result.model_used}; trying {antigravity_attempts.models[antigravity_attempts.model_index]} "
+                    "without additional delay",
+                )
                 continue
         break
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2080,7 +2080,7 @@ def _run_validated_agent(
     log_paths: list[object] = []
     antigravity_attempts = (
         AntigravityAttemptState.from_config(config, config.agent_max_retries)
-        if agent == "antigravity" and not use_repair
+        if agent == "antigravity"
         else None
     )
     # Each fallback retains an initial attempt; retry allowance is shared.

--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -52,7 +52,6 @@ _ANTIGRAVITY_ERROR_LINE_RE = re.compile(r"(?i)^\s*(?:error|fatal)\s*[:\[]")
 _ANTIGRAVITY_ERROR_JSON_RE = re.compile(
     r'^\s*\{.{0,2000}?"(?:error|code|status|message)"\s*:', re.I
 )
-_QUOTED_REVIEW_CONTEXT_RE = re.compile(r"\b(?:review|quote[sd]?|example|report)\b", re.I)
 
 
 def classify_antigravity_capacity(
@@ -66,8 +65,9 @@ def classify_antigravity_capacity(
 
     Only failed or empty invocations are eligible. A signature on a provider
     error line (or its adjacent detail line), a compact JSON error line, or an
-    unframed standalone provider diagnostic qualifies. Quoted review content
-    is excluded, and authentication/billing retain non-retryable precedence.
+    unframed standalone provider diagnostic qualifies. Framed provider errors
+    must be terminal output so unrelated transcript wording cannot suppress a
+    real capacity failure; authentication/billing retain non-retryable precedence.
     """
     if (returncode in (None, 0) and not empty_response) or not text.strip():
         return AntigravityCapacityClassification(False)
@@ -86,15 +86,20 @@ def classify_antigravity_capacity(
     for index, line in enumerate(lines):
         if _ANTIGRAVITY_ERROR_LINE_RE.match(line) or _ANTIGRAVITY_ERROR_JSON_RE.match(line):
             adjacent = "\n".join(lines[max(0, index - 1): index + 2])
-            preceding = lines[index - 1] if index else ""
-            if has_signature(adjacent) and not _QUOTED_REVIEW_CONTEXT_RE.search(preceding):
+            # agy emits an error immediately before exiting. Limit the frame to
+            # the last few non-empty lines rather than inspecting normal reviewer
+            # transcript text that may precede it.
+            if has_signature(adjacent) and index >= len(lines) - 3:
                 return AntigravityCapacityClassification(True, diagnostic)
 
     # Older agy versions emitted bare provider diagnostics (for example,
     # "quota exceeded please try again") on a non-zero exit. Preserve that
-    # fallback trigger, while refusing transcript text that identifies itself
-    # as a quoted review/example rather than the provider's own diagnostic.
-    if has_signature(diagnostic) and not _QUOTED_REVIEW_CONTEXT_RE.search(diagnostic):
+    # fallback trigger. A bare diagnostic must be a single line beginning with
+    # a configured capacity signature, so an incidental phrase embedded in a
+    # review transcript cannot qualify.
+    if len(lines) == 1 and any(
+        lines[0].lower().startswith(signature) for signature in lowered_signatures
+    ):
         return AntigravityCapacityClassification(True, diagnostic)
     return AntigravityCapacityClassification(False)
 

--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -48,10 +48,11 @@ class AntigravityCapacityClassification:
     diagnostic: str = ""
 
 
-_ANTIGRAVITY_ERROR_LINE_RE = re.compile(r"(?im)^\s*(?:error|fatal)\s*[:\[]")
+_ANTIGRAVITY_ERROR_LINE_RE = re.compile(r"(?i)^\s*(?:error|fatal)\s*[:\[]")
 _ANTIGRAVITY_ERROR_JSON_RE = re.compile(
-    r'(?is)^\s*\{.{0,2000}?"(?:error|code|status|message)"\s*:',
+    r'^\s*\{.{0,2000}?"(?:error|code|status|message)"\s*:', re.I
 )
+_QUOTED_REVIEW_CONTEXT_RE = re.compile(r"\b(?:review|quote[sd]?|example|report)\b", re.I)
 
 
 def classify_antigravity_capacity(
@@ -63,26 +64,37 @@ def classify_antigravity_capacity(
 ) -> AntigravityCapacityClassification:
     """Recognize framed Antigravity provider-capacity diagnostics.
 
-    Capacity words in a normal review must not trigger fallback: this classifier
-    only considers a failed/empty invocation and an error-shaped standalone
-    diagnostic (or compact JSON error payload).  Authentication and billing
-    retain their non-retryable precedence.
+    Only failed or empty invocations are eligible. A signature on a provider
+    error line (or its adjacent detail line), a compact JSON error line, or an
+    unframed standalone provider diagnostic qualifies. Quoted review content
+    is excluded, and authentication/billing retain non-retryable precedence.
     """
     if (returncode in (None, 0) and not empty_response) or not text.strip():
         return AntigravityCapacityClassification(False)
     if NON_RETRYABLE_AGENT_OUTPUT_RE.search(text):
         return AntigravityCapacityClassification(False)
     # A provider normally prints its failure at either end; retaining a bounded
-    # tail also avoids a quoted issue report in a long agent transcript.
+    # tail avoids accepting a capacity phrase from an unrelated long transcript.
     stripped = text.strip()
     diagnostic = stripped if len(stripped) <= 2400 else f"{stripped[:1200]}\n{stripped[-1200:]}"
-    framed = bool(
-        _ANTIGRAVITY_ERROR_LINE_RE.search(diagnostic)
-        or _ANTIGRAVITY_ERROR_JSON_RE.search(diagnostic)
-    )
-    if not framed:
-        return AntigravityCapacityClassification(False)
-    if any(signature.lower() in diagnostic.lower() for signature in signatures):
+    lines = [line.strip() for line in diagnostic.splitlines() if line.strip()]
+    lowered_signatures = tuple(signature.lower() for signature in signatures)
+
+    def has_signature(value: str) -> bool:
+        return any(signature in value.lower() for signature in lowered_signatures)
+
+    for index, line in enumerate(lines):
+        if _ANTIGRAVITY_ERROR_LINE_RE.match(line) or _ANTIGRAVITY_ERROR_JSON_RE.match(line):
+            adjacent = "\n".join(lines[max(0, index - 1): index + 2])
+            preceding = lines[index - 1] if index else ""
+            if has_signature(adjacent) and not _QUOTED_REVIEW_CONTEXT_RE.search(preceding):
+                return AntigravityCapacityClassification(True, diagnostic)
+
+    # Older agy versions emitted bare provider diagnostics (for example,
+    # "quota exceeded please try again") on a non-zero exit. Preserve that
+    # fallback trigger, while refusing transcript text that identifies itself
+    # as a quoted review/example rather than the provider's own diagnostic.
+    if has_signature(diagnostic) and not _QUOTED_REVIEW_CONTEXT_RE.search(diagnostic):
         return AntigravityCapacityClassification(True, diagnostic)
     return AntigravityCapacityClassification(False)
 

--- a/src/coding_review_agent_loop/transient.py
+++ b/src/coding_review_agent_loop/transient.py
@@ -8,6 +8,7 @@ whether to retry an agent invocation without importing the full orchestrator.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 TRANSIENT_AGENT_OUTPUT_RE = re.compile(
     r"Invalid stream|empty response|malformed tool call|"
@@ -37,6 +38,53 @@ def is_transient_agent_output(text: str) -> bool:
     return bool(TRANSIENT_AGENT_OUTPUT_RE.search(text)) and not bool(
         NON_RETRYABLE_AGENT_OUTPUT_RE.search(text)
     )
+
+
+@dataclass(frozen=True)
+class AntigravityCapacityClassification:
+    """Provider-scoped capacity result used to decide model fallback."""
+
+    is_capacity: bool
+    diagnostic: str = ""
+
+
+_ANTIGRAVITY_ERROR_LINE_RE = re.compile(r"(?im)^\s*(?:error|fatal)\s*[:\[]")
+_ANTIGRAVITY_ERROR_JSON_RE = re.compile(
+    r'(?is)^\s*\{.{0,2000}?"(?:error|code|status|message)"\s*:',
+)
+
+
+def classify_antigravity_capacity(
+    text: str,
+    *,
+    returncode: int | None,
+    empty_response: bool,
+    signatures: tuple[str, ...],
+) -> AntigravityCapacityClassification:
+    """Recognize framed Antigravity provider-capacity diagnostics.
+
+    Capacity words in a normal review must not trigger fallback: this classifier
+    only considers a failed/empty invocation and an error-shaped standalone
+    diagnostic (or compact JSON error payload).  Authentication and billing
+    retain their non-retryable precedence.
+    """
+    if (returncode in (None, 0) and not empty_response) or not text.strip():
+        return AntigravityCapacityClassification(False)
+    if NON_RETRYABLE_AGENT_OUTPUT_RE.search(text):
+        return AntigravityCapacityClassification(False)
+    # A provider normally prints its failure at either end; retaining a bounded
+    # tail also avoids a quoted issue report in a long agent transcript.
+    stripped = text.strip()
+    diagnostic = stripped if len(stripped) <= 2400 else f"{stripped[:1200]}\n{stripped[-1200:]}"
+    framed = bool(
+        _ANTIGRAVITY_ERROR_LINE_RE.search(diagnostic)
+        or _ANTIGRAVITY_ERROR_JSON_RE.search(diagnostic)
+    )
+    if not framed:
+        return AntigravityCapacityClassification(False)
+    if any(signature.lower() in diagnostic.lower() for signature in signatures):
+        return AntigravityCapacityClassification(True, diagnostic)
+    return AntigravityCapacityClassification(False)
 
 
 # Phrases an agent uses when it has started required work (tests, builds) in

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3977,6 +3977,66 @@ def test_base_response_file_instruction_includes_must_write_before_turn_ends(tmp
 # ── Tests: issue #400 – toolPermission: "strict" injection for reviewer ────────
 
 
+def test_antigravity_reviewer_capacity_retry_falls_back_with_repair_enabled(tmp_path):
+    """Reviewer repair paths share Antigravity's retry budget across models."""
+    from coding_review_agent_loop.agents.base import AgentResult
+    from unittest.mock import patch
+
+    config = make_config(
+        tmp_path,
+        reviewer="antigravity",
+        agent_max_retries=1,
+        antigravity_models=("ModelA", "ModelB"),
+    )
+    results = iter((
+        AgentResult(
+            text="",
+            raw_output="Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+            returncode=1,
+            model_used="ModelA",
+        ),
+        AgentResult(text="", raw_output="quota exceeded please try again", returncode=1, model_used="ModelA"),
+        AgentResult(text="valid review", returncode=0, model_used="ModelB"),
+    ))
+    models: list[tuple[str, ...]] = []
+
+    def mock_run(_runner, *, config, **_kwargs):
+        models.append(config.antigravity_models)
+        return next(results)
+
+    with patch("coding_review_agent_loop.orchestrator.run_agent_result", mock_run):
+        response = _run_validated_agent(
+            FakeRunner(), agent="antigravity", config=config, prompt="Review.",
+            marker_description="test", validate=lambda text: text, use_repair=True, role="reviewer",
+        )
+
+    assert response.text == "valid review"
+    assert response.model_used == "ModelB"
+    assert models == [("ModelA",), ("ModelA",), ("ModelB",)]
+
+
+def test_antigravity_capacity_exhaustion_is_reported_transient(tmp_path):
+    """A real orchestration retry path keeps capacity exhaustion transient."""
+    from coding_review_agent_loop.agents.base import AgentResult
+    from coding_review_agent_loop.errors import AgentInvocationError
+    from unittest.mock import patch
+
+    config = make_config(tmp_path, reviewer="antigravity", agent_max_retries=1, antigravity_models=("ModelA",))
+    result = AgentResult(
+        text="",
+        raw_output="Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+        returncode=1,
+        model_used="ModelA",
+    )
+
+    with patch("coding_review_agent_loop.orchestrator.run_agent_result", return_value=result):
+        with pytest.raises(AgentInvocationError, match="transient"):
+            _run_validated_agent(
+                FakeRunner(), agent="antigravity", config=config, prompt="Review.",
+                marker_description="test", validate=lambda text: text, use_repair=True, role="reviewer",
+            )
+
+
 def test_reviewer_and_coder_call_sites_pass_correct_role(tmp_path):
     """_run_validated_agent propagates role= to run_agent_result correctly."""
     from unittest.mock import patch

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -126,6 +126,7 @@ def test_antigravity_backend_stops_on_other_errors(tmp_path):
 
 def test_antigravity_backend_ignores_stale_partial_response_file(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    from coding_review_agent_loop.agents.base import public_response_path
     agy_dir = tmp_path / "antigravity"
     agy_dir.mkdir(parents=True, exist_ok=True)
     runner = FakeRunner(antigravity_outputs=[("success", 0)], public_response_outputs=["successful response"])
@@ -135,10 +136,14 @@ def test_antigravity_backend_ignores_stale_partial_response_file(tmp_path):
         antigravity_models=("ModelA",),
         antigravity_quota_signatures=("quota",)
     )
+    stale_path = public_response_path(config, "antigravity")
+    stale_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_path.write_text("stale partial response", encoding="utf-8")
     result = AntigravityBackend().run(runner, config, "Review", run_id="r1")
     
     assert result.text == "successful response"
     assert result.model_used == "ModelA"
+    assert result.text != "stale partial response"
 
 def test_antigravity_backend_writes_gemini_md_single_shot_instruction(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -85,31 +85,22 @@ def test_antigravity_backend_places_large_prompt_in_injected_gemini_md(tmp_path)
     assert captured and prompt in captured[0]
     assert not (agy_dir / "GEMINI.md").exists()
 
-def test_antigravity_backend_fallback_chain_on_quota_signal(tmp_path):
-    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+def test_antigravity_attempt_state_retries_then_falls_back(tmp_path):
+    from coding_review_agent_loop.agents.antigravity import AntigravityAttemptState
     agy_dir = tmp_path / "antigravity"
     agy_dir.mkdir(parents=True, exist_ok=True)
-    runner = FakeRunner(
-        antigravity_outputs=[
-            ("quota exceeded please try again", 1),
-            ("quota exceeded again", 1),
-            ("ok fallback answered", 0)
-        ]
-    )
     config = make_config(
         tmp_path,
         antigravity_dir=agy_dir,
         antigravity_models=("ModelA", "ModelB", "ModelC"),
         antigravity_quota_signatures=("quota",)
     )
-    result = AntigravityBackend().run(runner, config, "Review", run_id="r1")
-    
-    assert runner.commands[-3][0][runner.commands[-3][0].index("--model") + 1] == "ModelA"
-    assert runner.commands[-2][0][runner.commands[-2][0].index("--model") + 1] == "ModelB"
-    assert runner.commands[-1][0][runner.commands[-1][0].index("--model") + 1] == "ModelC"
-    
-    assert result.text == "ok fallback answered"
-    assert result.model_used == "ModelC"
+    state = AntigravityAttemptState.from_config(config, retries=2)
+    models = []
+    for expected in ("retry", "retry", "fallback", "fallback", "stop"):
+        models.append(state.singleton_config(config).antigravity_models)
+        assert state.next_after_failure(retryable=True, provider_capacity=True) == expected
+    assert models == [("ModelA",), ("ModelA",), ("ModelA",), ("ModelB",), ("ModelC",)]
 
 def test_antigravity_backend_stops_on_other_errors(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
@@ -133,30 +124,21 @@ def test_antigravity_backend_stops_on_other_errors(tmp_path):
     assert result.returncode == 1
     assert result.model_used == "ModelA"
 
-def test_antigravity_backend_ignores_partial_response_file_on_fallback(tmp_path):
+def test_antigravity_backend_ignores_stale_partial_response_file(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
     agy_dir = tmp_path / "antigravity"
     agy_dir.mkdir(parents=True, exist_ok=True)
-    runner = FakeRunner(
-        antigravity_outputs=[
-            ("quota error", 1),
-            ("success", 0)
-        ],
-        public_response_outputs=[
-            "partial failed response",
-            "successful response"
-        ]
-    )
+    runner = FakeRunner(antigravity_outputs=[("success", 0)], public_response_outputs=["successful response"])
     config = make_config(
         tmp_path,
         antigravity_dir=agy_dir,
-        antigravity_models=("ModelA", "ModelB"),
+        antigravity_models=("ModelA",),
         antigravity_quota_signatures=("quota",)
     )
     result = AntigravityBackend().run(runner, config, "Review", run_id="r1")
     
     assert result.text == "successful response"
-    assert result.model_used == "ModelB"
+    assert result.model_used == "ModelA"
 
 def test_antigravity_backend_writes_gemini_md_single_shot_instruction(tmp_path):
     from coding_review_agent_loop.agents.antigravity import AntigravityBackend
@@ -447,7 +429,11 @@ def test_config_from_args_antigravity_defaults(tmp_path):
         "Gemini 3.1 Pro (High)",
     )
     assert config.antigravity_print_timeout_seconds == 600
-    assert config.antigravity_quota_signatures == ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")
+    assert config.antigravity_quota_signatures == (
+        "quota", "rate limit", "too many requests", "resource exhausted",
+        "RESOURCE_EXHAUSTED", "429", "high traffic", "try again in a minute",
+        "overload", "no capacity", "temporarily at capacity",
+    )
     assert config.antigravity_args == ("--dangerously-skip-permissions",)
     assert config.antigravity_dir == default_agent_workdir("OWNER/REPO", "antigravity").resolve()
     # antigravity is the coder -> primary/log dir lives under its checkout.

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1287,6 +1287,7 @@ class TestRunExternalRetries:
             def run(self, runner, config, prompt):
                 i = calls["n"]
                 calls["n"] += 1
+                calls.setdefault("models", []).append(config.antigravity_models)
                 outcome = outcomes[min(i, len(outcomes) - 1)]
                 if isinstance(outcome, Exception):
                     raise outcome
@@ -1294,6 +1295,7 @@ class TestRunExternalRetries:
 
         monkeypatch.setattr("coding_review_agent_loop.agents.codex.CodexBackend", FakeBackend)
         monkeypatch.setattr("coding_review_agent_loop.agents.gemini.GeminiBackend", FakeBackend)
+        monkeypatch.setattr("coding_review_agent_loop.agents.antigravity.AntigravityBackend", FakeBackend)
         sleeps: list[int] = []
         monkeypatch.setattr(rex.time, "sleep", lambda s: sleeps.append(s))
 
@@ -1372,6 +1374,28 @@ class TestRunExternalRetries:
         )
         assert exit_code == 1
         assert "Invalid stream" in Path(output_path).read_text(encoding="utf-8")
+
+    def test_antigravity_capacity_retries_then_uses_next_model(self, monkeypatch) -> None:
+        from coding_review_agent_loop.agents.base import AgentResult
+
+        outcomes = [
+            AgentResult(text="", raw_output="Error: high traffic, try again in a minute", returncode=1),
+            AgentResult(text="", raw_output="quota exceeded please try again", returncode=1),
+            AgentResult(text="final review body", returncode=0),
+        ]
+        calls, sleeps, output_path, exit_code = self._invoke(
+            monkeypatch, "antigravity", outcomes, max_retries=1
+        )
+
+        assert exit_code == 0
+        assert calls["n"] == 3
+        assert calls["models"] == [
+            ("Gemini 3.6 Flash (High)",),
+            ("Gemini 3.6 Flash (High)",),
+            ("Gemini 3.5 Flash (High)",),
+        ]
+        assert sleeps == [1]
+        assert Path(output_path).read_text(encoding="utf-8") == "final review body"
 
     def test_writes_minimal_response_evidence_sidecar(self, monkeypatch, tmp_path) -> None:
         import helpers.run_external as rex
@@ -3915,13 +3939,13 @@ class TestAntigravitySkill:
             (
                 (),
                 ("Gemini 3.6 Flash (High)", "Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)"),
-                ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"),
+                ("quota", "rate limit", "too many requests", "resource exhausted", "RESOURCE_EXHAUSTED", "429", "high traffic", "try again in a minute", "overload", "no capacity", "temporarily at capacity"),
             ),
-            (("--model", "Model X"), ("Model X",), ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429")),
+            (("--model", "Model X"), ("Model X",), ("quota", "rate limit", "too many requests", "resource exhausted", "RESOURCE_EXHAUSTED", "429", "high traffic", "try again in a minute", "overload", "no capacity", "temporarily at capacity")),
             (
                 ("--antigravity-models", "Model A", "Model B"),
                 ("Model A", "Model B"),
-                ("quota", "rate limit", "resource exhausted", "RESOURCE_EXHAUSTED", "429"),
+                ("quota", "rate limit", "too many requests", "resource exhausted", "RESOURCE_EXHAUSTED", "429", "high traffic", "try again in a minute", "overload", "no capacity", "temporarily at capacity"),
             ),
             (
                 ("--antigravity-quota-signatures", "Quota Hit", "429"),
@@ -3969,7 +3993,9 @@ class TestAntigravitySkill:
 
         config = captured["config"]
         assert config.reviewer == ("antigravity",)
-        assert config.antigravity_models == expected_models
+        # run_external gives the backend one model at a time; its retry loop
+        # owns traversal of the complete configured chain.
+        assert config.antigravity_models == (expected_models[0],)
         assert config.antigravity_quota_signatures == expected_signatures
 
     @pytest.mark.parametrize(

--- a/tests/test_transient.py
+++ b/tests/test_transient.py
@@ -47,7 +47,17 @@ def test_antigravity_capacity_requires_framed_provider_failure() -> None:
         signatures=signatures,
     ).is_capacity
     assert not transient.classify_antigravity_capacity(
+        "The review quotes the provider failure below:\n"
+        "Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+        returncode=1,
+        empty_response=False,
+        signatures=signatures,
+    ).is_capacity
+    assert not transient.classify_antigravity_capacity(
         "Error: high traffic but invalid API key", returncode=1, empty_response=False, signatures=signatures
+    ).is_capacity
+    assert transient.classify_antigravity_capacity(
+        "quota exceeded please try again", returncode=1, empty_response=False, signatures=("quota",)
     ).is_capacity
 
 

--- a/tests/test_transient.py
+++ b/tests/test_transient.py
@@ -40,6 +40,13 @@ def test_antigravity_capacity_requires_framed_provider_failure() -> None:
         assert transient.classify_antigravity_capacity(
             text, returncode=1, empty_response=False, signatures=signatures
         ).is_capacity
+    assert transient.classify_antigravity_capacity(
+        "Reading the diff to draft the review...\n"
+        "Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+        returncode=1,
+        empty_response=False,
+        signatures=signatures,
+    ).is_capacity
     assert not transient.classify_antigravity_capacity(
         "The review quotes: Error: Our servers are experiencing high traffic right now, please try again in a minute.",
         returncode=1,
@@ -48,7 +55,7 @@ def test_antigravity_capacity_requires_framed_provider_failure() -> None:
     ).is_capacity
     assert not transient.classify_antigravity_capacity(
         "The review quotes the provider failure below:\n"
-        "Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+        "> Error: Our servers are experiencing high traffic right now, please try again in a minute.",
         returncode=1,
         empty_response=False,
         signatures=signatures,

--- a/tests/test_transient.py
+++ b/tests/test_transient.py
@@ -30,6 +30,27 @@ def test_non_retryable_overrides_transient_signal() -> None:
     assert not transient.is_transient_agent_output("got 429 but the api key is unauthorized")
 
 
+def test_antigravity_capacity_requires_framed_provider_failure() -> None:
+    signatures = ("high traffic", "try again in a minute", "429", "overload", "no capacity")
+    for text in (
+        "Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+        "Fatal: 429 Too Many Requests; temporarily at capacity",
+        '{"error": {"code": "RESOURCE_EXHAUSTED", "message": "overload: no capacity"}}',
+    ):
+        assert transient.classify_antigravity_capacity(
+            text, returncode=1, empty_response=False, signatures=signatures
+        ).is_capacity
+    assert not transient.classify_antigravity_capacity(
+        "The review quotes: Error: Our servers are experiencing high traffic right now, please try again in a minute.",
+        returncode=1,
+        empty_response=False,
+        signatures=signatures,
+    ).is_capacity
+    assert not transient.classify_antigravity_capacity(
+        "Error: high traffic but invalid API key", returncode=1, empty_response=False, signatures=signatures
+    ).is_capacity
+
+
 def test_orchestrator_alias_preserves_identity() -> None:
     # orchestrator keeps the old private name as an alias to the moved implementation.
     assert orchestrator._is_transient_agent_output is transient.is_transient_agent_output


### PR DESCRIPTION
## Summary
- classify framed Antigravity provider capacity diagnostics separately from generic transient output
- share bounded retry-before-fallback state across normal and skill-mode invocations
- preserve deterministic handling for settings, model, timeout, and schema failures

## Tests
- `timeout 300s python3 -m pytest tests/test_transient.py tests/test_antigravity.py -q`
- `timeout 300s python3 -m pytest tests/test_transient.py tests/test_antigravity.py tests/test_orchestrator_pr.py tests/test_skill_helpers.py tests/test_repair.py -q`
- `timeout 900s python3 -m pytest tests/ -q`

Fixes #613