### PR TITLE
Preserve carried review item identity

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1859,6 +1859,36 @@ The remaining legacy compatibility surface is intentionally narrow:
 - Resume reconstruction should rely on `AGENT_LOOP_META` instead of reparsing
   old prose whenever metadata exists for the active round.
 
+### Carried item identity
+
+Every unresolved item has an immutable canonical claim (`text`) and accumulated
+reviewer/coder evidence (`notes`). Review prompts show these separately as
+**Original claim** and **Updates/evidence**. Legacy records that appended
+`Update from ...` lines to the claim are split only when displayed; the stored
+record and resume signatures remain unchanged.
+
+When reviewing a carried item, reviewers must evaluate its original predicate.
+More specific evidence for the same defect may keep the same ID. If the old
+predicate is accepted but a materially different defect is found, resolve the
+old item and add the different concern as a new `blocking_items` or
+`same_pr_followups` entry (or `blocking_plan_issues` / `same_plan_followups`
+for a plan review) in the same response. Those arrays contain new findings
+only; an active carried claim appears only as a `blocking`, `same-pr`, or
+`same-plan` disposition plus its note. Each explicit new finding receives a
+fresh stable ID.
+
+Reconciliation remains conservative for a genuine same-claim disagreement: a
+valid active disposition still outweighs another reviewer's `resolved` vote.
+An active carried disposition is actionable even without a new-finding array,
+so it is neither classified as an incomplete review nor converted from summary
+prose into a duplicate new item. Summary fallback remains available only when
+there is no explicit new finding and no active carried disposition.
+
+Fresh findings do not inherit coder-dispute lineage because semantic
+equivalence cannot be inferred safely. If a disputed claim is improperly
+re-filed as a fresh item, the coder gets one additional dispute on that new ID
+before the existing continued-blocking escalation applies.
+
 ## Logs
 
 Agent stdout/stderr is written to `.agent-loop-logs/` under the active coder

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3288,13 +3288,21 @@ def _is_infrastructure_ci_only_review(parsed_review: ParsedReview, pr_checks: Pu
     return True
 
 
-def _should_record_new_blocking_item(summary: str, *, had_prior_items: bool, had_dispositions: bool) -> bool:
+def _should_record_new_blocking_item(
+    summary: str,
+    *,
+    had_prior_items: bool,
+    had_dispositions: bool,
+    has_active_carried_disposition: bool = False,
+) -> bool:
     if not summary:
         return False
     if summary.strip() in {"Review complete.", "Plan review complete."}:
         return False
     if not had_prior_items or not had_dispositions:
         return True
+    if has_active_carried_disposition:
+        return False
     non_empty_lines = [line.strip() for line in summary.splitlines() if line.strip()]
     if len(non_empty_lines) > 1:
         return True
@@ -3321,6 +3329,8 @@ def _is_incomplete_pr_review(parsed_review: ParsedReview) -> bool:
     if parsed_review.state != "blocking":
         return False
     if parsed_review.blocking_items or parsed_review.followups.same_pr:
+        return False
+    if any(disposition.disposition in {"blocking", "same-pr"} for disposition in parsed_review.dispositions):
         return False
     candidate_texts = [parsed_review.summary]
     candidate_texts.extend(disposition.note for disposition in parsed_review.dispositions)
@@ -6387,10 +6397,15 @@ def run_pr_loop(
                 has_structured_blocking_content = bool(
                     parsed_review.blocking_items or parsed_review.followups.same_pr
                 )
+                has_active_carried_disposition = any(
+                    disposition.disposition in {"blocking", "same-pr"}
+                    for disposition in parsed_review.dispositions
+                )
                 has_blocking_summary = not has_structured_blocking_content and _should_record_new_blocking_item(
                     blocking_summary,
                     had_prior_items=bool(prior_unresolved_items),
                     had_dispositions=bool(parsed_review.dispositions),
+                    has_active_carried_disposition=has_active_carried_disposition,
                 )
                 log(
                     config,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3397,6 +3397,8 @@ def _is_incomplete_plan_review(parsed_review: ParsedPlanReview) -> bool:
         return False
     if parsed_review.items.blocking or parsed_review.items.same_plan:
         return False
+    if any(disposition.disposition in {"blocking", "same-plan"} for disposition in parsed_review.dispositions):
+        return False
     candidate_texts = [parsed_review.summary]
     candidate_texts.extend(disposition.note for disposition in parsed_review.dispositions)
     return any(text and _INCOMPLETE_PR_REVIEW_RE.search(text) for text in candidate_texts)
@@ -6582,7 +6584,12 @@ def run_pr_loop(
                 ]
                 if disputed_still_blocking:
                     item_summaries = "\n".join(
-                        f"- [{item.item_id}] from {item.reviewer}: {item.text[:300]}"
+                        "\n".join(
+                            [
+                                f"- [{item.item_id}] from {item.reviewer}: {item.text[:300]}",
+                                *[f"  Update/evidence: {note}" for note in item.notes],
+                            ]
+                        )
                         for item in disputed_still_blocking
                     )
                     raise AgentLoopError(

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -733,14 +733,15 @@ def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewI
         "Prior unresolved review items from earlier rounds",
         "",
         "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
-        "For carried future follow-ups, record their status only in `prior_item_dispositions`; do not repeat the same concern in new `future_followups`. Use `resolved` if later PR changes already handled it, or promote it to `same-pr`/`still blocking` if it must be fixed before merge.",
+        "Each item has an immutable Original claim and separate Updates/evidence. Evaluate the Original claim, not a replacement concern. For carried future follow-ups, record their status only in `prior_item_dispositions`; do not repeat the same concern in new `future_followups`. Use `resolved` if later PR changes already handled it, or promote it to `same-pr`/`still blocking` if it must be fixed before merge.",
         "",
     ]
     for item in unresolved_items:
-        details = [indent(item.text, "  ")]
-        if item.notes:
-            details.append("  Latest reviewer updates:")
-            details.extend(f"  - {note}" for note in item.notes)
+        claim, updates = _render_unresolved_item_claim_and_updates(item)
+        details = ["  Original claim:", indent(claim, "    ")]
+        if updates:
+            details.append("  Updates/evidence:")
+            details.extend(f"  - {note}" for note in updates)
         lines.extend(
             [
                 f"- [{item.item_id}] {item.status} from {item.reviewer} in round {item.source_round}",
@@ -758,14 +759,15 @@ def _format_unresolved_plan_items(unresolved_items: Sequence[UnresolvedReviewIte
         "Prior unresolved plan items from earlier rounds",
         "",
         "Explicitly evaluate every item below before approving. Use the item IDs exactly as written.",
-        "For carried future follow-ups, record their status only in `prior_plan_item_dispositions`; do not repeat the same concern in new `future_followups`. Use `resolved` if later plan changes already handled it, or promote it to `same-plan`/`still blocking` if it must be fixed before implementation.",
+        "Each item has an immutable Original claim and separate Updates/evidence. Evaluate the Original claim, not a replacement concern. For carried future follow-ups, record their status only in `prior_plan_item_dispositions`; do not repeat the same concern in new `future_followups`. Use `resolved` if later plan changes already handled it, or promote it to `same-plan`/`still blocking` if it must be fixed before implementation.",
         "",
     ]
     for item in unresolved_items:
-        details = [indent(item.text, "  ")]
-        if item.notes:
-            details.append("  Latest reviewer updates:")
-            details.extend(f"  - {note}" for note in item.notes)
+        claim, updates = _render_unresolved_item_claim_and_updates(item)
+        details = ["  Original claim:", indent(claim, "    ")]
+        if updates:
+            details.append("  Updates/evidence:")
+            details.extend(f"  - {note}" for note in updates)
         lines.extend(
             [
                 f"- [{item.item_id}] {item.status} from {item.reviewer} in round {item.source_round}",
@@ -774,6 +776,34 @@ def _format_unresolved_plan_items(unresolved_items: Sequence[UnresolvedReviewIte
         )
     lines.append("")
     return "\n".join(lines)
+
+
+_LEGACY_ITEM_UPDATE_SUFFIX_RE = re.compile(
+    r"(?s)(?P<claim>.*?)(?:\n{2,}Update from (?P<updates>[^\n]+(?:\n{2,}Update from [^\n]+)*))$"
+)
+
+
+def _render_unresolved_item_claim_and_updates(item: UnresolvedReviewItem) -> tuple[str, tuple[str, ...]]:
+    """Split legacy text updates only while rendering reviewer context.
+
+    Earlier ledgers appended ``Update from ...`` lines to text.  Preserve that
+    serialized form for resume signatures, but expose the pre-update claim as
+    the canonical predicate to new reviewers.
+    """
+    match = _LEGACY_ITEM_UPDATE_SUFFIX_RE.fullmatch(item.text)
+    claim = item.text
+    legacy_updates: tuple[str, ...] = ()
+    if match is not None:
+        claim = match.group("claim")
+        legacy_updates = tuple(
+            f"Update from {entry}"
+            for entry in match.group("updates").split("\n\nUpdate from ")
+        )
+    updates: list[str] = []
+    for update in (*legacy_updates, *item.notes):
+        if update not in updates:
+            updates.append(update)
+    return claim, tuple(updates)
 
 
 def format_pr_checks(checks: PullRequestChecks) -> str:
@@ -940,6 +970,14 @@ eligible for dispositions in this round. If same-round findings from other
 reviewers appear elsewhere in the issue discussion, treat them as
 informational only and do not disposition them until a later round carries
 them forward explicitly.
+When prior items are present, evaluate each displayed Original claim rather
+than replacing its meaning. Narrower evidence for the same defect may remain
+on that ID. If you accept the original predicate but discover a materially
+different defect, resolve the old item and report the new defect in a separate
+`blocking_plan_issues` or `same_plan_followups` entry in the same response.
+Those arrays contain new findings only; an active carried item is represented
+solely by its `blocking` or `same-plan` disposition and note. Use `same-plan`,
+never `same-pr`, for plan-only work.
 Structured responses must start with one top-level JSON object, place the
 `AGENT_PLAN_STATE` footer immediately after that payload, and end with only
 your standalone signature. Do not include prose or code fences before the JSON
@@ -1259,21 +1297,7 @@ def build_plan_review_prompt(
         requirement_label="signed human issue requirements",
         require_plan_dispositions=True,
     )
-    if unresolved_items:
-        unresolved_items_guidance = """Prior unresolved plan items are present. Disposition every listed item
-in the JSON `prior_plan_item_dispositions` array — do not add a separate prose section
-or bullet list for prior items outside the JSON object. Valid `disposition` values:
-- `"resolved"` — item is fixed in this revision.
-- `"blocking"` — item is still a blocking plan problem; include it in `blocking_plan_issues`.
-- `"same-plan"` — item needs to be incorporated before implementation; include it in `same_plan_followups`.
-- `"future"` — deferred; must include a `"note"` field; only valid when approving.
-
-Only use `"future"` when returning `approved`. If a plan item still needs to be fixed
-before implementation starts, use `"blocking"` or `"same-plan"` instead. For any prior
-item already marked `"future"`, explicitly re-evaluate.
-"""
-    else:
-        unresolved_items_guidance = ""
+    unresolved_items_guidance = _build_unresolved_plan_items_guidance() if unresolved_items else ""
     return f"""Review the implementation plan for GitHub issue #{issue_number} in {config.repo} (planning round {round_number}).
 
 Use this local checkout only to inspect context. Do not edit files, create a
@@ -1380,21 +1404,7 @@ def _build_compact_plan_review_prompt(
         requirement_label="signed human issue requirements",
         require_plan_dispositions=True,
     )
-    if unresolved_items:
-        unresolved_items_guidance = """Prior unresolved plan items are present. Disposition every listed item
-in the JSON `prior_plan_item_dispositions` array — do not add a separate prose section
-or bullet list for prior items outside the JSON object. Valid `disposition` values:
-- `"resolved"` — item is fixed in this revision.
-- `"blocking"` — item is still a blocking plan problem; include it in `blocking_plan_issues`.
-- `"same-plan"` — item needs to be incorporated before implementation; include it in `same_plan_followups`.
-- `"future"` — deferred; must include a `"note"` field; only valid when approving.
-
-Only use `"future"` when returning `approved`. If a plan item still needs to be fixed
-before implementation starts, use `"blocking"` or `"same-plan"` instead. For any prior
-item already marked `"future"`, explicitly re-evaluate.
-"""
-    else:
-        unresolved_items_guidance = ""
+    unresolved_items_guidance = _build_unresolved_plan_items_guidance() if unresolved_items else ""
     stable_prefix = _compact_plan_stable_prefix(
         config=config,
         workdir_guidance=_coder_workdir_guidance(config, implementation=False, agent=reviewer),
@@ -2160,14 +2170,45 @@ def _build_unresolved_items_guidance() -> str:
 item in the JSON `prior_item_dispositions` array — do not add a separate prose section
 or bullet list for prior items outside the JSON object. Valid `disposition` values:
 - `"resolved"` — item is fixed in this PR.
-- `"blocking"` — item is still a merge-blocking problem; include it in `blocking_items`.
-- `"same-pr"` — item needs to be fixed before merge; include it in `same_pr_followups`.
+- `"blocking"` — the displayed Original claim is still a merge-blocking problem.
+- `"same-pr"` — the displayed Original claim needs to be fixed before merge.
 - `"future"` — deferred; must include a `"note"` field; only valid when approving.
 
 Only use `"future"` when returning `approved`. If an item should still be fixed before
 merge, use `"blocking"` or `"same-pr"` instead. For any prior item already marked
 `"future"`, explicitly re-evaluate: `"resolved"`, still `"future"`, or back to
 `"blocking"`/`"same-pr"`.
+
+The displayed Original claim is this stable item ID's predicate. Narrower evidence
+for that same defect may remain on the old ID. If you accept the original predicate
+but discover a materially different defect, mark the old item `"resolved"` and put
+the new defect in a separate `blocking_items` or `same_pr_followups` entry in this
+same response. The new-finding arrays contain new findings only: never restate an
+active carried item there. A resolved carried item and a new blocker may appear in
+the same response.
+"""
+
+
+def _build_unresolved_plan_items_guidance() -> str:
+    return """Prior unresolved plan items are present. Disposition every listed item
+in the JSON `prior_plan_item_dispositions` array — do not add a separate prose section
+or bullet list for prior items outside the JSON object. Valid `disposition` values:
+- `"resolved"` — the displayed Original claim is fixed in this revision.
+- `"blocking"` — the displayed Original claim is still a blocking plan problem.
+- `"same-plan"` — the displayed Original claim needs to be incorporated before implementation.
+- `"future"` — deferred; must include a `"note"` field; only valid when approving.
+
+Only use `"future"` when returning `approved`. If a plan item still needs to be fixed
+before implementation starts, use `"blocking"` or `"same-plan"` instead. For any prior
+item already marked `"future"`, explicitly re-evaluate.
+
+The displayed Original claim is this stable item ID's predicate. Narrower evidence
+for that same defect may remain on the old ID. If you accept the original predicate
+but discover a materially different defect, mark the old item `"resolved"` and put
+the new defect in a separate `blocking_plan_issues` or `same_plan_followups` entry
+in the same response. The new-finding arrays contain new findings only: never
+restate an active carried item there. A resolved carried item and a new blocker may
+appear in the same response. Use `same-plan`, never `same-pr`, for plan-only work.
 """
 
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -779,7 +779,7 @@ def _format_unresolved_plan_items(unresolved_items: Sequence[UnresolvedReviewIte
 
 
 _LEGACY_ITEM_UPDATE_SUFFIX_RE = re.compile(
-    r"(?s)(?P<claim>.*?)(?:\n{2,}Update from (?P<updates>[^\n]+(?:\n{2,}Update from [^\n]+)*))$"
+    r"(?s)(?P<claim>.*?)(?:\n{2,}Update from (?P<updates>.*))$"
 )
 
 
@@ -801,7 +801,8 @@ def _render_unresolved_item_claim_and_updates(item: UnresolvedReviewItem) -> tup
         )
     updates: list[str] = []
     for update in (*legacy_updates, *item.notes):
-        if update not in updates:
+        normalized_update = update.removeprefix("Update from ")
+        if not any(existing.removeprefix("Update from ") == normalized_update for existing in updates):
             updates.append(update)
     return claim, tuple(updates)
 

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -446,19 +446,16 @@ def _apply_unresolved_item_dispositions(
         if not dispositions:
             next_unresolved.append(item)
             continue
+        # `text` is the item’s canonical claim.  Dispositions may add evidence
+        # for that claim, but must never rewrite it: a reviewer that discovers a
+        # different concern must file a fresh item rather than silently changing
+        # what this stable ID means.
         text = item.text
         notes = list(item.notes)
         outcomes = {disposition.disposition for disposition in dispositions}
-        preserve_note_in_text = bool({"blocking", same_status} & outcomes) or (
-            "future" in outcomes and not retain_future
-        )
         for disposition in dispositions:
             if disposition.note:
                 note_text = f"{disposition.reviewer}: {disposition.note}"
-                if preserve_note_in_text:
-                    update_line = f"Update from {note_text}"
-                    if update_line not in text:
-                        text = f"{text.rstrip()}\n\n{update_line}"
                 if note_text not in notes:
                     notes.append(note_text)
         if "blocking" in outcomes:

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -618,6 +618,66 @@ def test_is_incomplete_plan_review_matches_disposition_note():
     )
     assert orchestrator_module._is_incomplete_plan_review(parsed_review) is True
 
+
+def test_is_incomplete_plan_review_allows_active_carried_disposition():
+    parsed_review = ParsedPlanReview(
+        state="blocking",
+        summary="",
+        items=PlanReviewItems(blocking=(), same_plan=(), future=()),
+        dispositions=(
+            ReviewItemDisposition(
+                item_id="item-1",
+                reviewer="Codex",
+                disposition="blocking",
+                note="Could not confirm the revised plan covers migration ordering.",
+            ),
+        ),
+    )
+
+    assert orchestrator_module._is_incomplete_plan_review(parsed_review) is False
+
+
+def test_issue_loop_plan_review_allows_active_carried_blocking_disposition(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(summary="Initial plan.", plan_steps=["Document migration ordering."]),
+            structured_plan_revision(
+                summary="Added migration ordering.",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                plan_steps=["Document migration ordering."],
+            ),
+            structured_plan_revision(
+                summary="Clarified migration ordering.",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                plan_steps=["Document migration ordering."],
+            ),
+        ],
+        codex_outputs=[
+            structured_plan_review(
+                state="blocking",
+                blocking_plan_issues=["Document migration ordering."],
+            ),
+            structured_plan_review(
+                state="blocking",
+                summary="Could not confirm the revised plan covers migration ordering.",
+                prior_plan_item_dispositions=[{
+                    "item_id": "item-1",
+                    "disposition": "blocking",
+                    "note": "Could not confirm the revised plan covers migration ordering.",
+                }],
+            ),
+            structured_plan_review(
+                state="approved",
+                prior_plan_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, coder="claude", reviewer="codex", max_rounds=3)
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+    assert any("Could not confirm the revised plan" in comment for comment in runner.comments)
+
+
 def test_issue_loop_structured_plan_state_public_comment_renders_markdown_and_preserves_metadata(tmp_path):
     raw_structured_plan = structured_plan_state(
         summary="Plan the issue fix.",

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -5564,8 +5564,10 @@ def test_pr_loop_escalates_to_human_when_reviewer_rejects_dispute(tmp_path):
     with pytest.raises(
         AgentLoopError,
         match="Reviewer did not resolve 1 disputed item",
-    ):
+    ) as excinfo:
         run_pr_loop(runner, pr_number=55, config=config)
+
+    assert "Update/evidence: Codex: I checked and the pricing is still wrong." in str(excinfo.value)
 
 
 def test_pr_loop_escalates_when_reviewer_downgrades_disputed_item_to_same_pr(tmp_path):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -3671,7 +3671,7 @@ def test_pr_loop_stops_on_incomplete_review_without_coder_followup(tmp_path):
             "Review incomplete; item-1 requires further inspection of the PR diff "
             "and referenced files before a disposition can be confirmed."
             + prior_item_dispositions(
-                "[item-1] still blocking: Resolution could not be confirmed; "
+                "[item-1] resolved: Resolution could not be confirmed; "
                 "PR diff and referenced files need review."
             )
             + "\n<!-- AGENT_STATE: blocking -->\n-- OpenAI Codex",
@@ -3690,6 +3690,47 @@ def test_pr_loop_stops_on_incomplete_review_without_coder_followup(tmp_path):
     assert len(runner.comments) == 2
     assert "Review incomplete" not in "\n".join(runner.comments)
 
+
+def test_pr_loop_keeps_active_carried_disposition_actionable_without_duplicate_summary_item(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking", summary="Initial scope concern.",
+                blocking_items=["All 14 locale catalogs must be evaluated."],
+            ),
+            structured_pr_review(
+                state="blocking", summary="Unable to verify the translation detail today.",
+                prior_item_dispositions=[{
+                    "item_id": "item-1", "disposition": "blocking",
+                    "note": "The original scope-completeness claim remains unresolved.",
+                }],
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                state="blocking", summary="Evaluated every locale.",
+                addressed_items=["item-1"], remaining_items=[],
+            ),
+            structured_coder_followup(
+                state="blocking", summary="Need more evidence for the carried claim.",
+                addressed_items=[], remaining_items=["item-1"],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, max_rounds=2)
+
+    with pytest.raises(AgentLoopError, match="still reported blocking issues after round 2"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    reviewer_records = [
+        _decode_round_metadata(orchestrator.ROUND_RESUME_MARKER_RE.search(comment["body"])["payload"])
+        for comment in runner.pr_payload["comments"]
+        if orchestrator.ROUND_RESUME_MARKER_RE.search(comment["body"])
+    ]
+    round_two = next(record for record in reviewer_records if record.agent == "Codex" and record.round_number == 2)
+    assert round_two.new_items == ()
+    assert round_two.dispositions[0].disposition == "blocking"
+    assert not any("agent-unavailable" in comment["body"] for comment in runner.pr_payload["comments"])
 
 def test_pr_loop_quarantines_unavailable_reviewer_while_healthy_reviewer_finishes(tmp_path):
     unavailable = json.dumps(
@@ -4405,7 +4446,7 @@ def test_resume_pr_round_recovers_reviewer_only_with_aggregated_dispositions():
     assert resumed.unrecorded_head_advance is True
     assert [item.item_id for item in resumed.prior_items] == ["item-2", "item-4"]
     assert resumed.prior_items[0].status == "same-pr"
-    assert "Still needed before merge." in resumed.prior_items[0].text
+    assert "Google Gemini: Still needed before merge." in resumed.prior_items[0].notes
 
 def test_resume_pr_round_ignores_unrecorded_head_advance_with_no_active_items():
     future_item = UnresolvedReviewItem(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -418,6 +418,30 @@ def test_review_prompt_splits_legacy_updates_without_mutating_claim_and_preserve
     assert "accept the original predicate\nbut discover a materially different defect" in prompt
 
 
+def test_review_prompt_splits_multiline_legacy_updates_and_deduplicates_notes(tmp_path):
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    prompt = build_review_prompt(
+        77, 2, config, reviewer="codex",
+        unresolved_items=(UnresolvedReviewItem(
+            item_id="item-1", reviewer="Anthropic Claude", source_round=1,
+            text=(
+                "Scope completeness requires every locale.\n\n"
+                "Update from Anthropic Claude: Scope evidence was rechecked.\n"
+                "The audit covered the remaining catalogs."
+            ),
+            status="blocking",
+            notes=(
+                "Anthropic Claude: Scope evidence was rechecked.\n"
+                "The audit covered the remaining catalogs.",
+            ),
+        ),),
+    )
+
+    assert "Original claim:\n    Scope completeness requires every locale." in prompt
+    assert prompt.count("Scope evidence was rechecked.") == 1
+    assert "The audit covered the remaining catalogs." in prompt
+
+
 def test_plan_review_prompts_require_new_findings_for_changed_carried_claims(tmp_path):
     config = make_config(tmp_path, reviewer=("codex",))
     item = UnresolvedReviewItem(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -12,14 +12,22 @@ _EXPECTED_UNRESOLVED_ITEMS_GUIDANCE = """Prior unresolved items are present. Dis
 item in the JSON `prior_item_dispositions` array — do not add a separate prose section
 or bullet list for prior items outside the JSON object. Valid `disposition` values:
 - `"resolved"` — item is fixed in this PR.
-- `"blocking"` — item is still a merge-blocking problem; include it in `blocking_items`.
-- `"same-pr"` — item needs to be fixed before merge; include it in `same_pr_followups`.
+- `"blocking"` — the displayed Original claim is still a merge-blocking problem.
+- `"same-pr"` — the displayed Original claim needs to be fixed before merge.
 - `"future"` — deferred; must include a `"note"` field; only valid when approving.
 
 Only use `"future"` when returning `approved`. If an item should still be fixed before
 merge, use `"blocking"` or `"same-pr"` instead. For any prior item already marked
 `"future"`, explicitly re-evaluate: `"resolved"`, still `"future"`, or back to
 `"blocking"`/`"same-pr"`.
+
+The displayed Original claim is this stable item ID's predicate. Narrower evidence
+for that same defect may remain on the old ID. If you accept the original predicate
+but discover a materially different defect, mark the old item `"resolved"` and put
+the new defect in a separate `blocking_items` or `same_pr_followups` entry in this
+same response. The new-finding arrays contain new findings only: never restate an
+active carried item there. A resolved carried item and a new blocker may appear in
+the same response.
 """
 
 _EXPECTED_FOLLOWUP_IGNORE = """Do not include Same-PR follow-ups, Future follow-ups, or legacy
@@ -373,6 +381,8 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "Prior unresolved review items from earlier rounds" in prompt
     assert "[item-1] blocking from Anthropic Claude in round 1" in prompt
     assert "[item-2] same-pr from OpenAI Codex in round 1" in prompt
+    assert "Original claim:" in prompt
+    assert "Updates/evidence:" not in prompt
     assert "### Prior unresolved item dispositions" not in prompt
     assert 'Disposition every listed\nitem in the JSON `prior_item_dispositions` array' in prompt
     assert '"resolved"' in prompt
@@ -388,6 +398,40 @@ def test_review_prompt_includes_prior_unresolved_items_and_disposition_instructi
     assert "After the JSON object, include only:" in prompt
     assert "Use this mandatory structured PR review format" in prompt
     assert "Markdown fallback" not in prompt
+
+
+def test_review_prompt_splits_legacy_updates_without_mutating_claim_and_preserves_notes(tmp_path):
+    config = make_config(tmp_path, approved_followups="fix-and-summarize")
+    prompt = build_review_prompt(
+        77, 2, config, reviewer="codex",
+        unresolved_items=(UnresolvedReviewItem(
+            item_id="item-1", reviewer="Anthropic Claude", source_round=1,
+            text="Scope completeness requires every locale.\n\nUpdate from Anthropic Claude: Scope evidence was rechecked.",
+            status="blocking", notes=("Coder disputes this item: all locales were evaluated.",),
+        ),),
+    )
+
+    assert "Original claim:\n    Scope completeness requires every locale." in prompt
+    assert "Updates/evidence:" in prompt
+    assert "Update from Anthropic Claude: Scope evidence was rechecked." in prompt
+    assert "Coder disputes this item: all locales were evaluated." in prompt
+    assert "accept the original predicate\nbut discover a materially different defect" in prompt
+
+
+def test_plan_review_prompts_require_new_findings_for_changed_carried_claims(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex",))
+    item = UnresolvedReviewItem(
+        item_id="item-1", reviewer="Anthropic Claude", source_round=1,
+        text="The plan must cover all locales.", status="blocking",
+    )
+    for compact in (False, True):
+        prompt = build_plan_review_prompt(
+            56, 2, "1. Update locales.", config, reviewer="codex",
+            unresolved_items=(item,), compact_context=compact,
+        )
+        assert "Original claim:" in prompt
+        assert "new-finding arrays contain new findings only" in prompt
+        assert "Use `same-plan`, never `same-pr`" in prompt
 
 def test_compact_review_prompt_excludes_prose_disposition_heading(tmp_path):
     config = make_config(tmp_path, approved_followups="fix-and-summarize")
@@ -419,6 +463,8 @@ def test_compact_review_prompt_excludes_prose_disposition_heading(tmp_path):
     assert "### Prior unresolved item dispositions" not in prompt
     assert 'Disposition every listed\nitem in the JSON `prior_item_dispositions` array' in prompt
     assert "do not add a separate prose section" in prompt
+    assert "Original claim:" in prompt
+    assert "materially different defect" in prompt
 
 def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
     config = make_config(tmp_path, approved_followups="fix-and-summarize")
@@ -448,7 +494,7 @@ def test_review_prompt_indents_multiline_prior_unresolved_item_text(tmp_path):
     )
 
     assert "  Needs a regression test before merge." in prompt
-    assert "\n\n  Include the mixed-reviewer approval case." in prompt
+    assert "\n\n    Include the mixed-reviewer approval case." in prompt
 
 def test_plan_review_prompt_includes_structured_sections_and_prior_items(tmp_path):
     config = make_config(tmp_path, reviewer=("codex", "gemini"))

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -358,7 +358,7 @@ def test_validate_coder_followup_response_requires_regular_synthetic_human_requi
             human_requirements=(),
         )
 
-def test_apply_unresolved_item_dispositions_appends_disposition_notes_to_text():
+def test_apply_unresolved_item_dispositions_preserves_claim_and_appends_notes():
     unresolved_items = (
         UnresolvedReviewItem(
             item_id="item-1",
@@ -383,10 +383,7 @@ def test_apply_unresolved_item_dispositions_appends_disposition_notes_to_text():
 
     assert len(updated_items) == 1
     assert future_items == []
-    assert updated_items[0].text == (
-        "Needs regression coverage before merge.\n\n"
-        "Update from Anthropic Claude: include API error path too"
-    )
+    assert updated_items[0].text == "Needs regression coverage before merge."
     assert updated_items[0].notes == ("Anthropic Claude: include API error path too",)
 
 @pytest.mark.parametrize(

--- a/tests/test_review_parallel.py
+++ b/tests/test_review_parallel.py
@@ -178,6 +178,79 @@ def test_pr_loop_parallel_matches_sequential_comments(tmp_path):
     assert "reconciliation" in parallel_runner.comments[-1]
 
 
+def test_pr_parallel_resolves_disputed_scope_claim_and_tracks_translation_defect_as_fresh_item(tmp_path):
+    """PR #802 shape: accept the old premise, then file the distinct defect anew."""
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(
+                state="blocking", summary="Scope completeness is not established.",
+                blocking_items=["Only 3 of 14 locale catalogs appear to be evaluated."],
+            ),
+            structured_pr_review(
+                summary="The scope-completeness evidence is sufficient.",
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+            ),
+            structured_pr_review(
+                summary="Codex approves the translation correction.",
+                prior_item_dispositions=[{"item_id": "item-2", "disposition": "resolved"}],
+            ),
+        ],
+        gemini_outputs=[
+            structured_pr_review(summary="Gemini approves the initial diff.", reviewer="Google Gemini"),
+            structured_pr_review(
+                state="blocking",
+                summary="The scope premise is accepted, but a retained translation is wrong.",
+                blocking_items=["The retained German translation reverses the confirmation action."],
+                prior_item_dispositions=[{"item_id": "item-1", "disposition": "resolved"}],
+                reviewer="Google Gemini",
+            ),
+            structured_pr_review(
+                summary="Gemini approves the translation correction.",
+                prior_item_dispositions=[{"item_id": "item-2", "disposition": "resolved"}],
+                reviewer="Google Gemini",
+            ),
+        ],
+        claude_outputs=[
+            structured_coder_followup(
+                summary="All 14 locales and 49 keys were evaluated.",
+                disputed_items=["item-1"],
+                dispute_evidence={"item-1": "The approved no-churn audit covers every locale/key pair."},
+            ),
+            structured_coder_followup(
+                summary="Corrected the retained German translation.",
+                addressed_items=["item-2"],
+            ),
+        ],
+    )
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), review_parallel=True, max_rounds=3)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    reviewer_metadata = [
+        orchestrator._decode_round_metadata(match["payload"])
+        for comment in runner.pr_payload["comments"]
+        if (match := orchestrator.ROUND_RESUME_MARKER_RE.search(comment["body"]))
+    ]
+    gemini_round_two = next(
+        record for record in reviewer_metadata
+        if record.agent == "Gemini" and record.round_number == 2
+    )
+    # Parallel reviewer comments are published before deterministic allocation;
+    # reconciliation metadata is the authoritative fresh/resume ledger.
+    reconciliation = next(
+        record for record in reviewer_metadata
+        if record.role == "summary" and record.round_number == 2
+    )
+    assert gemini_round_two.dispositions[0].disposition == "resolved"
+    assert [item.item_id for item in reconciliation.new_items] == ["item-2"]
+    assert reconciliation.new_items[0].text == (
+        "The retained German translation reverses the confirmation action."
+    )
+    assert all(
+        item.item_id != "item-1" for item in reconciliation.new_items
+    )
+
+
 class _EarlyPublicationBarrierRunner(FakeRunner):
     """Makes Gemini slow enough to observe completion-order publication."""
 

--- a/tests/test_round_transport.py
+++ b/tests/test_round_transport.py
@@ -14,7 +14,9 @@ from coding_review_agent_loop.round_state import (
     _decode_round_metadata,
     _encode_round_metadata,
     _extract_round_metadata_records,
+    _prior_item_ledger_signature,
 )
+from coding_review_agent_loop.protocol import UnresolvedReviewItem
 
 
 def _random_text(size: int) -> str:
@@ -195,3 +197,29 @@ def test_round_metadata_decode_uses_mapping_without_reencoding() -> None:
     )
 
     assert _decode_round_metadata(_encode_round_metadata(metadata)) == metadata
+
+
+def test_round_metadata_preserves_mixed_legacy_claim_and_modern_evidence_exactly() -> None:
+    legacy_and_modern_item = UnresolvedReviewItem(
+        item_id="item-4",
+        reviewer="Anthropic Claude",
+        source_round=3,
+        text=(
+            "Only three of fourteen locales were updated.\n\n"
+            "Update from Anthropic Claude: Original scope evidence was rechecked."
+        ),
+        status="blocking",
+        source_status="blocking",
+        notes=("OpenAI Codex: all fourteen locales and 49 keys were evaluated.",),
+    )
+    metadata = PostedRoundMetadata(
+        flow="pr", role="coder", agent="Claude", round_number=4, subject="head",
+        prior_items=(legacy_and_modern_item,),
+    )
+
+    decoded = _decode_round_metadata(_encode_round_metadata(metadata))
+
+    assert decoded.prior_items == (legacy_and_modern_item,)
+    assert _prior_item_ledger_signature(decoded.prior_items) == _prior_item_ledger_signature(
+        (legacy_and_modern_item,)
+    )


### PR DESCRIPTION
Fixes #655

## Summary
- preserve each carried item’s canonical claim while storing reviewer evidence in notes
- present original claims separately from legacy and modern evidence, with an explicit fresh-finding rule
- keep active carried dispositions actionable without allocating duplicate summary items

## Tests
- `python3 -m pytest tests/test_prompts.py tests/test_response_validation.py tests/test_round_transport.py tests/test_orchestrator_pr.py tests/test_review_parallel.py`
- `python3 -m pytest tests/test_prompts.py`