### PR TITLE
Fix coder follow-up human requirement ledgers

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,11 @@ once in either `addressed_items` or `remaining_items`.
 The disposition ledger must contain one entry per surfaced signed requirement,
 marked `addressed`, `blocked`, or `not-applicable` with non-blank evidence;
 use an empty ledger when no signed requirements were surfaced.
+In structured follow-ups, `human_requirements.addressed_ids` contains exactly
+the requirements with an `addressed` disposition. A `blocked` disposition
+requires `state: "blocking"`; `not-applicable` may be used in an approved
+follow-up. Markdown fallback acknowledgements retain their legacy rule: they
+must list every surfaced requirement.
 Plan-revision responses use `kind: "plan_revision"` with `state: "blocking"`,
 `summary`, `prior_plan_item_dispositions`, and `plan_steps`. Structured
 responses must start with one top-level JSON object, place the matching

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1490,7 +1490,12 @@ response must classify every carried reviewer item exactly once:
 `human_requirement_dispositions` is an auditable ledger: include exactly one
 entry for each surfaced signed requirement, with disposition `addressed`,
 `blocked`, or `not-applicable` and non-blank evidence. It must be empty when
-no signed requirements were surfaced.
+no signed requirements were surfaced. In structured coder follow-ups,
+`human_requirements.addressed_ids` contains exactly requirements whose
+disposition is `addressed`; omit `blocked` and `not-applicable` requirements.
+A blocked disposition requires `state: "blocking"`, while not-applicable may
+appear in an approved response. Legacy markdown acknowledgements still list
+every surfaced requirement.
 
 A plan revision uses:
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -660,12 +660,16 @@ def _structured_coder_followup_guidance(
     human_requirements_context: CoderHumanRequirementsPromptContext,
     coder_signature: str,
 ) -> str:
-    example_human_requirement_ids = (
-        list(human_requirements_context.surfaced_requirement_ids[:1])
+    example_human_requirement_dispositions = (
+        [{
+            "requirement_id": human_requirements_context.surfaced_requirement_ids[0],
+            "disposition": "blocked",
+            "evidence": "The requested dependency is unavailable in this environment.",
+        }]
         if human_requirements_context.surfaced_requirement_ids
         else []
     )
-    example_human_requirement_ids_json = json.dumps(example_human_requirement_ids)
+    example_human_requirement_dispositions_json = json.dumps(example_human_requirement_dispositions)
     lines = [
         f"Use this mandatory structured JSON follow-up format so {reviewer_name} and the orchestrator can validate your response deterministically:",
         "",
@@ -680,9 +684,9 @@ def _structured_coder_followup_guidance(
         '  "addressed_item_notes": {"item-1": "Updated the parser and added regression coverage."},',
         '  "remaining_item_notes": {"item-2": "Deferred because it requires a separate UI change."},',
         '  "dispute_evidence": {"item-3": "Checked Google pricing page (https://...): $1.50/1M tokens is correct per the official docs."},',
-        '  "human_requirement_dispositions": [],',
+        f'  "human_requirement_dispositions": {example_human_requirement_dispositions_json},',
         '  "human_requirements": {',
-        f'    "addressed_ids": {example_human_requirement_ids_json},',
+        '    "addressed_ids": [],',
         '    "checked_discussion_directly": false',
         "  },",
         '  "tests_run": ["python -m pytest tests/test_agent_loop.py -k followup"]',
@@ -699,11 +703,11 @@ def _structured_coder_followup_guidance(
     if human_requirements_context.surfaced_requirement_ids:
         surfaced = ", ".join(f"`{item}`" for item in human_requirements_context.surfaced_requirement_ids)
         lines.append(
-            "In structured replies, set `human_requirements.addressed_ids` to exactly the surfaced signed human requirement IDs you addressed in this prompt: "
+            "In structured replies, `human_requirement_dispositions` must cover exactly these surfaced signed labels: "
             f"{surfaced}. Only exact surfaced labels such as `Requirement 1` are valid."
         )
         lines.append(
-            "Set `human_requirement_dispositions` to exactly one object per surfaced label, using the exact `requirement_id`, disposition `addressed`, `blocked`, or `not-applicable`, and non-blank evidence. This ledger is separate from reviewer item classifications and the legacy `human_requirements` acknowledgement."
+            "Set `human_requirement_dispositions` to exactly one object per surfaced label, using the exact `requirement_id`, disposition `addressed`, `blocked`, or `not-applicable`, and non-blank evidence. Put only `addressed` dispositions in `human_requirements.addressed_ids`; omit `blocked` and `not-applicable` dispositions. A `blocked` disposition requires `state: blocking`, while `not-applicable` may be used with `state: approved`."
         )
     elif human_requirements_context.requires_direct_discussion_ack:
         lines.append(

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -710,6 +710,7 @@ def validate_human_requirements_acknowledgement(
 def validate_structured_human_requirements_acknowledgement(
     addressed_ids: Sequence[str],
     *,
+    dispositions: Sequence[HumanRequirementDisposition] | None = None,
     checked_discussion_directly: bool,
     surfaced_requirement_ids: Sequence[str],
     requires_direct_discussion_ack: bool,
@@ -762,11 +763,29 @@ def validate_structured_human_requirements_acknowledgement(
         )
 
     if expected_ids:
-        missing = sorted(set(expected_ids) - set(normalized_addressed_ids))
+        if dispositions is None:
+            expected_addressed_ids = set(expected_ids)
+            missing_message = "Coder response did not address all surfaced signed human requirement IDs: "
+        else:
+            expected_addressed_ids = {
+                _normalize_requirement_label(item.requirement_id)
+                for item in dispositions
+                if item.disposition == "addressed"
+            }
+            missing_message = (
+                "Coder response human_requirements.addressed_ids must contain every requirement "
+                "with an `addressed` disposition: "
+            )
+        actual_addressed_ids = set(normalized_addressed_ids)
+        missing = sorted(expected_addressed_ids - actual_addressed_ids)
+        unexpected = sorted(actual_addressed_ids - expected_addressed_ids)
         if missing:
+            raise AgentLoopError(missing_message + ", ".join(missing))
+        if unexpected:
             raise AgentLoopError(
-                "Coder response did not address all surfaced signed human requirement IDs: "
-                + ", ".join(missing)
+                "Coder response human_requirements.addressed_ids may contain only requirements "
+                "with an `addressed` disposition: "
+                + ", ".join(unexpected)
             )
         return
 
@@ -1759,10 +1778,17 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
             "Coder follow-up listed unresolved reviewer item IDs more than once: "
             + ", ".join(duplicates)
         )
+    state = _expect_state(payload["state"], context="coder_followup.state")
+    if state == "approved" and any(
+        item.disposition == "blocked" for item in human_requirement_dispositions
+    ):
+        raise AgentLoopError(
+            "coder_followup.state must be `blocking` when a signed human requirement is blocked."
+        )
     return StructuredCoderFollowup(
         schema_version=1,
         kind="coder_followup",
-        state=_expect_state(payload["state"], context="coder_followup.state"),
+        state=state,
         summary=_expect_non_empty_string(payload["summary"], context="coder_followup.summary"),
         addressed_items=addressed_items,
         remaining_items=remaining_items,

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -272,8 +272,12 @@ You are a format-repair assistant. An AI agent produced an initial plan state, c
     "checked_discussion_directly": false
   }
 }
-<!-- AGENT_STATE: approved -->
+<!-- AGENT_STATE: blocking -->
 -- <Coder Name>
+
+This is a blocking example because it has a `blocked` human-requirement disposition.
+For an approved coder follow-up, use `"state": "approved"`, an
+`<!-- AGENT_STATE: approved -->` footer, and no `blocked` dispositions.
 
 ## Valid Format E — Discuss Review:
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -258,14 +258,17 @@ You are a format-repair assistant. An AI agent produced an initial plan state, c
 {
   "schema_version": 1,
   "kind": "coder_followup",
-  "state": "approved" | "blocking",
+  "state": "blocking",
   "summary": "<short summary>",
   "addressed_items": ["item-1"],
   "remaining_items": ["item-2"],
   "addressed_item_notes": {"item-1": "<how it was resolved>"},
   "remaining_item_notes": {"item-2": "<why it remains>"},
+  "human_requirement_dispositions": [
+    {"requirement_id": "Requirement 1", "disposition": "blocked", "evidence": "<why it cannot be completed>"}
+  ],
   "human_requirements": {
-    "addressed_ids": ["Requirement 1"],
+    "addressed_ids": [],
     "checked_discussion_directly": false
   }
 }
@@ -565,8 +568,11 @@ section and missing <!-- HUMAN_REQUIREMENTS_ADDRESSED --> marker.
   "summary": "Implemented the quota exit policy.",
   "addressed_items": ["item-1"],
   "remaining_items": [],
+  "human_requirement_dispositions": [
+    {"requirement_id": "Requirement 1", "disposition": "blocked", "evidence": "The required service is unavailable."}
+  ],
   "human_requirements": {
-    "addressed_ids": ["Requirement 1"],
+    "addressed_ids": [],
     "checked_discussion_directly": false
   }
 }
@@ -588,8 +594,11 @@ CORRECT repair — strip the fences, remove the prose, output bare JSON + footer
   "summary": "Implemented the quota exit policy.",
   "addressed_items": ["item-1"],
   "remaining_items": [],
+  "human_requirement_dispositions": [
+    {"requirement_id": "Requirement 1", "disposition": "blocked", "evidence": "The required service is unavailable."}
+  ],
   "human_requirements": {
-    "addressed_ids": ["Requirement 1"],
+    "addressed_ids": [],
     "checked_discussion_directly": false
   }
 }
@@ -598,7 +607,7 @@ CORRECT repair — strip the fences, remove the prose, output bare JSON + footer
 
 Notes:
 - addressed_items contains real reviewer item IDs (like "item-1"), never the human-requirements ack pseudo-item
-- "Requirement 1" stays in human_requirements.addressed_ids (it is a human requirement label, not an item ID)
+- Only `addressed` human-requirement dispositions belong in human_requirements.addressed_ids; blocked dispositions require state `blocking`.
 - <!-- HUMAN_REQUIREMENTS_ADDRESSED --> is NOT needed in the structured path
 - No prose, no ### sections after the JSON
 
@@ -660,6 +669,7 @@ CORRECT repair — keep reviewer items separate and rewrite human_requirements.a
   "summary": "Updated the implementation and left one reviewer item pending.",
   "addressed_items": ["item-1"],
   "remaining_items": ["item-2"],
+  "human_requirement_dispositions": [],
   "human_requirements": {
     "addressed_ids": [],
     "checked_discussion_directly": false
@@ -671,7 +681,7 @@ CORRECT repair — keep reviewer items separate and rewrite human_requirements.a
 Notes:
 - Issue acceptance criteria are not signed human requirements.
 - Reviewer items belong in addressed_items / remaining_items, never in human_requirements.addressed_ids.
-- If surfaced signed labels include "Requirement 1" and the malformed response has ["Requirement 1", "Issue #221 acceptance criteria"], keep ["Requirement 1"] and drop "Issue #221 acceptance criteria".
+- If surfaced signed labels include "Requirement 1", include one evidenced disposition for it and put it in addressed_ids only when that disposition is `addressed`; blocked dispositions require blocking state.
 
 ## WORKED EXAMPLE 6 — approved plan_review with same-plan disposition whose note says plan covers it:
 
@@ -1341,7 +1351,8 @@ def _coder_followup_human_requirements_instruction(
         f"{rendered_ids}\n"
         "Include exactly one `human_requirement_dispositions` object per listed ID, with the exact ID, disposition "
         "`addressed`, `blocked`, or `not-applicable`, and non-blank evidence.\n"
-        "Only the exact labels above may appear in `human_requirements.addressed_ids`.\n"
+        "Only labels with an `addressed` disposition may appear in `human_requirements.addressed_ids`; "
+        "omit `blocked` and `not-applicable` labels. A `blocked` disposition requires `state: blocking`.\n"
         "When the list is `(none)`, set `human_requirements.addressed_ids` to `[]`. "
         "Do not use issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, "
         "summaries, or arbitrary labels as human requirement IDs.\n"

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -248,6 +248,7 @@ def _reconcile_human_requirements_ack_item(
             )
             validate_structured_human_requirements_acknowledgement(
                 structured_followup.human_requirements.addressed_ids,
+                dispositions=structured_followup.human_requirement_dispositions,
                 checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
                 surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
                 requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
@@ -421,6 +422,7 @@ def _validate_coder_followup_response(
         )
         validate_structured_human_requirements_acknowledgement(
             structured_followup.human_requirements.addressed_ids,
+            dispositions=structured_followup.human_requirement_dispositions,
             checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
             surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
             requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,6 +3,10 @@ import pytest
 from agent_loop_helpers import *  # noqa: F403
 from coding_review_agent_loop.github import PullRequestCheck, PullRequestChecks
 from coding_review_agent_loop.prompts import build_task_clarification_prompt, format_pr_checks
+from coding_review_agent_loop.protocol import (
+    validate_structured_coder_followup,
+    validate_structured_human_requirements_acknowledgement,
+)
 
 _EXPECTED_UNRESOLVED_ITEMS_GUIDANCE = """Prior unresolved items are present. Disposition every listed
 item in the JSON `prior_item_dispositions` array — do not add a separate prose section
@@ -1402,6 +1406,31 @@ def test_non_plan_prompts_request_human_requirement_dispositions_not_plan_dispos
     assert '"human_requirement_dispositions"' in prompts[1]
     for prompt in prompts[2:]:
         assert '"human_requirement_dispositions"' not in prompt
+
+
+def test_coder_followup_guidance_renders_valid_blocked_requirement_example(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex",))
+    requirements = (HumanReviewRequirement(
+        source_type="PR comment", author="reviewer", created_at="2026-05-18T10:00:00Z",
+        url="https://github.com/OWNER/REPO/pull/77#issuecomment-1", body="Please use the absolute URL.",
+    ),)
+    prompt = build_followup_prompt(77, 1, "Fix the URL.", config, human_requirements=requirements)
+    example_start = prompt.index('{\n  "schema_version": 1,\n  "kind": "coder_followup"')
+    decoder = json.JSONDecoder()
+    payload, _ = decoder.raw_decode(prompt[example_start:])
+    example = json.dumps(payload) + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex"
+    parsed = validate_structured_coder_followup(example)
+
+    assert parsed.human_requirements.addressed_ids == ()
+    assert parsed.human_requirement_dispositions[0].disposition == "blocked"
+    assert "only `addressed` dispositions" in prompt
+    validate_structured_human_requirements_acknowledgement(
+        parsed.human_requirements.addressed_ids,
+        dispositions=parsed.human_requirement_dispositions,
+        checked_discussion_directly=False,
+        surfaced_requirement_ids=("Requirement 1",),
+        requires_direct_discussion_ack=False,
+    )
 
 
 def test_plan_review_prompt_surfaces_signed_issue_requirements_as_approval_critical(tmp_path):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2444,6 +2444,38 @@ def test_validate_structured_coder_followup_rejects_disputed_item_without_eviden
         validate_structured_coder_followup(payload)
 
 
+def test_validate_structured_coder_followup_rejects_approved_blocked_requirement():
+    payload = json.dumps({
+        "schema_version": 1, "kind": "coder_followup", "state": "approved",
+        "summary": "Cannot complete the requirement.", "addressed_items": [], "remaining_items": [],
+        "human_requirement_dispositions": [{
+            "requirement_id": "Requirement 1", "disposition": "blocked", "evidence": "The dependency is unavailable."
+        }],
+        "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+    }) + "\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"
+
+    with pytest.raises(AgentLoopError, match="must be `blocking`"):
+        validate_structured_coder_followup(payload)
+
+
+def test_validate_structured_human_requirements_acknowledgement_uses_disposition_ledger():
+    from coding_review_agent_loop.protocol import HumanRequirementDisposition
+
+    dispositions = (
+        HumanRequirementDisposition("Requirement 1", "blocked", "Dependency is unavailable."),
+        HumanRequirementDisposition("Requirement 2", "addressed", "Implemented the requested change."),
+    )
+    validate_structured_human_requirements_acknowledgement(
+        ("Requirement 2",), dispositions=dispositions, checked_discussion_directly=False,
+        surfaced_requirement_ids=("Requirement 1", "Requirement 2"), requires_direct_discussion_ack=False,
+    )
+    with pytest.raises(AgentLoopError, match="may contain only requirements with an `addressed` disposition"):
+        validate_structured_human_requirements_acknowledgement(
+            ("Requirement 1", "Requirement 2"), dispositions=dispositions, checked_discussion_directly=False,
+            surfaced_requirement_ids=("Requirement 1", "Requirement 2"), requires_direct_discussion_ack=False,
+        )
+
+
 @pytest.mark.parametrize(
     ("addressed_ids", "checked_discussion_directly", "surfaced_ids", "requires_direct_discussion_ack", "message"),
     [

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1660,10 +1660,8 @@ def test_repair_prompt_coder_followup_examples_include_current_requirement_schem
     assert '"human_requirement_dispositions"' in format_c
     assert '"disposition": "blocked"' in format_c
     assert '"addressed_ids": []' in format_c
-    payload, _ = json.JSONDecoder().raw_decode(format_c.lstrip())
-    parsed = validate_structured_coder_followup(
-        json.dumps(payload) + "\n<!-- AGENT_STATE: blocking -->\n-- Coder Name"
-    )
+    format_c_example = format_c.split("This is a blocking example", 1)[0].strip()
+    parsed = validate_structured_coder_followup(format_c_example)
     assert parsed.state == "blocking"
     assert parsed.human_requirement_dispositions[0].disposition == "blocked"
     assert '"state": "approved"' in format_c

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -681,7 +681,7 @@ def test_attempt_repair_includes_surfaced_requirement_labels_for_mixed_repairs()
     cmd = mock_run.call_args.args[0]
     prompt = cmd[cmd.index("--prompt") + 1]
     assert "`Requirement 1`" in prompt
-    assert "keep [\"Requirement 1\"] and drop \"Issue #221 acceptance criteria\"" in prompt
+    assert "put it in addressed_ids only when that disposition is `addressed`" in prompt
 
 def test_attempt_repair_rejects_unresolved_item_ids_for_non_coder_kind():
     with pytest.raises(ValueError, match="unresolved_item_ids"):
@@ -1650,6 +1650,19 @@ def test_repair_prompt_coder_followup_fenced_json_example():
     assert "HUMAN_REQUIREMENTS_ADDRESSED" in _REPAIR_PROMPT
     # The prompt explains the marker is not needed in structured path
     assert "NOT needed" in _REPAIR_PROMPT or "not needed" in _REPAIR_PROMPT.lower()
+
+
+def test_repair_prompt_coder_followup_examples_include_current_requirement_schema():
+    format_c = _REPAIR_PROMPT.split("## Valid Format C — Coder Follow-up:", 1)[1].split(
+        "## Valid Format E", 1
+    )[0]
+    assert '"human_requirement_dispositions"' in format_c
+    assert '"disposition": "blocked"' in format_c
+    assert '"addressed_ids": []' in format_c
+    example_3 = _REPAIR_PROMPT.split("## WORKED EXAMPLE 3", 1)[1].split("## WORKED EXAMPLE 4", 1)[0]
+    example_5 = _REPAIR_PROMPT.split("## WORKED EXAMPLE 5", 1)[1].split("## WORKED EXAMPLE 6", 1)[0]
+    assert example_3.count('"human_requirement_dispositions"') == 2
+    assert '"human_requirement_dispositions": []' in example_5
 
 def test_repair_prompt_plan_revision_preserves_human_requirements_acknowledgement():
     assert "WORKED EXAMPLE 4" in _REPAIR_PROMPT

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -11,6 +11,7 @@ from coding_review_agent_loop.repair import (
 )
 from coding_review_agent_loop.protocol import (
     validate_structured_discuss_answer,
+    validate_structured_coder_followup,
     validate_structured_plan_state,
 )
 from coding_review_agent_loop.orchestrator import _new_usage_context, _structured_response_candidates
@@ -1659,6 +1660,14 @@ def test_repair_prompt_coder_followup_examples_include_current_requirement_schem
     assert '"human_requirement_dispositions"' in format_c
     assert '"disposition": "blocked"' in format_c
     assert '"addressed_ids": []' in format_c
+    payload, _ = json.JSONDecoder().raw_decode(format_c.lstrip())
+    parsed = validate_structured_coder_followup(
+        json.dumps(payload) + "\n<!-- AGENT_STATE: blocking -->\n-- Coder Name"
+    )
+    assert parsed.state == "blocking"
+    assert parsed.human_requirement_dispositions[0].disposition == "blocked"
+    assert '"state": "approved"' in format_c
+    assert "<!-- AGENT_STATE: approved -->" in format_c
     example_3 = _REPAIR_PROMPT.split("## WORKED EXAMPLE 3", 1)[1].split("## WORKED EXAMPLE 4", 1)[0]
     example_5 = _REPAIR_PROMPT.split("## WORKED EXAMPLE 5", 1)[1].split("## WORKED EXAMPLE 6", 1)[0]
     assert example_3.count('"human_requirement_dispositions"') == 2

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -99,6 +99,57 @@ def test_validate_coder_followup_response_accepts_structured_item_partition():
     assert parsed.addressed_items == ("item-1",)
     assert parsed.remaining_items == ("item-2",)
 
+
+@pytest.mark.parametrize(
+    ("state", "disposition"),
+    [("blocking", "blocked"), ("approved", "not-applicable")],
+)
+def test_validate_coder_followup_response_uses_disposition_aware_requirement_ledger(state, disposition):
+    response = structured_coder_followup(
+        state=state,
+        addressed_items=["item-1"],
+        human_requirement_ids=[],
+        human_requirement_dispositions=[{
+            "requirement_id": "Requirement 1", "disposition": disposition,
+            "evidence": "The dependency is unavailable." if disposition == "blocked" else "Requirement does not apply.",
+        }],
+    )
+    parsed = _validate_coder_followup_response(
+        response,
+        unresolved_items=(UnresolvedReviewItem(
+            item_id="item-1", reviewer="OpenAI Codex", source_round=1,
+            text="Add a regression test.", status="blocking",
+        ),),
+        human_requirements=(HumanReviewRequirement(
+            source_type="PR comment", author="reviewer", created_at="2026-05-18T10:00:00Z",
+            url="https://github.com/OWNER/REPO/pull/77#issuecomment-1", body="Please use the absolute URL.",
+        ),),
+    )
+    assert parsed.human_requirements.addressed_ids == ()
+
+
+def test_validate_coder_followup_response_rejects_mismatched_requirement_ledger():
+    response = structured_coder_followup(
+        addressed_items=["item-1"],
+        human_requirement_ids=[],
+        human_requirement_dispositions=[{
+            "requirement_id": "Requirement 1", "disposition": "addressed",
+            "evidence": "Implemented the requested change.",
+        }],
+    )
+    with pytest.raises(AgentLoopError, match="must contain every requirement with an `addressed` disposition"):
+        _validate_coder_followup_response(
+            response,
+            unresolved_items=(UnresolvedReviewItem(
+                item_id="item-1", reviewer="OpenAI Codex", source_round=1,
+                text="Add a regression test.", status="blocking",
+            ),),
+            human_requirements=(HumanReviewRequirement(
+                source_type="PR comment", author="reviewer", created_at="2026-05-18T10:00:00Z",
+                url="https://github.com/OWNER/REPO/pull/77#issuecomment-1", body="Please use the absolute URL.",
+            ),),
+        )
+
 def test_validate_coder_followup_response_rejects_issue_acceptance_criteria_as_human_requirement():
     response = structured_coder_followup(
         state="blocking",


### PR DESCRIPTION
## Summary
- make structured human-requirement acknowledgements disposition-aware
- enforce blocked requirements only in blocking follow-ups
- align prompts, repairs, documentation, and regression coverage

## Testing
- `python3 -m pytest -q tests/test_protocol.py tests/test_response_validation.py tests/test_prompts.py tests/test_repair.py`
- `python3 -m pytest -q`

Fixes #571