### PR TITLE
Fix Gemini oversized prompt transport

### DIFF
--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -11,6 +11,7 @@ from .base import (
     AgentName,
     AgentResult,
     AgentTextSource,
+    STDIN_PROMPT_THRESHOLD_BYTES,
     public_response_path,
     read_public_response_file,
     with_public_response_file_instruction,
@@ -50,6 +51,15 @@ _GEMINI_RETIREMENT_SIGNATURES = (
     "unauthorized",
     "no longer",
     "retir",
+)
+
+# Gemini's documented headless mode is selected by --prompt.  For large tasks,
+# stdin carries the complete prompt and this short trailing prompt tells Gemini
+# how to treat that preceding input.
+_OVERSIZED_PROMPT_DIRECTIVE = (
+    "Treat the preceding stdin as the complete primary task and carry it out without "
+    "summarizing or replacing it. Follow its public-response-file destination and "
+    "PUBLIC_RESPONSE_MARKER instructions exactly."
 )
 
 
@@ -210,12 +220,14 @@ class GeminiBackend:
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")
         if date.today() >= GEMINI_CONSUMER_CUTOFF - timedelta(days=_GEMINI_CUTOFF_WARN_AHEAD_DAYS):
             log(config, f"Gemini CLI advisory: {_GEMINI_MIGRATION_GUIDANCE}")
+        rendered_prompt = _with_public_response_marker_instruction(
+            with_public_response_file_instruction(prompt, response_path)
+        )
+        oversized_prompt = len(rendered_prompt.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES
         args = [
             config.gemini_cmd,
             "--prompt",
-            _with_public_response_marker_instruction(
-                with_public_response_file_instruction(prompt, response_path)
-            ),
+            _OVERSIZED_PROMPT_DIRECTIVE if oversized_prompt else rendered_prompt,
             *config.gemini_args,
         ]
         # Pin the model when declared (#332); conflict validation guarantees this is
@@ -233,6 +245,7 @@ class GeminiBackend:
             check=False,
             env={"AGENT_LOOP_WORKDIR": str(config.gemini_dir.resolve())},
             timeout_seconds=timeout_seconds,
+            input_text=rendered_prompt if oversized_prompt else None,
         )
         log(config, f"Gemini finished; log: {log_path}")
         retired_failure = result.returncode != 0 and _gemini_retirement_signal(result.stdout or "")

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Literal
 
 from .agents.antigravity import AntigravityBackend
+from .agents.base import STDIN_PROMPT_THRESHOLD_BYTES
 from .agents.gemini import _parse_gemini_payload
 from .logging import agent_log_path
 from .runner import strip_ansi
@@ -36,6 +37,12 @@ if TYPE_CHECKING:
     from .runner import Runner
 
 _SIGNATURE_LINE_RE = re.compile(r"(?m)^--\s+\S[^\n]*")
+
+_OVERSIZED_REPAIR_PROMPT_DIRECTIVE = (
+    "Treat the preceding stdin as the complete repair task. Output only the repaired "
+    "response, starting directly with {. Do not write a response file and do not emit "
+    "PUBLIC_RESPONSE_MARKER."
+)
 
 
 def strip_unknown_prior_item_dispositions(
@@ -1173,6 +1180,7 @@ def execute_repair(
                 diagnostic_source = result.raw_output
             else:
                 log_path = agent_log_path(config, "gemini-repair", run_id=run_id)
+                oversized_prompt = len(prompt.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES
                 proc = subprocess.run(
                     [
                         config.gemini_cmd,
@@ -1180,11 +1188,12 @@ def execute_repair(
                         model,
                         "--skip-trust",
                         "--prompt",
-                        prompt,
+                        _OVERSIZED_REPAIR_PROMPT_DIRECTIVE if oversized_prompt else prompt,
                     ],
                     capture_output=True,
                     text=True,
                     timeout=config.repair_timeout_seconds,
+                    input=prompt if oversized_prompt else None,
                 )
                 returncode = proc.returncode
                 parsed, _, _, _, _ = _parse_gemini_payload(proc.stdout.strip())
@@ -1466,11 +1475,20 @@ def attempt_repair(
         same_round_context=same_round_context,
     )
     try:
+        oversized_prompt = len(prompt.encode("utf-8")) > STDIN_PROMPT_THRESHOLD_BYTES
         result = subprocess.run(
-            [gemini_cmd, "--model", _REPAIR_MODEL, "--skip-trust", "--prompt", prompt],
+            [
+                gemini_cmd,
+                "--model",
+                _REPAIR_MODEL,
+                "--skip-trust",
+                "--prompt",
+                _OVERSIZED_REPAIR_PROMPT_DIRECTIVE if oversized_prompt else prompt,
+            ],
             capture_output=True,
             text=True,
             timeout=120,
+            input=prompt if oversized_prompt else None,
         )
     except Exception as exc:
         _logger.debug("repair pass CLI invocation failed: %s", exc)

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -622,8 +622,8 @@ class FakeRunner(Runner):
                 stdout, returncode = output
             output = stdout
             if isinstance(output, str) and not explicit_stdout:
-                output = self._normalize_legacy_agent_output(output, "\n".join(cmd))
-            self._maybe_write_public_response_file(cmd)
+                output = self._normalize_legacy_agent_output(output, input_text or "\n".join(cmd))
+            self._maybe_write_public_response_file(cmd, prompt=input_text)
             self._maybe_advance_git_head_for_agent_pr(output)
             self._maybe_advance_pr_head_for_coder_followup(cmd)
             self._mark_agent_command_seen()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -480,11 +480,20 @@ def test_gemini_backend_sends_oversized_decorated_prompt_on_stdin(tmp_path, monk
 def test_gemini_backend_measures_fully_decorated_prompt_in_utf8_bytes(tmp_path, monkeypatch):
     import coding_review_agent_loop.agents.gemini as gemini_module
 
-    raw_prompt = "é" * 20  # 40 UTF-8 bytes, below the 50-byte threshold.
-    monkeypatch.setattr(gemini_module, "STDIN_PROMPT_THRESHOLD_BYTES", 50)
+    raw_prompt = "é" * 20
+    config = make_config(tmp_path)
+    response_path = gemini_module.public_response_path(
+        config, "gemini", root=gemini_module._gemini_public_response_root(config.gemini_dir)
+    )
+    rendered = gemini_module._with_public_response_marker_instruction(
+        gemini_module.with_public_response_file_instruction(raw_prompt, response_path)
+    )
+    # The raw multibyte text makes the UTF-8 payload 20 bytes larger than its
+    # character count, so a character-based threshold check would take argv.
+    monkeypatch.setattr(gemini_module, "STDIN_PROMPT_THRESHOLD_BYTES", len(rendered))
     runner = FakeRunner(gemini_outputs=["ok"])
 
-    GEMINI_BACKEND.run(runner, make_config(tmp_path), raw_prompt, run_id="run-1")
+    GEMINI_BACKEND.run(runner, config, raw_prompt, run_id="run-1")
 
     cmd = runner.commands[-1][0]
     assert cmd[2] == _OVERSIZED_PROMPT_DIRECTIVE

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -20,6 +20,7 @@ from coding_review_agent_loop.agents.codex import (
 from coding_review_agent_loop.agents.gemini import (
     BACKEND as GEMINI_BACKEND,
     PUBLIC_RESPONSE_MARKER,
+    _OVERSIZED_PROMPT_DIRECTIVE,
     _normalize_gemini_usage,
     _parse_gemini_payload,
 )
@@ -447,6 +448,68 @@ def test_gemini_backend_prefers_response_file_over_message_text(tmp_path):
     assert result.message_text == "stdout message text"
     assert result.text == "response file text"
     assert result.session_id == "gemini-session-1"
+
+
+def test_gemini_backend_sends_oversized_decorated_prompt_on_stdin(tmp_path, monkeypatch):
+    import coding_review_agent_loop.agents.gemini as gemini_module
+
+    monkeypatch.setattr(gemini_module, "STDIN_PROMPT_THRESHOLD_BYTES", 100)
+    raw_prompt = "review Ω " * 30
+    runner = FakeRunner(
+        gemini_outputs=[json.dumps({"response": "stdout message"})],
+        public_response_outputs=["response file text"],
+    )
+    config = make_config(
+        tmp_path,
+        gemini_args=("--yolo", "--skip-trust", "--output-format", "json"),
+        gemini_model="gemini-test",
+    )
+
+    result = GEMINI_BACKEND.run(runner, config, raw_prompt, session_id="resume-1", run_id="run-1")
+
+    cmd = runner.commands[-1][0]
+    assert cmd[:2] == ["gemini", "--prompt"]
+    assert cmd[2] == _OVERSIZED_PROMPT_DIRECTIVE
+    assert all(raw_prompt not in arg for arg in cmd)
+    assert runner.last_input_text is not None and raw_prompt in runner.last_input_text
+    assert all(flag in cmd for flag in ("--yolo", "--skip-trust", "--output-format", "--model", "--resume"))
+    assert "gemini-test" in cmd and "resume-1" in cmd
+    assert result.text == "response file text"
+
+
+def test_gemini_backend_measures_fully_decorated_prompt_in_utf8_bytes(tmp_path, monkeypatch):
+    import coding_review_agent_loop.agents.gemini as gemini_module
+
+    raw_prompt = "é" * 20  # 40 UTF-8 bytes, below the 50-byte threshold.
+    monkeypatch.setattr(gemini_module, "STDIN_PROMPT_THRESHOLD_BYTES", 50)
+    runner = FakeRunner(gemini_outputs=["ok"])
+
+    GEMINI_BACKEND.run(runner, make_config(tmp_path), raw_prompt, run_id="run-1")
+
+    cmd = runner.commands[-1][0]
+    assert cmd[2] == _OVERSIZED_PROMPT_DIRECTIVE
+    assert runner.last_input_text is not None and raw_prompt in runner.last_input_text
+
+
+def test_gemini_backend_uses_prompt_argument_at_exact_threshold(tmp_path, monkeypatch):
+    import coding_review_agent_loop.agents.gemini as gemini_module
+
+    config = make_config(tmp_path)
+    runner = FakeRunner(gemini_outputs=["ok"])
+    # Determine the decorated byte size so equality exercises the small path.
+    response_path = gemini_module.public_response_path(
+        config, "gemini", root=gemini_module._gemini_public_response_root(config.gemini_dir)
+    )
+    rendered = gemini_module._with_public_response_marker_instruction(
+        gemini_module.with_public_response_file_instruction("short", response_path)
+    )
+    monkeypatch.setattr(gemini_module, "STDIN_PROMPT_THRESHOLD_BYTES", len(rendered.encode("utf-8")))
+
+    GEMINI_BACKEND.run(runner, config, "short", run_id="run-1")
+
+    assert runner.last_input_text is None
+    assert runner.commands[-1][0][2] != _OVERSIZED_PROMPT_DIRECTIVE
+    assert len(runner.commands[-1][0][2].encode("utf-8")) == len(rendered.encode("utf-8"))
 
 
 def test_codex_backend_prefers_response_file_over_last_message_and_stdout(tmp_path):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -439,7 +439,6 @@ def test_attempt_repair_calls_cli_and_returns_text():
 
 def test_attempt_repair_sends_oversized_prompt_to_stdin(monkeypatch):
     import coding_review_agent_loop.repair as repair_module
-    from coding_review_agent_loop.agents.gemini import _OVERSIZED_PROMPT_DIRECTIVE
 
     monkeypatch.setattr(repair_module, "STDIN_PROMPT_THRESHOLD_BYTES", 100)
     proc = MagicMock(returncode=0, stdout="{}")
@@ -453,12 +452,6 @@ def test_attempt_repair_sends_oversized_prompt_to_stdin(monkeypatch):
     assert all(raw not in arg for arg in cmd)
     assert raw in run.call_args.kwargs["input"]
     assert "--skip-trust" in cmd and "gemini-3.1-flash-lite" in cmd
-    assert _OVERSIZED_REPAIR_PROMPT_DIRECTIVE == (
-        "Treat the preceding stdin as the complete repair task. Output only the repaired "
-        "response, starting directly with {. Do not write a response file and do not emit "
-        "PUBLIC_RESPONSE_MARKER."
-    )
-    assert _OVERSIZED_REPAIR_PROMPT_DIRECTIVE != _OVERSIZED_PROMPT_DIRECTIVE
 
 def test_attempt_repair_includes_expected_kind_instruction():
     repaired = (

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -3,6 +3,7 @@ from agent_loop_helpers import *  # noqa: F403
 
 from coding_review_agent_loop.repair import (
     _REPAIR_PROMPT,
+    _OVERSIZED_REPAIR_PROMPT_DIRECTIVE,
     _build_repair_prompt,
     attempt_envelope_normalization,
     attempt_repair,
@@ -433,6 +434,31 @@ def test_attempt_repair_calls_cli_and_returns_text():
     assert "--prompt" in cmd
     prompt_idx = cmd.index("--prompt")
     assert "malformed review" in cmd[prompt_idx + 1]
+    assert call_args.kwargs["input"] is None
+
+
+def test_attempt_repair_sends_oversized_prompt_to_stdin(monkeypatch):
+    import coding_review_agent_loop.repair as repair_module
+    from coding_review_agent_loop.agents.gemini import _OVERSIZED_PROMPT_DIRECTIVE
+
+    monkeypatch.setattr(repair_module, "STDIN_PROMPT_THRESHOLD_BYTES", 100)
+    proc = MagicMock(returncode=0, stdout="{}")
+    raw = "oversized malformed response " * 20
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=proc) as run:
+        attempt_repair(raw, "gemini")
+
+    cmd = run.call_args.args[0]
+    assert cmd[cmd.index("--prompt") + 1] == _OVERSIZED_REPAIR_PROMPT_DIRECTIVE
+    assert all(raw not in arg for arg in cmd)
+    assert raw in run.call_args.kwargs["input"]
+    assert "--skip-trust" in cmd and "gemini-3.1-flash-lite" in cmd
+    assert _OVERSIZED_REPAIR_PROMPT_DIRECTIVE == (
+        "Treat the preceding stdin as the complete repair task. Output only the repaired "
+        "response, starting directly with {. Do not write a response file and do not emit "
+        "PUBLIC_RESPONSE_MARKER."
+    )
+    assert _OVERSIZED_REPAIR_PROMPT_DIRECTIVE != _OVERSIZED_PROMPT_DIRECTIVE
 
 def test_attempt_repair_includes_expected_kind_instruction():
     repaired = (
@@ -872,6 +898,35 @@ def test_execute_repair_uses_configured_legacy_gemini_override(tmp_path):
     assert repaired == valid
     assert attempts[0].backend == "gemini"
     assert "gemini-enterprise-flash" in run.call_args.args[0]
+    assert run.call_args.kwargs["input"] is None
+
+
+def test_execute_repair_sends_oversized_gemini_prompt_to_stdin(tmp_path, monkeypatch):
+    import coding_review_agent_loop.repair as repair_module
+
+    monkeypatch.setattr(repair_module, "STDIN_PROMPT_THRESHOLD_BYTES", 100)
+    valid = structured_pr_review(state="approved", reviewer="Google Gemini")
+    proc = MagicMock(returncode=0, stdout=valid, stderr="")
+    config = make_config(tmp_path, repair_backend="gemini")
+    raw = "large malformed response " * 20
+
+    with patch("coding_review_agent_loop.repair.subprocess.run", return_value=proc) as run:
+        repaired, _, attempts = execute_repair(
+            raw,
+            runner=FakeRunner(),
+            config=config,
+            run_id="run-oversized",
+            usage_context=None,
+            validate=lambda text: parse_structured_pr_review(text, reviewer="Google Gemini"),
+            expected_kind="pr_review",
+        )
+
+    cmd = run.call_args.args[0]
+    assert repaired == valid and attempts[0].outcome == "succeeded"
+    assert cmd[cmd.index("--prompt") + 1] == _OVERSIZED_REPAIR_PROMPT_DIRECTIVE
+    assert all(raw not in arg for arg in cmd)
+    assert raw in run.call_args.kwargs["input"]
+    assert "--skip-trust" in cmd
 
 
 def test_antigravity_repair_validates_once_and_falls_back_to_catalog_chain(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #582

Keeps Gemini in documented headless mode for oversized prompts by retaining `--prompt` with a short directive and moving the full prompt to stdin. Applies the same byte-threshold transport to both Gemini repair paths and updates the fake runner plus regression coverage.

Tests:
- `timeout 900s python3 -m pytest tests/test_backends.py tests/test_repair.py tests/test_orchestrator_pr.py tests/test_orchestrator_issue.py tests/test_prompts.py tests/test_antigravity.py` (passed: 646 tests)
- Full `python3 -m pytest` was attempted three times with 900-second caps but this environment ended each run around 79% without a terminal pytest summary.