### PR TITLE
Allow loopback targets in coder test reports

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1123,7 +1123,25 @@ phrase ends at a negation word or at the next execution verb. A negated
 execution phrase (`Did not run curl https://...`, `ran the suite against the
 local stub and never against https://...`) and unattached URL-like prose
 (deployment notes, session-cookie mentions) are accepted, and
-this narrower prose latitude does not extend to command syntax. If an explicit
+this narrower prose latitude does not extend to command syntax.
+
+The one exception, in command syntax as well as prose, is a URL whose host is
+a loopback address: `localhost`, an IPv4 address in `127.0.0.0/8`, or the IPv6
+loopback `::1` (for example `http://localhost:8765`, `http://127.0.0.1:8765`,
+`http://127.42.0.9:8765`, `http://[::1]:8765`). Coders commonly need to stand
+up a local server and drive an E2E client such as Playwright or Node against
+it inside the assigned checkout; a loopback target reported as a test command
+is accepted while every other host -- including non-loopback private/LAN
+addresses such as `0.0.0.0` or `192.168.x.x` -- is still rejected. This
+exemption is host-classification only, not a blanket exemption for the
+clause: a loopback target reported alongside a live remote target in the same
+command (`... && curl https://live.example`) still fails on the live target.
+Authority syntax that a browser or Node client could parse differently than
+the loop's own classifier -- for example a backslash inside the URL, which
+WHATWG URL parsers treat as a path separator and could resolve to a different
+host than a strict URL parse reports -- is never treated as loopback, even if
+it superficially contains `localhost` or a loopback IP; it is rejected as an
+unverifiable live target instead. If an explicit
 test location is outside the assigned checkout, or a live remote target is
 detected, the loop fails with an `AgentLoopError` naming the offending
 command/URL and assigned checkout. When that failure happens after a PR was

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -17,7 +17,10 @@ from .protocol import DiscussEvidenceClaim
 TEST_SECTION_RE = re.compile(r"(?im)^\s*tests(?:\s+run)?\s*:\s*(?P<body>.*)$")
 WINDOWS_PATH_RE = re.compile(r"(?<![\w.-])[A-Za-z]:\\[^\s`'\"|;&)<>]+")
 URL_SCHEME_RE = re.compile(r"(?i)https?://")
-URL_VALUE_RE = re.compile(r"(?i)https?://[^\s'\"`;&|()<>]+")
+# Stops at a comma and refuses to consume into a subsequent http(s) scheme, so
+# a concatenated/delimited string such as "http://127.0.0.1/foo,http://evil.com"
+# yields two separate URL values instead of one that only reveals its first host.
+URL_VALUE_RE = re.compile(r"(?i)https?://(?:(?!https?://)[^\s'\"`;&|()<>,])+")
 BACKTICK_SPAN_RE = re.compile(r"`([^`]*)`")
 VAR_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 INTERPRETER_BASENAME_RE = re.compile(r"^(python|pypy)\d*(\.\d+)?$")
@@ -151,6 +154,14 @@ def _url_values(token: str) -> tuple[str, ...]:
 
 
 def _is_loopback_url(url: str) -> bool:
+    # WHATWG URL consumers (Node, browsers, and browser-driven E2E clients)
+    # treat a backslash as a path separator for special schemes like
+    # http(s), so "http://live.example\@localhost" resolves to live.example
+    # there even though `urlsplit` reports "localhost" as the hostname.
+    # Refuse to classify authority syntax that could disagree between
+    # parsers instead of trusting `urlsplit` alone.
+    if "\\" in url:
+        return False
     try:
         host = urlsplit(url).hostname
     except ValueError:
@@ -764,7 +775,17 @@ def _validate_single_command(command: str, *, assigned: Path, origin: Origin) ->
 
     for clause in clauses:
         for target in _url_targets_in_clause(clause):
-            for url in _url_values(target):
+            values = _url_values(target)
+            if not values and _is_url_token(target):
+                # A bare/incomplete scheme like "http://" has no extractable
+                # host for `_url_values` to yield, but it is still URL-shaped
+                # command syntax; treat it as unverifiable rather than
+                # silently skipping validation for it.
+                raise AgentLoopError(
+                    "Coder reported tests run against a live remote target: "
+                    f"{target!r} in command {command!r}. Assigned checkout: {assigned}"
+                )
+            for url in values:
                 if _is_loopback_url(url):
                     continue
                 raise AgentLoopError(

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -153,6 +153,28 @@ def _url_values(token: str) -> tuple[str, ...]:
     )
 
 
+def _has_unmatched_url_scheme(token: str) -> bool:
+    """True if a `https?://` occurrence in ``token`` is not the start of any
+    `URL_VALUE_RE` match.
+
+    This catches both a bare/incomplete scheme with no host at all
+    (`_url_values` yields nothing for it, e.g. a lone "http://") and a
+    scheme immediately followed by a *nested* scheme (e.g.
+    "http://https://localhost"): the outer "http://" can supply zero
+    characters to `URL_VALUE_RE`'s mandatory `+` group because the negative
+    lookahead refuses to let it consume into the nested "https://", so the
+    only match `_url_values` finds is the *inner* URL. Evaluating just that
+    inner fragment for loopback-ness (as opposed to the outer scheme's own,
+    unrelated host) would let a non-loopback outer target hide behind a
+    loopback-looking inner fragment.
+    """
+    text = _strip_wrap(token)
+    matched_starts = {match.start() for match in URL_VALUE_RE.finditer(text)}
+    return any(
+        match.start() not in matched_starts for match in URL_SCHEME_RE.finditer(text)
+    )
+
+
 def _is_loopback_url(url: str) -> bool:
     # WHATWG URL consumers (Node, browsers, and browser-driven E2E clients)
     # treat a backslash as a path separator for special schemes like
@@ -775,17 +797,19 @@ def _validate_single_command(command: str, *, assigned: Path, origin: Origin) ->
 
     for clause in clauses:
         for target in _url_targets_in_clause(clause):
-            values = _url_values(target)
-            if not values and _is_url_token(target):
-                # A bare/incomplete scheme like "http://" has no extractable
-                # host for `_url_values` to yield, but it is still URL-shaped
-                # command syntax; treat it as unverifiable rather than
-                # silently skipping validation for it.
+            if _has_unmatched_url_scheme(target):
+                # A scheme occurrence that produced no (or the wrong)
+                # matched URL value -- a bare "http://" with no host, or an
+                # outer scheme immediately followed by a nested one such as
+                # "http://https://localhost" -- is unverifiable rather than
+                # provably loopback; treat it as a live target instead of
+                # silently skipping it or judging it by an unrelated inner
+                # fragment.
                 raise AgentLoopError(
                     "Coder reported tests run against a live remote target: "
                     f"{target!r} in command {command!r}. Assigned checkout: {assigned}"
                 )
-            for url in values:
+            for url in _url_values(target):
                 if _is_loopback_url(url):
                     continue
                 raise AgentLoopError(

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Sequence
+from urllib.parse import urlsplit
 
 from .errors import AgentLoopError
 from .protocol import DiscussEvidenceClaim
@@ -15,6 +17,7 @@ from .protocol import DiscussEvidenceClaim
 TEST_SECTION_RE = re.compile(r"(?im)^\s*tests(?:\s+run)?\s*:\s*(?P<body>.*)$")
 WINDOWS_PATH_RE = re.compile(r"(?<![\w.-])[A-Za-z]:\\[^\s`'\"|;&)<>]+")
 URL_SCHEME_RE = re.compile(r"(?i)https?://")
+URL_VALUE_RE = re.compile(r"(?i)https?://[^\s'\"`;&|()<>]+")
 BACKTICK_SPAN_RE = re.compile(r"`([^`]*)`")
 VAR_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 INTERPRETER_BASENAME_RE = re.compile(r"^(python|pypy)\d*(\.\d+)?$")
@@ -138,6 +141,28 @@ def _strip_wrap(token: str) -> str:
 
 def _is_url_token(token: str) -> bool:
     return bool(URL_SCHEME_RE.search(_strip_wrap(token)))
+
+
+def _url_values(token: str) -> tuple[str, ...]:
+    return tuple(
+        match.group(0).rstrip(".,")
+        for match in URL_VALUE_RE.finditer(_strip_wrap(token))
+    )
+
+
+def _is_loopback_url(url: str) -> bool:
+    try:
+        host = urlsplit(url).hostname
+    except ValueError:
+        return False
+    if host is None:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _is_path_like_token(token: str) -> bool:
@@ -738,11 +763,14 @@ def _validate_single_command(command: str, *, assigned: Path, origin: Origin) ->
             _check_path_role(raw_path, role, command=command, assigned=assigned)
 
     for clause in clauses:
-        for url in _url_targets_in_clause(clause):
-            raise AgentLoopError(
-                "Coder reported tests run against a live remote target: "
-                f"{url!r} in command {command!r}. Assigned checkout: {assigned}"
-            )
+        for target in _url_targets_in_clause(clause):
+            for url in _url_values(target):
+                if _is_loopback_url(url):
+                    continue
+                raise AgentLoopError(
+                    "Coder reported tests run against a live remote target: "
+                    f"{url!r} in command {command!r}. Assigned checkout: {assigned}"
+                )
 
 
 def validate_test_commands_within_workdir(

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -418,6 +418,17 @@ def test_rejects_incomplete_url_scheme_token(tmp_path):
         validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
 
 
+def test_rejects_nested_scheme_hiding_behind_loopback_fragment(tmp_path):
+    # The outer "http://" scheme can't supply any characters to its own URL
+    # value because the next chars start a nested "https://" scheme, so a
+    # naive "only judge whatever _url_values found" check would evaluate
+    # just the inner "https://localhost" fragment (loopback) and miss that
+    # the outer target itself is unverifiable.
+    command = "E2E_BASE=http://https://localhost node tests/test_e2e.js"
+    with pytest.raises(AgentLoopError, match="live remote target"):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
 REJECTED_NARRATIVE_URLS = [
     "Tests: hit https://live.example/health",
     "Tests: curled https://live.example/health",

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -355,6 +355,48 @@ def test_rejects_strict_command_code_span_live_target(tmp_path):
         validate_response_tests_within_workdir(text, assigned_workdir=assigned)
 
 
+@pytest.mark.parametrize("url", [
+    "http://localhost:8765",
+    "http://127.0.0.1:8765",
+    "http://127.42.0.9:8765",
+    "http://[::1]:8765",
+])
+def test_accepts_loopback_test_targets(tmp_path, url):
+    validate_test_commands_within_workdir(
+        (f"E2E_BASE={url} node tests/test_e2e.js",),
+        assigned_workdir=_assigned(tmp_path),
+    )
+
+
+def test_accepts_loopback_target_in_nested_shell_command(tmp_path):
+    command = (
+        "timeout 180 bash -c 'ADMISSION_BACKEND=local DEPLOYMENT_MODE=single "
+        "python3 -m server --host 127.0.0.1 --port 8765 >/tmp/server.log 2>&1 & "
+        "server_pid=$!; trap \"kill $server_pid 2>/dev/null || true\" EXIT; sleep 4; "
+        "E2E_BASE=http://127.0.0.1:8765 timeout 120 node tests/test_e2e.js'"
+    )
+    validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+@pytest.mark.parametrize("url", [
+    "http://0.0.0.0:8765",
+    "http://192.168.1.10:8765",
+    "https://live.example",
+])
+def test_loopback_exemption_does_not_accept_other_network_targets(tmp_path, url):
+    with pytest.raises(AgentLoopError, match=re.escape(url)):
+        validate_test_commands_within_workdir(
+            (f"E2E_BASE={url} node tests/test_e2e.js",),
+            assigned_workdir=_assigned(tmp_path),
+        )
+
+
+def test_loopback_target_does_not_hide_remote_target_in_same_command(tmp_path):
+    command = "E2E_BASE=http://127.0.0.1:8765 node tests/test_e2e.js && curl https://live.example"
+    with pytest.raises(AgentLoopError, match="https://live.example"):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
 REJECTED_NARRATIVE_URLS = [
     "Tests: hit https://live.example/health",
     "Tests: curled https://live.example/health",

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -397,6 +397,27 @@ def test_loopback_target_does_not_hide_remote_target_in_same_command(tmp_path):
         validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
 
 
+def test_rejects_backslash_ambiguous_loopback_authority(tmp_path):
+    # WHATWG URL consumers (Node, browsers) treat `\` as a path separator for
+    # http(s) and would resolve this to live.example, not localhost, even
+    # though a strict URL parse reports "localhost" as the hostname.
+    command = "E2E_BASE='http://live.example\\@localhost' node tests/test_e2e.js"
+    with pytest.raises(AgentLoopError, match="live remote target"):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+def test_rejects_live_target_concatenated_with_loopback_url(tmp_path):
+    command = "E2E_BASE=http://127.0.0.1:8765/foo,http://evil.com node tests/test_e2e.js"
+    with pytest.raises(AgentLoopError, match=re.escape("http://evil.com")):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+def test_rejects_incomplete_url_scheme_token(tmp_path):
+    command = "curl http:// tests/test_e2e.js"
+    with pytest.raises(AgentLoopError, match="live remote target"):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
 REJECTED_NARRATIVE_URLS = [
     "Tests: hit https://live.example/health",
     "Tests: curled https://live.example/health",


### PR DESCRIPTION
## Summary

- parse the actual URLs embedded in reported test commands instead of treating an entire nested shell payload as one URL
- allow HTTP(S) targets whose host is strictly loopback: `localhost`, IPv4 `127.0.0.0/8`, or IPv6 `::1`
- continue rejecting wildcard, private-network, public, malformed, and mixed loopback/remote targets

## Context

A coder follow-up on `wwind123/llm-dialectic` PR #661 started a temporary server from its assigned checkout on `127.0.0.1:8765`, ran a browser regression against that server, passed, committed, and pushed. The workdir guard nevertheless rejected the report as a live remote test because the URL validation added by #601 had no loopback exception.

## Tests

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_workdir_guard.py -q` (`137 passed`)
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_orchestrator_issue.py tests/test_orchestrator_pr.py -q` (`266 passed`)
