### PR TITLE
Raise coder test timeout policy to 1,800 seconds

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,9 @@ the two model options are mutually exclusive. Customize fallback detection with
 call passes `--print-timeout` from `--antigravity-print-timeout-seconds`
 (default `600`, i.e. ten minutes, matching the `agent-loop` CLI), overriding
 `agy`'s own five-minute print-mode default so long turns are not cut short.
+For a required local test that may run up to 1,800 seconds, configure this
+whole-invocation deadline above that cap with additional budget for analysis,
+edits, reporting, and other turn work; the default cannot accommodate it.
 Provider capacity failures retry the active model before fallback; the
 `--max-retries` allowance is shared across the chain, capping calls at
 `models + retries`. Custom quota signatures control eligibility, while settings,
@@ -386,10 +389,12 @@ python -m helpers.skill_runner run-task-round \
   touches those surfaces, focused tests demonstrably do not cover it, or a
   human or the issue explicitly asked for full-suite verification. Run
   required completion tests in the foreground with visible output under an
-  explicit bounded timeout; never launch pytest (or any required test) in the
-  background, and never spawn a shell loop that polls a process ID, `ps`/
-  `kill -0`/`wait`, or a task-output file to learn whether it finished. If a
-  required test exceeds its bound, terminate it and report the blocker
+  explicit bounded timeout (at most 1,800 seconds per required test command).
+  That maximum allowance requires an individually justified command; it is not
+  a reason to choose a broad suite. Never launch pytest (or any required test)
+  in the background, and never spawn a shell loop that polls a process ID,
+  `ps`/`kill -0`/`wait`, or a task-output file to learn whether it finished. If
+  a required test exceeds its bound, terminate it and report the blocker
   immediately, naming the exact command and the timeout, rather than waiting
   silently or retrying with a broader selection. The `coding_review_agent_loop`
   CLI orchestrator's coder prompts carry the same policy; this bullet covers

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1461,10 +1461,11 @@ Every coder prompt built by `coding_review_agent_loop.prompts` requires:
   the unnecessary or mis-targeted case is prohibited.
 - **Foreground execution under a bounded timeout.** Required completion
   tests run in the foreground with visible output and a concrete stated cap
-  (at most 900 seconds per required test command). Coders must not launch
-  pytest in the background or spawn auxiliary shell loops that poll process
-  IDs, `ps`/`kill -0`/`wait`, or task-output files to learn whether a test
-  finished.
+  (at most 1,800 seconds per required test command). This is a maximum
+  allowance for one individually justified command, not a default reason to
+  choose a broad suite. Coders must not launch pytest in the background or
+  spawn auxiliary shell loops that poll process IDs, `ps`/`kill -0`/`wait`,
+  or task-output files to learn whether a test finished.
 - **A valid terminal path on timeout.** If a required test exceeds its
   bound, the coder terminates the run and returns a valid terminal response
   immediately, naming the exact command and the timeout, rather than
@@ -1474,6 +1475,16 @@ Every coder prompt built by `coding_review_agent_loop.prompts` requires:
   stop after a bounded timeout has an ordinary terminal path instead of
   being forced into an `agent_unavailable` report reserved for genuine
   environment/tooling failure.
+
+This per-command coder policy is separate from the three-snapshot,
+120-second GitHub CI observation limit and from the orchestrator's optional
+`--test-command` parsing and execution path; it does not change either one.
+When `antigravity` is the coder, configure
+`--antigravity-print-timeout-seconds` above the 1,800-second command cap and
+leave additional budget for analysis, edits, reporting, and other turn work.
+Its default 600-second whole-invocation deadline cannot accommodate even one
+such command. Apply the same headroom principle to any other backend-imposed
+whole-turn deadline.
 
 The completion-recovery prompt (sent once, when a prior implementation turn
 ended without a valid terminal marker and its text suggested deferring to

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -96,7 +96,10 @@ output signatures that trigger fallback. Use
 `--antigravity-print-timeout-seconds SECONDS` (default `600`, matching the
 `agent-loop` CLI) to override the `--print-timeout` passed to each `agy
 --print` call, which otherwise falls back to `agy`'s own five-minute
-print-mode default. These options are available on plan, task, PR-review,
+print-mode default. For a required local test that may run up to 1,800
+seconds, configure this whole-invocation deadline above that cap with
+additional budget for analysis, edits, reporting, and other turn work; the
+default cannot accommodate it. These options are available on plan, task, PR-review,
 implementation, decomposition, phased implementation, and PR-fix commands.
 Antigravity turns are single-shot (no cross-round session resume) and report
 estimated token usage.
@@ -232,11 +235,14 @@ module to a changed file or reviewer item. Broad suites remain available when
 the change genuinely touches those surfaces, focused tests demonstrably do
 not cover it, or a human or the issue explicitly asked for full-suite
 verification. Required completion tests must run in the foreground with
-visible output under an explicit bounded timeout; never launch pytest in the
-background or poll a process ID, `ps`/`kill -0`/`wait`, or a task-output file
-to learn whether it finished. If a required test exceeds its bound, terminate
-it and report the blocker immediately, naming the exact command and the
-timeout, instead of waiting silently or retrying with a broader selection.
+visible output under an explicit bounded timeout (at most 1,800 seconds per
+required test command). That maximum allowance requires an individually
+justified command; it is not a reason to choose a broad suite. Never launch
+pytest in the background or poll a process ID, `ps`/`kill -0`/`wait`, or a
+task-output file to learn whether it finished. If a required test exceeds its
+bound, terminate it and report the blocker immediately, naming the exact
+command and the timeout, instead of waiting silently or retrying with a
+broader selection.
 
 Every coder prompt built by `coding_review_agent_loop.prompts` — including the
 ones `helpers/prompt_builders.py` reuses for skill mode's `run-pr-fix` —

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -109,6 +109,10 @@ def _coder_test_reporting_guidance(*, structured: bool = False) -> str:
     )
 
 
+CODER_TEST_COMMAND_TIMEOUT_SECONDS = 1800
+"""Maximum foreground timeout for one required coder test command (#648)."""
+
+
 def _coder_local_test_scope_guidance(*, structured: bool = False) -> str:
     if structured:
         rationale = (
@@ -138,8 +142,9 @@ def _coder_local_test_scope_guidance(*, structured: bool = False) -> str:
         "cover it, or a human or the issue explicitly asked for full-suite "
         f"verification — and when a broad run is justified, state that reason in {broad_reason_location}. "
         "Run required completion tests in the foreground with visible output "
-        "and an explicit bounded timeout (a concrete stated cap, at most 900 "
-        "seconds per required test command). Never launch pytest in the "
+        "and an explicit bounded timeout (a concrete stated cap, at most "
+        f"{CODER_TEST_COMMAND_TIMEOUT_SECONDS} seconds per required test command). "
+        "Never launch pytest in the "
         "background (`&`, `nohup`, background task/tool invocations) and never "
         "spawn auxiliary shell loops that poll process IDs, `ps`/`kill -0`/"
         "`wait`, or task-output files to learn whether it finished. If a "

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -11,6 +11,10 @@ HEADING_TEXT = "Phased decomposition versus split materialization"
 CI_STALL_HEADING_TEXT = "External CI infrastructure stalls"
 MANAGED_CI_HEADING_TEXT = "Managed exact-head CI"
 LOCAL_TEST_SCOPE_HEADING_TEXT = "Focused, bounded local test selection"
+SKILL_LOCAL_TEST_SCOPE_HEADING_TEXT = "Gates & guardrails"
+SKILL_MODE_LOCAL_TEST_SCOPE_HEADING_TEXT = "Focused, bounded local test runs"
+SKILL = REPO_ROOT / "SKILL.md"
+SKILL_MODE_DOC = REPO_ROOT / "docs" / "skill_mode.md"
 
 
 def _github_anchor(heading_text: str) -> str:
@@ -123,7 +127,8 @@ def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
 
     assert "External CI infrastructure" in section
     assert "distinct from" in section
-    assert "900 seconds" in section
+    assert "1,800 seconds" in section
+    assert section.count("1,800 seconds") == 1
     assert "must not launch pytest in the background" in section
     assert "poll process" in section
     assert "`ps`/`kill -0`/`wait`" in section
@@ -131,6 +136,34 @@ def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
     assert "a human or the issue explicitly asked for full-suite" in section
     assert "no-PR `AGENT_STATE: blocking`" in section
     assert "agent_unavailable" in section
+    assert "three-snapshot" in section
+    assert "120-second GitHub CI observation limit" in section
+    assert "`--test-command` parsing and execution path" in section
+    assert "`--antigravity-print-timeout-seconds` above the 1,800-second command cap" in section
+    assert "default 600-second whole-invocation deadline cannot accommodate" in section
+    assert "additional budget for analysis, edits, reporting, and other turn work" in section
+    assert "other backend-imposed whole-turn deadline" in section
+
+
+def test_skill_docs_keep_focused_bounded_local_test_policy_aligned():
+    skill_text = SKILL.read_text(encoding="utf-8")
+    skill_section_start = skill_text.index(f"## {SKILL_LOCAL_TEST_SCOPE_HEADING_TEXT}")
+    skill_section_end = skill_text.index("\n---", skill_section_start)
+    skill_section = " ".join(skill_text[skill_section_start:skill_section_end].split())
+
+    skill_mode_text = SKILL_MODE_DOC.read_text(encoding="utf-8")
+    skill_mode_section_start = skill_mode_text.index(f"## {SKILL_MODE_LOCAL_TEST_SCOPE_HEADING_TEXT}")
+    skill_mode_section_end = skill_mode_text.index("## Session state", skill_mode_section_start)
+    skill_mode_section = " ".join(skill_mode_text[skill_mode_section_start:skill_mode_section_end].split())
+
+    for section in (skill_section, skill_mode_section):
+        assert section.count("1,800 seconds per required test command") == 1
+        assert "individually justified command" in section
+        assert "not a reason to choose a broad suite" in section
+        assert "foreground with visible output" in section
+        assert "background" in section
+        assert "`ps`/`kill -0`/`wait`" in section
+        assert "naming the exact command and the timeout" in section
 
 
 def test_cli_help_documents_ci_queued_grace_seconds():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1770,6 +1770,15 @@ def test_coder_prompts_forbid_unbounded_ci_waits_with_exact_bound(tmp_path, buil
         lambda config: build_task_clarification_prompt("Fix the bug.", [], config),
         lambda config: build_followup_prompt(77, 1, "Needs tests.", config),
         lambda config: build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+        lambda config: build_merge_conflict_prompt(
+            77,
+            1,
+            "Resolve the conflict.",
+            config,
+            base_branch="main",
+            head_sha="deadbeef",
+            merge_state_detail="mergeable=CONFLICTING",
+        ),
     ],
 )
 def test_coder_prompts_require_focused_bounded_local_tests(tmp_path, builder):
@@ -1781,13 +1790,15 @@ def test_coder_prompts_require_focused_bounded_local_tests(tmp_path, builder):
     assert "one-line rationale for each" in prompt
     assert "Do not run the whole `tests/` suite" in prompt
     assert "broad server/database/integration/end-to-end suites" in prompt
-    assert "at most 900" in prompt
+    assert "at most 1800" in prompt
+    assert "at most 900" not in prompt
     assert "Never launch pytest in the background" in prompt
     assert "poll process IDs" in prompt
     assert "`ps`/`kill -0`/`wait`" in prompt
     assert "task-output files" in prompt
     assert "terminate the run and return a valid" in prompt
     assert "naming the exact command and the timeout" in prompt
+    assert "Reserve agent-unavailable for a genuine environment/tooling failure" in prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/test_task_loop.py
+++ b/tests/test_task_loop.py
@@ -180,7 +180,7 @@ def test_task_loop_terminates_on_no_pr_blocking_result(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
             "Local test `python -m pytest tests/test_foo.py -q` exceeded its "
-            "900 second bound; terminated and did not open a PR.\n"
+            "1800 second bound; terminated and did not open a PR.\n"
             "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
         ],
     )
@@ -232,4 +232,3 @@ def test_codex_task_loop_rejects_empty_task_text(tmp_path):
         run_task_loop(runner, task_text="   ", config=config)
 
     assert runner.commands == []
-


### PR DESCRIPTION
## Summary
- centralize the 1,800-second foreground coder test-command cap across all implementation prompts
- document the focused-test rule, timeout terminal path, and Antigravity whole-turn deadline prerequisite
- keep skill-mode guidance and regression fixtures aligned

## Tests
- `timeout 1800s python3 -m pytest tests/test_prompts.py tests/test_docs_guidance.py tests/test_task_loop.py`

Fixes #648