### PR TITLE
Add authenticated managed CI v2 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,10 @@ With `--auto-merge`, repositories that advertise the managed exact-head CI
 contract use a dedicated flow. The v2 rollout atomically opens a trusted draft
 with `agent-loop-managed`, dispatches qualification from the base workflow,
 and accepts only nonce/run/attempt-correlated statuses; v1 keeps its post-open
-label handoff. Agent-loop may
+label handoff. V2 is enabled only when `--managed-ci-trusted-actor <login>`
+matches both the authenticated GitHub CLI user and the repository Actions
+variable `AGENT_LOOP_MANAGED_ACTOR`; without that explicit trust configuration,
+the normal CI path remains in effect. Agent-loop may
 publish local round readiness after a configured pre-review test succeeds,
 dispatches final CI for the reviewers' exact approved SHA, and merges only that
 qualified SHA with `--match-head-commit`. `--watch-pending-ci` and

--- a/README.md
+++ b/README.md
@@ -638,7 +638,10 @@ being treated as unresolved. See
 [Merge conflicts](docs/local_agent_loop.md#merge-conflicts) for details.
 
 With `--auto-merge`, repositories that advertise the managed exact-head CI
-contract use a dedicated flow: agent-loop applies `agent-loop-managed`, may
+contract use a dedicated flow. The v2 rollout atomically opens a trusted draft
+with `agent-loop-managed`, dispatches qualification from the base workflow,
+and accepts only nonce/run/attempt-correlated statuses; v1 keeps its post-open
+label handoff. Agent-loop may
 publish local round readiness after a configured pre-review test succeeds,
 dispatches final CI for the reviewers' exact approved SHA, and merges only that
 qualified SHA with `--match-head-commit`. `--watch-pending-ci` and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1262,6 +1262,49 @@ Failing GitHub checks always block approval and can route back to the coder. Pen
 
 ### Managed exact-head CI
 
+#### v2 authenticated opening and exact-head provenance
+
+V2 is an explicit opt-in migration that prevents the opening-event matrix race.
+Set the base repository Actions variable `AGENT_LOOP_MANAGED_ACTOR` and pass
+the same login with `--managed-ci-trusted-actor`. Agent-loop verifies both that
+variable and the authenticated `gh api user` login/ID, reads the workflow from
+the resolved base ref, and requires its `AGENT_LOOP_MANAGED_CI_V2` marker.
+Missing/mismatched trust disables v2 suppression; marker-free repositories use
+ordinary CI and complete v1 workflows keep their post-open label handoff.
+
+For auto-merge issue work, a v2 preflight gives the coder an atomic creation
+intent: create or verify `agent-loop-managed`, use the reserved
+`agent-loop/managed-<issue>` branch, then run `gh pr create --draft --label
+agent-loop-managed`. The workflow can suppress opened/reopened/synchronize
+matrices only for the complete tuple: same-repository head, trusted REST
+author, reserved branch, draft, and label. A contributor-editable label,
+branch, or body alone is never trusted. Forks, ordinary PRs, and prematurely
+ready managed PRs retain regular CI; removing the managed label from a draft is
+the explicit recovery path back to ordinary current-head CI.
+
+V2 dispatches `ci.yml` at the base ref with protocol version, PR, exact SHA,
+and a random nonce. The workflow run name, checkout verification, per-PR/SHA
+concurrency group, and always-running publisher must carry those inputs. Its
+`final-ci/exact-head` status description includes nonce, run ID, and attempt,
+and targets that run. Agent-loop persists one actor-owned hidden
+`AGENT_MANAGED_CI_INTENT_V2` comment, rediscovers it after interruption, and
+converges same-nonce duplicate dispatches to the newest surviving run. It
+accepts neither green nor red same-context statuses unless publisher, nonce,
+attached run, and latest attempt all correlate. A failure is reported from the
+validated run's failing jobs, not base-ref PR checks.
+
+After correlated success, agent-loop applies `agent-loop-exact-head-qualified`,
+marks the PR ready, rechecks its head, and merges with `--match-head-commit`.
+Interrupted labeled drafts remain non-mergeable; rerun the issue loop to resume
+the intent, or remove the managed label to deliberately release ordinary CI.
+
+A v2 issue-created PR has zero billed routing jobs at opening, zero hosted
+minutes per intermediate revision, one final matrix, and one rounded
+publisher/aggregate minute—about 11–14 minutes for a 10–13 minute matrix.
+`agent-loop pr <n>` has already paid the ordinary opening matrix and remains
+roughly the earlier 20–25-minute shape plus recovery work. Keep routing,
+aggregate, and qualification telemetry separate for billing comparisons.
+
 Under `--auto-merge`, agent-loop automatically detects a same-repository PR
 whose `.github/workflows/ci.yml` advertises the `agent-loop-managed`,
 `final-ci/exact-head`, and `expected_head_sha` contract. It applies the managed

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1272,6 +1272,32 @@ the resolved base ref, and requires its `AGENT_LOOP_MANAGED_CI_V2` marker.
 Missing/mismatched trust disables v2 suppression; marker-free repositories use
 ordinary CI and complete v1 workflows keep their post-open label handoff.
 
+Participating repositories must make the v2 workflow contract literal and
+complete. The committed `.github/workflows/ci.yml` must contain all of these
+feature markers exactly: `AGENT_LOOP_MANAGED_CI_V2`, `workflow_dispatch`,
+`managed_nonce`, and `final-ci/exact-head`. Its `workflow_dispatch` inputs must
+be named `protocol_version`, `pr_number`, `expected_head_sha`, and
+`managed_nonce`. The dispatched workflow must set this exact run name (where
+`managed_nonce` is the input):
+
+```yaml
+run-name: managed-ci-v2 nonce=${{ inputs.managed_nonce }}
+```
+
+The final publisher must post the `final-ci/exact-head` commit status to
+`expected_head_sha`, with a semicolon-delimited description containing these
+exact tokens (in any order):
+
+```text
+nonce=<managed_nonce>;run_id=<github.run_id>;attempt=<github.run_attempt>
+```
+
+Its `target_url` must end in `/actions/runs/<github.run_id>`. Agent-loop
+matches each token and the final URL path segment exactly; a matching prefix,
+another run, or an earlier rerun attempt is not accepted. The publisher should
+run under `github-actions[bot]` (or the configured trusted actor when posting
+through that account).
+
 For auto-merge issue work, a v2 preflight gives the coder an atomic creation
 intent: create or verify `agent-loop-managed`, use the reserved
 `agent-loop/managed-<issue>` branch, then run `gh pr create --draft --label

--- a/src/coding_review_agent_loop/ci_health.py
+++ b/src/coding_review_agent_loop/ci_health.py
@@ -25,6 +25,9 @@ class PullRequestCheck:
     created_at: str | None = None
     started_at: str | None = None
     completed_at: str | None = None
+    creator_login: str | None = None
+    creator_id: int | None = None
+    description: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -137,6 +137,14 @@ def build_parser() -> argparse.ArgumentParser:
             help=f"Maximum review/revision rounds (default: {DEFAULT_MAX_ROUNDS}).",
         )
         subparser.add_argument("--auto-merge", action="store_true")
+        subparser.add_argument(
+            "--managed-ci-trusted-actor",
+            default=None,
+            help=(
+                "GitHub login trusted for v2 managed CI; must match the repository "
+                "Actions variable AGENT_LOOP_MANAGED_ACTOR."
+            ),
+        )
         subparser.add_argument("--dry-run", action="store_true")
         subparser.add_argument(
             "--implementation-coder",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -175,6 +175,9 @@ class AgentLoopConfig:
     # invocations enable this automatically with --auto-merge; direct config
     # constructions remain conservative unless they set it explicitly.
     watch_pending_ci: bool = False
+    # Optional v2 managed-CI identity. A repository must independently opt in
+    # with its Actions variable before this can suppress any automatic matrix.
+    managed_ci_trusted_actor: str | None = None
     invocation_argv: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -950,6 +953,7 @@ def config_from_args(
             if getattr(args, "watch_pending_ci", None) is None
             else bool(args.watch_pending_ci)
         ),
+        managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
         invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -47,11 +47,6 @@ class PullRequestMetadata:
     head_sha: str | None
     url: str | None
     body: str | None = None
-    author_login: str | None = None
-    author_id: int | None = None
-    head_repo: str | None = None
-    is_draft: bool | None = None
-    labels: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -424,23 +419,12 @@ def _parse_pr_metadata(
         head_sha=_optional_str(data.get("headRefOid")),
         url=_optional_str(data.get("url")),
         body=_optional_str(data.get("body")),
-        author_login=_author_login(data.get("author")),
-        author_id=_author_id(data.get("author")),
-        head_repo=_optional_str((data.get("headRepository") or {}).get("nameWithOwner"))
-        if isinstance(data.get("headRepository"), dict)
-        else None,
-        is_draft=data.get("isDraft") if isinstance(data.get("isDraft"), bool) else None,
-        labels=tuple(
-            label.get("name")
-            for label in ((data.get("labels") or {}).get("nodes") or [])
-            if isinstance(label, dict) and isinstance(label.get("name"), str)
-        ) if isinstance(data.get("labels"), dict) else (),
     )
 
 
 def _author_login(raw: object) -> str | None:
     if isinstance(raw, dict):
-        login = raw.get("login")
+        login = raw.get("login") or raw.get("slug")
         return str(login) if login else None
     return None
 
@@ -695,7 +679,6 @@ def _parse_check_runs_payload(payload: object) -> tuple[list[PullRequestCheck], 
                 started_at=_optional_str(raw_check.get("started_at")),
                 completed_at=_optional_str(raw_check.get("completed_at")),
                 creator_login=_author_login(raw_check.get("app")),
-                creator_id=_author_id(raw_check.get("app")),
                 description=(
                     _optional_str(raw_check["output"].get("summary"))
                     if isinstance(raw_check.get("output"), dict)

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -47,6 +47,11 @@ class PullRequestMetadata:
     head_sha: str | None
     url: str | None
     body: str | None = None
+    author_login: str | None = None
+    author_id: int | None = None
+    head_repo: str | None = None
+    is_draft: bool | None = None
+    labels: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -419,6 +424,17 @@ def _parse_pr_metadata(
         head_sha=_optional_str(data.get("headRefOid")),
         url=_optional_str(data.get("url")),
         body=_optional_str(data.get("body")),
+        author_login=_author_login(data.get("author")),
+        author_id=_author_id(data.get("author")),
+        head_repo=_optional_str((data.get("headRepository") or {}).get("nameWithOwner"))
+        if isinstance(data.get("headRepository"), dict)
+        else None,
+        is_draft=data.get("isDraft") if isinstance(data.get("isDraft"), bool) else None,
+        labels=tuple(
+            label.get("name")
+            for label in ((data.get("labels") or {}).get("nodes") or [])
+            if isinstance(label, dict) and isinstance(label.get("name"), str)
+        ) if isinstance(data.get("labels"), dict) else (),
     )
 
 
@@ -426,6 +442,12 @@ def _author_login(raw: object) -> str | None:
     if isinstance(raw, dict):
         login = raw.get("login")
         return str(login) if login else None
+    return None
+
+
+def _author_id(raw: object) -> int | None:
+    if isinstance(raw, dict) and isinstance(raw.get("id"), int):
+        return raw["id"]
     return None
 
 
@@ -672,6 +694,13 @@ def _parse_check_runs_payload(payload: object) -> tuple[list[PullRequestCheck], 
                 created_at=_optional_str(raw_check.get("created_at")),
                 started_at=_optional_str(raw_check.get("started_at")),
                 completed_at=_optional_str(raw_check.get("completed_at")),
+                creator_login=_author_login(raw_check.get("app")),
+                creator_id=_author_id(raw_check.get("app")),
+                description=(
+                    _optional_str(raw_check["output"].get("summary"))
+                    if isinstance(raw_check.get("output"), dict)
+                    else None
+                ),
             )
         )
     return checks, errors
@@ -697,6 +726,9 @@ def _parse_commit_statuses_payload(payload: object) -> tuple[list[PullRequestChe
                 url=_optional_str(raw_status.get("target_url")),
                 created_at=_optional_str(raw_status.get("created_at")),
                 completed_at=_optional_str(raw_status.get("updated_at")),
+                creator_login=_author_login(raw_status.get("creator")),
+                creator_id=_author_id(raw_status.get("creator")),
+                description=_optional_str(raw_status.get("description")),
             )
         )
     return checks, errors

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -7,6 +7,7 @@ import secrets
 import time
 from dataclasses import dataclass, replace
 from typing import Literal
+from urllib.parse import urlparse
 
 from .ci_health import (
     CiInfrastructureStall,
@@ -138,7 +139,6 @@ def activate_managed_ci(
             config=config,
             pr_number=pr_number,
             metadata=metadata,
-            workflow=workflow,
         )
 
     pr_result = runner.run(
@@ -298,7 +298,6 @@ def _activate_v2_managed_ci(
     config: AgentLoopConfig,
     pr_number: int,
     metadata: PullRequestMetadata,
-    workflow: str,
 ) -> ManagedCiContract | None:
     """Validate the non-forgeable v2 opening tuple without mutating a PR.
 
@@ -610,8 +609,8 @@ def _ensure_v2_intent(
         try:
             parsed = json.loads(comments_result.stdout or "[]")
             comments = parsed if isinstance(parsed, list) else []
-        except json.JSONDecodeError:
-            raise AgentLoopError("Managed-CI intent comments response was invalid JSON.")
+        except json.JSONDecodeError as exc:
+            raise AgentLoopError("Managed-CI intent comments response was invalid JSON.") from exc
     matching: list[tuple[int, dict[str, object]]] = []
     for raw in comments:
         if not isinstance(raw, dict):
@@ -689,7 +688,6 @@ def _discover_v2_run(runner: Runner, *, config: AgentLoopConfig, contract: Manag
     if not contract.nonce:
         return None
     run_name = _v2_run_name(contract)
-    candidates: list[dict[str, object]] = []
     for attempt in range(retries):
         result = runner.run(
             [config.gh_cmd, "api", f"repos/{config.repo}/actions/workflows/{contract.workflow_file}/runs?event=workflow_dispatch&per_page=100"],
@@ -715,6 +713,41 @@ def _discover_v2_run(runner: Runner, *, config: AgentLoopConfig, contract: Manag
         if attempt < retries - 1:
             runner.run(["sleep", str(min(config.ci_poll_interval_seconds, 2))], cwd=active_workdir(config))
     return None
+
+
+def _refresh_v2_attached_run_attempt(
+    runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract
+) -> int | None:
+    """Read the current attempt for the already-attached workflow run.
+
+    GitHub increments ``run_attempt`` when a run is re-run.  The run ID remains
+    the durable correlation key, so status validation must follow that current
+    attempt rather than the attempt present when agent-loop dispatched it.
+    """
+    if contract.attached_run_id is None or not contract.nonce:
+        return None
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/actions/runs/{contract.attached_run_id}",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        run = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(run, dict) or run.get("id") != contract.attached_run_id:
+        return None
+    run_name = _v2_run_name(contract)
+    if not _is_v2_intent_run(run, contract=contract, run_name=run_name):
+        return None
+    attempt = run.get("run_attempt")
+    return attempt if isinstance(attempt, int) else None
 
 
 def _v2_run_name(contract: ManagedCiContract) -> str:
@@ -779,6 +812,13 @@ def wait_for_final_qualification(
                 attached = _discover_v2_run(runner, config=config, contract=contract, retries=1)
                 if attached is not None:
                     contract.attached_run_id, contract.run_attempt = attached
+                    _patch_intent(runner, config=config, contract=contract, state="attached")
+            else:
+                current_attempt = _refresh_v2_attached_run_attempt(
+                    runner, config=config, contract=contract
+                )
+                if current_attempt is not None and current_attempt != contract.run_attempt:
+                    contract.run_attempt = current_attempt
                     _patch_intent(runner, config=config, contract=contract, state="attached")
             final = _v2_correlated_status(
                 runner, config=config, expected_head=expected_head, contract=contract
@@ -862,9 +902,16 @@ def _v2_correlated_status(
             (login or "").casefold() == "github-actions[bot]"
             or (login == contract.trusted_actor_login and creator_id == contract.trusted_actor_id)
         )
-        if not allowed_publisher or not all(token in description for token in required):
+        description_tokens = {token.strip() for token in description.split(";") if token.strip()}
+        if not allowed_publisher or not set(required).issubset(description_tokens):
             continue
-        if f"/actions/runs/{contract.attached_run_id}" not in target:
+        target_path = urlparse(target).path.rstrip("/")
+        target_segments = target_path.split("/")
+        if (
+            len(target_segments) < 3
+            or target_segments[-3:-1] != ["actions", "runs"]
+            or target_segments[-1] != str(contract.attached_run_id)
+        ):
             continue
         return PullRequestCheck(
             name=FINAL_CONTEXT,
@@ -919,12 +966,14 @@ def prepare_v2_merge(
     )
     if labelled.returncode != 0:
         raise AgentLoopError(f"Unable to apply `{QUALIFIED_LABEL}` before readying PR #{pr_number}.")
-    ready = runner.run(
-        [config.gh_cmd, "pr", "ready", str(pr_number), "--repo", config.repo],
-        cwd=active_workdir(config), check=False,
-    )
-    if ready.returncode != 0:
-        raise AgentLoopError(f"Unable to mark qualified PR #{pr_number} ready for review.")
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
+    if pr.get("draft") is True:
+        ready = runner.run(
+            [config.gh_cmd, "pr", "ready", str(pr_number), "--repo", config.repo],
+            cwd=active_workdir(config), check=False,
+        )
+        if ready.returncode != 0:
+            raise AgentLoopError(f"Unable to mark qualified PR #{pr_number} ready for review.")
     if get_pr_head_sha(runner, config, pr_number) != expected_head_sha:
         raise AgentLoopError(f"PR #{pr_number} head changed while it was being readied for merge.")
 

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import secrets
+import time
 from dataclasses import dataclass, replace
 from typing import Literal
 
@@ -27,15 +29,40 @@ from .workdirs import active_workdir
 
 
 MANAGED_LABEL = "agent-loop-managed"
+QUALIFIED_LABEL = "agent-loop-exact-head-qualified"
 FINAL_CONTEXT = "final-ci/exact-head"
 READINESS_CONTEXT = "agent-loop/round-readiness"
 WORKFLOW_FILE = "ci.yml"
 _CONTRACT_MARKERS = (MANAGED_LABEL, FINAL_CONTEXT, "expected_head_sha")
+V2_MARKER = "AGENT_LOOP_MANAGED_CI_V2"
+INTENT_MARKER = "AGENT_MANAGED_CI_INTENT_V2"
+V2_FEATURE_MARKERS = (V2_MARKER, "workflow_dispatch", "managed_nonce", FINAL_CONTEXT)
+
+
+@dataclass
+class ManagedCiContract:
+    workflow_file: str = WORKFLOW_FILE
+    protocol_version: int = 1
+    base_ref: str | None = None
+    trusted_actor_login: str | None = None
+    trusted_actor_id: int | None = None
+    workflow_revision: str | None = None
+    intent_comment_id: int | None = None
+    nonce: str | None = None
+    attached_run_id: int | None = None
+    run_attempt: int | None = None
+    pr_number: int | None = None
+    expected_head_sha: str | None = None
+    repository: str | None = None
+    created_at: int | None = None
 
 
 @dataclass(frozen=True)
-class ManagedCiContract:
-    workflow_file: str = WORKFLOW_FILE
+class ManagedCiCreationIntent:
+    """Instructions that make the opened event atomically recognizable as v2."""
+
+    branch: str
+    trusted_actor: str
 
 
 @dataclass(frozen=True)
@@ -52,6 +79,7 @@ class ManagedCiOutcome:
     mergeability: PullRequestMergeability | None = None
     head_sha: str | None = None
     stall: CiInfrastructureStall | None = None
+    failure_details: tuple[str, ...] = ()
 
 
 def activate_managed_ci(
@@ -92,6 +120,25 @@ def activate_managed_ci(
         raise AgentLoopError(
             "Repository CI advertises an incomplete managed-CI contract; missing marker(s): "
             + ", ".join(missing)
+        )
+
+    # v2 is deliberately an explicit migration.  A v1 workflow continues to
+    # use the post-open label handoff below; a v2 workflow must prove both the
+    # invoking identity and the complete PR creation tuple before it can make
+    # an automatic pull_request matrix disappear.
+    if V2_MARKER in workflow:
+        missing_v2 = tuple(marker for marker in V2_FEATURE_MARKERS if marker not in workflow)
+        if missing_v2:
+            raise AgentLoopError(
+                "Repository CI advertises an incomplete managed-CI v2 contract; missing marker(s): "
+                + ", ".join(missing_v2)
+            )
+        return _activate_v2_managed_ci(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            metadata=metadata,
+            workflow=workflow,
         )
 
     pr_result = runner.run(
@@ -210,6 +257,146 @@ def activate_managed_ci(
     return ManagedCiContract()
 
 
+def preflight_managed_ci_creation(
+    runner: Runner, *, config: AgentLoopConfig, issue_number: int
+) -> ManagedCiCreationIntent | None:
+    """Return an atomic creation intent only for an authenticated v2 rollout.
+
+    This happens before the coder is prompted, avoiding the opened-event race:
+    the PR is born as a draft with its managed label, or it is ordinary CI.
+    """
+    if not config.auto_merge or config.dry_run or not config.managed_ci_trusted_actor or not config.base:
+        return None
+    workflow = runner.run(
+        [
+            config.gh_cmd, "api",
+            f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}?ref={config.base}",
+            "-H", "Accept: application/vnd.github.raw+json",
+        ], cwd=active_workdir(config), check=False,
+    )
+    if workflow.returncode != 0 or V2_MARKER not in (workflow.stdout or ""):
+        return None
+    if any(marker not in (workflow.stdout or "") for marker in V2_FEATURE_MARKERS):
+        raise AgentLoopError("Repository CI advertises an incomplete managed-CI v2 contract.")
+    who = _api_json(runner, config, "user", quiet=True)
+    actor = who.get("login") if isinstance(who.get("login"), str) else None
+    advertised = _api_json(
+        runner, config, f"repos/{config.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR", quiet=True
+    ).get("value")
+    if not isinstance(actor, str) or not isinstance(advertised, str):
+        return None
+    if actor.casefold() != config.managed_ci_trusted_actor.casefold() or actor.casefold() != advertised.casefold():
+        return None
+    return ManagedCiCreationIntent(
+        branch=f"agent-loop/managed-{issue_number}", trusted_actor=actor
+    )
+
+
+def _activate_v2_managed_ci(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+    workflow: str,
+) -> ManagedCiContract | None:
+    """Validate the non-forgeable v2 opening tuple without mutating a PR.
+
+    Labels and branch names are only continuity/convention signals here.  The
+    REST author identity is checked against both the configured actor and the
+    repository Actions variable, which is not contributor-editable.
+    """
+    configured = (config.managed_ci_trusted_actor or "").strip()
+    if not configured:
+        return None
+    who = _api_json(runner, config, "user")
+    actor_login = who.get("login") if isinstance(who.get("login"), str) else None
+    actor_id = who.get("id") if isinstance(who.get("id"), int) else None
+    if not actor_login or actor_id is None or actor_login.casefold() != configured.casefold():
+        return None
+    variable = _api_json(
+        runner, config, f"repos/{config.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR", quiet=True
+    )
+    advertised = variable.get("value") if isinstance(variable.get("value"), str) else None
+    if not advertised or advertised.casefold() != actor_login.casefold():
+        return None
+
+    # Resolve workflow source from the protected base ref.  The dispatch later
+    # uses the same ref, so PR-authored YAML cannot redefine qualification.
+    base_ref = metadata.base_branch or config.base
+    if not base_ref:
+        return None
+    base_workflow = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}?ref={base_ref}",
+            "-H",
+            "Accept: application/vnd.github.raw+json",
+        ],
+        cwd=active_workdir(config),
+        check=False,
+    )
+    if base_workflow.returncode != 0:
+        return None
+    if any(marker not in (base_workflow.stdout or "") for marker in V2_FEATURE_MARKERS):
+        raise AgentLoopError("The base branch does not contain the complete managed-CI v2 workflow.")
+
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+    author = pr.get("user") if isinstance(pr.get("user"), dict) else {}
+    labels = {
+        item.get("name") for item in (pr.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+    head_repo_name = head_repo.get("full_name") if isinstance(head_repo.get("full_name"), str) else None
+    live_sha = head.get("sha") if isinstance(head.get("sha"), str) else None
+    head_ref = head.get("ref") if isinstance(head.get("ref"), str) else None
+    author_login = author.get("login") if isinstance(author.get("login"), str) else None
+    author_id = author.get("id") if isinstance(author.get("id"), int) else None
+    # Reserved branches are generated by the typed creation prompt. A mere
+    # lookalike branch cannot pass without all the other authenticated fields.
+    managed_tuple = (
+        head_repo_name is not None and head_repo_name.casefold() == config.repo.casefold()
+        and author_login is not None and author_login.casefold() == actor_login.casefold()
+        and author_id == actor_id
+        and isinstance(head_ref, str) and head_ref.startswith("agent-loop/managed-")
+        and MANAGED_LABEL in labels
+        and pr.get("draft") is True
+        and base.get("ref") == base_ref
+        and live_sha is not None and live_sha == metadata.head_sha
+    )
+    if not managed_tuple:
+        return None
+    workflow_revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True)
+    revision = workflow_revision.get("sha") if isinstance(workflow_revision.get("sha"), str) else None
+    log(config, f"PR #{pr_number}: activated authenticated managed exact-head CI v2")
+    return ManagedCiContract(
+        protocol_version=2,
+        base_ref=base_ref,
+        trusted_actor_login=actor_login,
+        trusted_actor_id=actor_id,
+        workflow_revision=revision,
+    )
+
+
+def _api_json(runner: Runner, config: AgentLoopConfig, endpoint: str, *, quiet: bool = False) -> dict[str, object]:
+    result = runner.run(
+        [config.gh_cmd, "api", endpoint], cwd=active_workdir(config), check=False
+    )
+    if result.returncode != 0:
+        if quiet:
+            return {}
+        raise AgentLoopError(f"Managed-CI API request failed: {endpoint}.")
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError(f"Managed-CI API response was invalid JSON: {endpoint}.") from exc
+    return payload if isinstance(payload, dict) else {}
+
+
 def intermediate_managed_checks(checks: PullRequestChecks) -> PullRequestChecks:
     """Hide contract-controlled absence while reviewers inspect an intermediate head.
 
@@ -288,6 +475,15 @@ def dispatch_final_qualification(
             f"PR #{pr_number} head moved from approved SHA {expected_head_sha} "
             f"to {live_head} before CI dispatch."
         )
+    if contract.protocol_version == 2:
+        _dispatch_v2_qualification(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            contract=contract,
+        )
+        return
     result = runner.run(
         [
             config.gh_cmd,
@@ -312,12 +508,253 @@ def dispatch_final_qualification(
     log(config, f"PR #{pr_number}: dispatched managed final CI at {expected_head_sha}")
 
 
+def _dispatch_v2_qualification(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    expected_head_sha: str,
+    contract: ManagedCiContract,
+) -> None:
+    """Create/resume one authenticated intent and converge duplicate dispatches.
+
+    GitHub dispatches are asynchronous: discovering first prevents normal
+    retries from creating a second run, while selecting the newest surviving
+    run makes a crash between dispatch and ledger PATCH deterministic.
+    """
+    if not contract.base_ref or not contract.trusted_actor_login or contract.trusted_actor_id is None:
+        raise AgentLoopError("Managed-CI v2 contract is missing authenticated dispatch provenance.")
+    current_base = _api_json(
+        runner, config, f"repos/{config.repo}/commits/{contract.base_ref}", quiet=True
+    ).get("sha")
+    if (
+        contract.workflow_revision
+        and isinstance(current_base, str)
+        and current_base != contract.workflow_revision
+    ):
+        raise AgentLoopError(
+            "The managed-CI base workflow revision changed after activation; rerun review before dispatch."
+        )
+    _ensure_v2_intent(
+        runner, config=config, pr_number=pr_number, expected_head_sha=expected_head_sha, contract=contract
+    )
+    attached = _discover_v2_run(runner, config=config, contract=contract, retries=3)
+    if attached is None:
+        _patch_intent(runner, config=config, contract=contract, state="dispatch-requested")
+        result = runner.run(
+            [
+                config.gh_cmd,
+                "api",
+                "--method",
+                "POST",
+                f"repos/{config.repo}/actions/workflows/{contract.workflow_file}/dispatches",
+                "-f",
+                f"ref={contract.base_ref}",
+                "-f",
+                "inputs[protocol_version]=2",
+                "-f",
+                f"inputs[pr_number]={pr_number}",
+                "-f",
+                f"inputs[expected_head_sha]={expected_head_sha}",
+                "-f",
+                f"inputs[managed_nonce]={contract.nonce}",
+            ],
+            cwd=active_workdir(config),
+            check=False,
+        )
+        if result.returncode != 0:
+            raise AgentLoopError(
+                f"Unable to dispatch managed final CI for PR #{pr_number} at {expected_head_sha}."
+            )
+        attached = _discover_v2_run(runner, config=config, contract=contract, retries=3)
+    if attached is not None:
+        contract.attached_run_id = attached[0]
+        contract.run_attempt = attached[1]
+        _patch_intent(runner, config=config, contract=contract, state="attached")
+        log(config, f"PR #{pr_number}: attached managed-CI v2 run {attached[0]}")
+    else:
+        # Do not guess a run ID. The waiter will continue bounded discovery;
+        # an uncorrelated green status is never accepted in the meantime.
+        log(config, f"PR #{pr_number}: dispatch accepted; waiting for run visibility")
+
+
+def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_sha: str, state: str) -> str:
+    payload = {
+        "version": 2,
+        "repository": contract.repository,
+        "pr": pr_number,
+        "expected_head_sha": expected_head_sha,
+        "base_ref": contract.base_ref,
+        "workflow_revision": contract.workflow_revision,
+        "nonce": contract.nonce,
+        "created_at": contract.created_at,
+        "state": state,
+        "run_id": contract.attached_run_id,
+        "run_attempt": contract.run_attempt,
+    }
+    return f"<!-- {INTENT_MARKER} {json.dumps(payload, separators=(',', ':'), sort_keys=True)} -->"
+
+
+def _ensure_v2_intent(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, expected_head_sha: str, contract: ManagedCiContract
+) -> None:
+    contract.pr_number = pr_number
+    contract.expected_head_sha = expected_head_sha
+    contract.repository = config.repo
+    comments_result = runner.run(
+        [config.gh_cmd, "api", "--paginate", f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100"],
+        cwd=active_workdir(config), check=False,
+    )
+    comments: list[object] = []
+    if comments_result.returncode == 0:
+        try:
+            parsed = json.loads(comments_result.stdout or "[]")
+            comments = parsed if isinstance(parsed, list) else []
+        except json.JSONDecodeError:
+            raise AgentLoopError("Managed-CI intent comments response was invalid JSON.")
+    matching: list[tuple[int, dict[str, object]]] = []
+    for raw in comments:
+        if not isinstance(raw, dict):
+            continue
+        body = raw.get("body")
+        author = raw.get("user") if isinstance(raw.get("user"), dict) else {}
+        if not isinstance(body, str) or INTENT_MARKER not in body:
+            continue
+        if author.get("login") != contract.trusted_actor_login or author.get("id") != contract.trusted_actor_id:
+            continue
+        try:
+            encoded = body.split(INTENT_MARKER, 1)[1].split("-->", 1)[0].strip()
+            intent = json.loads(encoded)
+        except (IndexError, json.JSONDecodeError):
+            continue
+        if not isinstance(intent, dict):
+            continue
+        if intent.get("repository") != config.repo:
+            continue
+        if intent.get("pr") == pr_number and intent.get("expected_head_sha") == expected_head_sha:
+            cid = raw.get("id")
+            if isinstance(cid, int):
+                matching.append((cid, intent))
+    distinct = {str(item.get("nonce")) for _, item in matching}
+    if len(distinct) > 1:
+        raise AgentLoopError("Competing managed-CI v2 intent comments exist for this PR head.")
+    if matching:
+        contract.intent_comment_id, intent = matching[-1]
+        nonce = intent.get("nonce")
+        if not isinstance(nonce, str) or not nonce:
+            raise AgentLoopError("Managed-CI v2 intent comment lacks a nonce.")
+        contract.nonce = nonce
+        contract.created_at = intent.get("created_at") if isinstance(intent.get("created_at"), int) else None
+        contract.attached_run_id = intent.get("run_id") if isinstance(intent.get("run_id"), int) else None
+        contract.run_attempt = intent.get("run_attempt") if isinstance(intent.get("run_attempt"), int) else None
+        return
+    contract.nonce = secrets.token_urlsafe(24)
+    contract.created_at = int(time.time())
+    body = _intent_body(contract, pr_number=pr_number, expected_head_sha=expected_head_sha, state="prepared")
+    created = runner.run(
+        [config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={body}"],
+        cwd=active_workdir(config), check=False,
+    )
+    if created.returncode != 0:
+        raise AgentLoopError("Unable to create managed-CI v2 intent ledger comment.")
+    try:
+        payload = json.loads(created.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError("Managed-CI intent create response was invalid JSON.") from exc
+    if not isinstance(payload.get("id"), int):
+        raise AgentLoopError("Managed-CI intent comment was created without an ID.")
+    contract.intent_comment_id = payload["id"]
+
+
+def _patch_intent(runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract, state: str) -> None:
+    if contract.intent_comment_id is None or contract.nonce is None:
+        return
+    body = _intent_body(
+        contract,
+        pr_number=contract.pr_number or 0,
+        expected_head_sha=contract.expected_head_sha or "",
+        state=state,
+    )
+    # The immutable identifying fields are already in the original marker;
+    # state updates add only live provenance and are still actor-owned.
+    updated = runner.run(
+        [config.gh_cmd, "api", "--method", "PATCH", f"repos/{config.repo}/issues/comments/{contract.intent_comment_id}", "-f", f"body={body}"],
+        cwd=active_workdir(config), check=False,
+    )
+    if updated.returncode != 0:
+        raise AgentLoopError("Unable to persist managed-CI v2 intent state.")
+
+
+def _discover_v2_run(runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract, retries: int) -> tuple[int, int | None] | None:
+    if not contract.nonce:
+        return None
+    run_name = _v2_run_name(contract)
+    candidates: list[dict[str, object]] = []
+    for attempt in range(retries):
+        result = runner.run(
+            [config.gh_cmd, "api", f"repos/{config.repo}/actions/workflows/{contract.workflow_file}/runs?event=workflow_dispatch&per_page=100"],
+            cwd=active_workdir(config), check=False,
+        )
+        if result.returncode == 0:
+            try:
+                runs = json.loads(result.stdout or "{}").get("workflow_runs", [])
+            except (json.JSONDecodeError, AttributeError):
+                runs = []
+            candidates = [
+                run
+                for run in runs
+                if isinstance(run, dict) and _is_v2_intent_run(run, contract=contract, run_name=run_name)
+            ]
+            survivors = [run for run in candidates if run.get("status") != "completed" or run.get("conclusion") != "cancelled"]
+            if survivors:
+                newest = sorted(survivors, key=lambda run: (str(run.get("created_at") or ""), int(run.get("id") or 0)))[-1]
+                rid = newest.get("id")
+                if isinstance(rid, int):
+                    attempt_no = newest.get("run_attempt")
+                    return rid, attempt_no if isinstance(attempt_no, int) else None
+        if attempt < retries - 1:
+            runner.run(["sleep", str(min(config.ci_poll_interval_seconds, 2))], cwd=active_workdir(config))
+    return None
+
+
+def _v2_run_name(contract: ManagedCiContract) -> str:
+    return f"managed-ci-v2 nonce={contract.nonce}"
+
+
+def _is_v2_intent_run(
+    run: dict[str, object], *, contract: ManagedCiContract, run_name: str
+) -> bool:
+    """Validate the API fields available for a dispatched base workflow."""
+    if run.get("name") != run_name or run.get("event") != "workflow_dispatch":
+        return False
+    path = run.get("path")
+    if isinstance(path, str) and contract.base_ref and path != f".github/workflows/{WORKFLOW_FILE}@{contract.base_ref}":
+        return False
+    if isinstance(run.get("head_branch"), str) and contract.base_ref and run["head_branch"] != contract.base_ref:
+        return False
+    if isinstance(run.get("head_sha"), str) and contract.workflow_revision and run["head_sha"] != contract.workflow_revision:
+        return False
+    for field in ("actor", "triggering_actor"):
+        identity = run.get(field)
+        if not isinstance(identity, dict):
+            continue
+        login = identity.get("login")
+        actor_id = identity.get("id")
+        if (
+            login != contract.trusted_actor_login
+            or actor_id != contract.trusted_actor_id
+        ):
+            return False
+    return True
+
+
 def wait_for_final_qualification(
     runner: Runner,
     *,
     config: AgentLoopConfig,
     pr_number: int,
     metadata: PullRequestMetadata,
+    contract: ManagedCiContract | None = None,
 ) -> ManagedCiOutcome:
     expected_head = metadata.head_sha
     if not expected_head:
@@ -337,10 +774,22 @@ def wait_for_final_qualification(
                 head_sha=live_head,
             )
         latest = get_pr_checks(runner, config=config, metadata=metadata)
-        final = _find_context(latest, FINAL_CONTEXT)
+        if contract is not None and contract.protocol_version == 2:
+            if contract.attached_run_id is None:
+                attached = _discover_v2_run(runner, config=config, contract=contract, retries=1)
+                if attached is not None:
+                    contract.attached_run_id, contract.run_attempt = attached
+                    _patch_intent(runner, config=config, contract=contract, state="attached")
+            final = _v2_correlated_status(
+                runner, config=config, expected_head=expected_head, contract=contract
+            )
+        else:
+            final = _find_context(latest, FINAL_CONTEXT)
         status = final.status.lower() if final is not None else "pending"
         log(config, f"Managed CI context '{FINAL_CONTEXT}' status: {status}")
         if status == "success":
+            if contract is not None and contract.protocol_version == 2:
+                _patch_intent(runner, config=config, contract=contract, state="completed")
             return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
         if status in {
             "failure",
@@ -351,7 +800,13 @@ def wait_for_final_qualification(
             "startup_failure",
             "stale",
         }:
-            return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
+            details = ()
+            if contract is not None and contract.protocol_version == 2:
+                _patch_intent(runner, config=config, contract=contract, state="completed")
+                details = _v2_failed_jobs(runner, config=config, run_id=contract.attached_run_id)
+            return ManagedCiOutcome(
+                status="failed", checks=latest, head_sha=live_head, failure_details=details
+            )
         stall_checks = intermediate_managed_checks(latest)
         if is_wholly_infrastructure_blocked(stall_checks):
             stall = CiInfrastructureStall(checks=stall_checks.infrastructure_stalls)
@@ -364,6 +819,114 @@ def wait_for_final_qualification(
         if attempt < attempts - 1:
             runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
     return ManagedCiOutcome(status="timeout", checks=latest, head_sha=expected_head)
+
+
+def _v2_correlated_status(
+    runner: Runner, *, config: AgentLoopConfig, expected_head: str, contract: ManagedCiContract
+) -> PullRequestCheck | None:
+    """Return only the status published by the attached, current run.
+
+    A context name is deliberately insufficient: an older duplicate or a
+    contributor-created status must remain pending, including if it is red.
+    """
+    if contract.attached_run_id is None or not contract.nonce:
+        return None
+    result = runner.run(
+        [config.gh_cmd, "api", f"repos/{config.repo}/commits/{expected_head}/status"],
+        cwd=active_workdir(config), check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    statuses = payload.get("statuses") if isinstance(payload, dict) else None
+    if not isinstance(statuses, list):
+        return None
+    required = (
+        f"nonce={contract.nonce}",
+        f"run_id={contract.attached_run_id}",
+    )
+    if contract.run_attempt is not None:
+        required += (f"attempt={contract.run_attempt}",)
+    for raw in statuses:
+        if not isinstance(raw, dict) or raw.get("context") != FINAL_CONTEXT:
+            continue
+        description = raw.get("description") if isinstance(raw.get("description"), str) else ""
+        target = raw.get("target_url") if isinstance(raw.get("target_url"), str) else ""
+        creator = raw.get("creator") if isinstance(raw.get("creator"), dict) else {}
+        login = creator.get("login") if isinstance(creator.get("login"), str) else None
+        creator_id = creator.get("id") if isinstance(creator.get("id"), int) else None
+        allowed_publisher = (
+            (login or "").casefold() == "github-actions[bot]"
+            or (login == contract.trusted_actor_login and creator_id == contract.trusted_actor_id)
+        )
+        if not allowed_publisher or not all(token in description for token in required):
+            continue
+        if f"/actions/runs/{contract.attached_run_id}" not in target:
+            continue
+        return PullRequestCheck(
+            name=FINAL_CONTEXT,
+            kind="status_context",
+            status=str(raw.get("state") or "pending"),
+            url=target or None,
+            run_id=str(contract.attached_run_id),
+            created_at=raw.get("created_at") if isinstance(raw.get("created_at"), str) else None,
+            completed_at=raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None,
+            creator_login=login,
+            creator_id=creator_id,
+            description=description,
+        )
+    return None
+
+
+def _v2_failed_jobs(runner: Runner, *, config: AgentLoopConfig, run_id: int | None) -> tuple[str, ...]:
+    if run_id is None:
+        return ()
+    result = runner.run(
+        [config.gh_cmd, "api", "--paginate", f"repos/{config.repo}/actions/runs/{run_id}/jobs?filter=latest&per_page=100"],
+        cwd=active_workdir(config), check=False,
+    )
+    if result.returncode != 0:
+        return (f"Managed CI run {run_id} failed; job details were unavailable.",)
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return (f"Managed CI run {run_id} failed; job details were unavailable.",)
+    jobs = payload.get("jobs") if isinstance(payload, dict) else None
+    terminal = {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
+    details = []
+    for job in jobs if isinstance(jobs, list) else []:
+        if not isinstance(job, dict) or str(job.get("conclusion") or "").lower() not in terminal:
+            continue
+        name = job.get("name") if isinstance(job.get("name"), str) else "unnamed job"
+        conclusion = str(job.get("conclusion"))
+        url = job.get("html_url") if isinstance(job.get("html_url"), str) else ""
+        details.append(f"{name}: {conclusion}" + (f" ({url})" if url else ""))
+    return tuple(details) or (f"Managed CI run {run_id} failed; no failed job was exposed.",)
+
+
+def prepare_v2_merge(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, expected_head_sha: str, contract: ManagedCiContract
+) -> None:
+    """Publish continuity before readying the PR, then re-check its exact head."""
+    if contract.protocol_version != 2:
+        return
+    labelled = runner.run(
+        [config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/labels", "-f", f"labels[]={QUALIFIED_LABEL}"],
+        cwd=active_workdir(config), check=False,
+    )
+    if labelled.returncode != 0:
+        raise AgentLoopError(f"Unable to apply `{QUALIFIED_LABEL}` before readying PR #{pr_number}.")
+    ready = runner.run(
+        [config.gh_cmd, "pr", "ready", str(pr_number), "--repo", config.repo],
+        cwd=active_workdir(config), check=False,
+    )
+    if ready.returncode != 0:
+        raise AgentLoopError(f"Unable to mark qualified PR #{pr_number} ready for review.")
+    if get_pr_head_sha(runner, config, pr_number) != expected_head_sha:
+        raise AgentLoopError(f"PR #{pr_number} head changed while it was being readied for merge.")
 
 
 def _find_context(checks: PullRequestChecks, name: str) -> PullRequestCheck | None:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -758,10 +758,13 @@ def _is_v2_intent_run(
     run: dict[str, object], *, contract: ManagedCiContract, run_name: str
 ) -> bool:
     """Validate the API fields available for a dispatched base workflow."""
-    if run.get("name") != run_name or run.get("event") != "workflow_dispatch":
+    if (
+        run_name not in (run.get("name"), run.get("display_title"))
+        or run.get("event") != "workflow_dispatch"
+    ):
         return False
     path = run.get("path")
-    if isinstance(path, str) and contract.base_ref and path != f".github/workflows/{WORKFLOW_FILE}@{contract.base_ref}":
+    if isinstance(path, str) and f".github/workflows/{WORKFLOW_FILE}" not in path:
         return False
     if isinstance(run.get("head_branch"), str) and contract.base_ref and run["head_branch"] != contract.base_ref:
         return False

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -104,6 +104,8 @@ from .managed_ci import (
     activate_managed_ci,
     dispatch_final_qualification,
     intermediate_managed_checks,
+    preflight_managed_ci_creation,
+    prepare_v2_merge,
     publish_round_readiness,
     wait_for_final_qualification,
 )
@@ -3866,6 +3868,9 @@ def _implement_approved_issue(
         approved_plan_hash=plan_hash,
     )
     sync_coder_base_before_implementation(implementation_config, runner)
+    managed_ci_creation_intent = preflight_managed_ci_creation(
+        runner, config=implementation_config, issue_number=issue_number
+    )
     log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
     assigned_head_before = _read_assigned_workdir_head(runner, implementation_config)
     coder_response = _run_validated_agent(
@@ -3880,6 +3885,7 @@ def _implement_approved_issue(
             issue_context=issue_context,
             salvage_summary=salvage_summary,
             staged_parent_issue=staged_parent_issue,
+            managed_ci_creation_intent=managed_ci_creation_intent,
         ),
         session_id=implementation_session_id,
         marker_description="positive <!-- AGENT_PR: <number> -->, PR URL, blocking, or clarification",
@@ -7041,8 +7047,16 @@ def run_pr_loop(
                                 config=config,
                                 pr_number=pr_number,
                                 metadata=pr_metadata,
+                                contract=managed_ci,
                             )
                             if managed_outcome.status == "passed":
+                                prepare_v2_merge(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    expected_head_sha=pr_metadata.head_sha,
+                                    contract=managed_ci,
+                                )
                                 merge_pr(
                                     runner,
                                     config,
@@ -7111,7 +7125,9 @@ def run_pr_loop(
                                 return 0
                             elif managed_outcome.status == "failed":
                                 details = (
-                                    _pr_check_details(managed_outcome.checks)
+                                    list(managed_outcome.failure_details)
+                                    if managed_outcome.failure_details
+                                    else _pr_check_details(managed_outcome.checks)
                                     if managed_outcome.checks
                                     else ["Managed exact-head CI failed."]
                                 )

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -15,6 +15,7 @@ from .config import AgentLoopConfig, reviewers
 from .decomposition import MAX_DECOMPOSITION_PHASES
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
+from .managed_ci import ManagedCiCreationIntent
 from .salvage import AGENT_SALVAGE_MARKER_RE
 from .round_transport import is_round_transport_sidecar
 from .protocol import (
@@ -1703,7 +1704,7 @@ def build_issue_implementation_prompt(
     issue_context: IssueContext | None = None,
     salvage_summary: str | None = None,
     staged_parent_issue: int | None = None,
-    managed_ci_creation_intent: object | None = None,
+    managed_ci_creation_intent: ManagedCiCreationIntent | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -1719,7 +1720,7 @@ def build_issue_implementation_prompt(
     )
     managed_creation_guidance = ""
     if managed_ci_creation_intent is not None:
-        branch = getattr(managed_ci_creation_intent, "branch", "agent-loop/managed-<issue>")
+        branch = managed_ci_creation_intent.branch
         managed_creation_guidance = (
             "\nThis repository has authenticated managed-CI v2 enabled. Create the PR atomically: "
             f"use the reserved branch `{branch}`, create/verify the `agent-loop-managed` label first, "

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1703,6 +1703,7 @@ def build_issue_implementation_prompt(
     issue_context: IssueContext | None = None,
     salvage_summary: str | None = None,
     staged_parent_issue: int | None = None,
+    managed_ci_creation_intent: object | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -1716,6 +1717,15 @@ def build_issue_implementation_prompt(
         if staged_parent_issue is not None
         else _issue_pr_reference_guidance(issue_number)
     )
+    managed_creation_guidance = ""
+    if managed_ci_creation_intent is not None:
+        branch = getattr(managed_ci_creation_intent, "branch", "agent-loop/managed-<issue>")
+        managed_creation_guidance = (
+            "\nThis repository has authenticated managed-CI v2 enabled. Create the PR atomically: "
+            f"use the reserved branch `{branch}`, create/verify the `agent-loop-managed` label first, "
+            "then run `gh pr create --draft --label agent-loop-managed`. Do not mark it ready until "
+            "agent-loop's final exact-head qualification succeeds.\n"
+        )
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the
@@ -1725,6 +1735,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
+{managed_creation_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
     requirement_label="implementation requirements",

--- a/tests/test_ci_health.py
+++ b/tests/test_ci_health.py
@@ -43,6 +43,26 @@ def _check(**overrides):
     return PullRequestCheck(**defaults)
 
 
+def test_check_run_parser_uses_github_app_slug_without_misattributing_app_id():
+    checks, errors = github_module._parse_check_runs_payload(
+        {
+            "check_runs": [
+                {
+                    "id": 7,
+                    "name": "CI",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": {"slug": "github-actions", "id": 15368},
+                }
+            ]
+        }
+    )
+
+    assert errors == []
+    assert checks[0].creator_login == "github-actions"
+    assert checks[0].creator_id is None
+
+
 # --- classify_ci_infrastructure_stall ---------------------------------------
 
 

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -14,9 +14,14 @@ from coding_review_agent_loop.managed_ci import (
     MANAGED_LABEL,
     READINESS_CONTEXT,
     ManagedCiContract,
+    _dispatch_v2_qualification,
+    _ensure_v2_intent,
+    _v2_failed_jobs,
     activate_managed_ci,
     dispatch_final_qualification,
     intermediate_managed_checks,
+    preflight_managed_ci_creation,
+    prepare_v2_merge,
     publish_round_readiness,
     wait_for_final_qualification,
 )
@@ -34,6 +39,23 @@ on:
 jobs:
   route:
     if: contains(github.event.pull_request.labels.*.name, 'agent-loop-managed')
+  aggregate:
+    name: final-ci/exact-head
+"""
+
+V2_WORKFLOW = """
+# agent-loop-managed
+# expected_head_sha
+# AGENT_LOOP_MANAGED_CI_V2
+name: CI
+on:
+  workflow_dispatch:
+    inputs:
+      protocol_version: {required: true}
+      pr_number: {required: true}
+      expected_head_sha: {required: true}
+      managed_nonce: {required: true}
+jobs:
   aggregate:
     name: final-ci/exact-head
 """
@@ -89,6 +111,93 @@ class ManagedRunner(FakeRunner):
         return super()._run_locked(args, cwd=cwd, check=check)
 
 
+class V2ManagedRunner(ManagedRunner):
+    def __init__(
+        self,
+        *,
+        rest_pr=None,
+        workflow_runs=None,
+        intent_comments=None,
+        jobs=None,
+        actor_login="agent-loop",
+        actor_id=1,
+        advertised_actor=None,
+        **kwargs,
+    ):
+        workflow = kwargs.pop("workflow", V2_WORKFLOW)
+        super().__init__(workflow=workflow, **kwargs)
+        self.rest_pr = {
+            "head": {
+                "repo": {"full_name": "OWNER/REPO"},
+                "sha": "abc123",
+                "ref": "agent-loop/managed-643",
+            },
+            "base": {"ref": "main"},
+            "user": {"login": actor_login, "id": actor_id},
+            "labels": [{"name": MANAGED_LABEL}],
+            "draft": True,
+        }
+        if rest_pr:
+            self.rest_pr.update(rest_pr)
+        self.workflow_runs = list(workflow_runs or [])
+        self.intent_comments = list(intent_comments or [])
+        self.jobs = list(jobs or [])
+        self.actor_login = actor_login
+        self.actor_id = actor_id
+        self.advertised_actor = advertised_actor or actor_login
+
+    def _run_locked(self, args, *, cwd, check):
+        cmd = list(args)
+        endpoint = next(
+            (part for part in cmd if isinstance(part, str) and part.startswith("repos/")), ""
+        )
+        if cmd == ["gh", "api", "user"]:
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(
+                cmd,
+                cwd_path,
+                json.dumps({"login": self.actor_login, "id": self.actor_id}),
+                "",
+                0,
+            )
+        if endpoint.endswith("/actions/variables/AGENT_LOOP_MANAGED_ACTOR"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps({"value": self.advertised_actor}), "", 0)
+        if endpoint.startswith("repos/OWNER/REPO/contents/.github/workflows/ci.yml"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, self.workflow, "", 0)
+        if endpoint == "repos/OWNER/REPO/pulls/7":
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps(self.rest_pr), "", 0)
+        if endpoint == "repos/OWNER/REPO/commits/main":
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps({"sha": "base-sha"}), "", 0)
+        if endpoint.startswith("repos/OWNER/REPO/issues/7/comments?"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps(self.intent_comments), "", 0)
+        if endpoint == "repos/OWNER/REPO/issues/7/comments" and "POST" in cmd:
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps({"id": 17}), "", 0)
+        if endpoint.startswith("repos/OWNER/REPO/issues/comments/"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, "{}", "", 0)
+        if "/actions/workflows/ci.yml/runs?event=workflow_dispatch" in endpoint:
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps({"workflow_runs": self.workflow_runs}), "", 0)
+        if endpoint.endswith("/jobs?filter=latest&per_page=100"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps({"jobs": self.jobs}), "", 0)
+        if endpoint.startswith("repos/OWNER/REPO/actions/runs/"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            run_id = endpoint.rsplit("/", 1)[-1]
+            run = next((run for run in self.workflow_runs if str(run.get("id")) == run_id), {})
+            return CommandResult(cmd, cwd_path, json.dumps(run), "", 0)
+        if cmd[:3] == ["gh", "pr", "view"] and "--jq" in cmd and ".headRefOid" in cmd:
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, f"{self.pr_payload.get('headRefOid')}\n", "", 0)
+        return super()._run_locked(args, cwd=cwd, check=check)
+
+
 def metadata(*, base_branch="main"):
     return PullRequestMetadata(
         number=7,
@@ -99,6 +208,50 @@ def metadata(*, base_branch="main"):
         head_sha="abc123",
         url="https://github.com/OWNER/REPO/pull/7",
     )
+
+
+def v2_contract(**overrides):
+    fields = {
+        "protocol_version": 2,
+        "base_ref": "main",
+        "trusted_actor_login": "agent-loop",
+        "trusted_actor_id": 1,
+        "workflow_revision": "base-sha",
+        "nonce": "nonce-1",
+    }
+    fields.update(overrides)
+    return ManagedCiContract(**fields)
+
+
+def v2_run(*, run_id=100, attempt=1, status="completed", conclusion="success"):
+    return {
+        "id": run_id,
+        "run_attempt": attempt,
+        "name": "managed-ci-v2 nonce=nonce-1",
+        "event": "workflow_dispatch",
+        "path": ".github/workflows/ci.yml@main",
+        "head_branch": "main",
+        "head_sha": "base-sha",
+        "status": status,
+        "conclusion": conclusion,
+    }
+
+
+def v2_intent_comment(*, nonce="nonce-1", run_id=None, run_attempt=None):
+    payload = {
+        "repository": "OWNER/REPO",
+        "pr": 7,
+        "expected_head_sha": "abc123",
+        "nonce": nonce,
+        "created_at": 1,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }
+    return {
+        "id": 17,
+        "user": {"login": "agent-loop", "id": 1},
+        "body": f"<!-- AGENT_MANAGED_CI_INTENT_V2 {json.dumps(payload)} -->",
+    }
 
 
 def checks(*, pending=(), passing=(), failing=(), required=(FINAL_CONTEXT,), missing=()):
@@ -421,6 +574,243 @@ def test_v2_qualification_accepts_only_attached_run_status(tmp_path):
     )
 
     assert outcome.status == "passed"
+
+
+def test_v2_qualification_rejects_numeric_prefix_tokens_and_run_url(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1
+    )
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(run_id=100, attempt=1)],
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_status_payload={
+            "statuses": [
+                {
+                    "context": FINAL_CONTEXT,
+                    "state": "success",
+                    "description": "nonce=nonce-1;run_id=1001;attempt=10",
+                    "target_url": "https://github.com/OWNER/REPO/actions/runs/1001",
+                    "creator": {"login": "github-actions[bot]", "id": 41898282},
+                }
+            ]
+        },
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+
+    outcome = wait_for_final_qualification(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=metadata(),
+        contract=v2_contract(attached_run_id=100, run_attempt=1),
+    )
+
+    assert outcome.status == "timeout"
+
+
+def test_v2_qualification_refreshes_rerun_attempt_before_correlating_status(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1
+    )
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(run_id=100, attempt=2)],
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_status_payload={
+            "statuses": [
+                {
+                    "context": FINAL_CONTEXT,
+                    "state": "success",
+                    "description": "nonce=nonce-1;run_id=100;attempt=2",
+                    "target_url": "https://github.com/OWNER/REPO/actions/runs/100",
+                    "creator": {"login": "github-actions[bot]", "id": 41898282},
+                }
+            ]
+        },
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = v2_contract(attached_run_id=100, run_attempt=1)
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "passed"
+    assert contract.run_attempt == 2
+
+
+@pytest.mark.parametrize(
+    ("rest_pr", "config_overrides"),
+    [
+        ({"head": {"repo": {"full_name": "FORK/REPO"}, "sha": "abc123", "ref": "agent-loop/managed-643"}}, {}),
+        ({"draft": False}, {}),
+        ({"labels": []}, {}),
+        ({"head": {"repo": {"full_name": "OWNER/REPO"}, "sha": "new-head", "ref": "agent-loop/managed-643"}}, {}),
+        ({"user": {"login": "other", "id": 1}}, {}),
+        ({}, {"managed_ci_trusted_actor": "other"}),
+    ],
+)
+def test_v2_activation_rejects_untrusted_or_incomplete_opening_tuple(
+    tmp_path, rest_pr, config_overrides
+):
+    settings = {"auto_merge": True, "managed_ci_trusted_actor": "agent-loop"}
+    settings.update(config_overrides)
+    config = make_config(tmp_path, **settings)
+    runner = V2ManagedRunner(rest_pr=rest_pr, pr_payload={"headRefOid": "abc123"})
+
+    assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
+
+
+def test_v2_activation_and_preflight_require_authenticated_actor(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(pr_payload={"headRefOid": "abc123"})
+
+    intent = preflight_managed_ci_creation(runner, config=config, issue_number=643)
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert intent is not None
+    assert intent.branch == "agent-loop/managed-643"
+    assert contract is not None
+    assert contract.protocol_version == 2
+    assert contract.trusted_actor_login == "agent-loop"
+
+
+@pytest.mark.parametrize(
+    "runner_kwargs",
+    [
+        {"actor_login": "other"},
+        {"advertised_actor": "other"},
+    ],
+)
+def test_v2_preflight_rejects_configured_or_advertised_actor_mismatch(tmp_path, runner_kwargs):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+
+    assert preflight_managed_ci_creation(
+        V2ManagedRunner(**runner_kwargs), config=config, issue_number=643
+    ) is None
+
+
+def test_v2_preflight_fails_closed_for_incomplete_markers(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(workflow="# AGENT_LOOP_MANAGED_CI_V2\n")
+
+    with pytest.raises(AgentLoopError, match="incomplete managed-CI v2 contract"):
+        preflight_managed_ci_creation(runner, config=config, issue_number=643)
+
+
+def test_v2_intent_resumes_matching_comment_and_rejects_competing_nonce(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    comment = v2_intent_comment(run_id=100, run_attempt=1)
+    runner = V2ManagedRunner(intent_comments=[comment])
+    contract = v2_contract()
+
+    _ensure_v2_intent(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert (contract.intent_comment_id, contract.nonce, contract.attached_run_id) == (17, "nonce-1", 100)
+    competing = dict(comment)
+    competing["id"] = 18
+    competing["body"] = v2_intent_comment(nonce="nonce-2")["body"]
+    runner = V2ManagedRunner(intent_comments=[comment, competing])
+    with pytest.raises(AgentLoopError, match="Competing managed-CI v2 intent"):
+        _ensure_v2_intent(
+            runner, config=config, pr_number=7, expected_head_sha="abc123", contract=v2_contract()
+        )
+
+
+def test_v2_dispatch_discovers_existing_run_before_dispatching(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(workflow_runs=[v2_run()], intent_comments=[v2_intent_comment()])
+    contract = v2_contract()
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert contract.attached_run_id == 100
+    assert not any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
+
+
+def test_v2_dispatch_rejects_a_stale_approved_head(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(pr_payload={"headRefOid": "new-head"})
+
+    with pytest.raises(AgentLoopError, match="head moved from approved SHA"):
+        dispatch_final_qualification(
+            runner,
+            config=config,
+            pr_number=7,
+            expected_head_sha="abc123",
+            head_ref="agent-loop/managed-643",
+            contract=v2_contract(),
+        )
+
+
+def test_v2_qualification_reports_failed_jobs_from_the_attached_run(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1
+    )
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run()],
+        jobs=[{"name": "unit", "conclusion": "failure", "html_url": "https://example.test/job/1"}],
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_status_payload={
+            "statuses": [
+                {
+                    "context": FINAL_CONTEXT,
+                    "state": "failure",
+                    "description": "nonce=nonce-1;run_id=100;attempt=1",
+                    "target_url": "https://github.com/OWNER/REPO/actions/runs/100",
+                    "creator": {"login": "github-actions[bot]", "id": 41898282},
+                }
+            ]
+        },
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+
+    outcome = wait_for_final_qualification(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=metadata(),
+        contract=v2_contract(attached_run_id=100, run_attempt=1),
+    )
+
+    assert outcome.status == "failed"
+    assert outcome.failure_details == ("unit: failure (https://example.test/job/1)",)
+
+
+def test_v2_failed_jobs_and_ready_merge_recovery(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(
+        rest_pr={"draft": False},
+        jobs=[{"name": "unit", "conclusion": "failure", "html_url": "https://example.test/job/1"}],
+    )
+
+    assert _v2_failed_jobs(runner, config=config, run_id=100) == (
+        "unit: failure (https://example.test/job/1)",
+    )
+    prepare_v2_merge(
+        runner,
+        config=config,
+        pr_number=7,
+        expected_head_sha="abc123",
+        contract=v2_contract(),
+    )
+
+    assert not any(cmd[:3] == ["gh", "pr", "ready"] for cmd, _cwd in runner.commands)
 
 
 def test_merge_pr_uses_expected_head_guard(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -345,6 +345,84 @@ def test_wait_for_final_qualification_treats_all_terminal_failures_as_failed(
     assert outcome.status == "failed"
 
 
+def test_v2_qualification_ignores_same_context_status_from_another_run(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1
+    )
+    runner = ManagedRunner(
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_status_payload={
+            "statuses": [
+                {
+                    "context": FINAL_CONTEXT,
+                    "state": "failure",
+                    "description": "nonce=nonce-1;run_id=99;attempt=1",
+                    "target_url": "https://github.com/OWNER/REPO/actions/runs/99",
+                    "creator": {"login": "github-actions[bot]", "id": 41898282},
+                }
+            ]
+        },
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = ManagedCiContract(
+        protocol_version=2,
+        trusted_actor_login="agent-loop",
+        trusted_actor_id=1,
+        nonce="nonce-1",
+        attached_run_id=100,
+        run_attempt=1,
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "timeout"
+
+
+def test_v2_qualification_accepts_only_attached_run_status(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1
+    )
+    runner = ManagedRunner(
+        pr_payload={
+            "headRefOid": "abc123",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        pr_status_payload={
+            "statuses": [
+                {
+                    "context": FINAL_CONTEXT,
+                    "state": "success",
+                    "description": "nonce=nonce-1;run_id=100;attempt=1",
+                    "target_url": "https://github.com/OWNER/REPO/actions/runs/100",
+                    "creator": {"login": "github-actions[bot]", "id": 41898282},
+                }
+            ]
+        },
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = ManagedCiContract(
+        protocol_version=2,
+        trusted_actor_login="agent-loop",
+        trusted_actor_id=1,
+        nonce="nonce-1",
+        attached_run_id=100,
+        run_attempt=1,
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "passed"
+
+
 def test_merge_pr_uses_expected_head_guard(tmp_path):
     config = make_config(tmp_path, auto_merge=True)
     runner = FakeRunner()

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -223,13 +223,23 @@ def v2_contract(**overrides):
     return ManagedCiContract(**fields)
 
 
-def v2_run(*, run_id=100, attempt=1, status="completed", conclusion="success"):
+def v2_run(
+    *,
+    run_id=100,
+    attempt=1,
+    status="completed",
+    conclusion="success",
+    name="managed-ci-v2 nonce=nonce-1",
+    display_title=None,
+    path=".github/workflows/ci.yml@main",
+):
     return {
         "id": run_id,
         "run_attempt": attempt,
-        "name": "managed-ci-v2 nonce=nonce-1",
+        "name": name,
+        "display_title": display_title,
         "event": "workflow_dispatch",
-        "path": ".github/workflows/ci.yml@main",
+        "path": path,
         "head_branch": "main",
         "head_sha": "base-sha",
         "status": status,
@@ -729,6 +739,28 @@ def test_v2_intent_resumes_matching_comment_and_rejects_competing_nonce(tmp_path
 def test_v2_dispatch_discovers_existing_run_before_dispatching(tmp_path):
     config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
     runner = V2ManagedRunner(workflow_runs=[v2_run()], intent_comments=[v2_intent_comment()])
+    contract = v2_contract()
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert contract.attached_run_id == 100
+    assert not any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
+
+
+def test_v2_dispatch_discovers_run_with_display_title_and_qualified_path(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(
+        workflow_runs=[
+            v2_run(
+                name="CI",
+                display_title="managed-ci-v2 nonce=nonce-1",
+                path="OWNER/REPO/.github/workflows/ci.yml@refs/heads/main",
+            )
+        ],
+        intent_comments=[v2_intent_comment()],
+    )
     contract = v2_contract()
 
     _dispatch_v2_qualification(


### PR DESCRIPTION
Fixes #643

## Summary
- add opt-in authenticated v2 managed-CI creation, intent ledger, base-ref dispatch, and exact status provenance
- converge duplicate dispatches and return validated workflow-job failures to the coder
- document v1-to-v2 rollout, recovery, telemetry, and expected billing profile

## Tests
- `python3 -m pytest tests/test_managed_ci.py tests/test_orchestrator_pr.py tests/test_prompts.py tests/test_docs_guidance.py -q`