### PR TITLE
Recover Claude turns interrupted by self-update

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -714,8 +714,9 @@ Execution model:
   from comments, no thread pool is constructed at all.
 - Log files are isolated per turn: debater logs end in
   `-<agent>-discuss-r<N>.log` and analyzer logs in
-  `-<agent>-discuss-analyzer-r<N>.log`; response files already use a
-  per-invocation UUID.
+  `-<agent>-discuss-analyzer-r<N>.log`. Claude logs additionally include an
+  attempt suffix such as `-attempt1` or `-self-update-attempt2`; response
+  files already use a per-invocation UUID.
 - Parallel mode requires a distinct workdir per debater and rejects the run
   otherwise — deliberately not bypassed by `--allow-shared-dir`, because
   concurrent git/tool activity in a single worktree can corrupt it. The
@@ -1692,7 +1693,7 @@ with `/tmp` cleanup. The CLI prints heartbeat messages with the log path while
 agents run:
 
 ```text
-[agent-loop 12:00:31] Claude still running (30s); log: /path/to/.agent-loop-logs/20260425-120001-claude.log
+[agent-loop 12:00:31] Claude still running (30s); log: /path/to/.agent-loop-logs/20260425-120001-claude-attempt1.log
 ```
 
 Use `tail -f` on the displayed path to see live output. Logs are diagnostic

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -231,6 +231,7 @@ class AntigravityBackend:
         role: str | None = None,
         label: str | None = None,
         timeout_seconds: float | None = None,
+        attempt_suffix: str | None = None,
         log_path_override: Path | None = None,
     ) -> AgentResult:
         import json, fcntl  # Unix-only (fcntl); imported here so the module loads on Windows
@@ -261,7 +262,7 @@ class AntigravityBackend:
         # The prompt is the value of --print (must be last), not a positional.
         args += ["--print", _OVERSIZED_PROMPT_DIRECTIVE if oversized_prompt else prompt_text]
         log_path = log_path_override or agent_log_path(
-            config, "antigravity", run_id=run_id, label=label
+            config, "antigravity", run_id=run_id, label=label, attempt_suffix=attempt_suffix
         )
         log(config, f"Starting Antigravity (model: {model}) in {config.antigravity_dir}; log: {log_path}; response: {response_path}")
         # agy reads GEMINI.md from the workdir as high-priority system context before

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -8,7 +8,7 @@ import tempfile
 import uuid
 from typing import TYPE_CHECKING, Literal, Protocol, cast
 
-from ..runner import Runner
+from ..runner import CommandResult, Runner
 from ..usage import UsageMetadata
 
 if TYPE_CHECKING:
@@ -45,6 +45,8 @@ class AgentResult:
     # signature (#332); None when the backend could not determine it. The
     # antigravity fallback chain (#333) sets this to the model that answered.
     model_used: str | None = None
+    command_result: CommandResult | None = None
+    self_update_reason: str | None = None
 
 
 class AgentBackend(Protocol):
@@ -66,6 +68,7 @@ class AgentBackend(Protocol):
         role: str | None = None,
         label: str | None = None,
         timeout_seconds: float | None = None,
+        attempt_suffix: str | None = None,
     ) -> AgentResult: ...
 
 

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -97,7 +97,7 @@ _UPDATER_DIAGNOSTIC_RE = re.compile(
     r"(?:^(?:error|fatal).*?(?:auto-update|self-update|update failed|update in progress)|"
     r"^(?:Installing|Updating|Updated) Claude Code|"
     r"^(?:error|fatal).*?(?:npm (?:install|update)).*@anthropic-ai/claude-code)",
-    re.IGNORECASE,
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
@@ -136,12 +136,16 @@ def classify_self_update_interruption(
                 return None
         except json.JSONDecodeError:
             pass
-    diagnostic = _has_updater_diagnostic(result.stdout)
+    if _has_updater_diagnostic(result.stdout):
+        return "Claude Code updater diagnostic"
+    # A user-supplied absolute override is only eligible with an explicit
+    # updater diagnostic.  A managed bare command may additionally prove the
+    # race through an identity change while it was running.
     if os.path.isabs(command):
-        return "Claude Code updater diagnostic" if diagnostic else None
+        return None
     if _identity_changed(observation.before, observation.after, spawn_wall=observation.spawn_wall_time, exit_wall=observation.spawn_wall_time + observation.elapsed_seconds):
         return "Claude executable changed during invocation"
-    return "Claude Code updater diagnostic" if diagnostic else None
+    return None
 
 
 class ClaudeBackend:

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,7 +17,7 @@ from .base import (
     with_public_response_file_instruction,
 )
 from ..logging import agent_log_path, log
-from ..runner import Runner
+from ..runner import CommandResult, ExecutableIdentity, Runner
 from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
@@ -91,6 +93,57 @@ def _parse_claude_output(
     return raw, None, None, None, None
 
 
+_UPDATER_DIAGNOSTIC_RE = re.compile(
+    r"(?:^(?:error|fatal).*?(?:auto-update|self-update|update failed|update in progress)|"
+    r"^(?:Installing|Updating|Updated) Claude Code|"
+    r"^(?:error|fatal).*?(?:npm (?:install|update)).*@anthropic-ai/claude-code)",
+    re.IGNORECASE,
+)
+
+
+def _identity_changed(before: ExecutableIdentity, after: ExecutableIdentity, *, spawn_wall: float, exit_wall: float) -> bool:
+    changed = (before.path, before.target, before.entry_identity, before.target_identity) != (
+        after.path, after.target, after.entry_identity, after.target_identity
+    )
+    if not changed:
+        return False
+    mtimes = [identity[2] / 1_000_000_000 for identity in (after.entry_identity, after.target_identity) if identity]
+    return not mtimes or any(spawn_wall - 5 <= mtime <= exit_wall + 2 for mtime in mtimes)
+
+
+def _has_updater_diagnostic(output: str) -> bool:
+    lines = [line.strip() for line in output.splitlines() if line.strip()][-8:]
+    return bool(_UPDATER_DIAGNOSTIC_RE.search("\n".join(lines)[-2048:]))
+
+
+def classify_self_update_interruption(
+    result: CommandResult,
+    *,
+    command: str,
+    response_file_text: str | None,
+    session_id: str | None,
+) -> str | None:
+    """Return bounded Claude-updater evidence, never a generic failure classification."""
+    observation = result.observation
+    if not isinstance(result.returncode, int) or result.returncode == 0 or observation is None:
+        return None
+    if observation.interrupted or observation.elapsed_seconds > 30 or response_file_text or session_id:
+        return None
+    # Any parseable Claude JSON event is progress, even if it is not a terminal result.
+    for line in result.stdout.splitlines():
+        try:
+            if isinstance(json.loads(line), dict):
+                return None
+        except json.JSONDecodeError:
+            pass
+    diagnostic = _has_updater_diagnostic(result.stdout)
+    if os.path.isabs(command):
+        return "Claude Code updater diagnostic" if diagnostic else None
+    if _identity_changed(observation.before, observation.after, spawn_wall=observation.spawn_wall_time, exit_wall=observation.spawn_wall_time + observation.elapsed_seconds):
+        return "Claude executable changed during invocation"
+    return "Claude Code updater diagnostic" if diagnostic else None
+
+
 class ClaudeBackend:
     name: AgentName = "claude"
     display_name = "Claude"
@@ -112,6 +165,7 @@ class ClaudeBackend:
         role: str | None = None,
         label: str | None = None,
         timeout_seconds: float | None = None,
+        attempt_suffix: str | None = None,
     ) -> AgentResult:
         response_path = public_response_path(config, "claude")
         args = [config.claude_cmd, "--print", "--output-format", "json", *config.claude_args]
@@ -129,7 +183,7 @@ class ClaudeBackend:
             input_text = prompt_with_response_instruction
         else:
             args.append(prompt_with_response_instruction)
-        log_path = agent_log_path(config, "claude", run_id=run_id, label=label)
+        log_path = agent_log_path(config, "claude", run_id=run_id, label=label, attempt_suffix=attempt_suffix)
         log(config, f"Starting Claude in {config.claude_dir}; log: {log_path}; response: {response_path}")
         result = runner.run_with_log(
             args,
@@ -160,6 +214,10 @@ class ClaudeBackend:
             # Ground truth from Claude's own output; falls back to config.claude_model
             # at signature time when detection is unavailable (e.g. non-JSON output).
             model_used=model_detected,
+            command_result=result,
+            self_update_reason=classify_self_update_interruption(
+                result, command=config.claude_cmd, response_file_text=response_file_text, session_id=new_session_id,
+            ),
         )
 
 

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -240,8 +240,9 @@ class CodexBackend:
         role: str | None = None,
         label: str | None = None,
         timeout_seconds: float | None = None,
+        attempt_suffix: str | None = None,
     ) -> AgentResult:
-        log_path = agent_log_path(config, "codex", run_id=run_id, label=label)
+        log_path = agent_log_path(config, "codex", run_id=run_id, label=label, attempt_suffix=attempt_suffix)
         response_path = public_response_path(config, "codex")
         prompt_with_response_file = with_public_response_file_instruction(prompt, response_path)
         input_text = None

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -205,6 +205,7 @@ class GeminiBackend:
         role: str | None = None,
         label: str | None = None,
         timeout_seconds: float | None = None,
+        attempt_suffix: str | None = None,
     ) -> AgentResult:
         # Gemini CLI only allows file writes inside the trusted workspace (or
         # its own private temp dir, whose path we do not know ahead of time).
@@ -216,7 +217,7 @@ class GeminiBackend:
             "gemini",
             root=_gemini_public_response_root(config.gemini_dir),
         )
-        log_path = agent_log_path(config, "gemini", run_id=run_id, label=label)
+        log_path = agent_log_path(config, "gemini", run_id=run_id, label=label, attempt_suffix=attempt_suffix)
         log(config, f"Starting Gemini in {config.gemini_dir}; log: {log_path}; response: {response_path}")
         if date.today() >= GEMINI_CONSUMER_CUTOFF - timedelta(days=_GEMINI_CUTOFF_WARN_AHEAD_DAYS):
             log(config, f"Gemini CLI advisory: {_GEMINI_MIGRATION_GUIDANCE}")

--- a/src/coding_review_agent_loop/agents/registry.py
+++ b/src/coding_review_agent_loop/agents/registry.py
@@ -90,14 +90,20 @@ def run_agent_result(
     role: str | None = None,
     label: str | None = None,
     timeout_seconds: float | None = None,
+    attempt_suffix: str | None = None,
 ) -> AgentResult:
-    return get_backend(agent).run(
-        runner,
-        config,
-        prompt,
+    kwargs: dict[str, object] = dict(
         session_id=session_id,
         run_id=run_id,
         role=role,
         label=label,
         timeout_seconds=timeout_seconds,
+    )
+    if attempt_suffix is not None:
+        kwargs["attempt_suffix"] = attempt_suffix
+    return get_backend(agent).run(
+        runner,
+        config,
+        prompt,
+        **kwargs,
     )

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -28,11 +28,13 @@ def agent_log_path(
     *,
     run_id: str | None = None,
     label: str | None = None,
+    attempt_suffix: str | None = None,
 ) -> Path:
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     prefix = f"{run_id}-" if run_id else ""
     suffix = f"-{label}" if label else ""
-    return config.log_dir / f"{prefix}{stamp}-{agent}{suffix}.log"
+    attempt = f"-{attempt_suffix}" if attempt_suffix else ""
+    return config.log_dir / f"{prefix}{stamp}-{agent}{suffix}{attempt}.log"
 
 
 def run_usage_summary_path(config: AgentLoopConfig, run_id: str) -> Path:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2160,7 +2160,10 @@ def _run_validated_agent(
     # re-parsing the message.
     terminal_public_response: str | None = None
     completion_recovery_attempted = False
-    updater_replay_used = False
+    # Keep the detection guard separate from the replay marker: a failed
+    # stability check must not make the next ordinary retry look like a replay.
+    updater_replay_considered = False
+    updater_replay_pending = False
     ordinary_retries_used = 0
     self_update_deadline: float | None = None
     self_update_stability_error: str | None = None
@@ -2173,9 +2176,12 @@ def _run_validated_agent(
             else config
         )
         invocation_kwargs: dict[str, object] = {}
+        is_self_update_replay = updater_replay_pending
         if agent == "claude":
             invocation_kwargs["attempt_suffix"] = (
-                "self-update-attempt2" if updater_replay_used else "attempt1"
+                "self-update-attempt2"
+                if is_self_update_replay
+                else f"attempt{ordinary_retries_used + 1}"
             )
         result = run_agent_result(
             runner,
@@ -2191,7 +2197,8 @@ def _run_validated_agent(
         )
         # The bounded deadline belongs only to the interrupted invocation and
         # its dedicated replay. A later ordinary retry has its normal budget.
-        if updater_replay_used:
+        if is_self_update_replay:
+            updater_replay_pending = False
             next_timeout_seconds = timeout_seconds
         last_result = result
         if result.log_path is not None:
@@ -2260,10 +2267,10 @@ def _run_validated_agent(
         if (
             agent == "claude"
             and result.self_update_reason is not None
-            and not updater_replay_used
+            and not updater_replay_considered
             and result.command_result is not None
         ):
-            updater_replay_used = True
+            updater_replay_considered = True
             observation = result.command_result.observation
             self_update_deadline = (
                 observation.spawn_monotonic + timeout_seconds
@@ -2288,6 +2295,7 @@ def _run_validated_agent(
                 # Preserve any ordinary transient retry allowance: a failed
                 # stability observation does not make provider errors final.
             else:
+                updater_replay_pending = True
                 if usage_record is not None:
                     usage_record.outcome = "self_update_interruption"
                     usage_record.log_path = str(result.log_path) if result.log_path else None
@@ -2866,6 +2874,7 @@ def _run_validated_agent(
 
     if self_update_stability_error is not None:
         last_error = f"{self_update_stability_error}; final failure: {last_error}"
+        last_failure_category = "self-update-interruption"
     diagnostics = _failed_run_diagnostics(
         runner=runner,
         config=config,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1278,6 +1278,8 @@ def _failure_suggestion(
             "Suggestion: resolve the reported agent environment/provider/tooling problem, "
             "or switch that agent/model before re-running."
         )
+    if category == "self-update-interruption":
+        return "Suggestion: wait for the Claude Code self-update to finish, then re-run."
     if category == "transient":
         if _QUOTA_RATE_LIMIT_RE.search(combined):
             return (
@@ -1365,6 +1367,8 @@ def _format_invalid_agent_response_error(
         category_hint = " Failure category: deterministic (may require a code fix)."
     elif category == "timeout":
         category_hint = " Failure category: timeout (the agent exceeded the configured time limit)."
+    elif category == "self-update-interruption":
+        category_hint = " Failure category: self-update-interruption (Claude Code updated during startup)."
     elif category == "agent-unavailable":
         category_hint = " Failure category: agent-unavailable (the agent explicitly could not continue)."
     if not classification_text:
@@ -2143,7 +2147,7 @@ def _run_validated_agent(
     max_attempts = (
         len(config.antigravity_models) + config.agent_max_retries
         if antigravity_attempts is not None
-        else config.agent_max_retries + 1
+        else config.agent_max_retries + 2 if agent == "claude" else config.agent_max_retries + 1
     )
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
@@ -2156,6 +2160,10 @@ def _run_validated_agent(
     # re-parsing the message.
     terminal_public_response: str | None = None
     completion_recovery_attempted = False
+    updater_replay_used = False
+    ordinary_retries_used = 0
+    self_update_deadline: float | None = None
+    next_timeout_seconds = timeout_seconds
 
     for attempt in range(1, max_attempts + 1):
         attempt_config = (
@@ -2163,6 +2171,11 @@ def _run_validated_agent(
             if antigravity_attempts is not None
             else config
         )
+        invocation_kwargs: dict[str, object] = {}
+        if agent == "claude":
+            invocation_kwargs["attempt_suffix"] = (
+                "self-update-attempt2" if updater_replay_used else "attempt1"
+            )
         result = run_agent_result(
             runner,
             agent=agent,
@@ -2172,8 +2185,13 @@ def _run_validated_agent(
             run_id=usage_context.run_id if usage_context is not None else None,
             role=role,
             label=label,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=next_timeout_seconds,
+            **invocation_kwargs,
         )
+        # The bounded deadline belongs only to the interrupted invocation and
+        # its dedicated replay. A later ordinary retry has its normal budget.
+        if updater_replay_used:
+            next_timeout_seconds = timeout_seconds
         last_result = result
         if result.log_path is not None:
             log_paths.append(result.log_path)
@@ -2234,6 +2252,47 @@ def _run_validated_agent(
                 # Let the existing agent-unavailable policy handle the valid
                 # envelope, even when the command itself failed.
                 text = artifact
+
+        # A Claude process can be replaced by its self-updater after it spawned.
+        # This is exclusive with ordinary transient classification and gets one
+        # full replay only after the bare executable is stable.
+        if (
+            agent == "claude"
+            and result.self_update_reason is not None
+            and not updater_replay_used
+            and result.command_result is not None
+        ):
+            updater_replay_used = True
+            observation = result.command_result.observation
+            self_update_deadline = (
+                observation.spawn_monotonic + timeout_seconds
+                if timeout_seconds is not None and observation is not None
+                else None
+            )
+            stable = runner.wait_for_executable_stability(
+                config.claude_cmd, deadline=self_update_deadline
+            )
+            remaining = (
+                self_update_deadline - time.monotonic()
+                if self_update_deadline is not None else None
+            )
+            if not stable or (remaining is not None and remaining <= 0):
+                last_error = (
+                    f"likely Claude self-update interruption ({result.self_update_reason}); "
+                    "executable did not stabilize within the invocation deadline"
+                )
+                last_classification_text = result.raw_output
+                last_failure_category = "self-update-interruption"
+                if usage_record is not None:
+                    usage_record.outcome = "self_update_interruption"
+                    usage_record.log_path = str(result.log_path) if result.log_path else None
+                break
+            if usage_record is not None:
+                usage_record.outcome = "self_update_interruption"
+                usage_record.log_path = str(result.log_path) if result.log_path else None
+            next_timeout_seconds = remaining
+            log(config, f"{agent_name}: {result.self_update_reason}; replaying once after executable stability")
+            continue
 
         should_retry = False
         provider_capacity = False
@@ -2771,9 +2830,11 @@ def _run_validated_agent(
                     retryable=should_retry, provider_capacity=provider_capacity
                 )
                 if antigravity_attempts is not None
-                else ("retry" if attempt < max_attempts else "stop")
+                else ("retry" if ordinary_retries_used < config.agent_max_retries else "stop")
             )
             if transition == "retry":
+                if antigravity_attempts is None:
+                    ordinary_retries_used += 1
                 delay = _retry_delay(config, attempt)
                 category = last_failure_category
                 log(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2163,6 +2163,7 @@ def _run_validated_agent(
     updater_replay_used = False
     ordinary_retries_used = 0
     self_update_deadline: float | None = None
+    self_update_stability_error: str | None = None
     next_timeout_seconds = timeout_seconds
 
     for attempt in range(1, max_attempts + 1):
@@ -2277,23 +2278,22 @@ def _run_validated_agent(
                 if self_update_deadline is not None else None
             )
             if not stable or (remaining is not None and remaining <= 0):
-                last_error = (
+                self_update_stability_error = (
                     f"likely Claude self-update interruption ({result.self_update_reason}); "
                     "executable did not stabilize within the invocation deadline"
                 )
-                last_classification_text = result.raw_output
-                last_failure_category = "self-update-interruption"
                 if usage_record is not None:
                     usage_record.outcome = "self_update_interruption"
                     usage_record.log_path = str(result.log_path) if result.log_path else None
-                break
-            if usage_record is not None:
-                usage_record.outcome = "self_update_interruption"
-                usage_record.log_path = str(result.log_path) if result.log_path else None
-            next_timeout_seconds = remaining
-            log(config, f"{agent_name}: {result.self_update_reason}; replaying once after executable stability")
-            continue
-
+                # Preserve any ordinary transient retry allowance: a failed
+                # stability observation does not make provider errors final.
+            else:
+                if usage_record is not None:
+                    usage_record.outcome = "self_update_interruption"
+                    usage_record.log_path = str(result.log_path) if result.log_path else None
+                next_timeout_seconds = remaining
+                log(config, f"{agent_name}: {result.self_update_reason}; replaying once after executable stability")
+                continue
         should_retry = False
         provider_capacity = False
         if result.returncode is None and artifact_unavailable is None:
@@ -2837,10 +2837,20 @@ def _run_validated_agent(
                     ordinary_retries_used += 1
                 delay = _retry_delay(config, attempt)
                 category = last_failure_category
+                retry_attempt = (
+                    ordinary_retries_used + 1
+                    if antigravity_attempts is None
+                    else attempt + 1
+                )
+                retry_budget = (
+                    config.agent_max_retries + 1
+                    if antigravity_attempts is None
+                    else max_attempts
+                )
                 log(
                     config,
                     f"{agent_name}: {category} failure ({last_error}); "
-                    f"retrying in {delay}s (attempt {attempt + 1}/{max_attempts})",
+                    f"retrying in {delay}s (attempt {retry_attempt}/{retry_budget})",
                 )
                 runner.run(("sleep", str(delay)), cwd=active_workdir(config))
                 continue
@@ -2854,6 +2864,8 @@ def _run_validated_agent(
                 continue
         break
 
+    if self_update_stability_error is not None:
+        last_error = f"{self_update_stability_error}; final failure: {last_error}"
     diagnostics = _failed_run_diagnostics(
         runner=runner,
         config=config,

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -19,12 +19,32 @@ from .errors import AgentLoopError
 
 
 @dataclass(frozen=True)
+class ExecutableIdentity:
+    path: str | None
+    target: str | None
+    entry_identity: tuple[int, int, int] | None
+    target_identity: tuple[int, int, int] | None
+
+
+@dataclass(frozen=True)
+class ExecutionObservation:
+    spawn_wall_time: float
+    spawn_monotonic: float
+    exit_monotonic: float
+    elapsed_seconds: float
+    before: ExecutableIdentity
+    after: ExecutableIdentity
+    interrupted: bool
+
+
+@dataclass(frozen=True)
 class CommandResult:
     args: list[str]
     cwd: Path
     stdout: str
     stderr: str
     returncode: int | None
+    observation: ExecutionObservation | None = None
 
 
 # Matches ANSI/VT100 control sequences (CSI, OSC, charset selection) that a
@@ -44,6 +64,25 @@ def strip_ansi(text: str) -> str:
 def tail_text(text: str, *, max_lines: int = 80) -> str:
     lines = text.splitlines()
     return "\n".join(lines[-max_lines:])
+
+
+def executable_identity(command: str) -> ExecutableIdentity:
+    """Capture an attempt-local identity for a bare command without caching it."""
+    path = shutil.which(command) if not os.path.isabs(command) else command
+    if path is None:
+        return ExecutableIdentity(None, None, None, None)
+    target = os.path.realpath(path)
+    def identity(stat_result: os.stat_result) -> tuple[int, int, int]:
+        return (stat_result.st_dev, stat_result.st_ino, stat_result.st_mtime_ns)
+    try:
+        entry = identity(os.lstat(path))
+    except OSError:
+        entry = None
+    try:
+        resolved = identity(os.stat(path))
+    except OSError:
+        resolved = None
+    return ExecutableIdentity(path, target, entry, resolved)
 
 
 def ensure_log_dir_ignored(log_dir: Path) -> None:
@@ -184,6 +223,23 @@ class Runner:
 
         raise AssertionError("spawn retry loop exited unexpectedly")
 
+    def wait_for_executable_stability(self, command: str, *, deadline: float | None = None) -> bool:
+        """Observe two matching command identities a second apart, for at most six seconds."""
+        if os.path.isabs(command) or self._interrupted:
+            return False
+        end = min(deadline, time.monotonic() + 6) if deadline is not None else time.monotonic() + 6
+        previous: ExecutableIdentity | None = None
+        while time.monotonic() < end and not self._interrupted:
+            current = executable_identity(command)
+            if current.path and current.entry_identity and current.target_identity and current == previous:
+                return True
+            previous = current
+            remaining = end - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(1.0, remaining))
+        return False
+
     def run(
         self,
         args: Sequence[str],
@@ -301,6 +357,9 @@ class Runner:
                     cmd,
                     spawn,
                 )
+                spawn_wall_time = time.time()
+                spawn_monotonic = time.monotonic()
+                before_identity = executable_identity(cmd[0])
                 self._register_active_process(proc)
                 try:
                     while True:
@@ -337,7 +396,11 @@ class Runner:
 
         full_output = log_path.read_text(encoding="utf-8")
         output = full_output[len(header):] if full_output.startswith(header) else full_output
-        result = CommandResult(cmd, cwd, output, "", returncode)
+        exited = time.monotonic()
+        result = CommandResult(cmd, cwd, output, "", returncode, ExecutionObservation(
+            spawn_wall_time, spawn_monotonic,
+            exited, exited - started, before_identity, executable_identity(cmd[0]), self._interrupted,
+        ))
         if check and returncode != 0:
             raise AgentLoopError(
                 f"Command failed with exit {returncode}: {' '.join(cmd)}\n"
@@ -405,6 +468,9 @@ class Runner:
                     raise
 
             proc = self._spawn_with_retry(cmd, spawn_pty)
+            spawn_wall_time = time.time()
+            spawn_monotonic = time.monotonic()
+            before_identity = executable_identity(cmd[0])
             assert allocated_fds is not None
             master_fd, slave_fd = allocated_fds
             os.close(slave_fd)
@@ -458,7 +524,11 @@ class Runner:
 
         raw = b"".join(chunks).decode("utf-8", errors="replace")
         output = strip_ansi(raw)
-        result = CommandResult(cmd, cwd, output, "", returncode)
+        exited = time.monotonic()
+        result = CommandResult(cmd, cwd, output, "", returncode, ExecutionObservation(
+            spawn_wall_time, spawn_monotonic, exited, exited - spawn_monotonic,
+            before_identity, executable_identity(cmd[0]), self._interrupted,
+        ))
         if check and returncode != 0:
             raise AgentLoopError(
                 f"Command failed with exit {returncode}: {' '.join(cmd)}\n"

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -225,7 +225,7 @@ class Runner:
 
     def wait_for_executable_stability(self, command: str, *, deadline: float | None = None) -> bool:
         """Observe two matching command identities a second apart, for at most six seconds."""
-        if os.path.isabs(command) or self._interrupted:
+        if self._interrupted:
             return False
         end = min(deadline, time.monotonic() + 6) if deadline is not None else time.monotonic() + 6
         previous: ExecutableIdentity | None = None
@@ -399,7 +399,7 @@ class Runner:
         exited = time.monotonic()
         result = CommandResult(cmd, cwd, output, "", returncode, ExecutionObservation(
             spawn_wall_time, spawn_monotonic,
-            exited, exited - started, before_identity, executable_identity(cmd[0]), self._interrupted,
+            exited, exited - spawn_monotonic, before_identity, executable_identity(cmd[0]), self._interrupted,
         ))
         if check and returncode != 0:
             raise AgentLoopError(

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -93,7 +93,7 @@ class UsageCallRecord:
     model: str | None = None
     outcome: Literal[
         "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
-        "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",
+        "unavailable_model", "accepted_nonzero_exit", "accepted_timeout", "self_update_interruption",
     ] | None = None
     log_path: str | None = None
     fallback_planned: bool | None = None
@@ -202,7 +202,7 @@ class RunUsageContext:
         model: str | None = None,
         outcome: Literal[
             "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
-            "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",
+            "unavailable_model", "accepted_nonzero_exit", "accepted_timeout", "self_update_interruption",
         ] | None = None,
         log_path: str | None = None,
         fallback_planned: bool | None = None,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3637,7 +3637,9 @@ def test_runner_retries_preflighted_command_disappearance_and_recovers(
     assert result.returncode == 0
     assert "recovered after preflight" in result.stdout
     assert len(popen_calls) == 3
-    assert which_calls == [command_name, command_name, command_name]
+    # Spawn retry keeps its existing three lookups; the completed invocation
+    # additionally records isolated pre/post executable observations.
+    assert which_calls == [command_name] * 5
     assert runner._resolved_commands[command_name] == str(command)
     assert sleep_calls[:2] == [2, 2]
     assert all(delay == 1 for delay in sleep_calls[2:])
@@ -4124,6 +4126,24 @@ def test_run_agent_result_passes_role_to_backend(tmp_path, monkeypatch):
     config = make_config(tmp_path, reviewer="gemini")
     run_agent_result(FakeRunner(), agent="gemini", config=config, prompt="Test", role="reviewer")
     assert captured["role"] == "reviewer"
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_records_attempt_local_executable_observation(tmp_path, use_pty):
+    """Both runner paths retain pre/post bare-command evidence for updater policy."""
+    result = Runner().run_with_log(
+        ["python3", "-c", "print('ok')"],
+        cwd=tmp_path,
+        log_path=tmp_path / f"observation-{use_pty}.log",
+        label="observation",
+        progress_interval_seconds=999,
+        use_pty=use_pty,
+    )
+    assert result.returncode == 0
+    assert result.observation is not None
+    assert result.observation.before.path
+    assert result.observation.after.path
+    assert result.observation.elapsed_seconds >= 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -31,6 +32,7 @@ from coding_review_agent_loop.config import (
 )
 from coding_review_agent_loop.errors import AgentInvocationError, QuotaResetExceededError
 from coding_review_agent_loop.github import IssueComment
+from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
     ValidatedAgentResponse,
@@ -3436,6 +3438,98 @@ def test_public_response_file_instruction_mentions_plan_revision_human_ack_excep
 # --- Integration tests via _run_validated_agent ---
 
 
+def test_claude_self_update_replay_recovers_valid_response_with_remaining_timeout(tmp_path):
+    """A spawned updater interruption gets one stable, bounded full replay."""
+    identity = ExecutableIdentity("claude", "claude", (1, 1, 1), (1, 1, 1))
+    observation = ExecutionObservation(
+        spawn_wall_time=1,
+        spawn_monotonic=time.monotonic() - 1,
+        exit_monotonic=time.monotonic(),
+        elapsed_seconds=1,
+        before=identity,
+        after=identity,
+        interrupted=False,
+    )
+
+    class ObservedClaudeRunner(FakeRunner):
+        def __init__(self):
+            super().__init__(claude_outputs=[
+                ("Loading...\nInstalling Claude Code v2.1.226", 1),
+                (structured_pr_review(state="approved", summary="Recovered.", reviewer="Anthropic Claude"), 0),
+            ])
+            self.timeouts = []
+
+        def run_with_log(self, *args, timeout_seconds=None, **kwargs):
+            self.timeouts.append(timeout_seconds)
+            result = super().run_with_log(*args, timeout_seconds=timeout_seconds, **kwargs)
+            if result.args[:1] == ["claude"]:
+                return CommandResult(
+                    result.args, result.cwd, result.stdout, result.stderr, result.returncode, observation
+                )
+            return result
+
+        def wait_for_executable_stability(self, command, *, deadline=None):
+            assert command == "claude"
+            assert deadline is not None
+            return True
+
+    runner = ObservedClaudeRunner()
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=0)
+    response = _run_validated_agent(
+        runner,
+        agent="claude",
+        config=config,
+        prompt="Review the PR.",
+        marker_description="<!-- AGENT_STATE: approved|blocking -->",
+        validate=lambda text: _validate_review_response(
+            text, reviewer="Anthropic Claude", unresolved_items=()
+        ),
+        timeout_seconds=12,
+    )
+
+    assert response.marker_value.state == "approved"
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 2
+    assert runner.timeouts[0] == 12
+    assert 0 < runner.timeouts[1] < 12
+
+
+def test_claude_self_update_stability_failure_preserves_ordinary_retry_budget(tmp_path):
+    """A transient updater failure still receives the configured ordinary retry."""
+    identity = ExecutableIdentity("claude", "claude", (1, 1, 1), (1, 1, 1))
+    observation = ExecutionObservation(1, time.monotonic(), time.monotonic(), 1, identity, identity, False)
+
+    class UnstableClaudeRunner(FakeRunner):
+        def run_with_log(self, *args, **kwargs):
+            result = super().run_with_log(*args, **kwargs)
+            if result.args[:1] == ["claude"]:
+                return CommandResult(
+                    result.args, result.cwd, result.stdout, result.stderr, result.returncode, observation
+                )
+            return result
+
+        def wait_for_executable_stability(self, command, *, deadline=None):
+            return False
+
+    runner = UnstableClaudeRunner(claude_outputs=[
+        ("fatal: auto-update in progress\noverloaded_error", 1),
+        (structured_pr_review(state="approved", summary="Recovered by ordinary retry.", reviewer="Anthropic Claude"), 0),
+    ])
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=1)
+    response = _run_validated_agent(
+        runner,
+        agent="claude",
+        config=config,
+        prompt="Review the PR.",
+        marker_description="<!-- AGENT_STATE: approved|blocking -->",
+        validate=lambda text: _validate_review_response(
+            text, reviewer="Anthropic Claude", unresolved_items=()
+        ),
+    )
+
+    assert response.marker_value.state == "approved"
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 2
+
+
 # ---------------------------------------------------------------------------
 # Antigravity (agy) backend + Gemini retirement guidance (#215)
 # ---------------------------------------------------------------------------
@@ -3467,6 +3561,35 @@ def test_runner_pty_reports_tty_and_strips_ansi(tmp_path):
     assert "GREEN" in result.stdout
     assert "\x1b[" not in result.stdout  # ANSI stripped from captured output
     assert result.returncode == 0
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_execution_observation_elapsed_begins_at_spawn(tmp_path, use_pty):
+    """Pipe and PTY observations use the same post-spawn elapsed interval."""
+    result = Runner().run_with_log(
+        [sys.executable, "-c", "print('done')"],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / f"observation-{use_pty}.log",
+        label="Observation probe",
+        progress_interval_seconds=999,
+        use_pty=use_pty,
+    )
+
+    assert result.observation is not None
+    assert result.observation.elapsed_seconds == (
+        result.observation.exit_monotonic - result.observation.spawn_monotonic
+    )
+
+
+def test_wait_for_executable_stability_accepts_absolute_command_with_matching_identity(monkeypatch, tmp_path):
+    """Explicit updater diagnostics may recover an absolute Claude override."""
+    import coding_review_agent_loop.runner as runner_module
+
+    command = str(tmp_path / "claude")
+    identity = ExecutableIdentity(command, command, (1, 1, 1), (1, 1, 1))
+    monkeypatch.setattr(runner_module, "executable_identity", lambda _command: identity)
+
+    assert Runner().wait_for_executable_stability(command)
 
 
 def test_runner_with_log_passes_large_input_on_stdin(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3455,12 +3455,16 @@ def test_claude_self_update_replay_recovers_valid_response_with_remaining_timeou
         def __init__(self):
             super().__init__(claude_outputs=[
                 ("Loading...\nInstalling Claude Code v2.1.226", 1),
+                ("overloaded_error", 1),
                 (structured_pr_review(state="approved", summary="Recovered.", reviewer="Anthropic Claude"), 0),
             ])
             self.timeouts = []
+            self.claude_log_paths = []
 
         def run_with_log(self, *args, timeout_seconds=None, **kwargs):
             self.timeouts.append(timeout_seconds)
+            if args[0][:1] == ["claude"]:
+                self.claude_log_paths.append(kwargs["log_path"])
             result = super().run_with_log(*args, timeout_seconds=timeout_seconds, **kwargs)
             if result.args[:1] == ["claude"]:
                 return CommandResult(
@@ -3474,7 +3478,7 @@ def test_claude_self_update_replay_recovers_valid_response_with_remaining_timeou
             return True
 
     runner = ObservedClaudeRunner()
-    config = make_config(tmp_path, reviewer="claude", agent_max_retries=0)
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=1)
     response = _run_validated_agent(
         runner,
         agent="claude",
@@ -3488,9 +3492,13 @@ def test_claude_self_update_replay_recovers_valid_response_with_remaining_timeou
     )
 
     assert response.marker_value.state == "approved"
-    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 2
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 3
     assert runner.timeouts[0] == 12
     assert 0 < runner.timeouts[1] < 12
+    assert runner.timeouts[2] == 12
+    assert runner.claude_log_paths[0].name.endswith("-attempt1.log")
+    assert runner.claude_log_paths[1].name.endswith("-self-update-attempt2.log")
+    assert runner.claude_log_paths[2].name.endswith("-attempt2.log")
 
 
 def test_claude_self_update_stability_failure_preserves_ordinary_retry_budget(tmp_path):
@@ -3499,7 +3507,13 @@ def test_claude_self_update_stability_failure_preserves_ordinary_retry_budget(tm
     observation = ExecutionObservation(1, time.monotonic(), time.monotonic(), 1, identity, identity, False)
 
     class UnstableClaudeRunner(FakeRunner):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.claude_log_paths = []
+
         def run_with_log(self, *args, **kwargs):
+            if args[0][:1] == ["claude"]:
+                self.claude_log_paths.append(kwargs["log_path"])
             result = super().run_with_log(*args, **kwargs)
             if result.args[:1] == ["claude"]:
                 return CommandResult(
@@ -3528,6 +3542,49 @@ def test_claude_self_update_stability_failure_preserves_ordinary_retry_budget(tm
 
     assert response.marker_value.state == "approved"
     assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 2
+    assert [path.name.rsplit("-", 1)[-1] for path in runner.claude_log_paths] == [
+        "attempt1.log",
+        "attempt2.log",
+    ]
+
+
+def test_claude_self_update_stability_failure_sets_final_category(tmp_path):
+    """An exhausted failed stability check remains explicitly diagnosable."""
+    identity = ExecutableIdentity("claude", "claude", (1, 1, 1), (1, 1, 1))
+    observation = ExecutionObservation(1, time.monotonic(), time.monotonic(), 1, identity, identity, False)
+
+    class UnstableClaudeRunner(FakeRunner):
+        def run_with_log(self, *args, **kwargs):
+            result = super().run_with_log(*args, **kwargs)
+            if result.args[:1] == ["claude"]:
+                return CommandResult(
+                    result.args, result.cwd, result.stdout, result.stderr, result.returncode, observation
+                )
+            return result
+
+        def wait_for_executable_stability(self, command, *, deadline=None):
+            return False
+
+    runner = UnstableClaudeRunner(claude_outputs=[
+        ("fatal: auto-update in progress\\noverloaded_error", 1),
+        ("ordinary failure", 1),
+    ])
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=1)
+
+    with pytest.raises(AgentInvocationError) as error:
+        _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Anthropic Claude", unresolved_items=()
+            ),
+        )
+
+    assert error.value.failure_category == "self-update-interruption"
+    assert "wait for the Claude Code self-update to finish" in str(error.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -91,7 +91,7 @@ def test_claude_self_update_classification_requires_bounded_evidence():
     assert classify_self_update_interruption(
         ordinary, command="claude", response_file_text=None, session_id=None
     ) is None
-    diagnostic = CommandResult(["claude"], Path.cwd(), "fatal: auto-update in progress", "", 1,
+    diagnostic = CommandResult(["claude"], Path.cwd(), "Loading...\nInstalling Claude Code v2.1.226", "", 1,
                                ExecutionObservation(2, 10, 11, 1, identity, identity, False))
     assert classify_self_update_interruption(
         diagnostic, command="claude", response_file_text=None, session_id=None

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,9 +9,11 @@ import pytest
 
 from coding_review_agent_loop.agents.claude import (
     BACKEND as CLAUDE_BACKEND,
+    classify_self_update_interruption,
     _normalize_claude_usage,
     _parse_claude_output,
 )
+from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
 from coding_review_agent_loop.agents.codex import (
     BACKEND as CODEX_BACKEND,
     _extract_codex_usage,
@@ -74,6 +76,26 @@ def test_parse_claude_output_falls_back_on_plain_text():
     assert usage is None
     assert raw_usage is None
     assert model is None
+
+
+def test_claude_self_update_classification_requires_bounded_evidence():
+    identity = ExecutableIdentity("/bin/claude", "/bin/claude", (1, 1, 1), (1, 1, 1))
+    changed = ExecutableIdentity("/bin/claude", "/bin/claude", (1, 2, 2_000_000_000), (1, 2, 2_000_000_000))
+    observation = ExecutionObservation(2, 10, 11, 1, identity, changed, False)
+    failed = CommandResult(["claude"], Path.cwd(), "", "", 1, observation)
+    assert classify_self_update_interruption(
+        failed, command="claude", response_file_text=None, session_id=None
+    ) == "Claude executable changed during invocation"
+    ordinary = CommandResult(["claude"], Path.cwd(), "ordinary failure", "", 1,
+                             ExecutionObservation(2, 10, 11, 1, identity, identity, False))
+    assert classify_self_update_interruption(
+        ordinary, command="claude", response_file_text=None, session_id=None
+    ) is None
+    diagnostic = CommandResult(["claude"], Path.cwd(), "fatal: auto-update in progress", "", 1,
+                               ExecutionObservation(2, 10, 11, 1, identity, identity, False))
+    assert classify_self_update_interruption(
+        diagnostic, command="claude", response_file_text=None, session_id=None
+    ) == "Claude Code updater diagnostic"
 
 
 def test_parse_claude_output_falls_back_on_non_string_result():

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -3236,7 +3236,7 @@ def test_discuss_parallel_artifacts_are_isolated_by_round_and_agent(tmp_path):
     assert len([n for n in log_names if n.endswith("-gemini-discuss-r1.log")]) == 1
     assert len([n for n in log_names if n.endswith("-codex-discuss-r2.log")]) == 1
     assert len([n for n in log_names if n.endswith("-gemini-discuss-r2.log")]) == 1
-    assert len([n for n in log_names if n.endswith("-claude-discuss-analyzer-r1.log")]) == 1
+    assert len([n for n in log_names if n.endswith("-claude-discuss-analyzer-r1-attempt1.log")]) == 1
     assert len(log_names) == len(set(log_names))
     # Usage records from parallel calls are all present with unique call ids.
     summary = read_usage_summary(config.log_dir)

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -194,7 +194,7 @@ def test_issue_loop_creates_pr_then_alternates_until_codex_approval(tmp_path):
     assert ["codex", "exec"] in command_names
     assert len(runner.comments) == 5
     assert runner.comments[-1].startswith("**Review verdict:** Approved\n\nLGTM.")
-    assert list((tmp_path / "logs").glob("*-claude.log"))
+    assert list((tmp_path / "logs").glob("*-claude-attempt1.log"))
     assert list((tmp_path / "logs").glob("*-codex.log"))
     assert (tmp_path / "logs" / ".gitignore").read_text(encoding="utf-8") == "*\n!.gitignore\n"
 


### PR DESCRIPTION
## Summary
- capture attempt-local executable identities for pipe and PTY command runs
- classify bounded Claude updater interruptions and replay one stable invocation
- preserve per-attempt logs, timeout budgets, and usage diagnostics

Fixes #635

## Tests
- `timeout 900 python3 -m pytest tests/test_agent_loop.py tests/test_backends.py tests/test_orchestrator_pr.py tests/test_completion_recovery.py`
- `timeout 900 python3 -m pytest -q`