### PR TITLE
Add opt-in managed CI adoption for existing PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,12 @@ qualified SHA with `--match-head-commit`. `--watch-pending-ci` and
 [Managed exact-head CI](docs/local_agent_loop.md#managed-exact-head-ci) for the
 repository contract and failure behavior.
 
+Already-open PRs remain ordinary CI by default. A repository can separately
+advertise safe adoption and an operator can explicitly request it only with
+`agent-loop pr <n> --auto-merge --managed-ci-trusted-actor <login>
+--managed-ci-adopt-existing-pr`. The managed-CI guide documents the required
+branch-protection guard, timeline provenance, and durable opt-out.
+
 For repositories without that contract, `--auto-merge` foreground-polls the
 complete check board after approval with
 `--ci-timeout-seconds` and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1304,9 +1304,58 @@ intent: create or verify `agent-loop-managed`, use the reserved
 agent-loop-managed`. The workflow can suppress opened/reopened/synchronize
 matrices only for the complete tuple: same-repository head, trusted REST
 author, reserved branch, draft, and label. A contributor-editable label,
-branch, or body alone is never trusted. Forks, ordinary PRs, and prematurely
-ready managed PRs retain regular CI; removing the managed label from a draft is
-the explicit recovery path back to ordinary current-head CI.
+branch, or body alone is never trusted. Forks and ordinary PRs retain regular
+CI unless they are explicitly adopted as described below. The issue-created
+opening tuple remains unchanged: it alone requires a trusted author, reserved
+branch, and draft state.
+
+#### Optional adoption of an existing PR
+
+Existing same-repository PRs, whether draft or ready and regardless of their
+author, may be adopted only when all of the following are true:
+
+```bash
+agent-loop pr <number> --auto-merge \
+  --managed-ci-trusted-actor <trusted-login> \
+  --managed-ci-adopt-existing-pr
+```
+
+This is a distinct opt-in capability. The base-ref workflow must contain the
+literal `AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION` marker in addition to the normal
+complete v2 markers. Its absence never changes issue-created v2 drafts; an
+adoption attempt simply retains ordinary CI. Agent-loop reads this workflow
+from the live base ref, rejects forks, base/head races, closed PRs, and a PR
+with `agent-loop-managed-opt-out`.
+
+Before it applies or trusts `agent-loop-managed`, agent-loop must be able to
+inspect the base branch's required-status-check protection and find
+`final-ci/exact-head`. It publishes a pending `final-ci/exact-head` guard on
+the live SHA before suppression and repeats that guard after each adopted head
+change. Missing, inaccessible, malformed, or ambiguous protection is
+unsupported: no label mutation occurs. This keeps every suppressed adopted
+head non-mergeable until nonce/run/attempt-correlated qualification.
+
+The workflow is the security boundary. For every adoption evaluation on
+`opened`, `reopened`, `labeled`, `unlabeled`, `synchronize`,
+`ready_for_review`, and `converted_to_draft`, it must query the complete issue
+event timeline from the base workflow and suppress only if the currently active
+managed-label application's actor login and immutable ID match the actor named
+by `AGENT_LOOP_MANAGED_ACTOR`. It must also require no opt-out label. API,
+pagination, or provenance failures, or a collaborator relabeling the PR, must
+fail open to the ordinary matrix. This prevents triage/write collaborators from
+suppressing CI by manipulating labels.
+
+The handshake records the active label event ID. A trusted existing label is
+reused and never removed by that invocation; a label created by the invocation
+is removed only if its exact application is still current on a terminal
+unqualified exit (max rounds, agent/reviewer error, interrupt, ordinary
+non-zero exit, or head movement). A relabel race is left untouched and ordinary
+CI resumes. After qualification/merge the label is retained.
+
+To opt out durably, apply `agent-loop-managed-opt-out` and remove
+`agent-loop-managed`: this immediately restores current-head CI and prevents a
+later explicit adoption. Removing only `agent-loop-managed` also restores CI
+immediately, but a later explicit adoption may apply it again.
 
 V2 dispatches `ci.yml` at the base ref with protocol version, PR, exact SHA,
 and a random nonce. The workflow run name, checkout verification, per-PR/SHA
@@ -1331,7 +1380,7 @@ publisher/aggregate minute—about 11–14 minutes for a 10–13 minute matrix.
 roughly the earlier 20–25-minute shape plus recovery work. Keep routing,
 aggregate, and qualification telemetry separate for billing comparisons.
 
-Under `--auto-merge`, agent-loop automatically detects a same-repository PR
+For the legacy v1 contract only, under `--auto-merge`, agent-loop automatically detects a same-repository PR
 whose `.github/workflows/ci.yml` advertises the `agent-loop-managed`,
 `final-ci/exact-head`, and `expected_head_sha` contract. It applies the managed
 label before iterative review, allowing that repository to suppress full

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -558,6 +558,14 @@ def build_parser() -> argparse.ArgumentParser:
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
     pr.add_argument("pr_number", type=int)
     add_common(pr)
+    pr.add_argument(
+        "--managed-ci-adopt-existing-pr",
+        action="store_true",
+        help=(
+            "Explicitly adopt an eligible already-open PR into the separately advertised "
+            "v2 managed-CI protocol. Requires --auto-merge and --managed-ci-trusted-actor."
+        ),
+    )
     add_review_parallel(pr)
 
     task = subparsers.add_parser(
@@ -716,6 +724,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.command != "issue" and implementation_override_requested:
             raise AgentLoopError("--implementation-coder options are only supported with issue --plan-first.")
+        if getattr(args, "managed_ci_adopt_existing_pr", False):
+            if args.command != "pr":
+                raise AgentLoopError("--managed-ci-adopt-existing-pr is only supported with `agent-loop pr <n>`.")
+            if not args.auto_merge:
+                raise AgentLoopError("--managed-ci-adopt-existing-pr requires --auto-merge.")
+            if not (args.managed_ci_trusted_actor or "").strip():
+                raise AgentLoopError(
+                    "--managed-ci-adopt-existing-pr requires --managed-ci-trusted-actor."
+                )
         if args.command == "issue":
             if args.implement_after_approval and not args.plan_first:
                 raise AgentLoopError("--implement-after-approval requires --plan-first.")

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -178,6 +178,9 @@ class AgentLoopConfig:
     # Optional v2 managed-CI identity. A repository must independently opt in
     # with its Actions variable before this can suppress any automatic matrix.
     managed_ci_trusted_actor: str | None = None
+    # Explicit PR-mode opt-in for adopting an already-open PR into the v2
+    # managed-CI protocol.  Kept separate from the issue-created v2 flow.
+    managed_ci_adopt_existing_pr: bool = False
     invocation_argv: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -954,6 +957,7 @@ def config_from_args(
             else bool(args.watch_pending_ci)
         ),
         managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
+        managed_ci_adopt_existing_pr=getattr(args, "managed_ci_adopt_existing_pr", False),
         invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -30,6 +30,7 @@ from .workdirs import active_workdir
 
 
 MANAGED_LABEL = "agent-loop-managed"
+MANAGED_OPT_OUT_LABEL = "agent-loop-managed-opt-out"
 QUALIFIED_LABEL = "agent-loop-exact-head-qualified"
 FINAL_CONTEXT = "final-ci/exact-head"
 READINESS_CONTEXT = "agent-loop/round-readiness"
@@ -38,6 +39,11 @@ _CONTRACT_MARKERS = (MANAGED_LABEL, FINAL_CONTEXT, "expected_head_sha")
 V2_MARKER = "AGENT_LOOP_MANAGED_CI_V2"
 INTENT_MARKER = "AGENT_MANAGED_CI_INTENT_V2"
 V2_FEATURE_MARKERS = (V2_MARKER, "workflow_dispatch", "managed_nonce", FINAL_CONTEXT)
+# Adoption is deliberately not a v2 feature marker: repositories which have
+# deployed the safe issue-created draft flow do not implicitly opt in to
+# suppressing CI for existing PRs.
+V2_ADOPTION_MARKER = "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION"
+V2_ADOPTION_FEATURE_MARKERS = (V2_ADOPTION_MARKER,)
 
 
 @dataclass
@@ -56,6 +62,10 @@ class ManagedCiContract:
     expected_head_sha: str | None = None
     repository: str | None = None
     created_at: int | None = None
+    adopted_existing_pr: bool = False
+    guard_head_sha: str | None = None
+    active_label_event_id: int | None = None
+    invocation_applied_label: bool = False
 
 
 @dataclass(frozen=True)
@@ -99,11 +109,15 @@ def activate_managed_ci(
     if not config.auto_merge or config.dry_run:
         return None
 
+    workflow_ref = metadata.base_branch or config.base
+    workflow_endpoint = f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}"
+    if workflow_ref:
+        workflow_endpoint += f"?ref={workflow_ref}"
     result = runner.run(
         [
             config.gh_cmd,
             "api",
-            f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}",
+            workflow_endpoint,
             "-H",
             "Accept: application/vnd.github.raw+json",
         ],
@@ -134,7 +148,18 @@ def activate_managed_ci(
                 "Repository CI advertises an incomplete managed-CI v2 contract; missing marker(s): "
                 + ", ".join(missing_v2)
             )
-        return _activate_v2_managed_ci(
+        contract = _activate_v2_managed_ci(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            metadata=metadata,
+        )
+        if contract is not None or not config.managed_ci_adopt_existing_pr:
+            return contract
+        # A complete ordinary v2 workflow is not an adoption contract.  This
+        # path is intentionally quiet/fallback-compatible when the optional
+        # marker has not been deployed.
+        return _activate_v2_existing_pr_adoption(
             runner,
             config=config,
             pr_number=pr_number,
@@ -379,6 +404,266 @@ def _activate_v2_managed_ci(
         trusted_actor_id=actor_id,
         workflow_revision=revision,
     )
+
+
+def _api_list(runner: Runner, config: AgentLoopConfig, endpoint: str) -> list[dict[str, object]] | None:
+    """Fetch a paginated GitHub list, returning None for an uninspectable response."""
+    result = runner.run(
+        [config.gh_cmd, "api", "--paginate", "--slurp", endpoint], cwd=active_workdir(config), check=False
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    # `gh api --paginate --slurp` returns one array per page.  Accept a plain
+    # list too so single-page API implementations remain compatible.
+    if all(isinstance(item, list) for item in payload):
+        return [entry for page in payload for entry in page if isinstance(entry, dict)]
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _active_managed_label_event(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int
+) -> tuple[int, str, int] | None:
+    """Return the last label application, but only while it remains active.
+
+    Timeline provenance is an enforcement input for adoption.  Treat missing
+    actor IDs, malformed pagination, and an intervening unlabel as untrusted.
+    """
+    events = _api_list(
+        runner, config, f"repos/{config.repo}/issues/{pr_number}/events?per_page=100"
+    )
+    if events is None:
+        return None
+    latest: dict[str, object] | None = None
+    for event in events:
+        label = event.get("label") if isinstance(event.get("label"), dict) else {}
+        if label.get("name") == MANAGED_LABEL and event.get("event") in {"labeled", "unlabeled"}:
+            latest = event
+    if latest is None or latest.get("event") != "labeled":
+        return None
+    actor = latest.get("actor") if isinstance(latest.get("actor"), dict) else {}
+    event_id = latest.get("id")
+    login, actor_id = actor.get("login"), actor.get("id")
+    if not isinstance(event_id, int) or not isinstance(login, str) or not isinstance(actor_id, int):
+        return None
+    return event_id, login, actor_id
+
+
+def _has_exact_head_protection(runner: Runner, *, config: AgentLoopConfig, base_ref: str) -> bool:
+    """Require a concrete classic protection rule; ambiguity is unsupported."""
+    result = runner.run(
+        [
+            config.gh_cmd, "api",
+            f"repos/{config.repo}/branches/{base_ref}/protection/required_status_checks",
+        ],
+        cwd=active_workdir(config), check=False,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    contexts = payload.get("contexts")
+    checks = payload.get("checks")
+    return (
+        isinstance(contexts, list) and FINAL_CONTEXT in contexts
+    ) or (
+        isinstance(checks, list)
+        and any(isinstance(check, dict) and check.get("context") == FINAL_CONTEXT for check in checks)
+    )
+
+
+def _publish_adoption_guard(
+    runner: Runner, *, config: AgentLoopConfig, head_sha: str
+) -> bool:
+    result = runner.run(
+        [
+            config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/statuses/{head_sha}",
+            "-f", "state=pending", "-f", f"context={FINAL_CONTEXT}",
+            "-f", "description=Managed CI adoption awaits exact-head qualification",
+        ], cwd=active_workdir(config), check=False,
+    )
+    return result.returncode == 0
+
+
+def _ensure_managed_label(runner: Runner, *, config: AgentLoopConfig) -> bool:
+    """Create the repository label only when GitHub reports it absent."""
+    existing = runner.run(
+        [config.gh_cmd, "api", f"repos/{config.repo}/labels/{MANAGED_LABEL}"],
+        cwd=active_workdir(config), check=False,
+    )
+    if existing.returncode == 0:
+        return True
+    created = runner.run(
+        [
+            config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/labels",
+            "-f", f"name={MANAGED_LABEL}", "-f", "color=1f6feb",
+            "-f", "description=Suppress intermediate CI; agent-loop dispatches exact-head final CI",
+        ], cwd=active_workdir(config), check=False,
+    )
+    return created.returncode == 0
+
+
+def _adoption_identity(
+    runner: Runner, *, config: AgentLoopConfig
+) -> tuple[str, int] | None:
+    configured = (config.managed_ci_trusted_actor or "").strip()
+    if not configured:
+        return None
+    who = _api_json(runner, config, "user", quiet=True)
+    login, actor_id = who.get("login"), who.get("id")
+    advertised = _api_json(
+        runner, config, f"repos/{config.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR", quiet=True
+    ).get("value")
+    if (
+        not isinstance(login, str) or not isinstance(actor_id, int)
+        or not isinstance(advertised, str)
+        or login.casefold() != configured.casefold()
+        or login.casefold() != advertised.casefold()
+    ):
+        return None
+    return login, actor_id
+
+
+def _activate_v2_existing_pr_adoption(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+) -> ManagedCiContract | None:
+    """Explicitly adopt an already-open same-repository PR into v2.
+
+    All mutations occur only after capability, identity, branch protection and
+    stable-head checks.  The workflow remains the security boundary; this
+    client-side handshake is deliberately fail-closed hygiene.
+    """
+    identity = _adoption_identity(runner, config=config)
+    if identity is None:
+        return None
+    actor_login, actor_id = identity
+    base_ref = metadata.base_branch or config.base
+    if not base_ref:
+        return None
+    workflow = runner.run(
+        [config.gh_cmd, "api", f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}?ref={base_ref}",
+         "-H", "Accept: application/vnd.github.raw+json"],
+        cwd=active_workdir(config), check=False,
+    )
+    if workflow.returncode != 0:
+        return None
+    source = workflow.stdout or ""
+    # Incomplete optional adoption advertisement is unsupported rather than a
+    # reason to break the existing issue-created v2 route.
+    if any(marker not in source for marker in (*V2_FEATURE_MARKERS, *V2_ADOPTION_FEATURE_MARKERS)):
+        return None
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+    head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+    labels = {
+        item.get("name") for item in (pr.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    live_sha, head_ref = head.get("sha"), head.get("ref")
+    if (
+        pr.get("state") not in {None, "open"}
+        or head_repo.get("full_name", "").casefold() != config.repo.casefold()
+        or not isinstance(head_ref, str) or not head_ref
+        or not isinstance(live_sha, str) or live_sha != metadata.head_sha
+        or base.get("ref") != base_ref
+        or MANAGED_OPT_OUT_LABEL in labels
+        or not _has_exact_head_protection(runner, config=config, base_ref=base_ref)
+    ):
+        return None
+    # Publish the required blocking context before any possible suppression.
+    if not _publish_adoption_guard(runner, config=config, head_sha=live_sha):
+        return None
+    existing = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+    applied = False
+    if MANAGED_LABEL not in labels:
+        if not _ensure_managed_label(runner, config=config):
+            return None
+        created = runner.run(
+            [config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/labels",
+             "-f", f"labels[]={MANAGED_LABEL}"], cwd=active_workdir(config), check=False,
+        )
+        if created.returncode != 0:
+            return None
+        applied = True
+        existing = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+    if existing is None or existing[1].casefold() != actor_login.casefold() or existing[2] != actor_id:
+        # A newly-created but unprovable label must not remain as our claimed
+        # suppression.  The release helper fresh-checks event ownership.
+        provisional = ManagedCiContract(
+            protocol_version=2, adopted_existing_pr=True, active_label_event_id=existing[0] if existing else None,
+            invocation_applied_label=applied,
+        )
+        release_adopted_managed_ci(runner, config=config, pr_number=pr_number, contract=provisional)
+        return None
+    revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True).get("sha")
+    return ManagedCiContract(
+        protocol_version=2, base_ref=base_ref, trusted_actor_login=actor_login,
+        trusted_actor_id=actor_id, workflow_revision=revision if isinstance(revision, str) else None,
+        adopted_existing_pr=True, guard_head_sha=live_sha, active_label_event_id=existing[0],
+        invocation_applied_label=applied,
+    )
+
+
+def revalidate_adopted_managed_ci(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, metadata: PullRequestMetadata,
+    contract: ManagedCiContract,
+) -> bool:
+    """Recheck adoption security inputs before filtering or final dispatch."""
+    if not contract.adopted_existing_pr or not contract.base_ref:
+        return True
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    labels = {item.get("name") for item in (pr.get("labels") or []) if isinstance(item, dict)}
+    live_sha = head.get("sha")
+    if (
+        not isinstance(live_sha, str) or live_sha != metadata.head_sha
+        or MANAGED_OPT_OUT_LABEL in labels
+        or MANAGED_LABEL not in labels
+        or not _has_exact_head_protection(runner, config=config, base_ref=contract.base_ref)
+    ):
+        return False
+    event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+    if (
+        event is None or event[0] != contract.active_label_event_id
+        or event[1].casefold() != (contract.trusted_actor_login or "").casefold()
+        or event[2] != contract.trusted_actor_id
+    ):
+        return False
+    if contract.guard_head_sha != live_sha:
+        if not _publish_adoption_guard(runner, config=config, head_sha=live_sha):
+            return False
+        contract.guard_head_sha = live_sha
+    return True
+
+
+def release_adopted_managed_ci(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, contract: ManagedCiContract
+) -> bool:
+    """Remove only the still-current label event created by this invocation."""
+    if not contract.adopted_existing_pr or not contract.invocation_applied_label:
+        return True
+    event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+    if event is None or event[0] != contract.active_label_event_id:
+        return True
+    result = runner.run(
+        [config.gh_cmd, "api", "--method", "DELETE", f"repos/{config.repo}/issues/{pr_number}/labels/{MANAGED_LABEL}"],
+        cwd=active_workdir(config), check=False,
+    )
+    return result.returncode == 0
 
 
 def _api_json(runner: Runner, config: AgentLoopConfig, endpoint: str, *, quiet: bool = False) -> dict[str, object]:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -576,7 +576,8 @@ def _activate_v2_existing_pr_adoption(
     live_sha, head_ref = head.get("sha"), head.get("ref")
     if (
         pr.get("state") not in {None, "open"}
-        or head_repo.get("full_name", "").casefold() != config.repo.casefold()
+        or not isinstance(head_repo.get("full_name"), str)
+        or head_repo["full_name"].casefold() != config.repo.casefold()
         or not isinstance(head_ref, str) or not head_ref
         or not isinstance(live_sha, str) or live_sha != metadata.head_sha
         or base.get("ref") != base_ref
@@ -610,6 +611,7 @@ def _activate_v2_existing_pr_adoption(
         release_adopted_managed_ci(runner, config=config, pr_number=pr_number, contract=provisional)
         return None
     revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True).get("sha")
+    log(config, f"PR #{pr_number}: activated authenticated managed exact-head CI v2 adoption")
     return ManagedCiContract(
         protocol_version=2, base_ref=base_ref, trusted_actor_login=actor_login,
         trusted_actor_id=actor_id, workflow_revision=revision if isinstance(revision, str) else None,
@@ -627,7 +629,10 @@ def revalidate_adopted_managed_ci(
         return True
     pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
     head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
-    labels = {item.get("name") for item in (pr.get("labels") or []) if isinstance(item, dict)}
+    labels = {
+        item.get("name") for item in (pr.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
     live_sha = head.get("sha")
     if (
         not isinstance(live_sha, str) or live_sha != metadata.head_sha
@@ -653,12 +658,18 @@ def revalidate_adopted_managed_ci(
 def release_adopted_managed_ci(
     runner: Runner, *, config: AgentLoopConfig, pr_number: int, contract: ManagedCiContract
 ) -> bool:
-    """Remove only the still-current label event created by this invocation."""
+    """Remove an invocation-owned adoption label without removing a later label.
+
+    If post-apply provenance is unreadable, the label cannot safely remain as
+    our claimed suppression.  It is then removed unconditionally; when an
+    event ID was recorded, retain the normal fresh event-ID ownership check.
+    """
     if not contract.adopted_existing_pr or not contract.invocation_applied_label:
         return True
-    event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
-    if event is None or event[0] != contract.active_label_event_id:
-        return True
+    if contract.active_label_event_id is not None:
+        event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        if event is None or event[0] != contract.active_label_event_id:
+            return True
     result = runner.run(
         [config.gh_cmd, "api", "--method", "DELETE", f"repos/{config.repo}/issues/{pr_number}/labels/{MANAGED_LABEL}"],
         cwd=active_workdir(config), check=False,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6806,7 +6806,7 @@ def run_pr_loop(
                         "Actions runners recover."
                     )
                     return 0
-                if not must_fix_items and config.watch_pending_ci and managed_ci is None:
+                if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
                     if watch_deadline is None:
                         watch_deadline = time.monotonic() + config.ci_timeout_seconds
                         watch_attempts_remaining = max(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -107,6 +107,8 @@ from .managed_ci import (
     preflight_managed_ci_creation,
     prepare_v2_merge,
     publish_round_readiness,
+    release_adopted_managed_ci,
+    revalidate_adopted_managed_ci,
     wait_for_final_qualification,
 )
 from .migrations import validate_pr_migration_topology
@@ -5644,6 +5646,8 @@ def run_pr_loop(
 ) -> int:
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
+    managed_ci = None
+    managed_ci_qualified = False
     try:
         bootstrap_cwd = github_bootstrap_cwd(config)
         initial_pr_context = get_pr_review_context(
@@ -5694,6 +5698,24 @@ def run_pr_loop(
             pr_number=pr_number,
             metadata=initial_pr_context.metadata,
         )
+
+        def managed_ci_active(metadata: PullRequestMetadata) -> bool:
+            """Drop adopted filtering immediately when its live handshake changes."""
+            nonlocal managed_ci
+            if managed_ci is None:
+                return False
+            if revalidate_adopted_managed_ci(
+                runner, config=config, pr_number=pr_number, metadata=metadata, contract=managed_ci
+            ):
+                return True
+            if managed_ci.adopted_existing_pr:
+                if not release_adopted_managed_ci(
+                    runner, config=config, pr_number=pr_number, contract=managed_ci
+                ):
+                    log(config, f"PR #{pr_number}: unable to release invocation-owned managed-CI label")
+            log(config, f"PR #{pr_number}: managed-CI adoption provenance changed; using ordinary CI")
+            managed_ci = None
+            return False
         memory = prepare_agent_memory(runner, config)
         reviewer_session_ids: dict[AgentName, str | None] = {}
         unavailable_reviewer_failures: dict[AgentName, AgentInvocationError] = {}
@@ -5760,7 +5782,7 @@ def run_pr_loop(
             initial_pr_context = pr_context
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
-            if managed_ci is not None and pre_review_tests_passed and pr_metadata.head_sha:
+            if managed_ci_active(pr_metadata) and pre_review_tests_passed and pr_metadata.head_sha:
                 publish_round_readiness(
                     runner,
                     config=config,
@@ -5960,7 +5982,7 @@ def run_pr_loop(
                         shared_reviewer_pr_checks = get_pr_checks(
                             runner, config=config, metadata=pr_metadata
                         )
-                        if managed_ci is not None:
+                        if managed_ci_active(pr_metadata):
                             shared_reviewer_pr_checks = intermediate_managed_checks(
                                 shared_reviewer_pr_checks
                             )
@@ -6203,7 +6225,7 @@ def run_pr_loop(
                     reviewer_pr_checks = get_pr_checks(
                         runner, config=config, metadata=pr_metadata
                     )
-                    if managed_ci is not None:
+                    if managed_ci_active(pr_metadata):
                         reviewer_pr_checks = intermediate_managed_checks(reviewer_pr_checks)
                     compact_tail = (
                         CompactPrReviewTailContext(
@@ -6741,7 +6763,7 @@ def run_pr_loop(
                     pr_checks = None
                 else:
                     pr_checks = get_pr_checks(runner, config=config, metadata=pr_metadata)
-                    if managed_ci is not None:
+                    if managed_ci_active(pr_metadata):
                         pr_checks = intermediate_managed_checks(pr_checks)
                 if pr_checks is not None and not must_fix_items and is_wholly_infrastructure_blocked(pr_checks):
                     # Every remaining blocking/pending signal is external GitHub
@@ -7031,7 +7053,7 @@ def run_pr_loop(
                     )
                     run_optional_tests(runner, config)
                     if config.auto_merge:
-                        if managed_ci is not None:
+                        if managed_ci_active(pr_metadata):
                             assert pr_metadata.head_sha is not None
                             assert pr_metadata.head_branch is not None
                             dispatch_final_qualification(
@@ -7050,6 +7072,7 @@ def run_pr_loop(
                                 contract=managed_ci,
                             )
                             if managed_outcome.status == "passed":
+                                managed_ci_qualified = True
                                 prepare_v2_merge(
                                     runner,
                                     config=config,
@@ -7468,6 +7491,15 @@ def run_pr_loop(
             f"Reached max rounds ({config.max_rounds}) for PR #{pr_number}; human review required."
         )
     finally:
+        if (
+            managed_ci is not None
+            and managed_ci.adopted_existing_pr
+            and not managed_ci_qualified
+            and not release_adopted_managed_ci(
+                runner, config=config, pr_number=pr_number, contract=managed_ci
+            )
+        ):
+            log(config, f"PR #{pr_number}: unable to release invocation-owned managed-CI label")
         if owned_usage_context:
             _persist_usage_summary(config, usage_context)
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1266,6 +1266,18 @@ def test_config_enables_ci_watch_with_auto_merge_without_rebuilding_antigravity_
     assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
 
 
+def test_config_records_explicit_existing_pr_managed_ci_adoption(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge",
+        "--managed-ci-trusted-actor", "agent-loop", "--managed-ci-adopt-existing-pr",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.managed_ci_adopt_existing_pr is True
+
+
 def test_config_does_not_enable_ci_watch_without_auto_merge(tmp_path):
     parser = build_parser()
     args = parser.parse_args(["pr", "77", "--repo", "OWNER/REPO"])

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -118,6 +118,15 @@ def test_readme_links_to_managed_exact_head_ci_and_scopes_watch_mode():
     )
 
 
+def test_managed_ci_docs_describe_explicit_existing_pr_adoption_and_opt_out():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert "#### Optional adoption of an existing PR" in text
+    assert "--managed-ci-adopt-existing-pr" in text
+    assert "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION" in text
+    assert "agent-loop-managed-opt-out" in text
+    assert "triage/write collaborators" in text
+
+
 def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert f"### {LOCAL_TEST_SCOPE_HEADING_TEXT}" in text

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -129,6 +129,7 @@ class V2ManagedRunner(ManagedRunner):
         actor_id=1,
         advertised_actor=None,
         issue_events=None,
+        unreadable_issue_events_after_label=False,
         **kwargs,
     ):
         workflow = kwargs.pop("workflow", V2_WORKFLOW)
@@ -153,6 +154,8 @@ class V2ManagedRunner(ManagedRunner):
         self.actor_id = actor_id
         self.advertised_actor = advertised_actor or actor_login
         self.issue_events = list(issue_events or [])
+        self.unreadable_issue_events_after_label = unreadable_issue_events_after_label
+        self.labels_posted = False
 
     def _run_locked(self, args, *, cwd, check):
         cmd = list(args)
@@ -179,7 +182,20 @@ class V2ManagedRunner(ManagedRunner):
             return CommandResult(cmd, cwd_path, json.dumps(self.rest_pr), "", 0)
         if endpoint.startswith("repos/OWNER/REPO/issues/7/events?"):
             cmd, cwd_path = self._record_command(args, cwd)
+            if self.unreadable_issue_events_after_label and self.labels_posted:
+                return CommandResult(cmd, cwd_path, "", "events unavailable", 1)
             return CommandResult(cmd, cwd_path, json.dumps(self.issue_events), "", 0)
+        if endpoint == "repos/OWNER/REPO/issues/7/labels" and "POST" in cmd:
+            cmd, cwd_path = self._record_command(args, cwd)
+            self.labels_posted = True
+            self.rest_pr["labels"] = [{"name": MANAGED_LABEL}]
+            self.issue_events.append(label_event())
+            return CommandResult(cmd, cwd_path, "{}", "", 0)
+        if endpoint == f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}" and "DELETE" in cmd:
+            cmd, cwd_path = self._record_command(args, cwd)
+            self.rest_pr["labels"] = []
+            self.issue_events.append(label_event(event="unlabeled"))
+            return CommandResult(cmd, cwd_path, "", "", 0)
         if endpoint == "repos/OWNER/REPO/commits/main":
             cmd, cwd_path = self._record_command(args, cwd)
             return CommandResult(cmd, cwd_path, json.dumps({"sha": "base-sha"}), "", 0)
@@ -730,6 +746,25 @@ def test_existing_pr_adoption_requires_separate_marker_but_keeps_draft_v2(tmp_pa
     assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
 
 
+def test_existing_pr_adoption_rejects_null_head_repository_name(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        managed_ci_adopt_existing_pr=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=adoption_workflow(),
+        rest_pr={
+            "draft": False,
+            "state": "open",
+            "head": {"repo": {"full_name": None}, "sha": "abc123", "ref": "feature"},
+            "labels": [],
+        },
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+
+    assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
+
+
 def test_existing_pr_adoption_reuses_trusted_label_and_revalidates(tmp_path):
     config = make_config(
         tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
@@ -756,8 +791,65 @@ def test_existing_pr_adoption_reuses_trusted_label_and_revalidates(tmp_path):
     assert revalidate_adopted_managed_ci(
         runner, config=config, pr_number=7, metadata=metadata(), contract=contract
     )
+    runner.rest_pr["labels"].append({"name": []})
+    assert revalidate_adopted_managed_ci(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
     assert release_adopted_managed_ci(runner, config=config, pr_number=7, contract=contract)
-    assert not any("DELETE" in cmd and MANAGED_LABEL in cmd for cmd, _ in runner.commands)
+    assert not any(
+        cmd[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
+        for cmd, _ in runner.commands
+    )
+
+
+def test_existing_pr_adoption_applies_and_releases_invocation_label(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        managed_ci_adopt_existing_pr=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=adoption_workflow(),
+        rest_pr={"draft": False, "state": "open", "labels": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.invocation_applied_label is True
+    assert contract.active_label_event_id == 101
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"]
+        for cmd, _ in runner.commands
+    )
+    assert release_adopted_managed_ci(runner, config=config, pr_number=7, contract=contract)
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
+        for cmd, _ in runner.commands
+    )
+
+
+def test_existing_pr_adoption_removes_unprovable_invocation_label(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        managed_ci_adopt_existing_pr=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=adoption_workflow(),
+        rest_pr={"draft": False, "state": "open", "labels": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+        unreadable_issue_events_after_label=True,
+    )
+
+    assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"]
+        for cmd, _ in runner.commands
+    )
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
+        for cmd, _ in runner.commands
+    )
 
 
 @pytest.mark.parametrize(
@@ -779,7 +871,10 @@ def test_existing_pr_adoption_fails_closed_before_suppression(tmp_path, labels, 
     )
 
     assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
-    assert not any("issues/7/labels" in cmd and "POST" in cmd for cmd, _ in runner.commands)
+    assert not any(
+        cmd[:5] == ["gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"]
+        for cmd, _ in runner.commands
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -12,6 +12,7 @@ from coding_review_agent_loop.github import (
 from coding_review_agent_loop.managed_ci import (
     FINAL_CONTEXT,
     MANAGED_LABEL,
+    MANAGED_OPT_OUT_LABEL,
     READINESS_CONTEXT,
     ManagedCiContract,
     _dispatch_v2_qualification,
@@ -23,6 +24,8 @@ from coding_review_agent_loop.managed_ci import (
     preflight_managed_ci_creation,
     prepare_v2_merge,
     publish_round_readiness,
+    release_adopted_managed_ci,
+    revalidate_adopted_managed_ci,
     wait_for_final_qualification,
 )
 from coding_review_agent_loop.runner import CommandResult
@@ -78,7 +81,10 @@ class ManagedRunner(FakeRunner):
 
     def _run_locked(self, args, *, cwd, check):
         cmd = list(args)
-        if cmd[:3] == ["gh", "api", "repos/OWNER/REPO/contents/.github/workflows/ci.yml"]:
+        if (
+            cmd[:2] == ["gh", "api"]
+            and cmd[2].startswith("repos/OWNER/REPO/contents/.github/workflows/ci.yml")
+        ):
             cmd, cwd_path = self._record_command(args, cwd)
             return CommandResult(cmd, cwd_path, self.workflow, "", 0)
         if cmd[:3] == ["gh", "api", "repos/OWNER/REPO/pulls/7"]:
@@ -122,6 +128,7 @@ class V2ManagedRunner(ManagedRunner):
         actor_login="agent-loop",
         actor_id=1,
         advertised_actor=None,
+        issue_events=None,
         **kwargs,
     ):
         workflow = kwargs.pop("workflow", V2_WORKFLOW)
@@ -145,6 +152,7 @@ class V2ManagedRunner(ManagedRunner):
         self.actor_login = actor_login
         self.actor_id = actor_id
         self.advertised_actor = advertised_actor or actor_login
+        self.issue_events = list(issue_events or [])
 
     def _run_locked(self, args, *, cwd, check):
         cmd = list(args)
@@ -169,6 +177,9 @@ class V2ManagedRunner(ManagedRunner):
         if endpoint == "repos/OWNER/REPO/pulls/7":
             cmd, cwd_path = self._record_command(args, cwd)
             return CommandResult(cmd, cwd_path, json.dumps(self.rest_pr), "", 0)
+        if endpoint.startswith("repos/OWNER/REPO/issues/7/events?"):
+            cmd, cwd_path = self._record_command(args, cwd)
+            return CommandResult(cmd, cwd_path, json.dumps(self.issue_events), "", 0)
         if endpoint == "repos/OWNER/REPO/commits/main":
             cmd, cwd_path = self._record_command(args, cwd)
             return CommandResult(cmd, cwd_path, json.dumps({"sha": "base-sha"}), "", 0)
@@ -690,6 +701,85 @@ def test_v2_activation_and_preflight_require_authenticated_actor(tmp_path):
     assert contract is not None
     assert contract.protocol_version == 2
     assert contract.trusted_actor_login == "agent-loop"
+
+
+def adoption_workflow():
+    return V2_WORKFLOW + "\n# AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION\n"
+
+
+def label_event(event_id=101, *, event="labeled", login="agent-loop", actor_id=1):
+    return {
+        "id": event_id,
+        "event": event,
+        "label": {"name": MANAGED_LABEL},
+        "actor": {"login": login, "id": actor_id},
+    }
+
+
+def test_existing_pr_adoption_requires_separate_marker_but_keeps_draft_v2(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        managed_ci_adopt_existing_pr=True,
+    )
+    runner = V2ManagedRunner(
+        rest_pr={"draft": False, "user": {"login": "someone", "id": 55}},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+    # A complete existing v2 contract still serves issue-created drafts, but
+    # does not silently turn on adoption.
+    assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
+
+
+def test_existing_pr_adoption_reuses_trusted_label_and_revalidates(tmp_path):
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        managed_ci_adopt_existing_pr=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=adoption_workflow(),
+        rest_pr={
+            "draft": False,
+            "state": "open",
+            "user": {"login": "someone", "id": 55},
+            "head": {"repo": {"full_name": "OWNER/REPO"}, "sha": "abc123", "ref": "feature"},
+            "labels": [{"name": MANAGED_LABEL}],
+        },
+        issue_events=[label_event()],
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.adopted_existing_pr is True
+    assert contract.invocation_applied_label is False
+    assert revalidate_adopted_managed_ci(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+    assert release_adopted_managed_ci(runner, config=config, pr_number=7, contract=contract)
+    assert not any("DELETE" in cmd and MANAGED_LABEL in cmd for cmd, _ in runner.commands)
+
+
+@pytest.mark.parametrize(
+    "labels,events,protection",
+    [
+        ([{"name": MANAGED_OPT_OUT_LABEL}], [], {"contexts": [FINAL_CONTEXT]}),
+        ([{"name": MANAGED_LABEL}], [label_event(login="collaborator", actor_id=2)], {"contexts": [FINAL_CONTEXT]}),
+        ([], [], {"contexts": []}),
+    ],
+)
+def test_existing_pr_adoption_fails_closed_before_suppression(tmp_path, labels, events, protection):
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        managed_ci_adopt_existing_pr=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=adoption_workflow(), rest_pr={"draft": False, "labels": labels},
+        issue_events=events, pr_branch_protection_payload=protection,
+    )
+
+    assert activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata()) is None
+    assert not any("issues/7/labels" in cmd and "POST" in cmd for cmd, _ in runner.commands)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #647\n\nAdds an explicitly advertised v2 adoption path for existing same-repository PRs, guarded by branch protection, pending exact-head status, trusted timeline provenance, durable opt-out, and ownership-aware cleanup. Existing issue-created v2 draft activation remains unchanged.