### PR TITLE
Materialize only typed split child stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,12 +352,13 @@ over-cap response is rejected and must be consolidated, not truncated. This cap
 is separate from the approved-review follow-up issue cap used by
 `--approved-followups`.
 
-If the approved plan narrows scope (via explicit `child_stages`,
-`external_dependencies`, `deferred_work`, and `plan_actions` fields, or a legacy structured `deferred_stages` field,
-or a prior discuss `split` consensus), pass `--materialize-split-issues` to
-file each remaining stage as its own linked child issue instead of leaving it
-as unfiled text — default is off, and the orchestrator always warns explicitly
-when stages would otherwise go unfiled. When a parent's stages are already
+If the approved plan narrows scope via explicit `child_stages`, pass
+`--materialize-split-issues` to file those bounded implementation stages as
+linked child issues. `external_dependencies`, `deferred_work`, `plan_actions`,
+and legacy structured `deferred_stages` are recorded only; legacy discuss
+`split` proposals remain eligible for filing. Materialization is off by default,
+and the orchestrator warns explicitly when eligible stages would otherwise go
+unfiled. When a parent's stages are already
 fully materialized, `--implement-after-approval` hands implementation off to
 the specific child the plan covers (via a unique title match or an explicit
 `--split-stage <child>` flag) instead of treating the whole parent as solved,

--- a/README.md
+++ b/README.md
@@ -352,7 +352,8 @@ over-cap response is rejected and must be consolidated, not truncated. This cap
 is separate from the approved-review follow-up issue cap used by
 `--approved-followups`.
 
-If the approved plan narrows scope (via a structured `deferred_stages` field,
+If the approved plan narrows scope (via explicit `child_stages`,
+`external_dependencies`, `deferred_work`, and `plan_actions` fields, or a legacy structured `deferred_stages` field,
 or a prior discuss `split` consensus), pass `--materialize-split-issues` to
 file each remaining stage as its own linked child issue instead of leaving it
 as unfiled text — default is off, and the orchestrator always warns explicitly

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -846,8 +846,11 @@ What each mechanism produces and where the run stops:
   first phase is `human-action` or `manual-close`, it stops after creating the
   child issues without implementing anything. Resume the remaining phases with
   `agent-loop issue <child>`, not by rerunning the parent.
-- **`--materialize-split-issues`**: files one linked, generic child issue per
-  remaining discuss `split` proposal or plan `deferred_stages` entry. It is
+- **`--materialize-split-issues`**: files one linked child issue only for an
+  approved plan's explicit `child_stages` entries (or legacy discuss `split`
+  proposals). Use `external_dependencies` for existing `#N`, issue URL, or
+  `owner/repo#N` references; `deferred_work` and `plan_actions` are recorded
+  only. Legacy `deferred_stages` are record-only and are never auto-filed.
   idempotent (tracked by the parent's `AGENT_DISCUSS_SPLIT` marker), capped at
   8 children per parent, and files nothing from free-form prose narrowing
   alone — only from the two structured signals above.

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -294,7 +294,10 @@ def render_typed_plan_stages_section(stages: TypedPlanStages) -> str | None:
             lines.append(f"#### {title}")
             lines.extend(f"- {entry.title}: {entry.summary}" for entry in entries)
     payload = {
-        "child_stages": [{"title": item.title, "summary": item.summary, "allow_action_title": item.allow_action_title} for item in stages.child_stages],
+        "child_stages": [
+            {"title": item.title, "summary": item.summary}
+            for item in stages.child_stages
+        ],
         "external_dependencies": [{"title": item.title, "summary": item.summary} for item in stages.external_dependencies],
         "deferred_work": [{"title": item.title, "summary": item.summary} for item in stages.deferred_work],
         "plan_actions": [{"title": item.title, "summary": item.summary} for item in stages.plan_actions],

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -19,6 +19,7 @@ from .protocol import (
     SIGNATURE_RE,
     AgentUnavailable,
     DeferredStage,
+    TypedPlanStages,
     HumanRequirementDisposition,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
@@ -277,6 +278,31 @@ def render_deferred_stages_section(deferred_stages: Sequence[DeferredStage]) -> 
     return "\n".join(lines)
 
 
+def render_typed_plan_stages_section(stages: TypedPlanStages) -> str | None:
+    """Render #585 categories; only child stages are eligible for filing."""
+    groups = (
+        ("Child stages (eligible for child issues)", stages.child_stages),
+        ("External dependencies (linked, never created)", stages.external_dependencies),
+        ("Deferred work (recorded only)", stages.deferred_work),
+        ("Plan actions (recorded only)", stages.plan_actions),
+    )
+    if not any(entries for _, entries in groups):
+        return None
+    lines = ["### Structured scope categories"]
+    for title, entries in groups:
+        if entries:
+            lines.append(f"#### {title}")
+            lines.extend(f"- {entry.title}: {entry.summary}" for entry in entries)
+    payload = {
+        "child_stages": [{"title": item.title, "summary": item.summary, "allow_action_title": item.allow_action_title} for item in stages.child_stages],
+        "external_dependencies": [{"title": item.title, "summary": item.summary} for item in stages.external_dependencies],
+        "deferred_work": [{"title": item.title, "summary": item.summary} for item in stages.deferred_work],
+        "plan_actions": [{"title": item.title, "summary": item.summary} for item in stages.plan_actions],
+    }
+    lines.append(f"<!-- AGENT_TYPED_PLAN_STAGES: {_encode_json_payload(payload)} -->")
+    return "\n".join(lines)
+
+
 def _encode_deferred_stages_marker(deferred_stages: Sequence[DeferredStage]) -> str:
     return _encode_json_payload(
         {"stages": [{"title": stage.title, "summary": stage.summary} for stage in deferred_stages]}
@@ -337,6 +363,9 @@ def render_canonical_plan_revision(
     deferred_section = render_deferred_stages_section(parsed_revision.deferred_stages)
     if deferred_section:
         sections.append(deferred_section)
+    typed_section = render_typed_plan_stages_section(parsed_revision.typed_stages)
+    if typed_section:
+        sections.append(typed_section)
     return "\n\n".join(sections)
 
 
@@ -635,6 +664,9 @@ def _render_public_plan_state_comment(
     deferred_section = render_deferred_stages_section(parsed_plan.deferred_stages)
     if deferred_section:
         sections.append(deferred_section)
+    typed_section = render_typed_plan_stages_section(parsed_plan.typed_stages)
+    if typed_section:
+        sections.append(typed_section)
     sections.append(f"<!-- AGENT_PLAN_STATE: {parsed_plan.state} -->")
     sections.append(f"-- {_comment_signature(agent, config, model_used)}")
     return "\n\n".join(section for section in sections if section)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -298,9 +298,18 @@ def render_typed_plan_stages_section(stages: TypedPlanStages) -> str | None:
             {"title": item.title, "summary": item.summary}
             for item in stages.child_stages
         ],
-        "external_dependencies": [{"title": item.title, "summary": item.summary} for item in stages.external_dependencies],
-        "deferred_work": [{"title": item.title, "summary": item.summary} for item in stages.deferred_work],
-        "plan_actions": [{"title": item.title, "summary": item.summary} for item in stages.plan_actions],
+        "external_dependencies": [
+            {"title": item.title, "summary": item.summary}
+            for item in stages.external_dependencies
+        ],
+        "deferred_work": [
+            {"title": item.title, "summary": item.summary}
+            for item in stages.deferred_work
+        ],
+        "plan_actions": [
+            {"title": item.title, "summary": item.summary}
+            for item in stages.plan_actions
+        ],
     }
     lines.append(f"<!-- AGENT_TYPED_PLAN_STAGES: {_encode_json_payload(payload)} -->")
     return "\n".join(lines)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -30,6 +30,7 @@ from .config import (
     sync_reviewer_pr_before_review,
 )
 from .decomposition import (
+    _decode_json_payload,
     CreatedPhaseIssue,
     RecordedPhase,
     approved_plan_hash,
@@ -3360,6 +3361,27 @@ def _extract_current_deferred_stages(current_plan: str) -> tuple[DeferredStage, 
     return tuple(stages)
 
 
+def _extract_current_child_stages(current_plan: str) -> tuple[DeferredStage, ...]:
+    """Return only explicitly typed child stages; legacy entries are record-only."""
+    try:
+        structured = validate_structured_plan_state(current_plan)
+    except AgentLoopError:
+        structured = None
+    if structured is not None:
+        return tuple(DeferredStage(item.title, item.summary) for item in structured.typed_stages.child_stages)
+    marker = re.search(r"<!--\s*AGENT_TYPED_PLAN_STAGES:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", current_plan, re.I)
+    if not marker:
+        return ()
+    try:
+        payload = _decode_json_payload(marker.group("payload"), marker_name="AGENT_TYPED_PLAN_STAGES")
+        children = payload.get("child_stages", [])
+        if not isinstance(children, list):
+            return ()
+        return tuple(DeferredStage(str(item["title"]), str(item["summary"])) for item in children if isinstance(item, dict) and isinstance(item.get("title"), str) and isinstance(item.get("summary"), str))
+    except AgentLoopError:
+        return ()
+
+
 def _prior_discuss_split_proposals(
     issue_context: IssueContext, *, config: AgentLoopConfig
 ) -> list[str]:
@@ -3436,8 +3458,9 @@ def _handle_plan_first_split_scope(
     look stale and hide children materialized moments earlier in this same run.
     """
     current_deferred_stages = _extract_current_deferred_stages(current_plan)
+    current_child_stages = _extract_current_child_stages(current_plan)
     prior_discuss_proposals = _prior_discuss_split_proposals(issue_context, config=config)
-    if current_deferred_stages:
+    if current_child_stages or current_deferred_stages:
         # This plan structurally declares its own deferred_stages, so it keeps
         # a primary scope on the parent (the implement-one-shot branch below
         # never hands that scope off to a child in this case). If a prior
@@ -3451,7 +3474,7 @@ def _handle_plan_first_split_scope(
             if split_stage_proposal_from_text(proposal).key != plan_own_key
         ]
     remaining_proposals = dedupe_split_stage_proposals(
-        [split_stage_proposal_from_deferred_stage(stage) for stage in current_deferred_stages]
+        [split_stage_proposal_from_deferred_stage(stage) for stage in current_child_stages]
         + [split_stage_proposal_from_text(proposal) for proposal in prior_discuss_proposals]
     )
     if remaining_proposals:
@@ -4813,8 +4836,12 @@ def _run_plan_first_loop(
                 target_issue_number = issue_number
                 target_issue_context = issue_context
                 staged_parent_issue: int | None = None
+                # Explicit child stages are the parent plan's bounded remainder;
+                # legacy deferred entries preserve the same historical parent-owned
+                # behavior. Dependencies/actions alone must not suppress handoff.
                 current_plan_declares_own_deferred_stages = bool(
-                    _extract_current_deferred_stages(current_plan)
+                    _extract_current_child_stages(current_plan)
+                    or _extract_current_deferred_stages(current_plan)
                 )
                 split_metadata = find_existing_split_materialization(
                     issue_context.comments, parent_issue=issue_number

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -132,6 +132,7 @@ from .protocol import (
     ApprovedFollowups,
     DISCUSS_FAILED_OUTCOME,
     DISCUSS_RESEARCH_TARGET_VALUES,
+    ChildStage,
     DeferredStage,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
     ParsedDiscussAgenda,
@@ -3361,14 +3362,14 @@ def _extract_current_deferred_stages(current_plan: str) -> tuple[DeferredStage, 
     return tuple(stages)
 
 
-def _extract_current_child_stages(current_plan: str) -> tuple[DeferredStage, ...]:
+def _extract_current_child_stages(current_plan: str) -> tuple[ChildStage, ...]:
     """Return only explicitly typed child stages; legacy entries are record-only."""
     try:
         structured = validate_structured_plan_state(current_plan)
     except AgentLoopError:
         structured = None
     if structured is not None:
-        return tuple(DeferredStage(item.title, item.summary) for item in structured.typed_stages.child_stages)
+        return structured.typed_stages.child_stages
     marker = re.search(r"<!--\s*AGENT_TYPED_PLAN_STAGES:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", current_plan, re.I)
     if not marker:
         return ()
@@ -3377,9 +3378,57 @@ def _extract_current_child_stages(current_plan: str) -> tuple[DeferredStage, ...
         children = payload.get("child_stages", [])
         if not isinstance(children, list):
             return ()
-        return tuple(DeferredStage(str(item["title"]), str(item["summary"])) for item in children if isinstance(item, dict) and isinstance(item.get("title"), str) and isinstance(item.get("summary"), str))
+        return tuple(
+            ChildStage(str(item["title"]), str(item["summary"]))
+            for item in children
+            if isinstance(item, dict)
+            and isinstance(item.get("title"), str)
+            and isinstance(item.get("summary"), str)
+        )
     except AgentLoopError:
         return ()
+
+
+def _log_typed_plan_stage_dispositions(current_plan: str, *, config: AgentLoopConfig) -> None:
+    """Make the record-only typed categories visible in CLI output (#585)."""
+    try:
+        structured = validate_structured_plan_state(current_plan)
+    except AgentLoopError:
+        structured = None
+    if structured is not None:
+        categories = (
+            ("linked dependency", structured.typed_stages.external_dependencies),
+            ("recorded-only deferred work", structured.typed_stages.deferred_work),
+            ("recorded-only plan action", structured.typed_stages.plan_actions),
+        )
+        for disposition, entries in categories:
+            for entry in entries:
+                log(config, f"Plan scope: {disposition}: {entry.title}.")
+        return
+    marker = re.search(
+        r"<!--\s*AGENT_TYPED_PLAN_STAGES:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+        current_plan,
+        re.I,
+    )
+    if not marker:
+        return
+    try:
+        payload = _decode_json_payload(
+            marker.group("payload"), marker_name="AGENT_TYPED_PLAN_STAGES"
+        )
+    except AgentLoopError:
+        return
+    for field, disposition in (
+        ("external_dependencies", "linked dependency"),
+        ("deferred_work", "recorded-only deferred work"),
+        ("plan_actions", "recorded-only plan action"),
+    ):
+        entries = payload.get(field, [])
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and isinstance(entry.get("title"), str):
+                log(config, f"Plan scope: {disposition}: {entry['title']}.")
 
 
 def _prior_discuss_split_proposals(
@@ -3459,6 +3508,7 @@ def _handle_plan_first_split_scope(
     """
     current_deferred_stages = _extract_current_deferred_stages(current_plan)
     current_child_stages = _extract_current_child_stages(current_plan)
+    _log_typed_plan_stage_dispositions(current_plan, config=config)
     prior_discuss_proposals = _prior_discuss_split_proposals(issue_context, config=config)
     if current_child_stages or current_deferred_stages:
         # This plan structurally declares its own deferred_stages, so it keeps

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3396,6 +3396,8 @@ def _log_typed_plan_stage_dispositions(current_plan: str, *, config: AgentLoopCo
     except AgentLoopError:
         structured = None
     if structured is not None:
+        for entry in structured.deferred_stages:
+            log(config, f"Plan scope: recorded-only legacy deferred stage: {entry.title}.")
         categories = (
             ("linked dependency", structured.typed_stages.external_dependencies),
             ("recorded-only deferred work", structured.typed_stages.deferred_work),
@@ -3405,6 +3407,8 @@ def _log_typed_plan_stage_dispositions(current_plan: str, *, config: AgentLoopCo
             for entry in entries:
                 log(config, f"Plan scope: {disposition}: {entry.title}.")
         return
+    for entry in _extract_current_deferred_stages(current_plan):
+        log(config, f"Plan scope: recorded-only legacy deferred stage: {entry.title}.")
     marker = re.search(
         r"<!--\s*AGENT_TYPED_PLAN_STAGES:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
         current_plan,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -973,20 +973,22 @@ Use this mandatory structured JSON response format:
     "Normalize structured plan rendering and metadata-backed resume behavior in `src/coding_review_agent_loop/orchestrator.py`.",
     "Extend prompts and targeted tests for structured planning flows."
   ],
-  "deferred_stages": [
-    {"title": "Follow-up stage title", "summary": "One-sentence scope this plan intentionally leaves out."}
-  ]
+  "child_stages": [
+    {"title": "New implementation stage", "summary": "Bounded work eligible for a new child issue."}
+  ],
+  "external_dependencies": [{"title": "#481", "summary": "Existing issue to link, never create."}],
+  "deferred_work": [{"title": "Future work", "summary": "Recorded only."}],
+  "plan_actions": [{"title": "Post-approval materialization", "summary": "Tracker action, never an issue."}]
 }
 <!-- AGENT_PLAN_STATE: blocking -->
 -- coder signature shown in the volatile tail
 
 If the plan intentionally narrows scope (mentions a later stage, follow-up
 issue, or explicitly out-of-scope work), declare EVERY such stage in the
-optional `deferred_stages` field instead of leaving it only in prose; omit the
-field entirely (or use an empty list) when the plan covers full scope. The
-orchestrator uses `deferred_stages` to file or warn about unfiled follow-up
-work before implementation, so undeclared narrowing can leave scope silently
-untracked once this plan's PR merges.
+typed categories instead of overloading `deferred_stages`: only `child_stages`
+are eligible for filing. Put existing `#N`, issue URLs, or `owner/repo#N`
+references in `external_dependencies`; use `deferred_work` and `plan_actions`
+for record-only entries. Legacy `deferred_stages` remains record-only.
 
 The orchestrator will normalize structured plan revisions into canonical
 markdown for stored plan state, reviewer prompts, subject hashing, and resume.
@@ -1170,8 +1172,10 @@ For a plan (rather than a clarification), respond with exactly one structured JS
 intended approach, key files or areas to change, edge cases, and test strategy.
 When signed requirements are surfaced, the disposition array must contain every
 generated `Requirement N` exactly once; when none are surfaced, it must be empty.
-The optional `deferred_stages` field is a list of objects with non-empty `title`
-and `summary` strings.
+Use the optional typed `child_stages`, `external_dependencies`, `deferred_work`,
+and `plan_actions` arrays (each has non-empty `title` and `summary` strings).
+Only `child_stages` may be materialized; existing issue references belong in
+`external_dependencies`, not a child title or summary.
 Do not substitute a generic `implementation_plan` object or markdown plan for this
 schema. If signed human-requirements acknowledgement is required, put its
 `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` marker and `### Human requirements` section

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -247,6 +247,26 @@ class DeferredStage:
 
 
 @dataclass(frozen=True)
+class ChildStage:
+    """A bounded implementation stage that may be filed as a child issue."""
+
+    title: str
+    summary: str
+    allow_action_title: bool = False
+
+
+@dataclass(frozen=True)
+class TypedPlanStages:
+    """The four non-overlapping scope categories used by approved plans (#585)."""
+
+    child_stages: tuple[ChildStage, ...] = ()
+    external_dependencies: tuple[DeferredStage, ...] = ()
+    deferred_work: tuple[DeferredStage, ...] = ()
+    plan_actions: tuple[DeferredStage, ...] = ()
+    legacy_parent_owned_scope: bool = False
+
+
+@dataclass(frozen=True)
 class StructuredPlanRevision:
     schema_version: int
     kind: str
@@ -255,6 +275,7 @@ class StructuredPlanRevision:
     prior_plan_item_dispositions: tuple[ReviewItemDisposition, ...]
     plan_steps: tuple[str, ...]
     deferred_stages: tuple[DeferredStage, ...] = ()
+    typed_stages: TypedPlanStages = TypedPlanStages()
     human_requirement_dispositions: tuple[HumanRequirementDisposition, ...] = ()
 
 
@@ -266,6 +287,7 @@ class StructuredPlanState:
     summary: str
     plan_steps: tuple[str, ...]
     deferred_stages: tuple[DeferredStage, ...] = ()
+    typed_stages: TypedPlanStages = TypedPlanStages()
     human_requirement_dispositions: tuple[HumanRequirementDisposition, ...] = ()
 
 
@@ -943,6 +965,59 @@ def _expect_deferred_stage_list(
             )
         )
     return tuple(stages)
+
+
+def _expect_typed_plan_stages(payload: dict[str, object], *, context: str) -> TypedPlanStages:
+    """Parse #585's explicit plan categories and retain old payloads safely.
+
+    Legacy ``deferred_stages`` are deliberately *not* promoted to children:
+    old plans may contain dependencies and tracker actions.
+    """
+    categories = ("child_stages", "external_dependencies", "deferred_work", "plan_actions")
+    present = [name for name in categories if name in payload]
+    legacy = _expect_deferred_stage_list(payload, "deferred_stages", context=f"{context}.deferred_stages")
+    if not present:
+        return TypedPlanStages(deferred_work=legacy, legacy_parent_owned_scope=bool(legacy))
+
+    def stages(name: str, *, children: bool = False) -> tuple[DeferredStage, ...] | tuple[ChildStage, ...]:
+        value = payload.get(name, [])
+        if not isinstance(value, list):
+            raise AgentLoopError(f"{context}.{name} must be a JSON array.")
+        result: list[DeferredStage] | list[ChildStage] = []
+        for index, item in enumerate(value):
+            item_context = f"{context}.{name} at index {index}"
+            obj = _expect_object(item, context=item_context)
+            allowed = {"title", "summary", "allow_action_title"} if children else {"title", "summary"}
+            _expect_exact_keys(obj, context=item_context, required={"title", "summary"}, optional=allowed - {"title", "summary"})
+            title = _expect_non_empty_string(obj["title"], context=f"{item_context}.title")
+            summary = _expect_non_empty_string(obj["summary"], context=f"{item_context}.summary")
+            if children:
+                allow = obj.get("allow_action_title", False)
+                if not isinstance(allow, bool):
+                    raise AgentLoopError(f"{item_context}.allow_action_title must be a boolean.")
+                reference = re.search(r"(?:\B#[1-9]\d*\b|github\.com/[^/\s]+/[^/\s]+/issues/[1-9]\d*\b|[\w.-]+/[\w.-]+#[1-9]\d*\b)", title + "\n" + summary, re.I)
+                action = re.match(r"^(?:post|after)[ -]?approval.*\b(?:creat|fil|materializ).*\bchild issue", " ".join(title.split()), re.I)
+                if reference:
+                    raise AgentLoopError(f"{item_context} references an existing issue; use external_dependencies.")
+                if action and not allow:
+                    raise AgentLoopError(f"{item_context} is a tracker action; use plan_actions or set allow_action_title for implementation work.")
+                result.append(ChildStage(title, summary, allow))  # type: ignore[arg-type]
+            else:
+                result.append(DeferredStage(title, summary))  # type: ignore[arg-type]
+        return tuple(result)
+
+    child_stages = stages("child_stages", children=True)
+    dependencies = stages("external_dependencies")
+    deferred = stages("deferred_work")
+    actions = stages("plan_actions")
+    seen: dict[str, str] = {}
+    for category, entries in (("child_stages", child_stages), ("external_dependencies", dependencies), ("deferred_work", deferred), ("plan_actions", actions)):
+        for entry in entries:
+            key = " ".join(entry.title.casefold().split())
+            if key in seen:
+                raise AgentLoopError(f"{context} has a duplicate title in {seen[key]} and {category}: {entry.title!r}.")
+            seen[key] = category
+    return TypedPlanStages(child_stages, dependencies, deferred, actions, bool(legacy))
 
 
 def _expect_state(value: object, *, context: str) -> str:
@@ -1830,7 +1905,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
             "prior_plan_item_dispositions",
             "plan_steps",
         },
-        optional={"deferred_stages", "human_requirement_dispositions"},
+        optional={"deferred_stages", "child_stages", "external_dependencies", "deferred_work", "plan_actions", "human_requirement_dispositions"},
     )
     state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
     if state != "blocking":
@@ -1864,6 +1939,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         prior_plan_item_dispositions=dispositions,
         plan_steps=plan_steps,
         deferred_stages=deferred_stages,
+        typed_stages=_expect_typed_plan_stages(payload, context="plan_revision"),
         human_requirement_dispositions=human_requirement_dispositions,
     )
 
@@ -1880,7 +1956,7 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
         payload,
         context="plan_state",
         required={"schema_version", "kind", "state", "summary", "plan_steps"},
-        optional={"deferred_stages", "human_requirement_dispositions"},
+        optional={"deferred_stages", "child_stages", "external_dependencies", "deferred_work", "plan_actions", "human_requirement_dispositions"},
     )
     state = _expect_state(payload["state"], context="plan_state.state")
     if state != "blocking":
@@ -1899,6 +1975,7 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
         deferred_stages=_expect_deferred_stage_list(
             payload, "deferred_stages", context="plan_state.deferred_stages"
         ),
+        typed_stages=_expect_typed_plan_stages(payload, context="plan_state"),
         human_requirement_dispositions=_expect_human_requirement_dispositions(
             payload.get("human_requirement_dispositions", []),
             context="plan_state.human_requirement_dispositions",

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -988,7 +988,7 @@ def _expect_typed_plan_stages(payload: dict[str, object], *, context: str) -> Ty
     if not present:
         return TypedPlanStages()
 
-    def child_stages() -> tuple[ChildStage, ...]:
+    def parse_child_stages() -> tuple[ChildStage, ...]:
         value = payload.get("child_stages", [])
         if not isinstance(value, list):
             raise AgentLoopError(f"{context}.child_stages must be a JSON array.")
@@ -1000,9 +1000,14 @@ def _expect_typed_plan_stages(payload: dict[str, object], *, context: str) -> Ty
             title = _expect_non_empty_string(obj["title"], context=f"{item_context}.title")
             summary = _expect_non_empty_string(obj["summary"], context=f"{item_context}.summary")
             if ISSUE_REFERENCE_RE.search(title + "\n" + summary):
-                raise AgentLoopError(f"{item_context} references an existing issue; use external_dependencies.")
+                raise AgentLoopError(
+                    f"{item_context} references an existing issue; "
+                    "use external_dependencies."
+                )
             if TRACKER_ACTION_TITLE_RE.match(" ".join(title.split())):
-                raise AgentLoopError(f"{item_context} is a tracker action; use plan_actions.")
+                raise AgentLoopError(
+                    f"{item_context} is a tracker action; use plan_actions."
+                )
             result.append(ChildStage(title, summary))
         return tuple(result)
 
@@ -1020,7 +1025,7 @@ def _expect_typed_plan_stages(payload: dict[str, object], *, context: str) -> Ty
             result.append(DeferredStage(title, summary))
         return tuple(result)
 
-    child_stages = child_stages()
+    child_stages = parse_child_stages()
     dependencies = recorded_stages("external_dependencies")
     deferred = recorded_stages("deferred_work")
     actions = recorded_stages("plan_actions")
@@ -1927,7 +1932,14 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
             "prior_plan_item_dispositions",
             "plan_steps",
         },
-        optional={"deferred_stages", "child_stages", "external_dependencies", "deferred_work", "plan_actions", "human_requirement_dispositions"},
+        optional={
+            "deferred_stages",
+            "child_stages",
+            "external_dependencies",
+            "deferred_work",
+            "plan_actions",
+            "human_requirement_dispositions",
+        },
     )
     state = _expect_non_empty_string(payload["state"], context="plan_revision.state")
     if state != "blocking":
@@ -1978,7 +1990,14 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
         payload,
         context="plan_state",
         required={"schema_version", "kind", "state", "summary", "plan_steps"},
-        optional={"deferred_stages", "child_stages", "external_dependencies", "deferred_work", "plan_actions", "human_requirement_dispositions"},
+        optional={
+            "deferred_stages",
+            "child_stages",
+            "external_dependencies",
+            "deferred_work",
+            "plan_actions",
+            "human_requirement_dispositions",
+        },
     )
     state = _expect_state(payload["state"], context="plan_state.state")
     if state != "blocking":

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -252,7 +252,6 @@ class ChildStage:
 
     title: str
     summary: str
-    allow_action_title: bool = False
 
 
 @dataclass(frozen=True)
@@ -263,7 +262,17 @@ class TypedPlanStages:
     external_dependencies: tuple[DeferredStage, ...] = ()
     deferred_work: tuple[DeferredStage, ...] = ()
     plan_actions: tuple[DeferredStage, ...] = ()
-    legacy_parent_owned_scope: bool = False
+
+
+# Shared classification rules for typed plan validation and materialization.
+ISSUE_REFERENCE_RE = re.compile(
+    r"(?:\B#[1-9]\d*\b|github\.com/[^/\s]+/[^/\s]+/issues/[1-9]\d*\b|[\w.-]+/[\w.-]+#[1-9]\d*\b)",
+    re.I,
+)
+TRACKER_ACTION_TITLE_RE = re.compile(
+    r"^(?:post|after)[ -]?approval.*(?:\b(?:creat|fil|materializ).*\bchild issue|\bchild issue.*\bmaterializ)",
+    re.I,
+)
 
 
 @dataclass(frozen=True)
@@ -975,49 +984,62 @@ def _expect_typed_plan_stages(payload: dict[str, object], *, context: str) -> Ty
     """
     categories = ("child_stages", "external_dependencies", "deferred_work", "plan_actions")
     present = [name for name in categories if name in payload]
-    legacy = _expect_deferred_stage_list(payload, "deferred_stages", context=f"{context}.deferred_stages")
+    _expect_deferred_stage_list(payload, "deferred_stages", context=f"{context}.deferred_stages")
     if not present:
-        return TypedPlanStages(deferred_work=legacy, legacy_parent_owned_scope=bool(legacy))
+        return TypedPlanStages()
 
-    def stages(name: str, *, children: bool = False) -> tuple[DeferredStage, ...] | tuple[ChildStage, ...]:
+    def child_stages() -> tuple[ChildStage, ...]:
+        value = payload.get("child_stages", [])
+        if not isinstance(value, list):
+            raise AgentLoopError(f"{context}.child_stages must be a JSON array.")
+        result: list[ChildStage] = []
+        for index, item in enumerate(value):
+            item_context = f"{context}.child_stages at index {index}"
+            obj = _expect_object(item, context=item_context)
+            _expect_exact_keys(obj, context=item_context, required={"title", "summary"})
+            title = _expect_non_empty_string(obj["title"], context=f"{item_context}.title")
+            summary = _expect_non_empty_string(obj["summary"], context=f"{item_context}.summary")
+            if ISSUE_REFERENCE_RE.search(title + "\n" + summary):
+                raise AgentLoopError(f"{item_context} references an existing issue; use external_dependencies.")
+            if TRACKER_ACTION_TITLE_RE.match(" ".join(title.split())):
+                raise AgentLoopError(f"{item_context} is a tracker action; use plan_actions.")
+            result.append(ChildStage(title, summary))
+        return tuple(result)
+
+    def recorded_stages(name: str) -> tuple[DeferredStage, ...]:
         value = payload.get(name, [])
         if not isinstance(value, list):
             raise AgentLoopError(f"{context}.{name} must be a JSON array.")
-        result: list[DeferredStage] | list[ChildStage] = []
+        result: list[DeferredStage] = []
         for index, item in enumerate(value):
             item_context = f"{context}.{name} at index {index}"
             obj = _expect_object(item, context=item_context)
-            allowed = {"title", "summary", "allow_action_title"} if children else {"title", "summary"}
-            _expect_exact_keys(obj, context=item_context, required={"title", "summary"}, optional=allowed - {"title", "summary"})
+            _expect_exact_keys(obj, context=item_context, required={"title", "summary"})
             title = _expect_non_empty_string(obj["title"], context=f"{item_context}.title")
             summary = _expect_non_empty_string(obj["summary"], context=f"{item_context}.summary")
-            if children:
-                allow = obj.get("allow_action_title", False)
-                if not isinstance(allow, bool):
-                    raise AgentLoopError(f"{item_context}.allow_action_title must be a boolean.")
-                reference = re.search(r"(?:\B#[1-9]\d*\b|github\.com/[^/\s]+/[^/\s]+/issues/[1-9]\d*\b|[\w.-]+/[\w.-]+#[1-9]\d*\b)", title + "\n" + summary, re.I)
-                action = re.match(r"^(?:post|after)[ -]?approval.*\b(?:creat|fil|materializ).*\bchild issue", " ".join(title.split()), re.I)
-                if reference:
-                    raise AgentLoopError(f"{item_context} references an existing issue; use external_dependencies.")
-                if action and not allow:
-                    raise AgentLoopError(f"{item_context} is a tracker action; use plan_actions or set allow_action_title for implementation work.")
-                result.append(ChildStage(title, summary, allow))  # type: ignore[arg-type]
-            else:
-                result.append(DeferredStage(title, summary))  # type: ignore[arg-type]
+            result.append(DeferredStage(title, summary))
         return tuple(result)
 
-    child_stages = stages("child_stages", children=True)
-    dependencies = stages("external_dependencies")
-    deferred = stages("deferred_work")
-    actions = stages("plan_actions")
+    child_stages = child_stages()
+    dependencies = recorded_stages("external_dependencies")
+    deferred = recorded_stages("deferred_work")
+    actions = recorded_stages("plan_actions")
     seen: dict[str, str] = {}
-    for category, entries in (("child_stages", child_stages), ("external_dependencies", dependencies), ("deferred_work", deferred), ("plan_actions", actions)):
+    for category, entries in (
+        ("child_stages", child_stages),
+        ("external_dependencies", dependencies),
+        ("deferred_work", deferred),
+        ("plan_actions", actions),
+    ):
         for entry in entries:
             key = " ".join(entry.title.casefold().split())
             if key in seen:
-                raise AgentLoopError(f"{context} has a duplicate title in {seen[key]} and {category}: {entry.title!r}.")
+                raise AgentLoopError(
+                    f"{context} has a duplicate title in {seen[key]} and {category}: "
+                    f"{entry.title!r}."
+                )
             seen[key] = category
-    return TypedPlanStages(child_stages, dependencies, deferred, actions, bool(legacy))
+    return TypedPlanStages(child_stages, dependencies, deferred, actions)
 
 
 def _expect_state(value: object, *, context: str) -> str:

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -23,6 +23,10 @@ from .protocol import DeferredStage
 from .runner import Runner
 
 MAX_SPLIT_CHILDREN = 8
+_ISSUE_REFERENCE_RE = re.compile(r"(?:\B#[1-9]\d*\b|github\.com/[^/\s]+/[^/\s]+/issues/[1-9]\d*\b|[\w.-]+/[\w.-]+#[1-9]\d*\b)", re.I)
+_TRACKER_ACTION_TITLE_RE = re.compile(
+    r"^(?:post|after)[ -]?approval.*\b(?:creat|fil|materializ).*\bchild issue", re.I
+)
 
 DISCUSS_SPLIT_MARKER_RE = re.compile(
     r"<!--\s*AGENT_DISCUSS_SPLIT:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
@@ -331,6 +335,20 @@ def materialize_split_proposals(
     deduped = dedupe_split_stage_proposals(proposals)
     if not deduped:
         return None
+
+    # Do this before the first create so a malformed approved plan cannot
+    # partially materialize placeholders.  Typed dependencies/actions never
+    # reach this function, but the guard also protects programmatic callers.
+    rejected = [
+        proposal.title for proposal in deduped
+        if _ISSUE_REFERENCE_RE.search(proposal.title + "\n" + proposal.body)
+        or _TRACKER_ACTION_TITLE_RE.match(" ".join(proposal.title.split()))
+    ]
+    if rejected:
+        raise AgentLoopError(
+            "Split child candidates reference an existing issue or are tracker actions; "
+            "place them in external_dependencies or plan_actions instead: " + ", ".join(rejected)
+        )
 
     existing = find_existing_split_materialization(issue_comments, parent_issue=parent_issue)
     known_by_key: dict[str, MaterializedSplitChild] = (

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -1,10 +1,9 @@
-"""Materialize discuss `split` proposals and plan `deferred_stages` into child issues (#476).
+"""Materialize discuss `split` proposals and typed plan child stages into child issues (#476).
 
 When a discuss consensus lands on `outcome: split`, or an approved plan-first
-plan narrows scope via `deferred_stages`, the proposed follow-up work should
-not remain text buried in issue comments: it should become concrete GitHub
-issues linked back to the parent, so an implementation run that scopes down to
-one stage cannot silently leave the rest unfiled.
+plan names explicit `child_stages`, the bounded implementation work should not
+remain text buried in issue comments: it becomes concrete GitHub issues linked
+back to the parent.
 """
 
 from __future__ import annotations
@@ -19,15 +18,10 @@ from .decomposition import _decode_json_payload, _encode_json_payload, _issue_nu
 from .errors import AgentLoopError
 from .github import FoundIssue, create_issue, post_issue_comment, search_issues
 from .logging import log
-from .protocol import DeferredStage
+from .protocol import ChildStage, DeferredStage, ISSUE_REFERENCE_RE, TRACKER_ACTION_TITLE_RE
 from .runner import Runner
 
 MAX_SPLIT_CHILDREN = 8
-_ISSUE_REFERENCE_RE = re.compile(r"(?:\B#[1-9]\d*\b|github\.com/[^/\s]+/[^/\s]+/issues/[1-9]\d*\b|[\w.-]+/[\w.-]+#[1-9]\d*\b)", re.I)
-_TRACKER_ACTION_TITLE_RE = re.compile(
-    r"^(?:post|after)[ -]?approval.*\b(?:creat|fil|materializ).*\bchild issue", re.I
-)
-
 DISCUSS_SPLIT_MARKER_RE = re.compile(
     r"<!--\s*AGENT_DISCUSS_SPLIT:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
     re.I,
@@ -54,6 +48,7 @@ class SplitStageProposal:
     title: str
     body: str
     key: str
+    typed_child: bool = False
 
 
 @dataclass(frozen=True)
@@ -99,8 +94,13 @@ def split_stage_proposal_from_text(text: str) -> SplitStageProposal:
     return SplitStageProposal(title=title, body=text.strip(), key=_stage_key(title))
 
 
-def split_stage_proposal_from_deferred_stage(stage: DeferredStage) -> SplitStageProposal:
-    return SplitStageProposal(title=stage.title, body=stage.summary, key=_stage_key(stage.title))
+def split_stage_proposal_from_deferred_stage(stage: DeferredStage | ChildStage) -> SplitStageProposal:
+    return SplitStageProposal(
+        title=stage.title,
+        body=stage.summary,
+        key=_stage_key(stage.title),
+        typed_child=isinstance(stage, ChildStage),
+    )
 
 
 def dedupe_split_stage_proposals(
@@ -313,6 +313,21 @@ def _adopt_from_search(
             key = _stage_key(_strip_child_title_prefix(found.title, parent_issue))
         if key in remaining_keys and key not in by_key:
             by_key[key] = found
+    # Also adopt a canonical child that was created by another workflow and
+    # therefore lacks our parent marker/prefix. This deterministic normalized
+    # title check prevents the #479-style duplicate placeholders.
+    for proposal in remaining:
+        if proposal.key in by_key:
+            continue
+        for found in search_issues(
+            runner,
+            config=config,
+            search=f'"{proposal.title}" in:title',
+            state="all",
+        ):
+            if found.title and _stage_key(found.title) == proposal.key:
+                by_key[proposal.key] = found
+                break
     return by_key
 
 
@@ -336,13 +351,16 @@ def materialize_split_proposals(
     if not deduped:
         return None
 
-    # Do this before the first create so a malformed approved plan cannot
-    # partially materialize placeholders.  Typed dependencies/actions never
-    # reach this function, but the guard also protects programmatic callers.
+    # Do this before the first create so a malformed typed plan cannot
+    # partially materialize placeholders. Free-form discuss proposals remain
+    # eligible even when their explanatory prose references a parent issue.
     rejected = [
         proposal.title for proposal in deduped
-        if _ISSUE_REFERENCE_RE.search(proposal.title + "\n" + proposal.body)
-        or _TRACKER_ACTION_TITLE_RE.match(" ".join(proposal.title.split()))
+        if proposal.typed_child
+        and (
+            ISSUE_REFERENCE_RE.search(proposal.title + "\n" + proposal.body)
+            or TRACKER_ACTION_TITLE_RE.match(" ".join(proposal.title.split()))
+        )
     ]
     if rejected:
         raise AgentLoopError(
@@ -417,6 +435,14 @@ def materialize_split_proposals(
         )
         new_children.append(child)
         resolved_so_far.append(child)
+
+    for child in new_children:
+        location = child.url or (f"#{child.number}" if child.number is not None else "unavailable")
+        log(
+            config,
+            f"Split materialization for issue #{parent_issue}: {child.origin} child "
+            f"{child.title!r} ({location}).",
+        )
 
     if skipped:
         skipped_titles = ", ".join(proposal.title for proposal in skipped)

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -125,6 +125,18 @@ def _strip_child_title_prefix(title: str, parent_issue: int) -> str:
     return title[len(prefix):] if title.startswith(prefix) else title
 
 
+def _title_search(title: str) -> str:
+    """Quote a title safely for GitHub's issue-search syntax."""
+    return '"' + title.replace('"', r'\"') + '" in:title'
+
+
+def _references_parent_issue(body: str | None, parent_issue: int) -> bool:
+    """Whether a canonical child explicitly identifies its parent issue."""
+    if not body:
+        return False
+    return bool(re.search(rf"(?<![\w/])#{parent_issue}(?!\d)", body))
+
+
 def _sibling_lines(children: Sequence[MaterializedSplitChild]) -> list[str]:
     if not children:
         return ["- None yet."]
@@ -313,19 +325,25 @@ def _adopt_from_search(
             key = _stage_key(_strip_child_title_prefix(found.title, parent_issue))
         if key in remaining_keys and key not in by_key:
             by_key[key] = found
-    # Also adopt a canonical child that was created by another workflow and
-    # therefore lacks our parent marker/prefix. This deterministic normalized
-    # title check prevents the #479-style duplicate placeholders.
+    # A typed child can be canonicalized by another workflow and lack our
+    # marker/prefix. Only adopt an *open*, parent-linked candidate: generic
+    # titles and closed duplicate placeholders must never become handoff
+    # targets. Discuss proposals are free-form, so they do not use this
+    # cross-workflow fallback.
     for proposal in remaining:
-        if proposal.key in by_key:
+        if proposal.key in by_key or not proposal.typed_child:
             continue
         for found in search_issues(
             runner,
             config=config,
-            search=f'"{proposal.title}" in:title',
-            state="all",
+            search=_title_search(proposal.title),
+            state="open",
         ):
-            if found.title and _stage_key(found.title) == proposal.key:
+            if (
+                found.title
+                and _stage_key(found.title) == proposal.key
+                and _references_parent_issue(found.body, parent_issue)
+            ):
                 by_key[proposal.key] = found
                 break
     return by_key

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -1003,6 +1003,7 @@ def structured_plan_revision(
     human_requirements: str = "",
     human_requirement_dispositions: list[dict[str, str]] | None = None,
     deferred_stages: list[dict[str, str]] | None = None,
+    child_stages: list[dict[str, str]] | None = None,
 ) -> str:
     payload = {
         "schema_version": 1,
@@ -1018,6 +1019,8 @@ def structured_plan_revision(
     }
     if deferred_stages is not None:
         payload["deferred_stages"] = deferred_stages
+    if child_stages is not None:
+        payload["child_stages"] = child_stages
     return (
         json.dumps(payload)
         + human_requirements
@@ -1033,6 +1036,7 @@ def structured_plan_state(
     plan_steps: list[str] | None = None,
     reviewer: str = "Anthropic Claude",
     deferred_stages: list[dict[str, str]] | None = None,
+    child_stages: list[dict[str, str]] | None = None,
     human_requirement_dispositions: list[dict[str, str]] | None = None,
 ) -> str:
     payload = {
@@ -1045,6 +1049,8 @@ def structured_plan_state(
     }
     if deferred_stages is not None:
         payload["deferred_stages"] = deferred_stages
+    if child_stages is not None:
+        payload["child_stages"] = child_stages
     return (
         json.dumps(payload)
         + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n"

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -1024,7 +1024,11 @@ def structured_plan_revision(
         payload["deferred_stages"] = deferred_stages
     if child_stages is not None:
         payload["child_stages"] = child_stages
-    for name, value in (("external_dependencies", external_dependencies), ("deferred_work", deferred_work), ("plan_actions", plan_actions)):
+    for name, value in (
+        ("external_dependencies", external_dependencies),
+        ("deferred_work", deferred_work),
+        ("plan_actions", plan_actions),
+    ):
         if value is not None:
             payload[name] = value
     return (
@@ -1060,7 +1064,11 @@ def structured_plan_state(
         payload["deferred_stages"] = deferred_stages
     if child_stages is not None:
         payload["child_stages"] = child_stages
-    for name, value in (("external_dependencies", external_dependencies), ("deferred_work", deferred_work), ("plan_actions", plan_actions)):
+    for name, value in (
+        ("external_dependencies", external_dependencies),
+        ("deferred_work", deferred_work),
+        ("plan_actions", plan_actions),
+    ):
         if value is not None:
             payload[name] = value
     return (

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -1004,6 +1004,9 @@ def structured_plan_revision(
     human_requirement_dispositions: list[dict[str, str]] | None = None,
     deferred_stages: list[dict[str, str]] | None = None,
     child_stages: list[dict[str, str]] | None = None,
+    external_dependencies: list[dict[str, str]] | None = None,
+    deferred_work: list[dict[str, str]] | None = None,
+    plan_actions: list[dict[str, str]] | None = None,
 ) -> str:
     payload = {
         "schema_version": 1,
@@ -1021,6 +1024,9 @@ def structured_plan_revision(
         payload["deferred_stages"] = deferred_stages
     if child_stages is not None:
         payload["child_stages"] = child_stages
+    for name, value in (("external_dependencies", external_dependencies), ("deferred_work", deferred_work), ("plan_actions", plan_actions)):
+        if value is not None:
+            payload[name] = value
     return (
         json.dumps(payload)
         + human_requirements
@@ -1037,6 +1043,9 @@ def structured_plan_state(
     reviewer: str = "Anthropic Claude",
     deferred_stages: list[dict[str, str]] | None = None,
     child_stages: list[dict[str, str]] | None = None,
+    external_dependencies: list[dict[str, str]] | None = None,
+    deferred_work: list[dict[str, str]] | None = None,
+    plan_actions: list[dict[str, str]] | None = None,
     human_requirement_dispositions: list[dict[str, str]] | None = None,
 ) -> str:
     payload = {
@@ -1051,6 +1060,9 @@ def structured_plan_state(
         payload["deferred_stages"] = deferred_stages
     if child_stages is not None:
         payload["child_stages"] = child_stages
+    for name, value in (("external_dependencies", external_dependencies), ("deferred_work", deferred_work), ("plan_actions", plan_actions)):
+        if value is not None:
+            payload[name] = value
     return (
         json.dumps(payload)
         + f"\n<!-- AGENT_PLAN_STATE: {state} -->\n"

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -19,6 +19,7 @@ from coding_review_agent_loop.comment_rendering import (
     render_agent_unavailable_comment,
     render_deferred_stages_section,
     render_discuss_round_summary_comment,
+    render_typed_plan_stages_section,
 )
 from coding_review_agent_loop.protocol import DiscussUnresolvedItem, ParsedDiscussAnswer, ParsedFailedDiscussResponse, ParsedDiscussReview
 from coding_review_agent_loop.orchestrator import (
@@ -33,6 +34,7 @@ from coding_review_agent_loop.orchestrator import (
     render_public_agent_comment,
 )
 from coding_review_agent_loop.protocol import (
+    ChildStage,
     DeferredStage,
     ReviewItemDisposition,
     UnresolvedReviewItem,
@@ -44,6 +46,7 @@ from coding_review_agent_loop.protocol import (
     validate_structured_plan_revision,
     validate_structured_plan_state,
 )
+from coding_review_agent_loop.protocol import TypedPlanStages
 
 from agent_loop_helpers import (
     blocking_issues,
@@ -249,6 +252,37 @@ def test_render_structured_plan_state_to_public_markdown():
         "-- Google Antigravity: Gemini 3.1 Pro (High)"
     )
     assert '"kind": "plan_state"' not in public
+
+
+def test_legacy_deferred_stages_render_once_without_typed_marker():
+    parsed = validate_structured_plan_revision(
+        structured_plan_revision(
+            deferred_stages=[{"title": "Stage 4", "summary": "Record only."}]
+        )
+    )
+    assert parsed is not None
+
+    canonical = render_canonical_plan_revision(parsed, ())
+
+    assert canonical.count("Stage 4: Record only.") == 1
+    assert "AGENT_DEFERRED_STAGES" in canonical
+    assert "AGENT_TYPED_PLAN_STAGES" not in canonical
+
+
+def test_typed_plan_stages_marker_round_trips_child_categories():
+    section = render_typed_plan_stages_section(
+        TypedPlanStages(
+            child_stages=(ChildStage("3A implementation", "New work."),),
+            external_dependencies=(DeferredStage("#481", "Existing gate."),),
+            deferred_work=(DeferredStage("Stage 4", "Later."),),
+            plan_actions=(DeferredStage("Post-approval materialization", "Tracker."),),
+        )
+    )
+
+    assert section is not None
+    assert "AGENT_TYPED_PLAN_STAGES" in section
+    assert "Child stages (eligible for child issues)" in section
+    assert "External dependencies (linked, never created)" in section
 
 
 def test_render_public_coder_followup_comment():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -238,7 +238,7 @@ def test_issue_plan_prompt_requires_complete_structured_plan_state_contract(tmp_
     assert '"state": "blocking"' in prompt
     assert '"summary": "<non-empty concise implementation summary>"' in prompt
     assert '"plan_steps": ["<non-empty step>"]' in prompt
-    assert "optional `deferred_stages`" in prompt
+    assert "typed `child_stages`, `external_dependencies`, `deferred_work`," in prompt
     assert "generic `implementation_plan`" in prompt
     assert "after the JSON object and before the AGENT_PLAN_STATE footer" in prompt
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2601,6 +2601,55 @@ def test_validate_structured_plan_state_accepts_deferred_stages():
     )
 
 
+def test_typed_plan_categories_keep_only_child_stages_eligible_for_materialization():
+    parsed = validate_structured_plan_state(
+        structured_plan_state(
+            child_stages=[{"title": "3A implementation", "summary": "New bounded work."}],
+            external_dependencies=[{"title": "#481", "summary": "Existing external gate."}],
+            deferred_work=[{"title": "Stage 4", "summary": "Future work."}],
+            plan_actions=[
+                {"title": "Post-approval child issue materialization", "summary": "Tracker task."}
+            ],
+        )
+    )
+
+    assert parsed is not None
+    assert [stage.title for stage in parsed.typed_stages.child_stages] == ["3A implementation"]
+    assert [stage.title for stage in parsed.typed_stages.external_dependencies] == ["#481"]
+    assert [stage.title for stage in parsed.typed_stages.deferred_work] == ["Stage 4"]
+    assert [stage.title for stage in parsed.typed_stages.plan_actions] == [
+        "Post-approval child issue materialization"
+    ]
+
+
+@pytest.mark.parametrize(
+    "child_stage, pattern",
+    [
+        ({"title": "Depend on #481", "summary": "Already exists."}, "external_dependencies"),
+        (
+            {
+                "title": "Post-approval child issue materialization",
+                "summary": "Tracker task.",
+            },
+            "plan_actions",
+        ),
+    ],
+)
+def test_typed_child_stages_reject_dependencies_and_tracker_actions(child_stage, pattern):
+    with pytest.raises(AgentLoopError, match=pattern):
+        validate_structured_plan_state(structured_plan_state(child_stages=[child_stage]))
+
+
+def test_typed_plan_categories_reject_cross_category_duplicate_titles():
+    with pytest.raises(AgentLoopError, match="duplicate title"):
+        validate_structured_plan_state(
+            structured_plan_state(
+                child_stages=[{"title": "Stage 3A", "summary": "Implement."}],
+                deferred_work=[{"title": "stage   3a", "summary": "Do later."}],
+            )
+        )
+
+
 def test_validate_structured_plan_state_accepts_signed_human_requirements_before_footer():
     acknowledgement = (
         "\n<!-- HUMAN_REQUIREMENTS_ADDRESSED -->\n"

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -175,10 +175,7 @@ def test_materialize_split_proposals_partial_failure_adopts_existing_child(tmp_p
         issue_comments=(),
     )
 
-    assert runner.search_issues_calls == [
-        '"[#56 stage]" in:title',
-        '"Billing flow" in:title',
-    ]
+    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
     # Only the unmatched (billing) proposal was created; auth was adopted.
     assert len(runner.issues) == 1
     assert runner.issues[0]["title"] == "[#56 stage] Billing flow"
@@ -277,7 +274,7 @@ def test_materialize_split_proposals_dry_run_previews_search_and_create(tmp_path
     # Dry-run still previews the `gh issue list --search` and `gh issue create`
     # commands (so the materialization path is visible), it just never
     # persists application-level state outside of GitHub CLI echo commands.
-    assert runner.search_issues_calls == ['"[#56 stage]" in:title', '"Auth flow" in:title']
+    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
     assert len(runner.issues) == 1
 
 
@@ -290,7 +287,7 @@ def test_materialize_typed_child_adopts_existing_canonical_issue_instead_of_dupl
                     "number": 480,
                     "title": "3A implementation",
                     "url": "https://github.com/OWNER/REPO/issues/480",
-                    "body": "Canonical child from the tracker.",
+                    "body": "Canonical child from the tracker. Part of #479.",
                 }
             ],
         ]
@@ -308,6 +305,50 @@ def test_materialize_typed_child_adopts_existing_canonical_issue_instead_of_dupl
     assert runner.issues == []
     assert metadata.children[0].number == 480
     assert metadata.children[0].origin == "adopted"
+
+
+def test_materialize_typed_child_does_not_adopt_unrelated_title_match(tmp_path):
+    runner = FakeRunner(
+        issue_urls=["https://github.com/OWNER/REPO/issues/481"],
+        search_issues_payload=[
+            [],
+            [
+                {
+                    "number": 480,
+                    "title": "Stage 4",
+                    "url": "https://github.com/OWNER/REPO/issues/480",
+                    "body": "Unrelated work.",
+                }
+            ],
+        ],
+    )
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=479,
+        subject="approved-plan",
+        proposals=[split_stage_proposal_from_deferred_stage(ChildStage("Stage 4", "New work."))],
+    )
+
+    assert metadata is not None
+    assert runner.issues[0]["title"] == "[#479 stage] Stage 4"
+    assert metadata.children[0].number == 481
+    assert metadata.children[0].origin == "created"
+
+
+def test_materialize_discuss_proposal_skips_canonical_title_search(tmp_path):
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/481"])
+
+    materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=479,
+        subject="discussion",
+        proposals=[split_stage_proposal_from_text('Stage "4"\n\nNew work.')],
+    )
+
+    assert runner.search_issues_calls == ['"[#479 stage]" in:title']
 
 
 def test_discuss_split_proposal_can_reference_parent_issue_without_rejection(tmp_path):

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -21,7 +21,7 @@ from coding_review_agent_loop.split_materialization import (
     split_stage_proposal_from_deferred_stage,
     split_stage_proposal_from_text,
 )
-from coding_review_agent_loop.protocol import DeferredStage
+from coding_review_agent_loop.protocol import ChildStage, DeferredStage
 from agent_loop_helpers import FakeRunner, make_config
 
 
@@ -175,7 +175,10 @@ def test_materialize_split_proposals_partial_failure_adopts_existing_child(tmp_p
         issue_comments=(),
     )
 
-    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
+    assert runner.search_issues_calls == [
+        '"[#56 stage]" in:title',
+        '"Billing flow" in:title',
+    ]
     # Only the unmatched (billing) proposal was created; auth was adopted.
     assert len(runner.issues) == 1
     assert runner.issues[0]["title"] == "[#56 stage] Billing flow"
@@ -274,8 +277,52 @@ def test_materialize_split_proposals_dry_run_previews_search_and_create(tmp_path
     # Dry-run still previews the `gh issue list --search` and `gh issue create`
     # commands (so the materialization path is visible), it just never
     # persists application-level state outside of GitHub CLI echo commands.
-    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
+    assert runner.search_issues_calls == ['"[#56 stage]" in:title', '"Auth flow" in:title']
     assert len(runner.issues) == 1
+
+
+def test_materialize_typed_child_adopts_existing_canonical_issue_instead_of_duplicate(tmp_path):
+    runner = FakeRunner(
+        search_issues_payload=[
+            [],
+            [
+                {
+                    "number": 480,
+                    "title": "3A implementation",
+                    "url": "https://github.com/OWNER/REPO/issues/480",
+                    "body": "Canonical child from the tracker.",
+                }
+            ],
+        ]
+    )
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=479,
+        subject="approved-plan",
+        proposals=[split_stage_proposal_from_deferred_stage(ChildStage("3A implementation", "New work."))],
+    )
+
+    assert metadata is not None
+    assert runner.issues == []
+    assert metadata.children[0].number == 480
+    assert metadata.children[0].origin == "adopted"
+
+
+def test_discuss_split_proposal_can_reference_parent_issue_without_rejection(tmp_path):
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/101"])
+
+    metadata = materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=56,
+        subject="discuss",
+        proposals=[split_stage_proposal_from_text("Split the auth flow out of #56\n\nDetailed rationale.")],
+    )
+
+    assert metadata is not None
+    assert runner.issues[0]["title"] == "[#56 stage] Split the auth flow out of #56"
 
 
 def test_find_existing_split_materialization_rejects_invalid_marker():

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -100,6 +100,36 @@ def test_plan_first_materializes_explicit_child_stages_before_implementation(tmp
     assert "Fixes #56" in runner.pr_payload["body"]
 
 
+def test_470_legacy_deferred_stages_are_recorded_without_placeholder_children(tmp_path):
+    """Regression for #470: overloaded legacy entries must never be filed."""
+    runner = FakeRunner(
+        pr_payload={"body": "Fixes #470"},
+        claude_outputs=[
+            structured_plan_state(
+                state="blocking",
+                summary="Implement the approved scope.",
+                deferred_stages=[
+                    {"title": "Post-approval child issue materialization", "summary": "Tracker action."},
+                    {"title": "#481", "summary": "Existing external gate."},
+                    {"title": "Stage 4", "summary": "Future work."},
+                ],
+            ),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[
+            structured_plan_review(state="approved"),
+            structured_pr_review(state="approved", summary="LGTM."),
+        ],
+    )
+
+    assert run_issue_loop(
+        runner, issue_number=470, config=make_config(tmp_path, materialize_split_issues=True),
+        plan_first=True, implement_after_approval=True,
+    ) == 0
+
+    assert runner.issues == []
+
+
 def test_plan_first_child_stage_title_with_colon_round_trips_through_canonical_markdown(tmp_path):
     """A revised plan's `deferred_stages` are carried in `current_plan` as the
     canonical revision markdown (not the raw structured JSON), which renders

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -62,14 +62,14 @@ def _existing_split_children_comment() -> dict:
     }
 
 
-def test_plan_first_no_prior_split_materializes_deferred_stages_before_implementation(tmp_path):
+def test_plan_first_materializes_explicit_child_stages_before_implementation(tmp_path):
     runner = FakeRunner(
         pr_payload={"body": "Fixes #56"},
         claude_outputs=[
             structured_plan_state(
                 state="blocking",
                 summary="Implement the core parser change.",
-                deferred_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
+                child_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
             ),
             "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],
@@ -100,7 +100,7 @@ def test_plan_first_no_prior_split_materializes_deferred_stages_before_implement
     assert "Fixes #56" in runner.pr_payload["body"]
 
 
-def test_plan_first_deferred_stage_title_with_colon_round_trips_through_canonical_markdown(tmp_path):
+def test_plan_first_child_stage_title_with_colon_round_trips_through_canonical_markdown(tmp_path):
     """A revised plan's `deferred_stages` are carried in `current_plan` as the
     canonical revision markdown (not the raw structured JSON), which renders
     each stage as a human-readable `- {title}: {summary}` bullet. A title that
@@ -113,7 +113,7 @@ def test_plan_first_deferred_stage_title_with_colon_round_trips_through_canonica
             structured_plan_state(state="blocking", summary="Initial plan."),
             structured_plan_revision(
                 summary="Implement the core parser change.",
-                deferred_stages=[
+                child_stages=[
                     {"title": "Stage 2: API follow-up", "summary": "Split out the API work."}
                 ],
             ),
@@ -155,7 +155,7 @@ def test_plan_first_no_prior_split_warns_when_materialization_disabled(tmp_path)
             structured_plan_state(
                 state="blocking",
                 summary="Implement the core parser change.",
-                deferred_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
+                child_stages=[{"title": "Auth flow", "summary": "Split follow-up out."}],
             ),
             "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -14,8 +14,11 @@ from coding_review_agent_loop.issue_pr_handoff import format_issue_pr_handoff_co
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
     _attach_round_metadata,
+    _log_typed_plan_stage_dispositions,
     _plan_subject,
 )
+from coding_review_agent_loop.comment_rendering import render_typed_plan_stages_section
+from coding_review_agent_loop.protocol import DeferredStage, TypedPlanStages
 from coding_review_agent_loop.split_materialization import (
     MaterializedSplitChild,
     SplitMaterializationMetadata,
@@ -60,6 +63,41 @@ def _existing_split_children_comment() -> dict:
         "createdAt": "2026-05-23T00:00:00Z",
         "body": format_split_materialization_summary(parent_issue=56, metadata=metadata),
     }
+
+
+def test_log_typed_plan_stage_dispositions_from_structured_payload(tmp_path, capsys):
+    plan = structured_plan_state(
+        child_stages=[{"title": "Implementation", "summary": "Create this."}],
+        external_dependencies=[{"title": "#481", "summary": "Already exists."}],
+        deferred_work=[{"title": "Stage 4", "summary": "Future work."}],
+        plan_actions=[{"title": "Post approval", "summary": "Tracker action."}],
+        deferred_stages=[{"title": "Legacy stage", "summary": "Recorded only."}],
+    )
+
+    _log_typed_plan_stage_dispositions(plan, config=make_config(tmp_path, quiet=False))
+
+    stderr = capsys.readouterr().err
+    assert "linked dependency: #481." in stderr
+    assert "recorded-only deferred work: Stage 4." in stderr
+    assert "recorded-only plan action: Post approval." in stderr
+    assert "recorded-only legacy deferred stage: Legacy stage." in stderr
+
+
+def test_log_typed_plan_stage_dispositions_from_marker(tmp_path, capsys):
+    marker = render_typed_plan_stages_section(
+        TypedPlanStages(
+            external_dependencies=(DeferredStage("#481", "Already exists."),),
+            deferred_work=(DeferredStage("Stage 4", "Future work."),),
+            plan_actions=(DeferredStage("Post approval", "Tracker action."),),
+        )
+    )
+
+    _log_typed_plan_stage_dispositions(marker or "", config=make_config(tmp_path, quiet=False))
+
+    stderr = capsys.readouterr().err
+    assert "linked dependency: #481." in stderr
+    assert "recorded-only deferred work: Stage 4." in stderr
+    assert "recorded-only plan action: Post approval." in stderr
 
 
 def test_plan_first_materializes_explicit_child_stages_before_implementation(tmp_path):


### PR DESCRIPTION
## Summary
- add typed plan categories for child stages, dependencies, deferred work, and actions
- materialize only explicit child stages and reject issue-reference/action candidates
- retain legacy deferred stages as record-only

Fixes #585

## Tests
- `timeout 300 python3 -m pytest tests/test_protocol.py tests/test_comment_rendering.py tests/test_split_materialization.py tests/test_split_orchestration.py tests/test_docs_guidance.py`