### PR TITLE
Add managed exact-head CI orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,8 +637,17 @@ still-computing (`UNKNOWN`) GitHub mergeability result is re-checked before
 being treated as unresolved. See
 [Merge conflicts](docs/local_agent_loop.md#merge-conflicts) for details.
 
-With `--auto-merge`, agent-loop foreground-polls the complete check board after
-approval with
+With `--auto-merge`, repositories that advertise the managed exact-head CI
+contract use a dedicated flow: agent-loop applies `agent-loop-managed`, may
+publish local round readiness after a configured pre-review test succeeds,
+dispatches final CI for the reviewers' exact approved SHA, and merges only that
+qualified SHA with `--match-head-commit`. `--watch-pending-ci` and
+`--no-watch-pending-ci` do not alter this managed flow. See
+[Managed exact-head CI](docs/local_agent_loop.md#managed-exact-head-ci) for the
+repository contract and failure behavior.
+
+For repositories without that contract, `--auto-merge` foreground-polls the
+complete check board after approval with
 `--ci-timeout-seconds` and
 `--ci-poll-interval-seconds`, without invoking agents while checks are pending.
 Failure resumes the coder with the failed-check details; a successful/no-check

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1247,8 +1247,9 @@ agent-loop pr 123 \
   --ci-check-name test
 ```
 
-When enabled with the full-board watcher (the default — see "Watch pending CI"
-below), the tool foreground-polls the whole PR check board before merging.
+For repositories without the managed exact-head CI contract, enabling auto-merge
+with the full-board watcher (the default — see "Watch pending CI" below) makes
+the tool foreground-poll the whole PR check board before merging.
 With `--no-watch-pending-ci`, it instead waits for the single configured
 `--ci-check-name` check-run to pass before merging, as in earlier releases.
 Local `--test-command` is an additional local gate, not a replacement for CI.
@@ -1280,11 +1281,15 @@ repository's `CI` workflow with the PR number and that exact expected SHA. It
 polls `final-ci/exact-head`, routes a real failure back to the coder, and
 restarts review if the head moves. A passing aggregate is merged with
 `--match-head-commit`, so a different head cannot inherit the approval or CI
-result. The managed label remains in place through merge.
+result. The managed label remains in place through merge. The managed route is
+selected independently of `--watch-pending-ci`; neither that flag nor
+`--no-watch-pending-ci` replaces exact-head qualification with an ordinary
+full-board or named-check wait.
 
 ### Watch pending CI
 
-`--watch-pending-ci` is enabled by default whenever `--auto-merge` is set;
+For repositories not using managed exact-head CI, `--watch-pending-ci` is
+enabled by default whenever `--auto-merge` is set;
 pass `--no-watch-pending-ci` to fall back to the legacy single
 `--ci-check-name` waiter described above. It can also be passed explicitly
 without `--auto-merge`, in which case it watches checks after approval and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1259,6 +1259,29 @@ on code that already fails the configured local test command. Use
 
 Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps watching until checks resolve before merging.
 
+### Managed exact-head CI
+
+Under `--auto-merge`, agent-loop automatically detects a same-repository PR
+whose `.github/workflows/ci.yml` advertises the `agent-loop-managed`,
+`final-ci/exact-head`, and `expected_head_sha` contract. It applies the managed
+label before iterative review, allowing that repository to suppress full
+hosted test matrices on intermediate heads. Repositories without those markers
+retain the ordinary CI behavior above; a partial contract fails closed.
+
+During managed rounds, the intentionally pending final aggregate and missing
+hosted matrix contexts are not presented as actionable review failures.
+Actually observed non-final failures remain visible. If a configured
+pre-review `--test-command` passes, agent-loop also publishes the non-required
+`agent-loop/round-readiness` status on that head; it never publishes readiness
+without running that command.
+
+After every required reviewer approves one live head, agent-loop dispatches the
+repository's `CI` workflow with the PR number and that exact expected SHA. It
+polls `final-ci/exact-head`, routes a real failure back to the coder, and
+restarts review if the head moves. A passing aggregate is merged with
+`--match-head-commit`, so a different head cannot inherit the approval or CI
+result. The managed label remains in place through merge.
+
 ### Watch pending CI
 
 `--watch-pending-ci` is enabled by default whenever `--auto-merge` is set;

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -1443,9 +1443,18 @@ def wait_for_ci(
     )
 
 
-def merge_pr(runner: Runner, config: AgentLoopConfig, pr_number: int) -> None:
+def merge_pr(
+    runner: Runner,
+    config: AgentLoopConfig,
+    pr_number: int,
+    *,
+    expected_head_sha: str | None = None,
+) -> None:
     log(config, f"Merging PR #{pr_number}")
+    command = [config.gh_cmd, "pr", "merge", str(pr_number), "--repo", config.repo, "--merge"]
+    if expected_head_sha:
+        command.extend(["--match-head-commit", expected_head_sha])
     runner.run(
-        [config.gh_cmd, "pr", "merge", str(pr_number), "--repo", config.repo, "--merge"],
+        command,
         cwd=active_workdir(config),
     )

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -6,7 +6,12 @@ import json
 from dataclasses import dataclass, replace
 from typing import Literal
 
-from .ci_health import PullRequestCheck, PullRequestChecks
+from .ci_health import (
+    CiInfrastructureStall,
+    PullRequestCheck,
+    PullRequestChecks,
+    is_wholly_infrastructure_blocked,
+)
 from .config import AgentLoopConfig
 from .errors import AgentLoopError
 from .github import (
@@ -35,10 +40,18 @@ class ManagedCiContract:
 
 @dataclass(frozen=True)
 class ManagedCiOutcome:
-    status: Literal["passed", "failed", "timeout", "head_changed", "merge_conflict"]
+    status: Literal[
+        "passed",
+        "failed",
+        "timeout",
+        "head_changed",
+        "merge_conflict",
+        "infrastructure_stall",
+    ]
     checks: PullRequestChecks | None = None
     mergeability: PullRequestMergeability | None = None
     head_sha: str | None = None
+    stall: CiInfrastructureStall | None = None
 
 
 def activate_managed_ci(
@@ -101,7 +114,7 @@ def activate_managed_ci(
     base_ref = (pr_data.get("base") or {}).get("ref")
     if not isinstance(head_repo, str) or head_repo.casefold() != config.repo.casefold():
         return None
-    if base_ref != "main":
+    if not metadata.base_branch or base_ref != metadata.base_branch:
         return None
     if not metadata.head_sha:
         raise AgentLoopError(f"PR #{pr_number} has no head SHA; managed CI cannot be activated.")
@@ -167,13 +180,32 @@ def activate_managed_ci(
         )
         if apply_result.returncode != 0:
             raise AgentLoopError(f"Unable to apply `{MANAGED_LABEL}` to PR #{pr_number}.")
-        _wait_for_label_handoff(
-            runner,
-            config=config,
-            pr_number=pr_number,
-            metadata=metadata,
-            prior_run_ids=prior_workflow_run_ids,
-        )
+        try:
+            _wait_for_label_handoff(
+                runner,
+                config=config,
+                pr_number=pr_number,
+                metadata=metadata,
+                prior_run_ids=prior_workflow_run_ids,
+            )
+        except AgentLoopError as exc:
+            remove_result = runner.run(
+                [
+                    config.gh_cmd,
+                    "api",
+                    "--method",
+                    "DELETE",
+                    f"repos/{config.repo}/issues/{pr_number}/labels/{MANAGED_LABEL}",
+                ],
+                cwd=active_workdir(config),
+                check=False,
+            )
+            if remove_result.returncode != 0:
+                raise AgentLoopError(
+                    f"{exc} Cleanup also failed: `{MANAGED_LABEL}` remains applied and "
+                    "suppresses hosted CI until it is removed."
+                ) from exc
+            raise
     log(config, f"PR #{pr_number}: activated managed exact-head CI")
     return ManagedCiContract()
 
@@ -189,11 +221,10 @@ def intermediate_managed_checks(checks: PullRequestChecks) -> PullRequestChecks:
     pending = tuple(check for check in checks.pending if check.name != FINAL_CONTEXT)
     failing = tuple(check for check in checks.failing if check.name != FINAL_CONTEXT)
     passing = tuple(check for check in checks.passing if check.name != FINAL_CONTEXT)
-    missing_required: tuple[str, ...] = ()
     required = tuple(name for name in checks.required_checks if name != FINAL_CONTEXT)
     if failing:
         state = "failing"
-    elif pending or missing_required:
+    elif pending:
         state = "pending"
     elif passing:
         state = "passing"
@@ -208,7 +239,7 @@ def intermediate_managed_checks(checks: PullRequestChecks) -> PullRequestChecks:
         passing=passing,
         pending=pending,
         failing=failing,
-        missing_required=missing_required,
+        missing_required=(),
         infrastructure_stalls=tuple(
             stall for stall in checks.infrastructure_stalls if stall.name != FINAL_CONTEXT
         ),
@@ -306,12 +337,28 @@ def wait_for_final_qualification(
                 head_sha=live_head,
             )
         latest = get_pr_checks(runner, config=config, metadata=metadata)
+        if is_wholly_infrastructure_blocked(latest):
+            stall = CiInfrastructureStall(checks=latest.infrastructure_stalls)
+            return ManagedCiOutcome(
+                status="infrastructure_stall",
+                checks=latest,
+                head_sha=live_head,
+                stall=stall,
+            )
         final = _find_context(latest, FINAL_CONTEXT)
         status = final.status.lower() if final is not None else "pending"
         log(config, f"Managed CI context '{FINAL_CONTEXT}' status: {status}")
         if status == "success":
             return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
-        if status in {"failure", "error", "cancelled", "timed_out", "action_required"}:
+        if status in {
+            "failure",
+            "error",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "startup_failure",
+            "stale",
+        }:
             return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
         if attempt < attempts - 1:
             runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -1,0 +1,406 @@
+"""External driver for repositories that implement managed exact-head CI."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from typing import Literal
+
+from .ci_health import PullRequestCheck, PullRequestChecks
+from .config import AgentLoopConfig
+from .errors import AgentLoopError
+from .github import (
+    PullRequestMergeability,
+    PullRequestMetadata,
+    get_pr_checks,
+    get_pr_head_sha,
+    get_pr_mergeability,
+)
+from .logging import log
+from .runner import Runner
+from .workdirs import active_workdir
+
+
+MANAGED_LABEL = "agent-loop-managed"
+FINAL_CONTEXT = "final-ci/exact-head"
+READINESS_CONTEXT = "agent-loop/round-readiness"
+WORKFLOW_FILE = "ci.yml"
+_CONTRACT_MARKERS = (MANAGED_LABEL, FINAL_CONTEXT, "expected_head_sha")
+
+
+@dataclass(frozen=True)
+class ManagedCiContract:
+    workflow_file: str = WORKFLOW_FILE
+
+
+@dataclass(frozen=True)
+class ManagedCiOutcome:
+    status: Literal["passed", "failed", "timeout", "head_changed", "merge_conflict"]
+    checks: PullRequestChecks | None = None
+    mergeability: PullRequestMergeability | None = None
+    head_sha: str | None = None
+
+
+def activate_managed_ci(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+) -> ManagedCiContract | None:
+    """Activate a repository-advertised managed-CI contract for auto-merge runs.
+
+    Repositories without any contract markers retain legacy behavior. A partial
+    contract fails closed because applying its suppression label could otherwise
+    disable hosted tests without a usable final qualification path.
+    """
+    if not config.auto_merge or config.dry_run:
+        return None
+
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}",
+            "-H",
+            "Accept: application/vnd.github.raw+json",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    workflow = result.stdout or ""
+    present = tuple(marker for marker in _CONTRACT_MARKERS if marker in workflow)
+    if not present:
+        return None
+    missing = tuple(marker for marker in _CONTRACT_MARKERS if marker not in workflow)
+    if missing:
+        raise AgentLoopError(
+            "Repository CI advertises an incomplete managed-CI contract; missing marker(s): "
+            + ", ".join(missing)
+        )
+
+    pr_result = runner.run(
+        [config.gh_cmd, "api", f"repos/{config.repo}/pulls/{pr_number}"],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if pr_result.returncode != 0:
+        raise AgentLoopError(f"Unable to validate managed-CI eligibility for PR #{pr_number}.")
+    try:
+        pr_data = json.loads(pr_result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError(
+            f"Managed-CI eligibility response for PR #{pr_number} was invalid JSON."
+        ) from exc
+    head = pr_data.get("head") or {}
+    head_repo = (head.get("repo") or {}).get("full_name")
+    live_head_sha = head.get("sha")
+    live_head_ref = head.get("ref")
+    base_ref = (pr_data.get("base") or {}).get("ref")
+    if not isinstance(head_repo, str) or head_repo.casefold() != config.repo.casefold():
+        return None
+    if base_ref != "main":
+        return None
+    if not metadata.head_sha:
+        raise AgentLoopError(f"PR #{pr_number} has no head SHA; managed CI cannot be activated.")
+    if not metadata.head_branch or live_head_ref != metadata.head_branch:
+        raise AgentLoopError(
+            f"PR #{pr_number} has no stable same-repository head branch for managed CI."
+        )
+    if live_head_sha != metadata.head_sha:
+        raise AgentLoopError(
+            f"PR #{pr_number} moved from {metadata.head_sha} to "
+            f"{live_head_sha or 'an unknown head'} "
+            "while managed CI was being activated; rerun against the live head."
+        )
+
+    labels = {
+        label.get("name")
+        for label in pr_data.get("labels") or []
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    }
+    label_result = runner.run(
+        [config.gh_cmd, "api", f"repos/{config.repo}/labels/{MANAGED_LABEL}"],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if label_result.returncode != 0:
+        create_result = runner.run(
+            [
+                config.gh_cmd,
+                "api",
+                "--method",
+                "POST",
+                f"repos/{config.repo}/labels",
+                "-f",
+                f"name={MANAGED_LABEL}",
+                "-f",
+                "color=1f6feb",
+                "-f",
+                "description=Suppress intermediate CI; agent-loop dispatches exact-head final CI",
+            ],
+            cwd=active_workdir(config),
+            check=False,
+        )
+        if create_result.returncode != 0:
+            raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
+    if MANAGED_LABEL not in labels:
+        prior_workflow_run_ids = _workflow_run_ids(
+            runner,
+            config=config,
+            head_sha=metadata.head_sha,
+        )
+        apply_result = runner.run(
+            [
+                config.gh_cmd,
+                "api",
+                "--method",
+                "POST",
+                f"repos/{config.repo}/issues/{pr_number}/labels",
+                "-f",
+                f"labels[]={MANAGED_LABEL}",
+            ],
+            cwd=active_workdir(config),
+            check=False,
+        )
+        if apply_result.returncode != 0:
+            raise AgentLoopError(f"Unable to apply `{MANAGED_LABEL}` to PR #{pr_number}.")
+        _wait_for_label_handoff(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            metadata=metadata,
+            prior_run_ids=prior_workflow_run_ids,
+        )
+    log(config, f"PR #{pr_number}: activated managed exact-head CI")
+    return ManagedCiContract()
+
+
+def intermediate_managed_checks(checks: PullRequestChecks) -> PullRequestChecks:
+    """Hide contract-controlled absence while reviewers inspect an intermediate head.
+
+    The managed route intentionally does not create the repository's test
+    matrix contexts, so branch protection reports those contexts as missing
+    until the exact-head workflow is dispatched. Actually observed non-final
+    checks remain visible, especially failures from independent integrations.
+    """
+    pending = tuple(check for check in checks.pending if check.name != FINAL_CONTEXT)
+    failing = tuple(check for check in checks.failing if check.name != FINAL_CONTEXT)
+    passing = tuple(check for check in checks.passing if check.name != FINAL_CONTEXT)
+    missing_required: tuple[str, ...] = ()
+    required = tuple(name for name in checks.required_checks if name != FINAL_CONTEXT)
+    if failing:
+        state = "failing"
+    elif pending or missing_required:
+        state = "pending"
+    elif passing:
+        state = "passing"
+    elif checks.check_query_status == "unavailable":
+        state = "unavailable"
+    else:
+        state = "no_checks"
+    return replace(
+        checks,
+        state=state,
+        required_checks=required,
+        passing=passing,
+        pending=pending,
+        failing=failing,
+        missing_required=missing_required,
+        infrastructure_stalls=tuple(
+            stall for stall in checks.infrastructure_stalls if stall.name != FINAL_CONTEXT
+        ),
+    )
+
+
+def publish_round_readiness(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    head_sha: str,
+) -> None:
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            "--method",
+            "POST",
+            f"repos/{config.repo}/statuses/{head_sha}",
+            "-f",
+            "state=success",
+            "-f",
+            f"context={READINESS_CONTEXT}",
+            "-f",
+            "description=Configured local pre-review verification passed",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AgentLoopError(f"Unable to publish `{READINESS_CONTEXT}` for {head_sha}.")
+
+
+def dispatch_final_qualification(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    expected_head_sha: str,
+    head_ref: str,
+    contract: ManagedCiContract,
+) -> None:
+    live_head = get_pr_head_sha(runner, config, pr_number)
+    if live_head != expected_head_sha:
+        raise AgentLoopError(
+            f"PR #{pr_number} head moved from approved SHA {expected_head_sha} "
+            f"to {live_head} before CI dispatch."
+        )
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            "--method",
+            "POST",
+            f"repos/{config.repo}/actions/workflows/{contract.workflow_file}/dispatches",
+            "-f",
+            f"ref={head_ref}",
+            "-f",
+            f"inputs[pr_number]={pr_number}",
+            "-f",
+            f"inputs[expected_head_sha]={expected_head_sha}",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AgentLoopError(
+            f"Unable to dispatch managed final CI for PR #{pr_number} at {expected_head_sha}."
+        )
+    log(config, f"PR #{pr_number}: dispatched managed final CI at {expected_head_sha}")
+
+
+def wait_for_final_qualification(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+) -> ManagedCiOutcome:
+    expected_head = metadata.head_sha
+    if not expected_head:
+        raise AgentLoopError(f"PR #{pr_number} has no approved head SHA.")
+    attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
+    latest: PullRequestChecks | None = None
+    for attempt in range(attempts):
+        live_head = get_pr_head_sha(runner, config, pr_number)
+        if live_head != expected_head:
+            return ManagedCiOutcome(status="head_changed", checks=latest, head_sha=live_head)
+        mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
+        if mergeability.state == "conflicted":
+            return ManagedCiOutcome(
+                status="merge_conflict",
+                checks=latest,
+                mergeability=mergeability,
+                head_sha=live_head,
+            )
+        latest = get_pr_checks(runner, config=config, metadata=metadata)
+        final = _find_context(latest, FINAL_CONTEXT)
+        status = final.status.lower() if final is not None else "pending"
+        log(config, f"Managed CI context '{FINAL_CONTEXT}' status: {status}")
+        if status == "success":
+            return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
+        if status in {"failure", "error", "cancelled", "timed_out", "action_required"}:
+            return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
+        if attempt < attempts - 1:
+            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
+    return ManagedCiOutcome(status="timeout", checks=latest, head_sha=expected_head)
+
+
+def _find_context(checks: PullRequestChecks, name: str) -> PullRequestCheck | None:
+    for check in (*checks.failing, *checks.pending, *checks.passing):
+        if check.name == name:
+            return check
+    return None
+
+
+def _workflow_run_ids(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    head_sha: str,
+) -> set[int]:
+    payload = _workflow_runs_payload(runner, config=config, head_sha=head_sha)
+    return {
+        run["id"]
+        for run in payload
+        if isinstance(run, dict) and isinstance(run.get("id"), int)
+    }
+
+
+def _workflow_runs_payload(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    head_sha: str,
+) -> list[dict[str, object]]:
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/actions/workflows/{WORKFLOW_FILE}/runs"
+            f"?event=pull_request&head_sha={head_sha}&per_page=20",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AgentLoopError("Unable to inspect managed-CI workflow runs.")
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError("Managed-CI workflow-run response was invalid JSON.") from exc
+    runs = payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise AgentLoopError("Managed-CI workflow-run response omitted `workflow_runs`.")
+    return runs
+
+
+def _wait_for_label_handoff(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+    prior_run_ids: set[int],
+) -> None:
+    assert metadata.head_sha is not None
+    attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
+    for attempt in range(attempts):
+        live_head = get_pr_head_sha(runner, config, pr_number)
+        if live_head != metadata.head_sha:
+            raise AgentLoopError(
+                f"PR #{pr_number} head moved while waiting for the managed-label CI handoff."
+            )
+        runs = _workflow_runs_payload(runner, config=config, head_sha=metadata.head_sha)
+        new_runs = [
+            run
+            for run in runs
+            if isinstance(run.get("id"), int) and run["id"] not in prior_run_ids
+        ]
+        if any(run.get("status") == "completed" for run in new_runs):
+            checks = get_pr_checks(runner, config=config, metadata=metadata)
+            final = _find_context(checks, FINAL_CONTEXT)
+            if final is None or final.status.lower() not in {"pending", "queued", "in_progress"}:
+                raise AgentLoopError(
+                    f"Managed-label handoff for PR #{pr_number} completed without publishing "
+                    f"`{FINAL_CONTEXT}=pending`."
+                )
+            return
+        if attempt < attempts - 1:
+            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
+    raise AgentLoopError(
+        f"Managed-label handoff for PR #{pr_number} did not complete within "
+        f"{config.ci_timeout_seconds}s."
+    )

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -337,14 +337,6 @@ def wait_for_final_qualification(
                 head_sha=live_head,
             )
         latest = get_pr_checks(runner, config=config, metadata=metadata)
-        if is_wholly_infrastructure_blocked(latest):
-            stall = CiInfrastructureStall(checks=latest.infrastructure_stalls)
-            return ManagedCiOutcome(
-                status="infrastructure_stall",
-                checks=latest,
-                head_sha=live_head,
-                stall=stall,
-            )
         final = _find_context(latest, FINAL_CONTEXT)
         status = final.status.lower() if final is not None else "pending"
         log(config, f"Managed CI context '{FINAL_CONTEXT}' status: {status}")
@@ -360,6 +352,15 @@ def wait_for_final_qualification(
             "stale",
         }:
             return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
+        stall_checks = intermediate_managed_checks(latest)
+        if is_wholly_infrastructure_blocked(stall_checks):
+            stall = CiInfrastructureStall(checks=stall_checks.infrastructure_stalls)
+            return ManagedCiOutcome(
+                status="infrastructure_stall",
+                checks=latest,
+                head_sha=live_head,
+                stall=stall,
+            )
         if attempt < attempts - 1:
             runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
     return ManagedCiOutcome(status="timeout", checks=latest, head_sha=expected_head)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -100,6 +100,13 @@ from .evidence_reconciliation import (
     reconcile_evidence,
 )
 from .memory import AgentMemoryContext, prepare_agent_memory
+from .managed_ci import (
+    activate_managed_ci,
+    dispatch_final_qualification,
+    intermediate_managed_checks,
+    publish_round_readiness,
+    wait_for_final_qualification,
+)
 from .migrations import validate_pr_migration_topology
 from .prompts import (
     CompactPlanTailContext,
@@ -5675,6 +5682,12 @@ def run_pr_loop(
             _ensure_parallel_reviewer_workdirs(config, flag_name="--review-parallel", role_label="reviewer")
         log(config, f"Validating PR #{pr_number}")
         validate_open_pr(runner, config=config, pr_number=pr_number)
+        managed_ci = activate_managed_ci(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            metadata=initial_pr_context.metadata,
+        )
         memory = prepare_agent_memory(runner, config)
         reviewer_session_ids: dict[AgentName, str | None] = {}
         unavailable_reviewer_failures: dict[AgentName, AgentInvocationError] = {}
@@ -5726,8 +5739,10 @@ def run_pr_loop(
                     f"One or more reviewers still reported blocking issues after round {allowed_rounds}; human review required."
                 )
             coder_name = agent_display_name(config.coder)
+            pre_review_tests_passed = False
             if pre_review_test_pending:
                 run_pre_review_tests(runner, config)
+                pre_review_tests_passed = bool(config.pre_review_tests and config.test_command)
                 pre_review_test_pending = False
             if round_number == start_round_number:
                 pr_context = initial_pr_context
@@ -5739,6 +5754,12 @@ def run_pr_loop(
             initial_pr_context = pr_context
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
+            if managed_ci is not None and pre_review_tests_passed and pr_metadata.head_sha:
+                publish_round_readiness(
+                    runner,
+                    config=config,
+                    head_sha=pr_metadata.head_sha,
+                )
             human_requirements = _merge_human_requirements(issue_context, pr_context)
             current_resume = resumed_round if resumed_round is not None and round_number == resumed_round.round_number else None
             unresolved_items = _reconcile_human_requirements_ack_item(
@@ -5930,7 +5951,13 @@ def run_pr_loop(
                         # instead of one fetch per reviewer as sequential mode
                         # does, so every concurrently launched prompt and the
                         # post-turn pending-CI-only downgrade agree.
-                        shared_reviewer_pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+                        shared_reviewer_pr_checks = get_pr_checks(
+                            runner, config=config, metadata=pr_metadata
+                        )
+                        if managed_ci is not None:
+                            shared_reviewer_pr_checks = intermediate_managed_checks(
+                                shared_reviewer_pr_checks
+                            )
                         pr_parallel_compact_tail = (
                             CompactPrReviewTailContext(
                                 head_sha=pr_metadata.head_sha,
@@ -6167,7 +6194,11 @@ def run_pr_loop(
                         f"(context mode: {context_mode})",
                     )
                     sync_reviewer_pr_before_review(config, runner, reviewer, pr_number, pr_metadata)
-                    reviewer_pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+                    reviewer_pr_checks = get_pr_checks(
+                        runner, config=config, metadata=pr_metadata
+                    )
+                    if managed_ci is not None:
+                        reviewer_pr_checks = intermediate_managed_checks(reviewer_pr_checks)
                     compact_tail = (
                         CompactPrReviewTailContext(
                             head_sha=pr_metadata.head_sha,
@@ -6704,6 +6735,8 @@ def run_pr_loop(
                     pr_checks = None
                 else:
                     pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
+                    if managed_ci is not None:
+                        pr_checks = intermediate_managed_checks(pr_checks)
                 if pr_checks is not None and not must_fix_items and is_wholly_infrastructure_blocked(pr_checks):
                     # Every remaining blocking/pending signal is external GitHub
                     # Actions infrastructure (a queued check that never started a
@@ -6745,7 +6778,7 @@ def run_pr_loop(
                         "Actions runners recover."
                     )
                     return 0
-                if not must_fix_items and config.watch_pending_ci:
+                if not must_fix_items and config.watch_pending_ci and managed_ci is None:
                     if watch_deadline is None:
                         watch_deadline = time.monotonic() + config.ci_timeout_seconds
                         watch_attempts_remaining = max(
@@ -6992,8 +7025,103 @@ def run_pr_loop(
                     )
                     run_optional_tests(runner, config)
                     if config.auto_merge:
-                        wait_outcome = wait_for_ci(runner, config, pr_number, metadata=pr_metadata)
-                        if wait_outcome.status == "infrastructure_stall":
+                        if managed_ci is not None:
+                            assert pr_metadata.head_sha is not None
+                            assert pr_metadata.head_branch is not None
+                            dispatch_final_qualification(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                expected_head_sha=pr_metadata.head_sha,
+                                head_ref=pr_metadata.head_branch,
+                                contract=managed_ci,
+                            )
+                            managed_outcome = wait_for_final_qualification(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                metadata=pr_metadata,
+                            )
+                            if managed_outcome.status == "passed":
+                                merge_pr(
+                                    runner,
+                                    config,
+                                    pr_number,
+                                    expected_head_sha=pr_metadata.head_sha,
+                                )
+                                print(
+                                    f"PR #{pr_number} approved by "
+                                    f"{format_agent_list(configured_reviewers)}."
+                                )
+                                return 0
+                            if managed_outcome.status == "head_changed":
+                                log(
+                                    config,
+                                    f"PR #{pr_number} head changed during managed CI; re-review is required",
+                                )
+                                if round_number == allowed_rounds and not watch_head_extension_used:
+                                    allowed_rounds += 1
+                                    watch_head_extension_used = True
+                                resumed_round = None
+                                current_resume = None
+                                prefetched_pr_context = get_pr_review_context(
+                                    runner, config=config, pr_number=pr_number
+                                )
+                                continue
+                            if managed_outcome.status == "merge_conflict":
+                                assert managed_outcome.mergeability is not None
+                                latest_mergeability = managed_outcome.mergeability
+                                unresolved_items = _reconcile_merge_conflict_item(
+                                    unresolved_items,
+                                    mergeability=managed_outcome.mergeability,
+                                    source_round=round_number,
+                                    current_head_sha=pr_metadata.head_sha,
+                                )
+                            elif managed_outcome.status == "failed":
+                                details = (
+                                    _pr_check_details(managed_outcome.checks)
+                                    if managed_outcome.checks
+                                    else ["Managed exact-head CI failed."]
+                                )
+                                post_pr_comment(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    body=_format_pr_checks_comment(pr_number, "failing", details),
+                                )
+                                unresolved_items.append(
+                                    _next_unresolved_item(
+                                        item_number=next_unresolved_item_number,
+                                        reviewer="GitHub managed exact-head CI",
+                                        source_round=round_number,
+                                        text=_pr_check_blocking_review(
+                                            pr_number, "failing", details
+                                        ),
+                                        status="blocking",
+                                    )
+                                )
+                                next_unresolved_item_number += 1
+                                if round_number == allowed_rounds and not watch_failure_extension_used:
+                                    allowed_rounds += 1
+                                    watch_failure_extension_used = True
+                            else:
+                                raise AgentLoopError(
+                                    f"Managed exact-head CI for PR #{pr_number} did not pass within "
+                                    f"{config.ci_timeout_seconds}s."
+                                )
+                            must_fix_items = [
+                                item
+                                for item in unresolved_items
+                                if item.status in {"blocking", "same-pr"}
+                            ]
+                            wait_outcome = None
+                        else:
+                            wait_outcome = wait_for_ci(
+                                runner, config, pr_number, metadata=pr_metadata
+                            )
+                        if wait_outcome is None:
+                            pass
+                        elif wait_outcome.status == "infrastructure_stall":
                             assert wait_outcome.stall is not None
                             post_pr_comment(
                                 runner,
@@ -7021,7 +7149,7 @@ def run_pr_loop(
                                 "runners recover."
                             )
                             return 0
-                        if wait_outcome.status == "merge_conflict":
+                        elif wait_outcome.status == "merge_conflict":
                             assert wait_outcome.mergeability is not None
                             latest_mergeability = wait_outcome.mergeability
                             unresolved_items = _reconcile_merge_conflict_item(
@@ -7039,7 +7167,7 @@ def run_pr_loop(
                                 f"{wait_outcome.mergeability.base_branch or config.base or 'the base branch'} "
                                 "during the CI wait; no merge attempted",
                             )
-                        else:
+                        elif managed_ci is None:
                             merge_pr(runner, config, pr_number)
                     if not must_fix_items:
                         print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -7077,6 +7077,38 @@ def run_pr_loop(
                                     source_round=round_number,
                                     current_head_sha=pr_metadata.head_sha,
                                 )
+                            elif managed_outcome.status == "infrastructure_stall":
+                                assert managed_outcome.stall is not None
+                                post_pr_comment(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    body=_format_ci_infrastructure_comment(
+                                        pr_number, managed_outcome.stall
+                                    ),
+                                )
+                                post_pr_comment(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    body=_ci_infrastructure_stop_message(
+                                        pr_number, managed_outcome.stall, []
+                                    ),
+                                )
+                                log(
+                                    config,
+                                    f"Round {round_number}: PR #{pr_number} managed CI wait "
+                                    "stopped on external infrastructure blocking; no merge attempted",
+                                )
+                                print(
+                                    f"PR #{pr_number} was approved by "
+                                    f"{format_agent_list(configured_reviewers)}, but external GitHub "
+                                    "Actions infrastructure is blocking managed exact-head CI "
+                                    f"({'; '.join(_ci_infrastructure_details(managed_outcome.stall))}). "
+                                    "No merge was attempted; rerun the same command once GitHub Actions "
+                                    "runners recover."
+                                )
+                                return 0
                             elif managed_outcome.status == "failed":
                                 details = (
                                     _pr_check_details(managed_outcome.checks)
@@ -7167,7 +7199,7 @@ def run_pr_loop(
                                 f"{wait_outcome.mergeability.base_branch or config.base or 'the base branch'} "
                                 "during the CI wait; no merge attempted",
                             )
-                        elif managed_ci is None:
+                        else:
                             merge_pr(runner, config, pr_number)
                     if not must_fix_items:
                         print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -9,6 +9,7 @@ README = REPO_ROOT / "README.md"
 
 HEADING_TEXT = "Phased decomposition versus split materialization"
 CI_STALL_HEADING_TEXT = "External CI infrastructure stalls"
+MANAGED_CI_HEADING_TEXT = "Managed exact-head CI"
 LOCAL_TEST_SCOPE_HEADING_TEXT = "Focused, bounded local test selection"
 
 
@@ -95,6 +96,22 @@ def test_readme_links_to_ci_infrastructure_stall_section():
     readme_text = README.read_text(encoding="utf-8")
     assert f"docs/local_agent_loop.md#{expected_anchor}" in readme_text
     assert "`--ci-queued-grace-seconds`" in readme_text
+
+
+def test_readme_links_to_managed_exact_head_ci_and_scopes_watch_mode():
+    doc_text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert f"### {MANAGED_CI_HEADING_TEXT}" in doc_text
+    expected_anchor = _github_anchor(MANAGED_CI_HEADING_TEXT)
+
+    readme_text = README.read_text(encoding="utf-8")
+    normalized_readme_text = " ".join(readme_text.split())
+    assert f"docs/local_agent_loop.md#{expected_anchor}" in readme_text
+    assert "`--match-head-commit`" in readme_text
+    assert "merges only that qualified SHA" in normalized_readme_text
+    assert (
+        "`--watch-pending-ci` and `--no-watch-pending-ci` do not alter"
+        in normalized_readme_text
+    )
 
 
 def test_local_agent_loop_doc_has_focused_bounded_local_test_section():

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -12,10 +12,12 @@ from coding_review_agent_loop.github import (
 from coding_review_agent_loop.managed_ci import (
     FINAL_CONTEXT,
     MANAGED_LABEL,
+    READINESS_CONTEXT,
     ManagedCiContract,
     activate_managed_ci,
     dispatch_final_qualification,
     intermediate_managed_checks,
+    publish_round_readiness,
     wait_for_final_qualification,
 )
 from coding_review_agent_loop.runner import CommandResult
@@ -38,9 +40,18 @@ jobs:
 
 
 class ManagedRunner(FakeRunner):
-    def __init__(self, *, workflow=WORKFLOW, **kwargs):
+    def __init__(
+        self,
+        *,
+        workflow=WORKFLOW,
+        base_ref="main",
+        handoff_completes=True,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.workflow = workflow
+        self.base_ref = base_ref
+        self.handoff_completes = handoff_completes
         self.label_applied = False
 
     def _run_locked(self, args, *, cwd, check):
@@ -56,7 +67,7 @@ class ManagedRunner(FakeRunner):
                     "sha": "abc123",
                     "ref": "feature",
                 },
-                "base": {"ref": "main"},
+                "base": {"ref": self.base_ref},
                 "labels": [],
             }
             return CommandResult(cmd, cwd_path, json.dumps(payload), "", 0)
@@ -67,22 +78,24 @@ class ManagedRunner(FakeRunner):
             cmd, cwd_path = self._record_command(args, cwd)
             runs = (
                 [{"id": 2, "status": "completed", "conclusion": "success"}]
-                if self.label_applied
+                if self.label_applied and self.handoff_completes
                 else [{"id": 1, "status": "completed", "conclusion": "success"}]
             )
             return CommandResult(cmd, cwd_path, json.dumps({"workflow_runs": runs}), "", 0)
-        if "repos/OWNER/REPO/issues/7/labels" in cmd:
+        if cmd[:4] == ["gh", "api", "--method", "DELETE"]:
+            self.label_applied = False
+        elif "repos/OWNER/REPO/issues/7/labels" in cmd:
             self.label_applied = True
         return super()._run_locked(args, cwd=cwd, check=check)
 
 
-def metadata():
+def metadata(*, base_branch="main"):
     return PullRequestMetadata(
         number=7,
         repo="OWNER/REPO",
         title="Managed CI",
         head_branch="feature",
-        base_branch="main",
+        base_branch=base_branch,
         head_sha="abc123",
         url="https://github.com/OWNER/REPO/pull/7",
     )
@@ -137,6 +150,51 @@ def test_activate_managed_ci_fails_closed_for_partial_contract(tmp_path):
         activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
 
 
+def test_activate_managed_ci_accepts_resolved_non_main_base(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, base="release")
+    runner = ManagedRunner(
+        base_ref="release",
+        pr_payload={"headRefOid": "abc123"},
+        pr_status_payload={"statuses": [{"context": FINAL_CONTEXT, "state": "pending"}]},
+    )
+
+    assert activate_managed_ci(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=metadata(base_branch="release"),
+    ) == ManagedCiContract()
+
+
+def test_activate_managed_ci_removes_label_when_handoff_times_out(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        ci_timeout_seconds=1,
+        ci_poll_interval_seconds=1,
+    )
+    runner = ManagedRunner(
+        handoff_completes=False,
+        pr_payload={"headRefOid": "abc123"},
+    )
+
+    with pytest.raises(AgentLoopError, match="handoff.*did not complete"):
+        activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert runner.label_applied is False
+    assert any(
+        cmd[:5]
+        == [
+            "gh",
+            "api",
+            "--method",
+            "DELETE",
+            f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}",
+        ]
+        for cmd, _cwd in runner.commands
+    )
+
+
 def test_intermediate_checks_remove_only_expected_final_pending_context():
     final = PullRequestCheck(FINAL_CONTEXT, "status_context", "pending")
     lint = PullRequestCheck("lint", "check_run", "failure")
@@ -185,6 +243,103 @@ def test_dispatch_and_wait_bind_final_qualification_to_exact_head(tmp_path):
     )
     assert "ref=feature" in dispatch
     assert "inputs[expected_head_sha]=abc123" in dispatch
+
+
+def test_publish_round_readiness_posts_success_status(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = FakeRunner()
+
+    publish_round_readiness(runner, config=config, head_sha="abc123")
+
+    assert runner.commands[-1][0] == [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        "repos/OWNER/REPO/statuses/abc123",
+        "-f",
+        "state=success",
+        "-f",
+        f"context={READINESS_CONTEXT}",
+        "-f",
+        "description=Configured local pre-review verification passed",
+    ]
+
+
+def test_wait_for_final_qualification_returns_infrastructure_stall(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        ci_timeout_seconds=1,
+        ci_poll_interval_seconds=1,
+        ci_queued_grace_seconds=1,
+    )
+    runner = ManagedRunner(
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_check_runs_payload={
+            "check_runs": [
+                {
+                    "id": 99,
+                    "name": FINAL_CONTEXT,
+                    "status": "queued",
+                    "conclusion": None,
+                    "html_url": "https://github.com/OWNER/REPO/actions/runs/123/job/99",
+                    "created_at": "2020-01-01T00:00:00Z",
+                    "started_at": None,
+                    "completed_at": None,
+                }
+            ]
+        },
+        pr_status_payload={"state": "pending", "statuses": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata()
+    )
+
+    assert outcome.status == "infrastructure_stall"
+    assert outcome.stall is not None
+    assert outcome.stall.checks[0].name == FINAL_CONTEXT
+
+
+@pytest.mark.parametrize("status", ["startup_failure", "stale"])
+def test_wait_for_final_qualification_treats_all_terminal_failures_as_failed(
+    tmp_path, status
+):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1
+    )
+    runner = ManagedRunner(
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_check_runs_payload={
+            "check_runs": [
+                {
+                    "name": FINAL_CONTEXT,
+                    "status": "completed",
+                    "conclusion": status,
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "completed_at": "2026-01-01T00:01:00Z",
+                }
+            ]
+        },
+        pr_status_payload={"statuses": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata()
+    )
+
+    assert outcome.status == "failed"
 
 
 def test_merge_pr_uses_expected_head_guard(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -284,7 +284,7 @@ def test_wait_for_final_qualification_returns_infrastructure_stall(tmp_path):
             "check_runs": [
                 {
                     "id": 99,
-                    "name": FINAL_CONTEXT,
+                    "name": "test (pr-inline)",
                     "status": "queued",
                     "conclusion": None,
                     "html_url": "https://github.com/OWNER/REPO/actions/runs/123/job/99",
@@ -294,7 +294,10 @@ def test_wait_for_final_qualification_returns_infrastructure_stall(tmp_path):
                 }
             ]
         },
-        pr_status_payload={"state": "pending", "statuses": []},
+        pr_status_payload={
+            "state": "pending",
+            "statuses": [{"context": FINAL_CONTEXT, "state": "pending"}],
+        },
         pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
     )
 
@@ -304,7 +307,7 @@ def test_wait_for_final_qualification_returns_infrastructure_stall(tmp_path):
 
     assert outcome.status == "infrastructure_stall"
     assert outcome.stall is not None
-    assert outcome.stall.checks[0].name == FINAL_CONTEXT
+    assert outcome.stall.checks[0].name == "test (pr-inline)"
 
 
 @pytest.mark.parametrize("status", ["startup_failure", "stale"])

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1,0 +1,197 @@
+import json
+
+import pytest
+
+from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.github import (
+    PullRequestCheck,
+    PullRequestChecks,
+    PullRequestMetadata,
+    merge_pr,
+)
+from coding_review_agent_loop.managed_ci import (
+    FINAL_CONTEXT,
+    MANAGED_LABEL,
+    ManagedCiContract,
+    activate_managed_ci,
+    dispatch_final_qualification,
+    intermediate_managed_checks,
+    wait_for_final_qualification,
+)
+from coding_review_agent_loop.runner import CommandResult
+
+from agent_loop_helpers import FakeRunner, make_config
+
+
+WORKFLOW = """
+name: CI
+on:
+  workflow_dispatch:
+    inputs:
+      expected_head_sha: {required: true}
+jobs:
+  route:
+    if: contains(github.event.pull_request.labels.*.name, 'agent-loop-managed')
+  aggregate:
+    name: final-ci/exact-head
+"""
+
+
+class ManagedRunner(FakeRunner):
+    def __init__(self, *, workflow=WORKFLOW, **kwargs):
+        super().__init__(**kwargs)
+        self.workflow = workflow
+        self.label_applied = False
+
+    def _run_locked(self, args, *, cwd, check):
+        cmd = list(args)
+        if cmd[:3] == ["gh", "api", "repos/OWNER/REPO/contents/.github/workflows/ci.yml"]:
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, self.workflow, "", 0)
+        if cmd[:3] == ["gh", "api", "repos/OWNER/REPO/pulls/7"]:
+            cmd, cwd_path = self._record_command(args, cwd)
+            payload = {
+                "head": {
+                    "repo": {"full_name": "OWNER/REPO"},
+                    "sha": "abc123",
+                    "ref": "feature",
+                },
+                "base": {"ref": "main"},
+                "labels": [],
+            }
+            return CommandResult(cmd, cwd_path, json.dumps(payload), "", 0)
+        if cmd[:3] == ["gh", "api", f"repos/OWNER/REPO/labels/{MANAGED_LABEL}"]:
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, "{}", "", 0)
+        if "repos/OWNER/REPO/actions/workflows/ci.yml/runs?" in " ".join(cmd):
+            cmd, cwd_path = self._record_command(args, cwd)
+            runs = (
+                [{"id": 2, "status": "completed", "conclusion": "success"}]
+                if self.label_applied
+                else [{"id": 1, "status": "completed", "conclusion": "success"}]
+            )
+            return CommandResult(cmd, cwd_path, json.dumps({"workflow_runs": runs}), "", 0)
+        if "repos/OWNER/REPO/issues/7/labels" in cmd:
+            self.label_applied = True
+        return super()._run_locked(args, cwd=cwd, check=check)
+
+
+def metadata():
+    return PullRequestMetadata(
+        number=7,
+        repo="OWNER/REPO",
+        title="Managed CI",
+        head_branch="feature",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/7",
+    )
+
+
+def checks(*, pending=(), passing=(), failing=(), required=(FINAL_CONTEXT,), missing=()):
+    return PullRequestChecks(
+        state="failing" if failing else "pending" if pending else "passing",
+        required_checks=required,
+        passing=passing,
+        pending=pending,
+        failing=failing,
+        missing_required=missing,
+        branch_protection_status="configured",
+    )
+
+
+def test_activate_managed_ci_only_for_complete_supported_contract(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = ManagedRunner(
+        pr_payload={"headRefOid": "abc123"},
+        pr_status_payload={
+            "statuses": [{"context": FINAL_CONTEXT, "state": "pending"}]
+        },
+    )
+
+    contract = activate_managed_ci(
+        runner, config=config, pr_number=7, metadata=metadata()
+    )
+
+    assert contract == ManagedCiContract()
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"]
+        for cmd, _cwd in runner.commands
+    )
+
+
+def test_activate_managed_ci_preserves_legacy_behavior_without_markers(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = ManagedRunner(workflow="name: CI\n")
+
+    assert activate_managed_ci(
+        runner, config=config, pr_number=7, metadata=metadata()
+    ) is None
+
+
+def test_activate_managed_ci_fails_closed_for_partial_contract(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = ManagedRunner(workflow=f"name: CI\n# {MANAGED_LABEL}\n")
+
+    with pytest.raises(AgentLoopError, match="incomplete managed-CI contract"):
+        activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+
+def test_intermediate_checks_remove_only_expected_final_pending_context():
+    final = PullRequestCheck(FINAL_CONTEXT, "status_context", "pending")
+    lint = PullRequestCheck("lint", "check_run", "failure")
+
+    filtered = intermediate_managed_checks(
+        checks(
+            pending=(final,),
+            failing=(lint,),
+            required=(FINAL_CONTEXT, "test (pr-inline)"),
+            missing=("test (pr-inline)",),
+        )
+    )
+
+    assert filtered.state == "failing"
+    assert filtered.required_checks == ("test (pr-inline)",)
+    assert filtered.pending == ()
+    assert filtered.failing == (lint,)
+    assert filtered.missing_required == ()
+
+
+def test_dispatch_and_wait_bind_final_qualification_to_exact_head(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, ci_poll_interval_seconds=1)
+    final = {"context": FINAL_CONTEXT, "state": "success", "target_url": None}
+    runner = ManagedRunner(
+        pr_payload={"headRefOid": "abc123", "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+        pr_status_payload={"statuses": [final]},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+
+    dispatch_final_qualification(
+        runner,
+        config=config,
+        pr_number=7,
+        expected_head_sha="abc123",
+        head_ref="feature",
+        contract=ManagedCiContract(),
+    )
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata()
+    )
+
+    assert outcome.status == "passed"
+    dispatch = next(
+        cmd for cmd, _cwd in runner.commands
+        if "repos/OWNER/REPO/actions/workflows/ci.yml/dispatches" in cmd
+    )
+    assert "ref=feature" in dispatch
+    assert "inputs[expected_head_sha]=abc123" in dispatch
+
+
+def test_merge_pr_uses_expected_head_guard(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = FakeRunner()
+
+    merge_pr(runner, config, 7, expected_head_sha="abc123")
+
+    command = runner.commands[-1][0]
+    assert command[-2:] == ["--match-head-commit", "abc123"]

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -26,6 +26,7 @@ from coding_review_agent_loop.github import (
     get_pr_checks,
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult
+from coding_review_agent_loop.managed_ci import ManagedCiContract, ManagedCiOutcome
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     PostedRoundMetadata,
@@ -926,6 +927,47 @@ def test_watch_mode_success_skips_legacy_wait_for_ci(
         cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "pr", "merge"]
     ]
     assert bool(merge_commands) is auto_merge
+
+
+def test_auto_merge_supported_repo_dispatches_and_merges_exact_approved_head(
+    tmp_path, monkeypatch
+):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]
+    )
+    config = make_config(tmp_path, watch_pending_ci=True, auto_merge=True)
+    monkeypatch.setattr(
+        orchestrator,
+        "activate_managed_ci",
+        lambda *args, **kwargs: ManagedCiContract(),
+    )
+    dispatches = []
+    monkeypatch.setattr(
+        orchestrator,
+        "dispatch_final_qualification",
+        lambda *args, **kwargs: dispatches.append(kwargs),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_final_qualification",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed", head_sha="abc123"),
+    )
+    merges = []
+    monkeypatch.setattr(
+        orchestrator,
+        "merge_pr",
+        lambda *args, **kwargs: merges.append(kwargs),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "watch_pr_checks",
+        lambda *args, **kwargs: pytest.fail("managed CI must bypass the ordinary watcher"),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert dispatches[0]["expected_head_sha"] == "abc123"
+    assert merges == [{"expected_head_sha": "abc123"}]
 
 
 def test_watch_failure_on_final_round_dispatches_coder_with_check_diagnostic(

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import coding_review_agent_loop.orchestrator as orchestrator
+from coding_review_agent_loop.ci_health import CiInfrastructureStall, StalledCheck
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop, run_pr_loop
 from coding_review_agent_loop.comment_rendering import (
     _render_public_coder_followup_comment,
@@ -22,6 +23,7 @@ from coding_review_agent_loop.github import (
     PullRequestCheck,
     PullRequestChecks,
     PullRequestMetadata,
+    PullRequestMergeability,
     PullRequestReviewContext,
     get_pr_checks,
 )
@@ -968,6 +970,264 @@ def test_auto_merge_supported_repo_dispatches_and_merges_exact_approved_head(
 
     assert dispatches[0]["expected_head_sha"] == "abc123"
     assert merges == [{"expected_head_sha": "abc123"}]
+
+
+def test_managed_ci_failure_routes_back_to_coder_and_uses_failure_extension(
+    tmp_path, monkeypatch
+):
+    failed_check = PullRequestCheck(
+        name="final-ci/exact-head",
+        kind="check_run",
+        status="failure",
+        url="https://github.com/OWNER/REPO/actions/runs/555",
+    )
+    failed_checks = _watch_check_board("failing", failing=(failed_check,))
+    outcomes = iter(
+        [
+            ManagedCiOutcome(status="failed", checks=failed_checks, head_sha="abc123"),
+            ManagedCiOutcome(status="passed", head_sha="abc123-coder-1"),
+        ]
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Approved."),
+            structured_pr_review(
+                state="approved",
+                summary="Approved after managed CI fix.",
+                prior_item_dispositions=[
+                    {"item_id": "item-1", "disposition": "resolved"}
+                ],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking",
+                summary="Fixed managed CI.",
+                addressed_items=["item-1"],
+            )
+        ],
+    )
+    config = make_config(tmp_path, auto_merge=True, max_rounds=1)
+    monkeypatch.setattr(
+        orchestrator, "activate_managed_ci", lambda *args, **kwargs: ManagedCiContract()
+    )
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        orchestrator, "wait_for_final_qualification", lambda *args, **kwargs: next(outcomes)
+    )
+    merges = []
+    monkeypatch.setattr(orchestrator, "merge_pr", lambda *args, **kwargs: merges.append(kwargs))
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    coder_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "GitHub managed exact-head CI unresolved blocking item [item-1]" in coder_prompt
+    assert "final-ci/exact-head (failure)" in coder_prompt
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 2
+    assert merges == [{"expected_head_sha": "abc123-coder-1"}]
+
+
+def test_managed_ci_head_change_restarts_review_without_coder(tmp_path, monkeypatch):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Old head approved."),
+            structured_pr_review(state="approved", summary="New head approved."),
+        ]
+    )
+    config = make_config(tmp_path, auto_merge=True, max_rounds=1)
+    monkeypatch.setattr(
+        orchestrator, "activate_managed_ci", lambda *args, **kwargs: ManagedCiContract()
+    )
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    call_count = 0
+
+    def wait_for_managed_ci(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            runner.pr_payload["headRefOid"] = "new-head"
+            return ManagedCiOutcome(status="head_changed", head_sha="new-head")
+        return ManagedCiOutcome(status="passed", head_sha="new-head")
+
+    monkeypatch.setattr(orchestrator, "wait_for_final_qualification", wait_for_managed_ci)
+    merges = []
+    monkeypatch.setattr(orchestrator, "merge_pr", lambda *args, **kwargs: merges.append(kwargs))
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert call_count == 2
+    assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 2
+    assert merges == [{"expected_head_sha": "new-head"}]
+
+
+def test_managed_ci_merge_conflict_routes_through_reconciliation(tmp_path, monkeypatch):
+    conflict = PullRequestMergeability(
+        state="conflicted",
+        mergeable_raw="CONFLICTING",
+        merge_state_raw="DIRTY",
+        head_sha="abc123",
+        base_branch="main",
+    )
+    outcomes = iter(
+        [
+            ManagedCiOutcome(
+                status="merge_conflict",
+                mergeability=conflict,
+                head_sha="abc123",
+            ),
+            ManagedCiOutcome(status="passed", head_sha="abc123-coder-1"),
+        ]
+    )
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Approved before conflict."),
+            structured_pr_review(state="approved", summary="Approved after rebase."),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking", summary="Rebased and resolved the conflict."
+            )
+        ],
+    )
+    config = make_config(tmp_path, auto_merge=True, max_rounds=2)
+    monkeypatch.setattr(
+        orchestrator, "activate_managed_ci", lambda *args, **kwargs: ManagedCiContract()
+    )
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        orchestrator, "wait_for_final_qualification", lambda *args, **kwargs: next(outcomes)
+    )
+    monkeypatch.setattr(orchestrator, "merge_pr", lambda *args, **kwargs: None)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    coder_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "merge conflict with its base branch `main`" in coder_prompt
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:2] == ["codex", "exec"]]) == 2
+
+
+def test_managed_ci_infrastructure_stall_stops_cleanly(tmp_path, monkeypatch):
+    stalled_check = StalledCheck(
+        name="final-ci/exact-head",
+        kind="check_run",
+        reason="queued_too_long",
+        check_id=99,
+        run_id="555",
+        url="https://github.com/OWNER/REPO/actions/runs/555",
+        age_seconds=1800,
+    )
+    stall = CiInfrastructureStall(checks=(stalled_check,))
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]
+    )
+    config = make_config(tmp_path, auto_merge=True, max_rounds=1)
+    monkeypatch.setattr(
+        orchestrator, "activate_managed_ci", lambda *args, **kwargs: ManagedCiContract()
+    )
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_final_qualification",
+        lambda *args, **kwargs: ManagedCiOutcome(
+            status="infrastructure_stall", head_sha="abc123", stall=stall
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "merge_pr",
+        lambda *args, **kwargs: pytest.fail("infrastructure stall must not merge"),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert any(
+        comment.startswith("External GitHub Actions infrastructure is blocking PR #77.")
+        for comment in runner.comments
+    )
+    assert runner.comments[-1].startswith(
+        "PR #77 is blocked on external GitHub Actions infrastructure, not a code defect."
+    )
+
+
+@pytest.mark.parametrize(
+    ("pre_review_tests", "test_command"),
+    [(False, ("python", "-m", "pytest", "focused")), (True, None)],
+)
+def test_managed_ci_does_not_publish_readiness_without_configured_pre_review_gate(
+    tmp_path, monkeypatch, pre_review_tests, test_command
+):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]
+    )
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        pre_review_tests=pre_review_tests,
+        test_command=test_command,
+    )
+    monkeypatch.setattr(
+        orchestrator, "activate_managed_ci", lambda *args, **kwargs: ManagedCiContract()
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "publish_round_readiness",
+        lambda *args, **kwargs: pytest.fail("readiness must not be published"),
+    )
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_final_qualification",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed", head_sha="abc123"),
+    )
+    monkeypatch.setattr(orchestrator, "merge_pr", lambda *args, **kwargs: None)
+
+    assert run_pr_loop(
+        runner,
+        pr_number=77,
+        config=config,
+        pre_review_test_pending=True,
+    ) == 0
+
+
+def test_managed_ci_publishes_readiness_after_configured_pre_review_gate(
+    tmp_path, monkeypatch
+):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]
+    )
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        pre_review_tests=True,
+        test_command=("verify-managed-head",),
+    )
+    monkeypatch.setattr(
+        orchestrator, "activate_managed_ci", lambda *args, **kwargs: ManagedCiContract()
+    )
+    published_heads = []
+    monkeypatch.setattr(
+        orchestrator,
+        "publish_round_readiness",
+        lambda *args, **kwargs: published_heads.append(kwargs["head_sha"]),
+    )
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_final_qualification",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed", head_sha="abc123"),
+    )
+    monkeypatch.setattr(orchestrator, "merge_pr", lambda *args, **kwargs: None)
+
+    assert run_pr_loop(
+        runner,
+        pr_number=77,
+        config=config,
+        pre_review_test_pending=True,
+    ) == 0
+
+    assert published_heads == ["abc123"]
+    assert ["verify-managed-head"] in [cmd for cmd, _cwd in runner.commands]
 
 
 def test_watch_failure_on_final_round_dispatches_coder_with_check_diagnostic(


### PR DESCRIPTION
## Context

`wwind123/llm-dialectic#714` implemented the repository-owned half of the managed exact-head CI contract. The external driver was intentionally out of scope because the iterative reviewer/coder loop lives in this repository, but the dependency was then easy to miss when the parent work was closed. Consequently, full hosted CI still ran on intermediate agent-loop heads.

Fixes #641.

## Changes

- Auto-detect the complete repository contract during `--auto-merge` runs while preserving legacy behavior elsewhere.
- Validate same-repository/main eligibility, create and apply `agent-loop-managed`, and wait for the label handoff before review.
- Hide only contract-controlled intermediate CI absence while retaining observed non-final failures.
- Publish non-required round readiness only after a configured pre-review command passes.
- Dispatch the final workflow with the approved head SHA, poll `final-ci/exact-head`, and route a real failure back to the coder.
- Restart review when the head moves and merge with `--match-head-commit` after exact-head success.
- Document the behavior and add focused contract/orchestrator coverage.

## Safety

- Partial contracts fail closed before CI suppression.
- Forks and non-`main` PRs retain ordinary CI.
- A delayed label event cannot overwrite final success because activation waits for the label handoff.
- Unsupported repositories and non-auto-merge runs are unchanged.

## Verification

- `python -m pytest tests/test_managed_ci.py tests/test_orchestrator_pr.py -q` (`172 passed`)
- `python -m pytest -q` (passed)
- `python -m py_compile src/coding_review_agent_loop/managed_ci.py src/coding_review_agent_loop/orchestrator.py src/coding_review_agent_loop/github.py tests/test_managed_ci.py`
- `git diff --check`

-- OpenAI Codex
