### PR TITLE
Accept valid response artifacts after failed exits

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1544,9 +1544,13 @@ treats signed requirements as resolved; otherwise the synthetic item is carried
 into the next round even if the visible review says approved.
 
 The loop validates required markers before posting agent output to GitHub. If
-an agent exits or returns only diagnostics, empty output, or normal prose
-without the required marker, the loop fails locally with `AgentLoopError` and
-the attempt log path instead of posting that raw output as a review.
+an agent exits unsuccessfully or returns only diagnostics, it first checks the
+uniquely assigned public response file for that invocation. A non-empty
+artifact that passes the normal schema and role validation is accepted and
+posted even after a timeout or nonzero exit. Stdout remains diagnostics only
+and is never salvaged as a public response. Empty, stale, malformed, and
+wrong-role artifacts continue through the normal retry/failure path; accepted
+failed exits record their outcome and return code in resume metadata.
 
 Coder prompts for a direct issue implementation explicitly forbid launching
 required tests or other completion work (builds, commits, pushes, PR creation)
@@ -1562,12 +1566,14 @@ terminal marker. Its result is validated exactly like a normal implementation
 response: a valid PR, a no-PR `AGENT_STATE: blocking`, or `AGENT_CLARIFY` is
 accepted and posted like any other outcome. If the resume turn instead
 declares `AGENT_UNAVAILABLE` itself, or if the resume command fails or still
-does not produce a valid terminal response, the loop renders (or reuses the
-agent's own verbatim) protocol-valid `AGENT_UNAVAILABLE` text, persists it to
-that attempt's own response file, and posts it to the GitHub issue before
-failing locally with `AgentLoopError` and the usual salvage artifacts — there
-is never more than one resume attempt, regardless of what the agent's own
-response says about retrying. A genuine, non-recovery no-PR
+does not produce a valid terminal response, the loop first applies the same
+per-invocation response-file rule. A valid artifact is accepted with the
+failed-exit diagnostic preserved in resume metadata; otherwise the loop renders
+(or reuses the agent's own verbatim) protocol-valid `AGENT_UNAVAILABLE` text,
+persists it to that attempt's own response file, and posts it to the GitHub
+issue before failing locally with `AgentLoopError` and the usual salvage
+artifacts — there is never more than one resume attempt, regardless of what
+the agent's own response says about retrying. A genuine, non-recovery no-PR
 `AGENT_STATE: blocking` or `AGENT_CLARIFY` result is likewise posted to the
 issue, matching how a successful PR-creating implementation is already posted.
 

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -79,6 +79,9 @@ def public_response_path(
     *,
     root: Path | None = None,
 ) -> Path:
+    # Every invocation gets a new path.  Backends read only this path after
+    # their command returns, so an artifact from an earlier invocation cannot
+    # be mistaken for the current response.
     base_dir = (
         root
         if root is not None
@@ -123,6 +126,7 @@ writing this file results in a review failure.
 
 
 def read_public_response_file(response_path: Path) -> str | None:
+    # A missing or whitespace-only file is deliberately not an artifact.
     try:
         text = response_path.read_text(encoding="utf-8")
     except FileNotFoundError:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1863,10 +1863,12 @@ def _attempt_claude_completion_recovery(
     Entirely self-contained and attempt-local: every variable here is scoped
     to this one recovery call, never the caller's original (failed) attempt.
     The caller's original ``AgentResult`` is not even passed in, so isolation
-    is structural rather than merely asserted. Three outcomes:
+    is structural rather than merely asserted. Four outcomes:
 
     - a valid PR/blocking/clarify per ``validate()`` -> success, returned as
       a normal ``ValidatedAgentResponse`` subject to ordinary PR validation;
+      this includes a current invocation response-file artifact that validates
+      after a timeout or nonzero exit, with its acquisition diagnostic retained;
     - the resume turn itself declares a protocol-valid ``AGENT_UNAVAILABLE``
       -> terminal, posted/persisted verbatim, never passed to ``validate()``,
       and always terminal regardless of its own ``retryable`` flag (the
@@ -2190,7 +2192,10 @@ def _run_validated_agent(
         # response; stdout is diagnostics only and must never be salvaged.
         artifact = result.response_file_text
         artifact_unavailable = None
-        if artifact:
+        # Preserve the normal zero-exit path below, including its marker
+        # recovery diagnostic. Failed exits alone may be salvaged from the
+        # per-invocation response-file artifact.
+        if artifact and result.returncode != 0:
             try:
                 artifact_unavailable = parse_agent_unavailable(artifact)
             except AgentLoopError:
@@ -4269,6 +4274,8 @@ def _run_plan_first_loop(
             if resumed_record is not None:
                 review_output = resumed_record.metadata.canonical_reviewer_response or resumed_record.body
                 review_model_used = resumed_record.metadata.model_used
+                review_acquisition_outcome = resumed_record.metadata.acquisition_outcome
+                review_acquisition_returncode = resumed_record.metadata.acquisition_returncode
                 structured_review = parse_structured_plan_review(
                     review_output,
                     reviewer=reviewer_name,
@@ -4305,6 +4312,8 @@ def _run_plan_first_loop(
                 assert review_response is not None
                 review_output = review_response.text
                 review_model_used = review_response.model_used
+                review_acquisition_outcome = review_response.acquisition_outcome
+                review_acquisition_returncode = review_response.acquisition_returncode
                 reviewer_session_ids[reviewer] = review_response.session_id
                 parsed_review = review_response.marker_value
                 assert isinstance(parsed_review, ParsedPlanReview)
@@ -4355,6 +4364,8 @@ def _run_plan_first_loop(
                 )
                 review_output = review_response.text
                 review_model_used = review_response.model_used
+                review_acquisition_outcome = review_response.acquisition_outcome
+                review_acquisition_returncode = review_response.acquisition_returncode
                 reviewer_session_ids[reviewer] = review_response.session_id
                 parsed_review = review_response.marker_value
                 assert isinstance(parsed_review, ParsedPlanReview)
@@ -4444,6 +4455,8 @@ def _run_plan_first_loop(
                     _post_plan_reviewer_comment(
                         reviewer_name, parsed_review, review_output=review_output,
                         model_used=review_model_used,
+                        acquisition_outcome=review_acquisition_outcome,
+                        acquisition_returncode=review_acquisition_returncode,
                         new_items=tuple(reviewer_new_unresolved_items),
                     )
             else:
@@ -5671,11 +5684,11 @@ def run_pr_loop(
                 reviewer_name: str,
                 parsed: ParsedReview,
                 *,
-            review_output: str,
-            model_used: str | None,
-            acquisition_outcome: str = "success",
-            acquisition_returncode: int | None = None,
-            new_items: tuple[UnresolvedReviewItem, ...] = (),
+                review_output: str,
+                model_used: str | None,
+                acquisition_outcome: str = "success",
+                acquisition_returncode: int | None = None,
+                new_items: tuple[UnresolvedReviewItem, ...] = (),
                 phase: str = "authoritative",
             ) -> None:
                 """Post one PR review using the same rendering and durable record."""
@@ -5895,6 +5908,8 @@ def run_pr_loop(
                 if resumed_record is not None:
                     review_output = resumed_record.metadata.canonical_reviewer_response or resumed_record.body
                     review_model_used = resumed_record.metadata.model_used
+                    review_acquisition_outcome = resumed_record.metadata.acquisition_outcome
+                    review_acquisition_returncode = resumed_record.metadata.acquisition_returncode
                     reparsed_review = parse_review(review_output, reviewer=reviewer_name)
                     parsed_review = ParsedReview(
                         state=resumed_record.metadata.state or parse_agent_state(review_output),
@@ -5922,6 +5937,8 @@ def run_pr_loop(
                     carried_approval_record = prior_approval
                     review_output = prior_approval.body
                     review_model_used = prior_approval.metadata.model_used
+                    review_acquisition_outcome = prior_approval.metadata.acquisition_outcome
+                    review_acquisition_returncode = prior_approval.metadata.acquisition_returncode
                     reparsed_review = parse_review(review_output, reviewer=reviewer_name)
                     parsed_review = ParsedReview(
                         state="approved",
@@ -5964,6 +5981,8 @@ def run_pr_loop(
                     reviewer_pr_checks = shared_reviewer_pr_checks
                     review_output = review_response.text
                     review_model_used = review_response.model_used
+                    review_acquisition_outcome = review_response.acquisition_outcome
+                    review_acquisition_returncode = review_response.acquisition_returncode
                     reviewer_session_ids[reviewer] = review_response.session_id
                     parsed_review = review_response.marker_value
                     assert isinstance(parsed_review, ParsedReview)
@@ -6064,6 +6083,8 @@ def run_pr_loop(
                     assert review_response is not None
                     review_output = review_response.text
                     review_model_used = review_response.model_used
+                    review_acquisition_outcome = review_response.acquisition_outcome
+                    review_acquisition_returncode = review_response.acquisition_returncode
                     reviewer_session_ids[reviewer] = review_response.session_id
                     parsed_review = review_response.marker_value
                     assert isinstance(parsed_review, ParsedReview)
@@ -6218,6 +6239,8 @@ def run_pr_loop(
                             _post_pr_reviewer_comment(
                                 reviewer_name, parsed_review, review_output=review_output,
                                 model_used=review_model_used,
+                                acquisition_outcome=review_acquisition_outcome,
+                                acquisition_returncode=review_acquisition_returncode,
                                 new_items=tuple(reviewer_new_unresolved_items),
                             )
                     else:
@@ -6246,6 +6269,8 @@ def run_pr_loop(
                         _post_pr_reviewer_comment(
                             reviewer_name, parsed_review, review_output=review_output,
                             model_used=review_model_used,
+                            acquisition_outcome=review_acquisition_outcome,
+                            acquisition_returncode=review_acquisition_returncode,
                             new_items=tuple(reviewer_new_unresolved_items),
                         )
                 else:
@@ -7088,10 +7113,10 @@ def run_pr_loop(
                         subject=str(updated_pr_context.metadata.head_sha or "unknown"),
                         prior_items=tuple(unresolved_items),
                         raw_structured_coder_response=raw_structured_coder_response,
-                    compact_prior_summaries=tuple(pr_compact_prior_summaries),
-                    model_used=coder_response.model_used,
-                    acquisition_outcome=coder_response.acquisition_outcome,
-                    acquisition_returncode=coder_response.acquisition_returncode,
+                        compact_prior_summaries=tuple(pr_compact_prior_summaries),
+                        model_used=coder_response.model_used,
+                        acquisition_outcome=coder_response.acquisition_outcome,
+                        acquisition_returncode=coder_response.acquisition_returncode,
                     ),
                 ),
             )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace as dataclasses_replace
 from pathlib import Path
+from typing import Literal
 
 from .agents.base import AgentName, AgentResult
 from .agents.antigravity import AntigravityAttemptState
@@ -446,6 +447,8 @@ class ValidatedAgentResponse:
     # Model the agent actually ran, for the dynamic signature (#332). Carried from
     # AgentResult.model_used so the orchestrator render sites can stamp it.
     model_used: str | None = None
+    acquisition_outcome: Literal["success", "accepted_nonzero_exit", "accepted_timeout"] = "success"
+    acquisition_returncode: int | None = None
 
 
 class _AgentUnavailableResponse(AgentLoopError):
@@ -1888,12 +1891,13 @@ def _attempt_claude_completion_recovery(
         label=label,
         timeout_seconds=timeout_seconds,
     )
+    recovery_usage_record = None
     if usage_context is not None:
         recovery_usage = _resolve_usage_metadata(
             config=config, prompt=recovery_prompt, result=recovery_result
         )
         if recovery_usage is not None:
-            usage_context.add_record(
+            recovery_usage_record = usage_context.add_record(
                 agent="claude",
                 session_id=recovery_result.session_id,
                 returncode=recovery_result.returncode,
@@ -1924,6 +1928,54 @@ def _attempt_claude_completion_recovery(
             terminal_public_response=rendered,
         )
 
+    # A response-file artifact is authoritative for this invocation even when
+    # the CLI reports a failed exit.  Do not consult stdout here: it may only
+    # contain diagnostics.  Invalid artifacts intentionally fall through to
+    # the existing terminal transport handling below.
+    recovery_artifact = recovery_result.response_file_text
+    if recovery_artifact:
+        try:
+            unavailable = parse_agent_unavailable(recovery_artifact)
+        except AgentLoopError:
+            unavailable = None
+        if unavailable is not None:
+            _post_completion_recovery_terminal_comment(
+                runner, config=config, completion_recovery=completion_recovery,
+                recovery_result=recovery_result, terminal_text=recovery_artifact,
+            )
+            return _CompletionRecoveryOutcome(
+                validated=None, result=recovery_result,
+                error=("agent explicitly reported it cannot continue after completion "
+                       f"recovery ({unavailable.category}): {unavailable.summary}"),
+                classification_text=recovery_artifact, failure_category="agent-unavailable",
+                terminal_public_response=recovery_artifact,
+            )
+        try:
+            marker_value = validate(recovery_artifact)
+        except AgentLoopError:
+            pass
+        else:
+            accepted_outcome = (
+                "accepted_timeout" if recovery_result.returncode is None
+                else "accepted_nonzero_exit" if recovery_result.returncode != 0 else "success"
+            )
+            if recovery_usage_record is not None:
+                recovery_usage_record.validation_status = "validated"
+                recovery_usage_record.outcome = accepted_outcome
+            if accepted_outcome != "success":
+                log(config, "claude completion-recovery accepted a valid response-file artifact "
+                    f"despite returncode={recovery_result.returncode!r}")
+            return _CompletionRecoveryOutcome(
+                validated=ValidatedAgentResponse(
+                    text=recovery_artifact, session_id=recovery_result.session_id,
+                    marker_value=marker_value, usage=recovery_usage,
+                    model_used=recovery_result.model_used,
+                    acquisition_outcome=accepted_outcome,
+                    acquisition_returncode=recovery_result.returncode,
+                ),
+                result=recovery_result, error="", classification_text="", failure_category="",
+                terminal_public_response=None,
+            )
     if recovery_result.returncode is None:
         limit = f" after {timeout_seconds:g}s" if timeout_seconds is not None else ""
         return _terminal(
@@ -2133,9 +2185,52 @@ def _run_validated_agent(
                 raw_backend_usage=result.raw_usage,
             )
 
+        # A backend always loads the uniquely assigned public response file.
+        # On a timeout/nonzero exit, that artifact can still be a complete
+        # response; stdout is diagnostics only and must never be salvaged.
+        artifact = result.response_file_text
+        artifact_unavailable = None
+        if artifact:
+            try:
+                artifact_unavailable = parse_agent_unavailable(artifact)
+            except AgentLoopError:
+                artifact_unavailable = None
+            if artifact_unavailable is None:
+                try:
+                    artifact_marker_value = validate(artifact)
+                except AgentLoopError:
+                    pass
+                else:
+                    acquisition_outcome = (
+                        "accepted_timeout" if result.returncode is None
+                        else "accepted_nonzero_exit" if result.returncode != 0 else "success"
+                    )
+                    if usage_record is not None:
+                        usage_record.validation_status = "validated"
+                        usage_record.outcome = acquisition_outcome
+                    if acquisition_outcome != "success":
+                        log(
+                            config,
+                            f"{agent_name}: accepted valid response-file artifact despite "
+                            f"returncode={result.returncode!r}",
+                        )
+                    return ValidatedAgentResponse(
+                        text=artifact,
+                        session_id=result.session_id,
+                        marker_value=artifact_marker_value,
+                        usage=usage,
+                        model_used=result.model_used,
+                        acquisition_outcome=acquisition_outcome,
+                        acquisition_returncode=result.returncode,
+                    )
+            else:
+                # Let the existing agent-unavailable policy handle the valid
+                # envelope, even when the command itself failed.
+                text = artifact
+
         should_retry = False
         provider_capacity = False
-        if result.returncode is None:
+        if result.returncode is None and artifact_unavailable is None:
             # Timed out (returncode=None from Runner.run_with_log). Detected
             # before transient classification: a kill deadline is not a
             # provider hiccup, so retrying or repairing would only waste the
@@ -2145,7 +2240,7 @@ def _run_validated_agent(
             last_classification_text = ""
             last_failure_category = "timeout"
             break
-        if result.returncode != 0:
+        if result.returncode != 0 and artifact_unavailable is None:
             last_error = f"agent command exited with {result.returncode}"
             classification_text = _agent_failure_classification_text(result, phase="command")
             last_classification_text = classification_text
@@ -3718,6 +3813,8 @@ def _implement_approved_issue(
                 subject=str(initial_pr_context.metadata.head_sha or "unknown"),
                 prior_items=(),
                 model_used=coder_response.model_used,
+                acquisition_outcome=coder_response.acquisition_outcome,
+                acquisition_returncode=coder_response.acquisition_returncode,
             ),
         ),
     )
@@ -3949,6 +4046,8 @@ def _run_plan_first_loop(
                     raw_structured_coder_response=raw_structured_coder_response,
                     compact_prior_summaries=tuple(compact_prior_summaries),
                     model_used=plan_response.model_used,
+                    acquisition_outcome=plan_response.acquisition_outcome,
+                    acquisition_returncode=plan_response.acquisition_returncode,
                 ),
             ),
         )
@@ -4037,6 +4136,8 @@ def _run_plan_first_loop(
             *,
             review_output: str,
             model_used: str | None,
+            acquisition_outcome: str = "success",
+            acquisition_returncode: int | None = None,
             new_items: tuple[UnresolvedReviewItem, ...] = (),
             phase: str = "authoritative",
         ) -> None:
@@ -4057,6 +4158,8 @@ def _run_plan_first_loop(
                         new_items=new_items, state=parsed.state,
                         compact_prior_summaries=tuple(compact_prior_summaries),
                         model_used=model_used, phase=phase,
+                        acquisition_outcome=acquisition_outcome,
+                        acquisition_returncode=acquisition_returncode,
                         canonical_reviewer_response=(review_output if phase == "publication" else None),
                     ),
                 ),
@@ -4145,7 +4248,10 @@ def _run_plan_first_loop(
                         return
                     _post_plan_reviewer_comment(
                         reviewer_name, parsed, review_output=turn.response.text,
-                        model_used=turn.response.model_used, phase="publication",
+                        model_used=turn.response.model_used,
+                        acquisition_outcome=turn.response.acquisition_outcome,
+                        acquisition_returncode=turn.response.acquisition_returncode,
+                        phase="publication",
                     )
                     early_published_plan_reviewers.add(reviewer)
 
@@ -4965,6 +5071,8 @@ def _run_plan_first_loop(
                     raw_structured_coder_response=raw_structured_coder_response,
                     compact_prior_summaries=tuple(compact_prior_summaries),
                     model_used=plan_response.model_used,
+                    acquisition_outcome=plan_response.acquisition_outcome,
+                    acquisition_returncode=plan_response.acquisition_returncode,
                 ),
             ),
         )
@@ -5143,6 +5251,8 @@ def run_issue_loop(
                     subject=str(initial_pr_metadata.head_sha or "unknown"),
                     prior_items=(),
                     model_used=coder_response.model_used,
+                    acquisition_outcome=coder_response.acquisition_outcome,
+                    acquisition_returncode=coder_response.acquisition_returncode,
                 ),
             ),
         )
@@ -5268,6 +5378,8 @@ def run_task_loop(
                             subject=str(initial_pr_metadata.head_sha or "unknown"),
                             prior_items=(),
                             model_used=coder_response.model_used,
+                            acquisition_outcome=coder_response.acquisition_outcome,
+                            acquisition_returncode=coder_response.acquisition_returncode,
                         ),
                     ),
                 )
@@ -5559,9 +5671,11 @@ def run_pr_loop(
                 reviewer_name: str,
                 parsed: ParsedReview,
                 *,
-                review_output: str,
-                model_used: str | None,
-                new_items: tuple[UnresolvedReviewItem, ...] = (),
+            review_output: str,
+            model_used: str | None,
+            acquisition_outcome: str = "success",
+            acquisition_returncode: int | None = None,
+            new_items: tuple[UnresolvedReviewItem, ...] = (),
                 phase: str = "authoritative",
             ) -> None:
                 """Post one PR review using the same rendering and durable record."""
@@ -5579,6 +5693,8 @@ def run_pr_loop(
                             round_number=round_number, subject=current_pr_subject,
                             prior_items=prior_unresolved_items, dispositions=parsed.dispositions,
                             new_items=new_items, state=parsed.state, model_used=model_used,
+                            acquisition_outcome=acquisition_outcome,
+                            acquisition_returncode=acquisition_returncode,
                             surfaced_reviewer_requirement_ids=surfaced_reviewer_requirement_ids,
                             phase=phase,
                             canonical_reviewer_response=(review_output if phase == "publication" else None),
@@ -5744,7 +5860,10 @@ def run_pr_loop(
                                 return
                             _post_pr_reviewer_comment(
                                 reviewer_name, parsed, review_output=turn.response.text,
-                                model_used=turn.response.model_used, phase="publication",
+                                model_used=turn.response.model_used,
+                                acquisition_outcome=turn.response.acquisition_outcome,
+                                acquisition_returncode=turn.response.acquisition_returncode,
+                                phase="publication",
                             )
                             early_published_pr_reviewers.add(reviewer)
 
@@ -6969,8 +7088,10 @@ def run_pr_loop(
                         subject=str(updated_pr_context.metadata.head_sha or "unknown"),
                         prior_items=tuple(unresolved_items),
                         raw_structured_coder_response=raw_structured_coder_response,
-                        compact_prior_summaries=tuple(pr_compact_prior_summaries),
-                        model_used=coder_response.model_used,
+                    compact_prior_summaries=tuple(pr_compact_prior_summaries),
+                    model_used=coder_response.model_used,
+                    acquisition_outcome=coder_response.acquisition_outcome,
+                    acquisition_returncode=coder_response.acquisition_returncode,
                     ),
                 ),
             )

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1265,6 +1265,7 @@ def execute_repair(
             or (
                 config.repair_backend == "antigravity"
                 and outcome in {"nonzero_exit", "timeout"}
+                and result.text_source == "response_file"
             )
         ):
             try:

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1002,7 +1002,7 @@ _REPAIR_MODEL = "gemini-3.1-flash-lite"
 _SUPPORTED_EXPECTED_KINDS = {"plan_state", "pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
-    "unavailable_model",
+    "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",
 ]
 
 
@@ -1257,19 +1257,38 @@ def execute_repair(
                 log_path=str(log_path) if log_path is not None else None,
                 fallback_planned=fallback_planned,
             )
-        if outcome == "succeeded":
+        # Antigravity's isolated repair result already prioritizes the
+        # invocation's response-file artifact.  A valid artifact is useful
+        # even if its CLI timed out or exited nonzero.
+        if output and (
+            outcome == "succeeded"
+            or (
+                config.repair_backend == "antigravity"
+                and outcome in {"nonzero_exit", "timeout"}
+            )
+        ):
             try:
                 validation_result = validate(output)
             except Exception as exc:
-                attempt.outcome = "invalid_output"
-                attempt.diagnostic = _sanitize_diagnostic(str(exc), config=config)
+                if outcome == "succeeded":
+                    attempt.outcome = "invalid_output"
+                validation_diagnostic = _sanitize_diagnostic(str(exc), config=config)
+                attempt.diagnostic = "\n".join(
+                    part for part in (attempt.diagnostic, validation_diagnostic) if part
+                )
                 if usage_record is not None:
-                    usage_record.outcome = "invalid_output"
+                    usage_record.outcome = attempt.outcome
             else:
+                if outcome != "succeeded":
+                    attempt.outcome = (
+                        "accepted_timeout" if outcome == "timeout"
+                        else "accepted_nonzero_exit"
+                    )
                 attempt.validation_result = validation_result
                 attempt.fallback_planned = False
                 if usage_record is not None:
                     usage_record.validation_status = "validated"
+                    usage_record.outcome = attempt.outcome
                     usage_record.fallback_planned = False
                 attempts.append(attempt)
                 return output, validation_result, attempts

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -49,6 +49,10 @@ class PostedRoundMetadata:
     compact_prior_summaries: tuple[str, ...] = ()
     usage: dict | None = None
     model_used: str | None = None
+    # How the response was acquired.  Legacy metadata represents ordinary
+    # zero-exit success.
+    acquisition_outcome: str = "success"
+    acquisition_returncode: int | None = None
     consensus_kind: str | None = None
     is_final: bool = False
     agenda: tuple[str, ...] = ()
@@ -176,6 +180,8 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "compact_prior_summaries": list(metadata.compact_prior_summaries),
         "usage": metadata.usage,
         "model_used": metadata.model_used,
+        "acquisition_outcome": metadata.acquisition_outcome,
+        "acquisition_returncode": metadata.acquisition_returncode,
         "consensus_kind": metadata.consensus_kind,
         "is_final": metadata.is_final,
         "agenda": list(metadata.agenda),
@@ -220,6 +226,11 @@ def _decode_round_metadata_mapping(payload: Mapping[str, object]) -> PostedRound
             ),
             usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else None,
             model_used=str(payload["model_used"]) if payload.get("model_used") is not None else None,
+            acquisition_outcome=str(payload.get("acquisition_outcome", "success")),
+            acquisition_returncode=(
+                int(payload["acquisition_returncode"])
+                if payload.get("acquisition_returncode") is not None else None
+            ),
             consensus_kind=str(payload["consensus_kind"]) if payload.get("consensus_kind") is not None else None,
             is_final=bool(payload.get("is_final", False)),
             agenda=tuple(str(item) for item in payload.get("agenda", [])),

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -93,7 +93,7 @@ class UsageCallRecord:
     model: str | None = None
     outcome: Literal[
         "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
-        "unavailable_model",
+        "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",
     ] | None = None
     log_path: str | None = None
     fallback_planned: bool | None = None
@@ -202,7 +202,7 @@ class RunUsageContext:
         model: str | None = None,
         outcome: Literal[
             "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
-            "unavailable_model",
+            "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",
         ] | None = None,
         log_path: str | None = None,
         fallback_planned: bool | None = None,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4162,6 +4162,47 @@ def test_posted_round_metadata_model_used_none_round_trip():
     assert decoded.model_used is None
 
 
+def test_posted_round_metadata_acquisition_fields_round_trip_and_legacy_default():
+    metadata = PostedRoundMetadata(
+        flow="plan", role="reviewer", agent="Claude", round_number=1,
+        subject="abc", acquisition_outcome="accepted_nonzero_exit",
+        acquisition_returncode=1,
+    )
+    decoded = _decode_round_metadata(_encode_round_metadata(metadata))
+    assert decoded.acquisition_outcome == "accepted_nonzero_exit"
+    assert decoded.acquisition_returncode == 1
+
+    legacy_payload = {
+        "flow": "plan", "role": "reviewer", "agent": "Claude",
+        "round_number": 1, "subject": "abc",
+    }
+    legacy = _decode_round_metadata(base64.urlsafe_b64encode(
+        json.dumps(legacy_payload).encode("utf-8")
+    ).decode("ascii"))
+    assert legacy.acquisition_outcome == "success"
+    assert legacy.acquisition_returncode is None
+
+
+@pytest.mark.parametrize("artifact", ["", "not a structured review", "wrong reviewer response"])
+def test_failed_exit_rejects_empty_malformed_or_wrong_role_response_artifact(tmp_path, artifact):
+    runner = FakeRunner(
+        gemini_outputs=[("command failed", 1)], public_response_outputs=[artifact]
+    )
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    def validate(text):
+        if text == "valid review":
+            return text
+        raise AgentLoopError("review does not match the expected reviewer role")
+
+    with pytest.raises(AgentInvocationError):
+        _run_validated_agent(
+            runner, agent="gemini", config=config, prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->", validate=validate,
+        )
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["gemini"]]) == 1
+
+
 def test_posted_round_metadata_model_used_backward_compat():
     payload = {
         "flow": "plan",

--- a/tests/test_completion_recovery.py
+++ b/tests/test_completion_recovery.py
@@ -174,6 +174,31 @@ def test_recovery_transport_failure_nonzero_exit_synthesizes_unavailable(tmp_pat
     assert len(_claude_resume_commands(runner)) == 1
 
 
+@pytest.mark.parametrize("returncode", [1, None])
+def test_recovery_accepts_valid_response_file_after_failed_exit(tmp_path, returncode):
+    valid = "Created PR.\n<!-- AGENT_PR: 99 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    runner = FakeRunner(
+        claude_outputs=[("Error: timeout waiting for response", returncode)],
+        public_response_outputs=[valid],
+    )
+    usage = _new_usage_context(make_config(tmp_path, coder="claude"))
+    config = make_config(tmp_path, coder="claude")
+    outcome = _attempt_claude_completion_recovery(
+        runner, config=config, completion_recovery=CompletionRecoveryPolicy(issue_number=56),
+        session_id="sess-1", validate=_require_issue_implementation_result,
+        usage_context=usage, run_id="run-1", role=None, label=None, timeout_seconds=30.0,
+    )
+    assert outcome.validated is not None
+    assert outcome.validated.text == valid
+    assert outcome.validated.acquisition_returncode == returncode
+    assert outcome.validated.acquisition_outcome == (
+        "accepted_timeout" if returncode is None else "accepted_nonzero_exit"
+    )
+    assert outcome.terminal_public_response is None
+    assert runner.comments == []
+    assert usage.records[0].validation_status == "validated"
+
+
 def test_recovery_transport_failure_empty_output_synthesizes_unavailable(tmp_path):
     runner = FakeRunner(claude_outputs=[("", 0)])
     config = make_config(tmp_path, coder="claude")

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -3032,7 +3032,9 @@ def test_plan_revision_quota_failure_reports_response_file_without_recording(tmp
                 blocking_plan_issues=["Missing a regression test."],
             )
         ],
-        public_response_outputs=["", "", valid_revision],
+        # A failed exit may only be salvaged when its current-attempt artifact
+        # passes the normal revision validator.
+        public_response_outputs=["", "", "partial revision"],
     )
     config = make_config(tmp_path, agent_max_retries=0)
 

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -644,6 +644,30 @@ def test_issue_loop_structured_plan_state_public_comment_renders_markdown_and_pr
     assert metadata.canonical_plan == raw_structured_plan
     assert metadata.raw_structured_coder_response == raw_structured_plan
 
+
+def test_plan_review_accepts_valid_response_file_after_nonzero_exit(tmp_path):
+    artifact = structured_plan_review(
+        state="approved", summary="The plan is sound.", reviewer="Anthropic Claude"
+    )
+    runner = FakeRunner(
+        codex_outputs=[structured_plan_state(summary="Plan the issue fix.")],
+        claude_outputs=[("Error: timeout waiting for response", 1)],
+        public_response_outputs=["", artifact],
+    )
+    config = make_config(tmp_path, coder="codex", reviewer="claude", agent_max_retries=0)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 1
+    metadata = next(
+        _decode_round_metadata(match.group("payload"))
+        for comment in runner.issue_comments
+        if (match := re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", comment["body"]))
+        and _decode_round_metadata(match.group("payload")).role == "reviewer"
+    )
+    assert metadata.acquisition_outcome == "accepted_nonzero_exit"
+    assert metadata.acquisition_returncode == 1
+
 def test_issue_loop_plan_first_rejects_marker_only_plan_before_posting_or_reviewer_dispatch(tmp_path):
     markdown_plan = "Initial markdown plan.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
     runner = FakeRunner(

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -4906,17 +4906,20 @@ def test_gemini_review_loop_prefers_public_response_file_over_stdout(tmp_path):
     assert str(config.gemini_dir / ".git" / "agent-loop" / "responses" / "gemini") in gemini_call[2]
     assert runner.comments == ["**Review verdict:** Approved\n\nLGTM from response file.\n<!-- AGENT_STATE: approved -->\n-- Google Gemini"]
 
-def test_claude_review_loop_prefers_public_response_file_over_stdout(tmp_path):
+def test_claude_review_loop_accepts_valid_response_file_after_nonzero_exit(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            json.dumps(
-                {
-                    "result": (
+            (
+                json.dumps(
+                    {
+                        "result": (
                         "I will inspect the PR diff.\n"
                         "Tool output chatter should not be posted.\n"
                     ),
-                    "session_id": "claude-session-1",
-                }
+                        "session_id": "claude-session-1",
+                    }
+                ),
+                1,
             ),
         ],
         public_response_outputs=[
@@ -4931,6 +4934,12 @@ def test_claude_review_loop_prefers_public_response_file_over_stdout(tmp_path):
     assert "PUBLIC RESPONSE FILE:" in claude_call[-1]
     assert "/coding-review-agent-loop/responses/OWNER-REPO/claude/" in claude_call[-1]
     assert runner.comments == ["**Review verdict:** Approved\n\nLGTM from response file.\n<!-- AGENT_STATE: approved -->\n-- Anthropic Claude"]
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 1
+    metadata_match = re.search(r"<!--\s*AGENT_LOOP_META:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", runner.pr_payload["comments"][0]["body"])
+    assert metadata_match is not None
+    metadata = _decode_round_metadata(metadata_match.group("payload"))
+    assert metadata.acquisition_outcome == "accepted_nonzero_exit"
+    assert metadata.acquisition_returncode == 1
 
 def test_claude_review_loop_runs_tests_and_merge_only_after_approval(tmp_path):
     runner = FakeRunner(

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -4913,9 +4913,9 @@ def test_claude_review_loop_accepts_valid_response_file_after_nonzero_exit(tmp_p
                 json.dumps(
                     {
                         "result": (
-                        "I will inspect the PR diff.\n"
-                        "Tool output chatter should not be posted.\n"
-                    ),
+                            "I will inspect the PR diff.\n"
+                            "Tool output chatter should not be posted.\n"
+                        ),
                         "session_id": "claude-session-1",
                     }
                 ),

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -13,7 +13,7 @@ from coding_review_agent_loop.protocol import (
     validate_structured_discuss_answer,
     validate_structured_plan_state,
 )
-from coding_review_agent_loop.orchestrator import _structured_response_candidates
+from coding_review_agent_loop.orchestrator import _new_usage_context, _structured_response_candidates
 
 
 def _initial_plan_with_human_requirements() -> str:
@@ -837,11 +837,30 @@ def test_execute_repair_records_antigravity_failure_outcomes(
         config=make_config(tmp_path),
         run_id="run-3",
         usage_context=None,
-        validate=lambda text: text,
+        validate=lambda text: (_ for _ in ()).throw(AgentLoopError("malformed repair")),
         expected_kind="pr_review",
     )
     assert repaired is None
     assert attempts[0].outcome == expected
+
+def test_execute_repair_accepts_valid_antigravity_artifact_after_nonzero_exit(tmp_path, monkeypatch):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: tmp_path / "settings.json")
+    valid = "valid repaired response"
+    usage = _new_usage_context(make_config(tmp_path))
+    repaired, marker, attempts = execute_repair(
+        "malformed", runner=FakeRunner(antigravity_outputs=[("CLI timeout", 1)], public_response_outputs=[valid]),
+        config=make_config(tmp_path), run_id="run-3", usage_context=usage,
+        validate=lambda text: text if text == valid else (_ for _ in ()).throw(AgentLoopError("bad")),
+        expected_kind="pr_review",
+    )
+    assert (repaired, marker) == (valid, valid)
+    assert attempts[0].outcome == "accepted_nonzero_exit"
+    assert attempts[0].fallback_planned is False
+    assert usage.records[0].validation_status == "validated"
+    assert usage.records[0].returncode == 1
+
 
 def test_execute_repair_records_spawn_error_with_log_path(tmp_path, monkeypatch):
     from coding_review_agent_loop.agents import antigravity as agy_mod
@@ -969,7 +988,9 @@ def test_antigravity_repair_attempts_directly_when_catalog_fails(tmp_path, monke
     config = make_config(tmp_path, repair_models=("ModelA",), antigravity_models=("ModelB",))
     _, _, attempts = execute_repair(
         "malformed", runner=runner, config=config, run_id="catalog-failure",
-        usage_context=None, validate=lambda text: text, expected_kind="pr_review",
+        usage_context=None,
+        validate=lambda text: (_ for _ in ()).throw(AgentLoopError("invalid repair")),
+        expected_kind="pr_review",
     )
 
     assert [attempt.model for attempt in attempts] == ["ModelA", "ModelB"]

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -843,23 +843,28 @@ def test_execute_repair_records_antigravity_failure_outcomes(
     assert repaired is None
     assert attempts[0].outcome == expected
 
-def test_execute_repair_accepts_valid_antigravity_artifact_after_nonzero_exit(tmp_path, monkeypatch):
+@pytest.mark.parametrize("returncode", [1, None])
+def test_execute_repair_accepts_valid_antigravity_artifact_after_nonzero_exit(
+    tmp_path, monkeypatch, returncode
+):
     from coding_review_agent_loop.agents import antigravity as agy_mod
 
     monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: tmp_path / "settings.json")
     valid = "valid repaired response"
     usage = _new_usage_context(make_config(tmp_path))
     repaired, marker, attempts = execute_repair(
-        "malformed", runner=FakeRunner(antigravity_outputs=[("CLI timeout", 1)], public_response_outputs=[valid]),
+        "malformed", runner=FakeRunner(antigravity_outputs=[("CLI timeout", returncode)], public_response_outputs=[valid]),
         config=make_config(tmp_path), run_id="run-3", usage_context=usage,
         validate=lambda text: text if text == valid else (_ for _ in ()).throw(AgentLoopError("bad")),
         expected_kind="pr_review",
     )
     assert (repaired, marker) == (valid, valid)
-    assert attempts[0].outcome == "accepted_nonzero_exit"
+    assert attempts[0].outcome == (
+        "accepted_timeout" if returncode is None else "accepted_nonzero_exit"
+    )
     assert attempts[0].fallback_planned is False
     assert usage.records[0].validation_status == "validated"
-    assert usage.records[0].returncode == 1
+    assert usage.records[0].returncode == returncode
 
 
 def test_execute_repair_records_spawn_error_with_log_path(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #628

Accept schema-valid, current-invocation response-file artifacts after timeout or nonzero CLI exits while retaining the original diagnostic and acquisition provenance. Covers completion recovery and Antigravity repair fallback behavior.