### PR TITLE
Add managed-CI readiness preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,10 @@ is the default. A personal, consciously supervised private repository that is
 otherwise ready but cannot use GitHub protection may use the deliberately
 per-invocation `--allow-unprotected-managed-ci` flag on authenticated plan-first
 issue work; it never applies to existing-PR adoption or dangerous permissions.
+This is an intentional tightening for suppression-capable v2 workflows: a
+repository that previously used issue-created v2 without non-bypassable GitHub
+protection now returns to ordinary CI unless that explicit per-run waiver is
+present.
 
 For repositories without that contract, `--auto-merge` foreground-polls the
 complete check board after approval with

--- a/README.md
+++ b/README.md
@@ -658,6 +658,20 @@ advertise safe adoption and an operator can explicitly request it only with
 --managed-ci-adopt-existing-pr`. The managed-CI guide documents the required
 branch-protection guard, timeline provenance, and durable opt-out.
 
+Before enabling managed CI, run the read-only readiness report:
+
+```bash
+agent-loop managed-ci preflight --repo OWNER/REPO --base main --trusted-actor LOGIN
+```
+
+It exits `0` only for GitHub-enforced exact-head protection, `10` for a
+deterministic configuration/fallback/explicit-override result, and `11` when
+GitHub evidence is unavailable or ambiguous. It makes no writes. Protected mode
+is the default. A personal, consciously supervised private repository that is
+otherwise ready but cannot use GitHub protection may use the deliberately
+per-invocation `--allow-unprotected-managed-ci` flag on authenticated plan-first
+issue work; it never applies to existing-PR adoption or dangerous permissions.
+
 For repositories without that contract, `--auto-merge` foreground-polls the
 complete check board after approval with
 `--ci-timeout-seconds` and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1297,6 +1297,15 @@ defect from bypassing the voluntary gate. The flag is rejected for adoption and
 does not waive identity, workflow, nonce, exact-head qualification, or
 `--match-head-commit` merge checks.
 
+This intentionally tightens the issue-created v2 path for workflows that can
+suppress `pull_request` CI. A repository that previously ran that v2 flow
+without non-bypassable GitHub protection now uses ordinary CI unless the
+operator supplies the explicit waiver for that invocation. If activation later
+cannot prove readiness, a later waiver is omitted, or the override audit
+comment cannot be written, agent-loop removes `agent-loop-managed` and waits
+for the workflow's `unlabeled` recovery CI instead of treating a `no_checks`
+board as mergeable.
+
 Suppression-capable v2 workflows must additionally advertise
 `AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1` and subscribe their
 `pull_request` trigger to `unlabeled`; when a managed label is released,
@@ -1349,6 +1358,13 @@ branch, or body alone is never trusted. Forks and ordinary PRs retain regular
 CI unless they are explicitly adopted as described below. The issue-created
 opening tuple remains unchanged: it alone requires a trusted author, reserved
 branch, and draft state.
+
+For an unprotected override, the coder carries the preflight-minted nonce in
+the creation trailer. During that same invocation agent-loop compares the
+trailer to its in-memory nonce and writes an actor-owned PR audit comment
+before accepting activation or dispatching qualification. A forged, stale, or
+mismatched trailer, or a failed audit write, releases the suppression label;
+a later invocation cannot reuse a body nonce as its authorization.
 
 #### Optional adoption of an existing PR
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1262,6 +1262,47 @@ Failing GitHub checks always block approval and can route back to the coder. Pen
 
 ### Managed exact-head CI
 
+#### Read-only readiness preflight and unprotected override
+
+Run this before starting agents or creating a PR:
+
+```bash
+agent-loop managed-ci preflight --repo OWNER/REPO --base main --trusted-actor LOGIN
+```
+
+The command only reads repository, identity, Actions-variable, workflow, branch
+protection, and ruleset APIs. It reports visibility, the authenticated and
+configured actors, workflow/recovery completeness, and whether GitHub can
+independently enforce `final-ci/exact-head`. Its deterministic exit values are
+`0` (strict-ready), `10` (known non-ready, ordinary fallback, invalid contract,
+or override-eligible), and `11` (ambiguous API/probe failure). A private-GitHub
+Free protection API response that says to upgrade or make the repository public
+is reported as a plan limitation, not as a missing actor permission.
+
+Strict means either classic required-status protection includes
+`final-ci/exact-head` *and* enforces administrators, or an active applicable
+ruleset requires that context without bypass actors. Context-only classic rules
+with admin bypass, evaluate/disabled rulesets, and rulesets with bypass actors
+are voluntary rather than strict. Existing-PR adoption always requires strict,
+non-bypassable enforcement.
+
+For an otherwise eligible authenticated plan-first issue-created v2 invocation,
+`--allow-unprotected-managed-ci` may waive only that protection prerequisite.
+It must be written on every invocation; an old label, audit trailer, or
+`--dangerous-agent-permissions` never re-enables it. The coder records the
+override nonce in the PR body and agent-loop warns locally. This is not suitable
+for shared repositories or unattended automation: GitHub cannot prevent a
+manual merge, another automation, a compromised credential, or an agent-loop
+defect from bypassing the voluntary gate. The flag is rejected for adoption and
+does not waive identity, workflow, nonce, exact-head qualification, or
+`--match-head-commit` merge checks.
+
+Suppression-capable v2 workflows must additionally advertise
+`AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1` and subscribe their
+`pull_request` trigger to `unlabeled`; when a managed label is released,
+ordinary CI must emit a new check on the current head. Agent-loop refuses to
+merge a managed-labeled PR on a `no_checks` board.
+
 #### v2 authenticated opening and exact-head provenance
 
 V2 is an explicit opt-in migration that prevents the opening-event matrix race.

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -26,6 +26,14 @@ from .config import (
     reviewers,
 )
 from .errors import AgentLoopError, QuotaResetExceededError
+from .managed_ci import (
+    PREFLIGHT_INDETERMINATE,
+    PREFLIGHT_KNOWN_NOT_READY,
+    PREFLIGHT_STRICT_READY,
+    ManagedCiProbeContext,
+    evaluate_managed_ci_readiness,
+    render_managed_ci_preflight,
+)
 from .github import (
     detect_repo,
     get_check_status,
@@ -553,11 +561,20 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     add_common(issue)
+    issue.add_argument(
+        "--allow-unprotected-managed-ci", action="store_true",
+        help=(
+            "Per-invocation waiver for plan-first issue-created managed CI when GitHub "
+            "cannot independently enforce final-ci/exact-head. Requires --auto-merge and "
+            "--managed-ci-trusted-actor; never applies to existing-PR adoption."
+        ),
+    )
     add_review_parallel(issue)
 
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
     pr.add_argument("pr_number", type=int)
     add_common(pr)
+    pr.add_argument("--allow-unprotected-managed-ci", action="store_true")
     pr.add_argument(
         "--managed-ci-adopt-existing-pr",
         action="store_true",
@@ -567,6 +584,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     add_review_parallel(pr)
+
+    managed_ci = subparsers.add_parser("managed-ci", help="Inspect managed-CI readiness without writes.")
+    managed_ci_subparsers = managed_ci.add_subparsers(dest="managed_ci_command", required=True)
+    preflight = managed_ci_subparsers.add_parser("preflight", help="Read-only managed-CI readiness report.")
+    preflight.add_argument("--repo", required=True, help="GitHub repository as owner/name.")
+    preflight.add_argument("--base", default=None, help="Base branch (defaults to repository default branch).")
+    preflight.add_argument("--trusted-actor", required=True, help="Expected authenticated GitHub login.")
+    preflight.add_argument("--gh-cmd", default="gh", help="GitHub CLI executable (default: gh).")
 
     task = subparsers.add_parser(
         "task",
@@ -711,6 +736,23 @@ def _resolve_task_text(args: argparse.Namespace) -> str:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command == "managed-ci" and args.managed_ci_command == "preflight":
+        try:
+            context = ManagedCiProbeContext(args.repo, args.gh_cmd, Path.cwd())
+            result = evaluate_managed_ci_readiness(
+                Runner(dry_run=False), context=context, base=args.base, trusted_actor=args.trusted_actor
+            )
+            # The evaluator resolved the default branch internally. Rendering a
+            # user-supplied base keeps the command deterministic without another read.
+            print(render_managed_ci_preflight(result, repo=args.repo, base=args.base or "<default>", trusted_actor=args.trusted_actor))
+            if result.state == "strict_ready":
+                return PREFLIGHT_STRICT_READY
+            if result.state == "indeterminate":
+                return PREFLIGHT_INDETERMINATE
+            return PREFLIGHT_KNOWN_NOT_READY
+        except AgentLoopError as exc:
+            print(f"agent-loop: {exc}", file=sys.stderr)
+            return PREFLIGHT_INDETERMINATE
     runner = Runner(dry_run=args.dry_run)
     try:
         # Preserve tokens (rather than a rendered command) so timeout guidance can
@@ -733,6 +775,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 raise AgentLoopError(
                     "--managed-ci-adopt-existing-pr requires --managed-ci-trusted-actor."
                 )
+        if getattr(args, "allow_unprotected_managed_ci", False):
+            if args.command not in {"issue", "pr"}:
+                raise AgentLoopError("--allow-unprotected-managed-ci is only supported with issue or pr.")
+            if not args.auto_merge:
+                raise AgentLoopError("--allow-unprotected-managed-ci requires --auto-merge.")
+            if not (args.managed_ci_trusted_actor or "").strip():
+                raise AgentLoopError("--allow-unprotected-managed-ci requires --managed-ci-trusted-actor.")
+            if getattr(args, "managed_ci_adopt_existing_pr", False):
+                raise AgentLoopError("--allow-unprotected-managed-ci cannot be used with --managed-ci-adopt-existing-pr.")
         if args.command == "issue":
             if args.implement_after_approval and not args.plan_first:
                 raise AgentLoopError("--implement-after-approval requires --plan-first.")

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -574,7 +574,14 @@ def build_parser() -> argparse.ArgumentParser:
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
     pr.add_argument("pr_number", type=int)
     add_common(pr)
-    pr.add_argument("--allow-unprotected-managed-ci", action="store_true")
+    pr.add_argument(
+        "--allow-unprotected-managed-ci", action="store_true",
+        help=(
+            "Per-invocation waiver for plan-first issue-created managed CI when GitHub "
+            "cannot independently enforce final-ci/exact-head. Requires --auto-merge and "
+            "--managed-ci-trusted-actor; never applies to existing-PR adoption."
+        ),
+    )
     pr.add_argument(
         "--managed-ci-adopt-existing-pr",
         action="store_true",
@@ -742,8 +749,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = evaluate_managed_ci_readiness(
                 Runner(dry_run=False), context=context, base=args.base, trusted_actor=args.trusted_actor
             )
-            # The evaluator resolved the default branch internally. Rendering a
-            # user-supplied base keeps the command deterministic without another read.
             print(render_managed_ci_preflight(result, repo=args.repo, base=args.base or "<default>", trusted_actor=args.trusted_actor))
             if result.state == "strict_ready":
                 return PREFLIGHT_STRICT_READY

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -181,6 +181,9 @@ class AgentLoopConfig:
     # Explicit PR-mode opt-in for adopting an already-open PR into the v2
     # managed-CI protocol.  Kept separate from the issue-created v2 flow.
     managed_ci_adopt_existing_pr: bool = False
+    # A consciously per-invocation waiver for issue-created v2 only. It is
+    # never read from the environment or durable PR state.
+    allow_unprotected_managed_ci: bool = False
     invocation_argv: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -958,6 +961,7 @@ def config_from_args(
         ),
         managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
         managed_ci_adopt_existing_pr=getattr(args, "managed_ci_adopt_existing_pr", False),
+        allow_unprotected_managed_ci=getattr(args, "allow_unprotected_managed_ci", False),
         invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -184,6 +184,10 @@ class AgentLoopConfig:
     # A consciously per-invocation waiver for issue-created v2 only. It is
     # never read from the environment or durable PR state.
     allow_unprotected_managed_ci: bool = False
+    # Runtime-only correlation value minted by the issue-created preflight.
+    # It is intentionally not a CLI option: a later invocation must perform a
+    # new preflight rather than accepting a PR-body token it did not create.
+    managed_ci_expected_override_nonce: str | None = None
     invocation_argv: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -372,12 +372,22 @@ def _is_http_error(result: object, *statuses: int) -> bool:
     return any(str(status) in combined for status in statuses)
 
 
-def _probe_raw_workflow(runner: Runner, context: ManagedCiProbeContext, base: str) -> str | None:
+def _is_plan_limited_error(result: object) -> bool:
+    """Recognize GitHub's plan restriction independently of endpoint wording."""
+    combined = " ".join(
+        str(getattr(result, field, "") or "") for field in ("stdout", "stderr")
+    ).casefold()
+    return "upgrade to github pro" in combined or "make this repository public" in combined
+
+
+def _probe_raw_workflow(
+    runner: Runner, context: ManagedCiProbeContext, base: str
+) -> tuple[str | None, object]:
     result = _probe(
         runner, context,
         f"repos/{context.repo}/contents/.github/workflows/{WORKFLOW_FILE}?ref={base}", raw=True,
     )
-    return (result.stdout or "") if result.returncode == 0 else None
+    return ((result.stdout or "") if result.returncode == 0 else None), result
 
 
 def _has_final_context(payload: dict[str, object]) -> bool:
@@ -406,8 +416,7 @@ def assess_exact_head_protection(
     classic_state: Literal["voluntary", "plan_limited", "indeterminate"] | None = None
     classic_detail = "final-ci/exact-head is not independently required"
     if required is None:
-        combined = " ".join((required_result.stdout or "", required_result.stderr or "")).casefold()
-        if "upgrade to github pro" in combined or "make this repository public" in combined:
+        if _is_plan_limited_error(required_result):
             classic_state = "plan_limited"
             classic_detail = "GitHub plan/API does not permit branch protection"
         elif _is_http_error(required_result, 404):
@@ -434,6 +443,11 @@ def assess_exact_head_protection(
 
     rules, rules_result = _probe_json_list(runner, context, f"repos/{context.repo}/rules/branches/{base}")
     if rules is None:
+        # A private-Free repository can reject both protection APIs.  The
+        # ruleset probe cannot turn an already known plan restriction into an
+        # unknown result, so retain the actionable classification.
+        if classic_state == "plan_limited":
+            return ProtectionAssessment("plan_limited", "classic", classic_detail)
         if _is_http_error(rules_result, 404, 422):
             return ProtectionAssessment(classic_state or "voluntary", "classic" if classic_state else "none", classic_detail)
         return ProtectionAssessment("indeterminate", "rulesets", "effective branch rules could not be inspected")
@@ -478,13 +492,27 @@ def evaluate_managed_ci_readiness(
     if not resolved_base:
         return ManagedCiReadiness("indeterminate", visibility, None, None, False, False,
             ProtectionAssessment("indeterminate", "none", "base branch unavailable"), ("base branch is unavailable",), ())
-    workflow = _probe_raw_workflow(runner, context, resolved_base)
+    workflow, workflow_result = _probe_raw_workflow(runner, context, resolved_base)
+    if workflow is None:
+        if _is_http_error(workflow_result, 404):
+            return ManagedCiReadiness(
+                "ordinary_fallback", visibility, None, None, False, False,
+                ProtectionAssessment("voluntary", "none", "base workflow is absent"),
+                ("base workflow is absent",),
+                ("deploy the documented managed-CI v2 workflow",),
+                resolved_base,
+            )
+        return ManagedCiReadiness(
+            "indeterminate", visibility, None, None, False, False,
+            ProtectionAssessment("indeterminate", "none", "base workflow could not be read"),
+            ("a required read-only GitHub probe failed",), (), resolved_base,
+        )
     who, _ = _probe_json(runner, context, "user")
     variable, variable_result = _probe_json(runner, context, f"repos/{context.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR")
     actor = who.get("login") if who and isinstance(who.get("login"), str) else None
     advertised = variable.get("value") if variable and isinstance(variable.get("value"), str) else None
     protection = assess_exact_head_protection(runner, context=context, base=resolved_base)
-    if workflow is None or who is None or (variable is None and not _is_http_error(variable_result, 404)):
+    if who is None or (variable is None and not _is_http_error(variable_result, 404)):
         return ManagedCiReadiness("indeterminate", visibility, actor, advertised, False, False, protection,
             ("a required read-only GitHub probe failed",), ())
     core = V2_MARKER in workflow
@@ -541,7 +569,7 @@ def preflight_managed_ci_creation(
     if not config.auto_merge or config.dry_run or not config.managed_ci_trusted_actor or not config.base:
         return None
     source_context = ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config))
-    source_workflow = _probe_raw_workflow(runner, source_context, config.base)
+    source_workflow, _ = _probe_raw_workflow(runner, source_context, config.base)
     if source_workflow is None or V2_MARKER not in source_workflow:
         return None
     if any(marker not in source_workflow for marker in V2_FEATURE_MARKERS):

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -81,6 +81,9 @@ class ManagedCiReadiness:
     protection: ProtectionAssessment
     reasons: tuple[str, ...]
     remediation: tuple[str, ...]
+    # The evaluator resolves the repository default before it probes the
+    # workflow.  Keep that value so preflight reports the branch it assessed.
+    base: str | None = None
 
 
 PREFLIGHT_STRICT_READY = 0
@@ -347,6 +350,28 @@ def _probe_json(runner: Runner, context: ManagedCiProbeContext, endpoint: str) -
     return (payload if isinstance(payload, dict) else None), result
 
 
+def _probe_json_list(
+    runner: Runner, context: ManagedCiProbeContext, endpoint: str
+) -> tuple[list[object] | None, object]:
+    """Read a GitHub list response without treating a valid array as malformed."""
+    result = _probe(runner, context, endpoint)
+    if result.returncode != 0:
+        return None, result
+    try:
+        payload = json.loads(result.stdout or "")
+    except json.JSONDecodeError:
+        return None, result
+    return (payload if isinstance(payload, list) else None), result
+
+
+def _is_http_error(result: object, *statuses: int) -> bool:
+    """`gh api` uses exit 1 for HTTP errors, so inspect its diagnostic text."""
+    combined = " ".join(
+        str(getattr(result, field, "") or "") for field in ("stdout", "stderr")
+    ).casefold()
+    return any(str(status) in combined for status in statuses)
+
+
 def _probe_raw_workflow(runner: Runner, context: ManagedCiProbeContext, base: str) -> str | None:
     result = _probe(
         runner, context,
@@ -378,23 +403,24 @@ def assess_exact_head_protection(
     required, required_result = _probe_json(
         runner, context, f"repos/{context.repo}/branches/{base}/protection/required_status_checks"
     )
-    if required is None:
-        stderr = (required_result.stderr or "").lower()
-        if "upgrade to github pro" in stderr or "make this repository public" in stderr:
-            return ProtectionAssessment("plan_limited", "classic", "GitHub plan/API does not permit branch protection")
-        if required_result.returncode == 404:
-            return ProtectionAssessment("voluntary", "classic", "required status protection is not configured")
-        return ProtectionAssessment("indeterminate", "classic", "required-status protection could not be inspected")
-
-    classic_state: Literal["voluntary", "indeterminate"] | None = None
+    classic_state: Literal["voluntary", "plan_limited", "indeterminate"] | None = None
     classic_detail = "final-ci/exact-head is not independently required"
-    if _has_final_context(required):
+    if required is None:
+        combined = " ".join((required_result.stdout or "", required_result.stderr or "")).casefold()
+        if "upgrade to github pro" in combined or "make this repository public" in combined:
+            classic_state = "plan_limited"
+            classic_detail = "GitHub plan/API does not permit branch protection"
+        elif _is_http_error(required_result, 404):
+            classic_state = "voluntary"
+            classic_detail = "required status protection is not configured"
+        else:
+            classic_state = "indeterminate"
+            classic_detail = "required-status protection could not be inspected"
+    elif _has_final_context(required):
         admins, admins_result = _probe_json(
             runner, context, f"repos/{context.repo}/branches/{base}/protection/enforce_admins"
         )
-        # Empty responses are accepted only for compatibility with older gh
-        # test doubles; GitHub's real endpoint is a JSON object with enabled.
-        if admins is not None and (not admins or admins.get("enabled") is True):
+        if admins is not None and admins.get("enabled") is True:
             return ProtectionAssessment("strict", "classic", "final-ci/exact-head is required and admins are enforced")
         if admins is not None and admins.get("enabled") is False:
             classic_state = "voluntary"
@@ -406,14 +432,13 @@ def assess_exact_head_protection(
             classic_state = "indeterminate"
             classic_detail = "admin enforcement response was malformed"
 
-    rules, rules_result = _probe_json(runner, context, f"repos/{context.repo}/rules/branches/{base}")
+    rules, rules_result = _probe_json_list(runner, context, f"repos/{context.repo}/rules/branches/{base}")
     if rules is None:
-        if rules_result.returncode in {404, 422}:
+        if _is_http_error(rules_result, 404, 422):
             return ProtectionAssessment(classic_state or "voluntary", "classic" if classic_state else "none", classic_detail)
         return ProtectionAssessment("indeterminate", "rulesets", "effective branch rules could not be inspected")
-    entries = rules.get("rules") if isinstance(rules.get("rules"), list) else []
     voluntary = False
-    for entry in entries:
+    for entry in rules:
         if not isinstance(entry, dict):
             continue
         ruleset_id = entry.get("ruleset_id") or entry.get("id")
@@ -431,6 +456,8 @@ def assess_exact_head_protection(
         return ProtectionAssessment("strict", "ruleset", "active ruleset requires final-ci/exact-head without bypass actors")
     if classic_state == "indeterminate":
         return ProtectionAssessment("indeterminate", "classic", classic_detail)
+    if classic_state == "plan_limited":
+        return ProtectionAssessment("plan_limited", "classic", classic_detail)
     return ProtectionAssessment(
         "voluntary", "rulesets" if voluntary else ("classic" if classic_state else "none"),
         "matching ruleset is bypassable/evaluate-mode" if voluntary else classic_detail,
@@ -457,7 +484,7 @@ def evaluate_managed_ci_readiness(
     actor = who.get("login") if who and isinstance(who.get("login"), str) else None
     advertised = variable.get("value") if variable and isinstance(variable.get("value"), str) else None
     protection = assess_exact_head_protection(runner, context=context, base=resolved_base)
-    if workflow is None or who is None or (variable is None and variable_result.returncode not in {404}):
+    if workflow is None or who is None or (variable is None and not _is_http_error(variable_result, 404)):
         return ManagedCiReadiness("indeterminate", visibility, actor, advertised, False, False, protection,
             ("a required read-only GitHub probe failed",), ())
     core = V2_MARKER in workflow
@@ -467,30 +494,31 @@ def evaluate_managed_ci_readiness(
     # any workflow that does opt into pull_request suppression must advertise
     # the explicit recovery marker and unlabeled activity.
     recovery = (RECOVERY_MARKER in workflow and "unlabeled" in workflow) or "pull_request" not in workflow
-    identity_ok = bool(actor and advertised and trusted_actor.strip() and actor.casefold() == trusted_actor.casefold() == advertised.casefold())
+    expected_actor = trusted_actor.strip()
+    identity_ok = bool(actor and advertised and expected_actor and actor.casefold() == expected_actor.casefold() == advertised.casefold())
     if not core:
         return ManagedCiReadiness("ordinary_fallback", visibility, actor, advertised, False, recovery, protection,
-            ("base workflow does not advertise managed-CI v2",), ("deploy the documented managed-CI v2 workflow",))
+            ("base workflow does not advertise managed-CI v2",), ("deploy the documented managed-CI v2 workflow",), resolved_base)
     if not complete or not recovery:
         missing = "complete v2 contract" if not complete else "unlabeled recovery contract"
         return ManagedCiReadiness("invalid", visibility, actor, advertised, complete, recovery, protection,
-            (f"workflow lacks the {missing}",), ("add the documented workflow markers and pull_request unlabeled trigger",))
+            (f"workflow lacks the {missing}",), ("add the documented workflow markers and pull_request unlabeled trigger",), resolved_base)
     if not identity_ok:
         return ManagedCiReadiness("ordinary_fallback", visibility, actor, advertised, complete, recovery, protection,
             ("authenticated login, trusted actor, and AGENT_LOOP_MANAGED_ACTOR do not match",),
-            (f"gh variable set AGENT_LOOP_MANAGED_ACTOR --repo {shlex.quote(context.repo)} --body {shlex.quote(trusted_actor)}",))
+            (f"gh variable set AGENT_LOOP_MANAGED_ACTOR --repo {shlex.quote(context.repo)} --body {shlex.quote(expected_actor)}",), resolved_base)
     if protection.state == "strict":
-        return ManagedCiReadiness("strict_ready", visibility, actor, advertised, complete, recovery, protection, (), ())
+        return ManagedCiReadiness("strict_ready", visibility, actor, advertised, complete, recovery, protection, (), (), resolved_base)
     if protection.state in {"voluntary", "plan_limited"}:
         return ManagedCiReadiness("override_eligible", visibility, actor, advertised, complete, recovery, protection,
-            (protection.detail,), ("configure non-bypassable final-ci/exact-head protection, or use --allow-unprotected-managed-ci for this invocation",))
+            (protection.detail,), ("configure non-bypassable final-ci/exact-head protection, or use --allow-unprotected-managed-ci for this invocation",), resolved_base)
     return ManagedCiReadiness("indeterminate", visibility, actor, advertised, complete, recovery, protection,
-        (protection.detail,), ())
+        (protection.detail,), (), resolved_base)
 
 
 def render_managed_ci_preflight(result: ManagedCiReadiness, *, repo: str, base: str, trusted_actor: str) -> str:
     lines = [
-        f"repository: {repo}", f"base: {base}", f"visibility: {result.repo_visibility or 'unknown'}",
+        f"repository: {repo}", f"base: {result.base or base}", f"visibility: {result.repo_visibility or 'unknown'}",
         f"workflow: {'v2 complete' if result.workflow_v2 else 'ordinary/absent'}",
         f"recovery: {'unlabeled capable' if result.recovery_capable else 'missing'}",
         f"actor: authenticated={result.actor or 'unknown'} trusted={trusted_actor} variable={result.advertised_actor or 'missing'}",
@@ -526,7 +554,8 @@ def preflight_managed_ci_creation(
         trusted_actor=config.managed_ci_trusted_actor,
     )
     if readiness.state == "indeterminate" and not legacy_non_suppressing:
-        raise AgentLoopError("Managed-CI readiness could not be determined; refusing to suppress CI.")
+        log(config, "Managed-CI readiness could not be determined; continuing with ordinary CI.")
+        return None
     if readiness.state == "indeterminate":
         who = _api_json(runner, config, "user", quiet=True)
         advertised = _api_json(
@@ -548,17 +577,31 @@ def preflight_managed_ci_creation(
         readiness.state == "override_eligible" and (config.allow_unprotected_managed_ci or legacy_non_suppressing)
     ):
         return None
-    workflow = source_workflow
-    if workflow is None or V2_MARKER not in workflow:
-        return None
-    if any(marker not in workflow for marker in V2_FEATURE_MARKERS):
-        raise AgentLoopError("Repository CI advertises an incomplete managed-CI v2 contract.")
     return ManagedCiCreationIntent(
         branch=f"agent-loop/managed-{issue_number}",
         trusted_actor=readiness.actor or config.managed_ci_trusted_actor,
         protection_mode=readiness.protection.state,
         audit_nonce=secrets.token_urlsafe(18) if config.allow_unprotected_managed_ci else None,
     )
+
+
+def _restore_ordinary_ci_after_v2_fallback(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, reason: str
+) -> None:
+    """Remove the issue-created suppression label before returning to ordinary CI."""
+    result = runner.run(
+        [
+            config.gh_cmd, "api", "--method", "DELETE",
+            f"repos/{config.repo}/issues/{pr_number}/labels/{MANAGED_LABEL}",
+        ],
+        cwd=active_workdir(config), check=False,
+    )
+    if result.returncode != 0:
+        raise AgentLoopError(
+            f"Managed-CI v2 could not activate ({reason}) and `{MANAGED_LABEL}` could not be removed. "
+            "Remove the label before relying on ordinary CI."
+        )
+    log(config, f"PR #{pr_number}: removed `{MANAGED_LABEL}`; continuing with ordinary CI ({reason})")
 
 
 def _activate_v2_managed_ci(
@@ -655,11 +698,25 @@ def _activate_v2_managed_ci(
             body = pr.get("body") if isinstance(pr.get("body"), str) else ""
             marker_line = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
             if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"} or not marker_line:
+                _restore_ordinary_ci_after_v2_fallback(
+                    runner, config=config, pr_number=pr_number,
+                    reason="strict protection or the explicit override is unavailable",
+                )
                 return None
             parts = marker_line.split("nonce=", 1)
             if len(parts) != 2 or not parts[1].strip():
+                _restore_ordinary_ci_after_v2_fallback(
+                    runner, config=config, pr_number=pr_number,
+                    reason="the override trailer has no nonce",
+                )
                 return None
             override_nonce = parts[1].strip().split()[0]
+            if override_nonce != config.managed_ci_expected_override_nonce:
+                _restore_ordinary_ci_after_v2_fallback(
+                    runner, config=config, pr_number=pr_number,
+                    reason="the override trailer is not correlated to this invocation",
+                )
+                return None
             audit = runner.run(
                 [
                     config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/comments",
@@ -672,11 +729,21 @@ def _activate_v2_managed_ci(
                 ], cwd=active_workdir(config), check=False,
             )
             if audit.returncode != 0:
+                _restore_ordinary_ci_after_v2_fallback(
+                    runner, config=config, pr_number=pr_number,
+                    reason="the override audit comment could not be recorded",
+                )
                 return None
             try:
                 audit_id = json.loads(audit.stdout or "{}").get("id")
             except json.JSONDecodeError:
                 audit_id = None
+            if not isinstance(audit_id, int):
+                _restore_ordinary_ci_after_v2_fallback(
+                    runner, config=config, pr_number=pr_number,
+                    reason="the override audit comment response was malformed",
+                )
+                return None
         else:
             audit_id = None
     else:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import secrets
+import shlex
 import time
 from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -44,6 +46,46 @@ V2_FEATURE_MARKERS = (V2_MARKER, "workflow_dispatch", "managed_nonce", FINAL_CON
 # suppressing CI for existing PRs.
 V2_ADOPTION_MARKER = "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION"
 V2_ADOPTION_FEATURE_MARKERS = (V2_ADOPTION_MARKER,)
+RECOVERY_MARKER = "AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1"
+UNPROTECTED_OVERRIDE_TRAILER = "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1"
+
+
+@dataclass(frozen=True)
+class ManagedCiProbeContext:
+    """The deliberately small, read-only context used by standalone preflight."""
+
+    repo: str
+    gh_cmd: str
+    cwd: Path
+
+
+@dataclass(frozen=True)
+class ProtectionAssessment:
+    """Whether GitHub, rather than this process, enforces the final context."""
+
+    state: Literal["strict", "voluntary", "plan_limited", "indeterminate"]
+    source: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ManagedCiReadiness:
+    """Stable, non-mutating readiness result consumed by CLI and runtime gates."""
+
+    state: Literal["strict_ready", "override_eligible", "ordinary_fallback", "invalid", "indeterminate"]
+    repo_visibility: str | None
+    actor: str | None
+    advertised_actor: str | None
+    workflow_v2: bool
+    recovery_capable: bool
+    protection: ProtectionAssessment
+    reasons: tuple[str, ...]
+    remediation: tuple[str, ...]
+
+
+PREFLIGHT_STRICT_READY = 0
+PREFLIGHT_KNOWN_NOT_READY = 10
+PREFLIGHT_INDETERMINATE = 11
 
 
 @dataclass
@@ -66,6 +108,9 @@ class ManagedCiContract:
     guard_head_sha: str | None = None
     active_label_event_id: int | None = None
     invocation_applied_label: bool = False
+    protection_mode: str | None = None
+    audit_nonce: str | None = None
+    audit_comment_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -74,6 +119,8 @@ class ManagedCiCreationIntent:
 
     branch: str
     trusted_actor: str
+    protection_mode: str = "strict"
+    audit_nonce: str | None = None
 
 
 @dataclass(frozen=True)
@@ -282,6 +329,179 @@ def activate_managed_ci(
     return ManagedCiContract()
 
 
+def _probe(runner: Runner, context: ManagedCiProbeContext, endpoint: str, *, raw: bool = False):
+    command = [context.gh_cmd, "api", endpoint]
+    if raw:
+        command.extend(["-H", "Accept: application/vnd.github.raw+json"])
+    return runner.run(command, cwd=context.cwd, check=False)
+
+
+def _probe_json(runner: Runner, context: ManagedCiProbeContext, endpoint: str) -> tuple[dict[str, object] | None, object]:
+    result = _probe(runner, context, endpoint)
+    if result.returncode != 0:
+        return None, result
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None, result
+    return (payload if isinstance(payload, dict) else None), result
+
+
+def _probe_raw_workflow(runner: Runner, context: ManagedCiProbeContext, base: str) -> str | None:
+    result = _probe(
+        runner, context,
+        f"repos/{context.repo}/contents/.github/workflows/{WORKFLOW_FILE}?ref={base}", raw=True,
+    )
+    return (result.stdout or "") if result.returncode == 0 else None
+
+
+def _has_final_context(payload: dict[str, object]) -> bool:
+    contexts = payload.get("contexts")
+    checks = payload.get("checks")
+    return (
+        isinstance(contexts, list) and FINAL_CONTEXT in contexts
+    ) or (
+        isinstance(checks, list)
+        and any(isinstance(check, dict) and check.get("context") == FINAL_CONTEXT for check in checks)
+    )
+
+
+def assess_exact_head_protection(
+    runner: Runner, *, context: ManagedCiProbeContext, base: str
+) -> ProtectionAssessment:
+    """Classify GitHub enforcement conservatively.
+
+    A required context alone is voluntary when administrators can bypass it.
+    Rulesets are inspected as an additional independent enforcement source;
+    evaluate-mode and bypass actors are deliberately not strict.
+    """
+    required, required_result = _probe_json(
+        runner, context, f"repos/{context.repo}/branches/{base}/protection/required_status_checks"
+    )
+    if required is None:
+        stderr = (required_result.stderr or "").lower()
+        if "upgrade to github pro" in stderr or "make this repository public" in stderr:
+            return ProtectionAssessment("plan_limited", "classic", "GitHub plan/API does not permit branch protection")
+        if required_result.returncode == 404:
+            return ProtectionAssessment("voluntary", "classic", "required status protection is not configured")
+        return ProtectionAssessment("indeterminate", "classic", "required-status protection could not be inspected")
+
+    classic_state: Literal["voluntary", "indeterminate"] | None = None
+    classic_detail = "final-ci/exact-head is not independently required"
+    if _has_final_context(required):
+        admins, admins_result = _probe_json(
+            runner, context, f"repos/{context.repo}/branches/{base}/protection/enforce_admins"
+        )
+        # Empty responses are accepted only for compatibility with older gh
+        # test doubles; GitHub's real endpoint is a JSON object with enabled.
+        if admins is not None and (not admins or admins.get("enabled") is True):
+            return ProtectionAssessment("strict", "classic", "final-ci/exact-head is required and admins are enforced")
+        if admins is not None and admins.get("enabled") is False:
+            classic_state = "voluntary"
+            classic_detail = "administrators can bypass required status checks"
+        elif admins_result.returncode != 0:
+            classic_state = "indeterminate"
+            classic_detail = "admin enforcement could not be inspected"
+        else:
+            classic_state = "indeterminate"
+            classic_detail = "admin enforcement response was malformed"
+
+    rules, rules_result = _probe_json(runner, context, f"repos/{context.repo}/rules/branches/{base}")
+    if rules is None:
+        if rules_result.returncode in {404, 422}:
+            return ProtectionAssessment(classic_state or "voluntary", "classic" if classic_state else "none", classic_detail)
+        return ProtectionAssessment("indeterminate", "rulesets", "effective branch rules could not be inspected")
+    entries = rules.get("rules") if isinstance(rules.get("rules"), list) else []
+    voluntary = False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        ruleset_id = entry.get("ruleset_id") or entry.get("id")
+        if not isinstance(ruleset_id, int):
+            continue
+        ruleset, ignored = _probe_json(runner, context, f"repos/{context.repo}/rulesets/{ruleset_id}")
+        if ruleset is None:
+            return ProtectionAssessment("indeterminate", "rulesets", "an applicable ruleset could not be inspected")
+        contexts = json.dumps(ruleset.get("rules") or [])
+        if FINAL_CONTEXT not in contexts:
+            continue
+        if ruleset.get("enforcement") != "active" or ruleset.get("bypass_actors"):
+            voluntary = True
+            continue
+        return ProtectionAssessment("strict", "ruleset", "active ruleset requires final-ci/exact-head without bypass actors")
+    if classic_state == "indeterminate":
+        return ProtectionAssessment("indeterminate", "classic", classic_detail)
+    return ProtectionAssessment(
+        "voluntary", "rulesets" if voluntary else ("classic" if classic_state else "none"),
+        "matching ruleset is bypassable/evaluate-mode" if voluntary else classic_detail,
+    )
+
+
+def evaluate_managed_ci_readiness(
+    runner: Runner, *, context: ManagedCiProbeContext, base: str | None, trusted_actor: str
+) -> ManagedCiReadiness:
+    """Read every v2 prerequisite without writes or AgentLoopConfig construction."""
+    repo, repo_result = _probe_json(runner, context, f"repos/{context.repo}")
+    if repo is None:
+        return ManagedCiReadiness("indeterminate", None, None, None, False, False,
+            ProtectionAssessment("indeterminate", "none", "repository metadata unavailable"),
+            ("repository metadata could not be read",), ())
+    resolved_base = base or (repo.get("default_branch") if isinstance(repo.get("default_branch"), str) else None)
+    visibility = "private" if repo.get("private") is True else "public" if repo.get("private") is False else None
+    if not resolved_base:
+        return ManagedCiReadiness("indeterminate", visibility, None, None, False, False,
+            ProtectionAssessment("indeterminate", "none", "base branch unavailable"), ("base branch is unavailable",), ())
+    workflow = _probe_raw_workflow(runner, context, resolved_base)
+    who, _ = _probe_json(runner, context, "user")
+    variable, variable_result = _probe_json(runner, context, f"repos/{context.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR")
+    actor = who.get("login") if who and isinstance(who.get("login"), str) else None
+    advertised = variable.get("value") if variable and isinstance(variable.get("value"), str) else None
+    protection = assess_exact_head_protection(runner, context=context, base=resolved_base)
+    if workflow is None or who is None or (variable is None and variable_result.returncode not in {404}):
+        return ManagedCiReadiness("indeterminate", visibility, actor, advertised, False, False, protection,
+            ("a required read-only GitHub probe failed",), ())
+    core = V2_MARKER in workflow
+    complete = core and all(marker in workflow for marker in V2_FEATURE_MARKERS)
+    # Pre-marker v2 fixtures/workflows that contain no pull_request trigger at
+    # all never suppress an opening matrix. Treat them as legacy-compatible;
+    # any workflow that does opt into pull_request suppression must advertise
+    # the explicit recovery marker and unlabeled activity.
+    recovery = (RECOVERY_MARKER in workflow and "unlabeled" in workflow) or "pull_request" not in workflow
+    identity_ok = bool(actor and advertised and trusted_actor.strip() and actor.casefold() == trusted_actor.casefold() == advertised.casefold())
+    if not core:
+        return ManagedCiReadiness("ordinary_fallback", visibility, actor, advertised, False, recovery, protection,
+            ("base workflow does not advertise managed-CI v2",), ("deploy the documented managed-CI v2 workflow",))
+    if not complete or not recovery:
+        missing = "complete v2 contract" if not complete else "unlabeled recovery contract"
+        return ManagedCiReadiness("invalid", visibility, actor, advertised, complete, recovery, protection,
+            (f"workflow lacks the {missing}",), ("add the documented workflow markers and pull_request unlabeled trigger",))
+    if not identity_ok:
+        return ManagedCiReadiness("ordinary_fallback", visibility, actor, advertised, complete, recovery, protection,
+            ("authenticated login, trusted actor, and AGENT_LOOP_MANAGED_ACTOR do not match",),
+            (f"gh variable set AGENT_LOOP_MANAGED_ACTOR --repo {shlex.quote(context.repo)} --body {shlex.quote(trusted_actor)}",))
+    if protection.state == "strict":
+        return ManagedCiReadiness("strict_ready", visibility, actor, advertised, complete, recovery, protection, (), ())
+    if protection.state in {"voluntary", "plan_limited"}:
+        return ManagedCiReadiness("override_eligible", visibility, actor, advertised, complete, recovery, protection,
+            (protection.detail,), ("configure non-bypassable final-ci/exact-head protection, or use --allow-unprotected-managed-ci for this invocation",))
+    return ManagedCiReadiness("indeterminate", visibility, actor, advertised, complete, recovery, protection,
+        (protection.detail,), ())
+
+
+def render_managed_ci_preflight(result: ManagedCiReadiness, *, repo: str, base: str, trusted_actor: str) -> str:
+    lines = [
+        f"repository: {repo}", f"base: {base}", f"visibility: {result.repo_visibility or 'unknown'}",
+        f"workflow: {'v2 complete' if result.workflow_v2 else 'ordinary/absent'}",
+        f"recovery: {'unlabeled capable' if result.recovery_capable else 'missing'}",
+        f"actor: authenticated={result.actor or 'unknown'} trusted={trusted_actor} variable={result.advertised_actor or 'missing'}",
+        f"protection: {result.protection.state} ({result.protection.source}; {result.protection.detail})",
+        f"result: {result.state}",
+    ]
+    lines.extend(f"reason: {reason}" for reason in result.reasons)
+    lines.extend(f"remediation: {command}" for command in result.remediation)
+    return "\n".join(lines)
+
+
 def preflight_managed_ci_creation(
     runner: Runner, *, config: AgentLoopConfig, issue_number: int
 ) -> ManagedCiCreationIntent | None:
@@ -292,28 +512,52 @@ def preflight_managed_ci_creation(
     """
     if not config.auto_merge or config.dry_run or not config.managed_ci_trusted_actor or not config.base:
         return None
-    workflow = runner.run(
-        [
-            config.gh_cmd, "api",
-            f"repos/{config.repo}/contents/.github/workflows/{WORKFLOW_FILE}?ref={config.base}",
-            "-H", "Accept: application/vnd.github.raw+json",
-        ], cwd=active_workdir(config), check=False,
-    )
-    if workflow.returncode != 0 or V2_MARKER not in (workflow.stdout or ""):
+    source_context = ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config))
+    source_workflow = _probe_raw_workflow(runner, source_context, config.base)
+    if source_workflow is None or V2_MARKER not in source_workflow:
         return None
-    if any(marker not in (workflow.stdout or "") for marker in V2_FEATURE_MARKERS):
+    if any(marker not in source_workflow for marker in V2_FEATURE_MARKERS):
         raise AgentLoopError("Repository CI advertises an incomplete managed-CI v2 contract.")
-    who = _api_json(runner, config, "user", quiet=True)
-    actor = who.get("login") if isinstance(who.get("login"), str) else None
-    advertised = _api_json(
-        runner, config, f"repos/{config.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR", quiet=True
-    ).get("value")
-    if not isinstance(actor, str) or not isinstance(advertised, str):
+    legacy_non_suppressing = "pull_request" not in source_workflow
+    readiness = evaluate_managed_ci_readiness(
+        runner,
+        context=source_context,
+        base=config.base,
+        trusted_actor=config.managed_ci_trusted_actor,
+    )
+    if readiness.state == "indeterminate" and not legacy_non_suppressing:
+        raise AgentLoopError("Managed-CI readiness could not be determined; refusing to suppress CI.")
+    if readiness.state == "indeterminate":
+        who = _api_json(runner, config, "user", quiet=True)
+        advertised = _api_json(
+            runner, config, f"repos/{config.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR", quiet=True
+        ).get("value")
+        actor = who.get("login") if isinstance(who.get("login"), str) else None
+        if not isinstance(actor, str) or not isinstance(advertised, str) or (
+            actor.casefold() != config.managed_ci_trusted_actor.casefold()
+            or actor.casefold() != advertised.casefold()
+        ):
+            return None
+        readiness = ManagedCiReadiness(
+            "override_eligible", None, actor, advertised, True, True,
+            ProtectionAssessment("voluntary", "legacy", "legacy non-suppressing workflow"), (), (),
+        )
+    if readiness.state == "override_eligible" and not (config.allow_unprotected_managed_ci or legacy_non_suppressing):
         return None
-    if actor.casefold() != config.managed_ci_trusted_actor.casefold() or actor.casefold() != advertised.casefold():
+    if readiness.state != "strict_ready" and not (
+        readiness.state == "override_eligible" and (config.allow_unprotected_managed_ci or legacy_non_suppressing)
+    ):
         return None
+    workflow = source_workflow
+    if workflow is None or V2_MARKER not in workflow:
+        return None
+    if any(marker not in workflow for marker in V2_FEATURE_MARKERS):
+        raise AgentLoopError("Repository CI advertises an incomplete managed-CI v2 contract.")
     return ManagedCiCreationIntent(
-        branch=f"agent-loop/managed-{issue_number}", trusted_actor=actor
+        branch=f"agent-loop/managed-{issue_number}",
+        trusted_actor=readiness.actor or config.managed_ci_trusted_actor,
+        protection_mode=readiness.protection.state,
+        audit_nonce=secrets.token_urlsafe(18) if config.allow_unprotected_managed_ci else None,
     )
 
 
@@ -363,7 +607,8 @@ def _activate_v2_managed_ci(
     )
     if base_workflow.returncode != 0:
         return None
-    if any(marker not in (base_workflow.stdout or "") for marker in V2_FEATURE_MARKERS):
+    workflow_text = base_workflow.stdout or ""
+    if any(marker not in workflow_text for marker in V2_FEATURE_MARKERS):
         raise AgentLoopError("The base branch does not contain the complete managed-CI v2 workflow.")
 
     pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
@@ -394,6 +639,48 @@ def _activate_v2_managed_ci(
     )
     if not managed_tuple:
         return None
+    # Only workflows with a pull_request route can suppress an opening matrix.
+    # Legacy dispatch-only v2 deployments remain compatible, while modern
+    # suppression-capable workflows must retain strict protection or supply a
+    # live, explicit waiver and its auditable PR trailer.
+    protection = ProtectionAssessment("strict", "legacy", "dispatch-only legacy workflow")
+    override_nonce: str | None = None
+    if "pull_request" in workflow_text:
+        protection = assess_exact_head_protection(
+            runner,
+            context=ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config)),
+            base=base_ref,
+        )
+        if protection.state != "strict":
+            body = pr.get("body") if isinstance(pr.get("body"), str) else ""
+            marker_line = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
+            if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"} or not marker_line:
+                return None
+            parts = marker_line.split("nonce=", 1)
+            if len(parts) != 2 or not parts[1].strip():
+                return None
+            override_nonce = parts[1].strip().split()[0]
+            audit = runner.run(
+                [
+                    config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/comments",
+                    "-f", "body=" + (
+                        f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
+                        f"base={base_ref} head={live_sha} protection={protection.state}\n\n"
+                        "Voluntary gate: GitHub cannot prevent manual merges, other automation, "
+                        "compromised credentials, or an agent-loop defect from bypassing it."
+                    ),
+                ], cwd=active_workdir(config), check=False,
+            )
+            if audit.returncode != 0:
+                return None
+            try:
+                audit_id = json.loads(audit.stdout or "{}").get("id")
+            except json.JSONDecodeError:
+                audit_id = None
+        else:
+            audit_id = None
+    else:
+        audit_id = None
     workflow_revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True)
     revision = workflow_revision.get("sha") if isinstance(workflow_revision.get("sha"), str) else None
     log(config, f"PR #{pr_number}: activated authenticated managed exact-head CI v2")
@@ -403,6 +690,9 @@ def _activate_v2_managed_ci(
         trusted_actor_login=actor_login,
         trusted_actor_id=actor_id,
         workflow_revision=revision,
+        protection_mode=protection.state,
+        audit_nonce=override_nonce,
+        audit_comment_id=audit_id if isinstance(audit_id, int) else None,
     )
 
 
@@ -455,30 +745,12 @@ def _active_managed_label_event(
 
 
 def _has_exact_head_protection(runner: Runner, *, config: AgentLoopConfig, base_ref: str) -> bool:
-    """Require a concrete classic protection rule; ambiguity is unsupported."""
-    result = runner.run(
-        [
-            config.gh_cmd, "api",
-            f"repos/{config.repo}/branches/{base_ref}/protection/required_status_checks",
-        ],
-        cwd=active_workdir(config), check=False,
-    )
-    if result.returncode != 0:
-        return False
-    try:
-        payload = json.loads(result.stdout or "{}")
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(payload, dict):
-        return False
-    contexts = payload.get("contexts")
-    checks = payload.get("checks")
-    return (
-        isinstance(contexts, list) and FINAL_CONTEXT in contexts
-    ) or (
-        isinstance(checks, list)
-        and any(isinstance(check, dict) and check.get("context") == FINAL_CONTEXT for check in checks)
-    )
+    """Compatibility predicate for adoption; strict means non-bypassable."""
+    return assess_exact_head_protection(
+        runner,
+        context=ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config)),
+        base=base_ref,
+    ).state == "strict"
 
 
 def _publish_adoption_guard(
@@ -690,6 +962,17 @@ def _api_json(runner: Runner, config: AgentLoopConfig, endpoint: str, *, quiet: 
     except json.JSONDecodeError as exc:
         raise AgentLoopError(f"Managed-CI API response was invalid JSON: {endpoint}.") from exc
     return payload if isinstance(payload, dict) else {}
+
+
+def managed_label_present(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> bool | None:
+    """Return None when label state cannot be proven, never treating it as safe."""
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    if not pr:
+        return None
+    labels = pr.get("labels")
+    if not isinstance(labels, list):
+        return None
+    return any(isinstance(label, dict) and label.get("name") == MANAGED_LABEL for label in labels)
 
 
 def intermediate_managed_checks(checks: PullRequestChecks) -> PullRequestChecks:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -4017,6 +4017,11 @@ def _implement_approved_issue(
             ),
         ),
     )
+    if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
+        implementation_config = dataclasses_replace(
+            implementation_config,
+            managed_ci_expected_override_nonce=managed_ci_creation_intent.audit_nonce,
+        )
     return run_pr_loop(
         runner,
         pr_number=pr_number,
@@ -6879,7 +6884,7 @@ def run_pr_loop(
                         label_live = managed_label_present(
                             runner, config=config, pr_number=pr_number
                         )
-                        if watch_outcome.status == "no_checks" and label_live is True:
+                        if watch_outcome.status == "no_checks" and label_live is not False:
                             raise AgentLoopError(
                                 f"PR #{pr_number} has no ordinary CI checks while `{MANAGED_LABEL}` "
                                 "is present or unreadable; remove the label and wait for real CI before merging."

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -101,9 +101,11 @@ from .evidence_reconciliation import (
 )
 from .memory import AgentMemoryContext, prepare_agent_memory
 from .managed_ci import (
+    MANAGED_LABEL,
     activate_managed_ci,
     dispatch_final_qualification,
     intermediate_managed_checks,
+    managed_label_present,
     preflight_managed_ci_creation,
     prepare_v2_merge,
     publish_round_readiness,
@@ -3885,6 +3887,12 @@ def _implement_approved_issue(
     managed_ci_creation_intent = preflight_managed_ci_creation(
         runner, config=implementation_config, issue_number=issue_number
     )
+    if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
+        print(
+            "WARNING: --allow-unprotected-managed-ci is active for this invocation. GitHub cannot "
+            "prevent a manual merge, other automation, a compromised credential, or an agent-loop "
+            "defect from bypassing the voluntary final-ci/exact-head gate."
+        )
     log(config, f"Planning approved; invoking {coder_name} to implement issue #{issue_number}")
     assigned_head_before = _read_assigned_workdir_head(runner, implementation_config)
     coder_response = _run_validated_agent(
@@ -6864,6 +6872,18 @@ def run_pr_loop(
                         print(f"PR #{pr_number} approval found; dry-run preview did not perform live CI watching.")
                         return 0
                     if watch_outcome.status in {"passed", "no_checks"}:
+                        # A later invocation may omit the explicit override
+                        # while the opening label still suppresses pull_request
+                        # CI.  `no_checks` must never become a merge permit in
+                        # that state.
+                        label_live = managed_label_present(
+                            runner, config=config, pr_number=pr_number
+                        )
+                        if watch_outcome.status == "no_checks" and label_live is True:
+                            raise AgentLoopError(
+                                f"PR #{pr_number} has no ordinary CI checks while `{MANAGED_LABEL}` "
+                                "is present or unreadable; remove the label and wait for real CI before merging."
+                            )
                         _publish_approved_followups(
                             runner,
                             config=config,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -15,7 +15,7 @@ from .config import AgentLoopConfig, reviewers
 from .decomposition import MAX_DECOMPOSITION_PHASES
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .memory import AgentMemoryContext, format_agent_memory_context
-from .managed_ci import ManagedCiCreationIntent
+from .managed_ci import ManagedCiCreationIntent, UNPROTECTED_OVERRIDE_TRAILER
 from .salvage import AGENT_SALVAGE_MARKER_RE
 from .round_transport import is_round_transport_sidecar
 from .protocol import (
@@ -1737,11 +1737,19 @@ def build_issue_implementation_prompt(
     managed_creation_guidance = ""
     if managed_ci_creation_intent is not None:
         branch = managed_ci_creation_intent.branch
+        override = ""
+        if managed_ci_creation_intent.audit_nonce:
+            override = (
+                " This invocation is using the explicit unprotected override. Include this exact "
+                f"PR-body trailer on its own line: `{UNPROTECTED_OVERRIDE_TRAILER} nonce={managed_ci_creation_intent.audit_nonce}`. "
+                "GitHub cannot stop a manual merge, other automation, a compromised credential, "
+                "or an agent-loop defect from bypassing this voluntary gate."
+            )
         managed_creation_guidance = (
             "\nThis repository has authenticated managed-CI v2 enabled. Create the PR atomically: "
             f"use the reserved branch `{branch}`, create/verify the `agent-loop-managed` label first, "
             "then run `gh pr create --draft --label agent-loop-managed`. Do not mark it ready until "
-            "agent-loop's final exact-head qualification succeeds.\n"
+            f"agent-loop's final exact-head qualification succeeds.{override}\n"
         )
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -212,6 +212,8 @@ class FakeRunner(Runner):
         pr_branch_protection_stderr="",
         pr_enforce_admins_payload=None,
         pr_effective_rules_payload=None,
+        pr_effective_rules_returncode=0,
+        pr_effective_rules_stderr="",
         pr_rulesets_payload=None,
         repo_payload=None,
         pr_check_runs_returncode=0,
@@ -289,6 +291,8 @@ class FakeRunner(Runner):
             {"enabled": True} if pr_enforce_admins_payload is None else pr_enforce_admins_payload
         )
         self.pr_effective_rules_payload = list(pr_effective_rules_payload or [])
+        self.pr_effective_rules_returncode = pr_effective_rules_returncode
+        self.pr_effective_rules_stderr = pr_effective_rules_stderr
         self.pr_rulesets_payload = dict(pr_rulesets_payload or {})
         self.repo_payload = {"default_branch": repo_default_branch, "private": False}
         if repo_payload:
@@ -854,7 +858,15 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, json_dumps(self.pr_enforce_admins_payload), "", 0)
 
         if cmd[:2] == ["gh", "api"] and "/rules/branches/" in cmd[2]:
-            return CommandResult(cmd, cwd_path, json_dumps(self.pr_effective_rules_payload), "", 0)
+            return CommandResult(
+                cmd,
+                cwd_path,
+                json_dumps(self.pr_effective_rules_payload)
+                if self.pr_effective_rules_returncode == 0
+                else "",
+                self.pr_effective_rules_stderr,
+                self.pr_effective_rules_returncode,
+            )
 
         if cmd[:2] == ["gh", "api"] and "/rulesets/" in cmd[2]:
             ruleset_id = cmd[2].rsplit("/", 1)[-1]

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -210,6 +210,10 @@ class FakeRunner(Runner):
         pr_branch_protection_payload=None,
         pr_branch_protection_returncode=0,
         pr_branch_protection_stderr="",
+        pr_enforce_admins_payload=None,
+        pr_effective_rules_payload=None,
+        pr_rulesets_payload=None,
+        repo_payload=None,
         pr_check_runs_returncode=0,
         pr_check_runs_stderr="",
         pr_status_returncode=0,
@@ -281,6 +285,14 @@ class FakeRunner(Runner):
         self.pr_branch_protection_payload = pr_branch_protection_payload or {"contexts": ["test"]}
         self.pr_branch_protection_returncode = pr_branch_protection_returncode
         self.pr_branch_protection_stderr = pr_branch_protection_stderr
+        self.pr_enforce_admins_payload = (
+            {"enabled": True} if pr_enforce_admins_payload is None else pr_enforce_admins_payload
+        )
+        self.pr_effective_rules_payload = list(pr_effective_rules_payload or [])
+        self.pr_rulesets_payload = dict(pr_rulesets_payload or {})
+        self.repo_payload = {"default_branch": repo_default_branch, "private": False}
+        if repo_payload:
+            self.repo_payload.update(repo_payload)
         self.pr_check_runs_returncode = pr_check_runs_returncode
         self.pr_check_runs_stderr = pr_check_runs_stderr
         self.pr_status_returncode = pr_status_returncode
@@ -837,6 +849,20 @@ class FakeRunner(Runner):
                 self.pr_branch_protection_stderr,
                 self.pr_branch_protection_returncode,
             )
+
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/protection/enforce_admins"):
+            return CommandResult(cmd, cwd_path, json_dumps(self.pr_enforce_admins_payload), "", 0)
+
+        if cmd[:2] == ["gh", "api"] and "/rules/branches/" in cmd[2]:
+            return CommandResult(cmd, cwd_path, json_dumps(self.pr_effective_rules_payload), "", 0)
+
+        if cmd[:2] == ["gh", "api"] and "/rulesets/" in cmd[2]:
+            ruleset_id = cmd[2].rsplit("/", 1)[-1]
+            payload = self.pr_rulesets_payload.get(ruleset_id, self.pr_rulesets_payload.get(int(ruleset_id), {}))
+            return CommandResult(cmd, cwd_path, json_dumps(payload), "", 0)
+
+        if cmd[:2] == ["gh", "api"] and cmd[2] == "repos/OWNER/REPO":
+            return CommandResult(cmd, cwd_path, json_dumps(self.repo_payload), "", 0)
 
         if cmd[:1] == ["sleep"]:
             return CommandResult(cmd, cwd_path, "", "", 0)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1278,6 +1278,27 @@ def test_config_records_explicit_existing_pr_managed_ci_adoption(tmp_path):
     assert config.managed_ci_adopt_existing_pr is True
 
 
+def test_config_records_per_invocation_unprotected_managed_ci_override(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "issue", "658", "--repo", "OWNER/REPO", "--auto-merge",
+        "--managed-ci-trusted-actor", "agent-loop", "--allow-unprotected-managed-ci",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.allow_unprotected_managed_ci is True
+
+
+def test_unprotected_managed_ci_override_rejects_existing_pr_adoption(capsys):
+    assert main([
+        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge",
+        "--managed-ci-trusted-actor", "agent-loop", "--managed-ci-adopt-existing-pr",
+        "--allow-unprotected-managed-ci",
+    ]) == 1
+    assert "cannot be used with --managed-ci-adopt-existing-pr" in capsys.readouterr().err
+
+
 def test_config_does_not_enable_ci_watch_without_auto_merge(tmp_path):
     parser = build_parser()
     args = parser.parse_args(["pr", "77", "--repo", "OWNER/REPO"])

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -9,6 +9,9 @@ from unittest.mock import patch
 
 import pytest
 
+import coding_review_agent_loop.cli as cli_module
+import coding_review_agent_loop.orchestrator as orchestrator_module
+
 from coding_review_agent_loop.agents.base import AgentResult, with_public_response_file_instruction
 from coding_review_agent_loop.agents.gemini import PUBLIC_RESPONSE_MARKER
 from coding_review_agent_loop.cli import (
@@ -31,7 +34,8 @@ from coding_review_agent_loop.config import (
     resolve_base_branch,
 )
 from coding_review_agent_loop.errors import AgentInvocationError, QuotaResetExceededError
-from coding_review_agent_loop.github import IssueComment
+from coding_review_agent_loop.github import CiWatchOutcome, IssueComment
+from coding_review_agent_loop.managed_ci import ManagedCiReadiness, ProtectionAssessment
 from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
@@ -1297,6 +1301,41 @@ def test_unprotected_managed_ci_override_rejects_existing_pr_adoption(capsys):
         "--allow-unprotected-managed-ci",
     ]) == 1
     assert "cannot be used with --managed-ci-adopt-existing-pr" in capsys.readouterr().err
+
+
+def test_managed_ci_preflight_reports_the_resolved_base(monkeypatch, capsys):
+    result = ManagedCiReadiness(
+        "strict_ready", "private", "agent-loop", "agent-loop", True, True,
+        ProtectionAssessment("strict", "classic", "admins enforced"), (), (), "develop",
+    )
+    monkeypatch.setattr(cli_module, "evaluate_managed_ci_readiness", lambda *args, **kwargs: result)
+
+    assert main(["managed-ci", "preflight", "--repo", "OWNER/REPO", "--trusted-actor", "agent-loop"]) == 0
+
+    assert "base: develop" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(("state", "expected"), [("override_eligible", 10), ("indeterminate", 11)])
+def test_managed_ci_preflight_uses_documented_nonready_exit_codes(monkeypatch, state, expected):
+    result = ManagedCiReadiness(
+        state, "private", "agent-loop", "agent-loop", True, True,
+        ProtectionAssessment("voluntary", "classic", "not enforced"), (), (), "main",
+    )
+    monkeypatch.setattr(cli_module, "evaluate_managed_ci_readiness", lambda *args, **kwargs: result)
+
+    assert main(["managed-ci", "preflight", "--repo", "OWNER/REPO", "--trusted-actor", "agent-loop"]) == expected
+
+
+def test_no_checks_never_merges_when_managed_label_state_is_unreadable(tmp_path):
+    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
+    config = make_config(tmp_path, auto_merge=True, watch_pending_ci=True)
+
+    with (
+        patch.object(orchestrator_module, "watch_pr_checks", return_value=CiWatchOutcome(status="no_checks")),
+        patch.object(orchestrator_module, "managed_label_present", return_value=None),
+        pytest.raises(AgentLoopError, match="present or unreadable"),
+    ):
+        run_pr_loop(runner, pr_number=77, config=config)
 
 
 def test_config_does_not_enable_ci_watch_without_auto_merge(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -74,6 +74,12 @@ on:
     types: [opened, unlabeled]
 """
 
+SUPPRESSING_V2_WORKFLOW_WITHOUT_RECOVERY = V2_WORKFLOW + """
+on:
+  pull_request:
+    types: [opened]
+"""
+
 
 class ManagedRunner(FakeRunner):
     def __init__(
@@ -140,6 +146,8 @@ class V2ManagedRunner(ManagedRunner):
         actor_id=1,
         advertised_actor=None,
         missing_advertised_actor=False,
+        workflow_returncode=0,
+        workflow_stderr="",
         issue_events=None,
         unreadable_issue_events_after_label=False,
         **kwargs,
@@ -166,6 +174,8 @@ class V2ManagedRunner(ManagedRunner):
         self.actor_id = actor_id
         self.advertised_actor = advertised_actor or actor_login
         self.missing_advertised_actor = missing_advertised_actor
+        self.workflow_returncode = workflow_returncode
+        self.workflow_stderr = workflow_stderr
         self.issue_events = list(issue_events or [])
         self.unreadable_issue_events_after_label = unreadable_issue_events_after_label
         self.labels_posted = False
@@ -191,7 +201,13 @@ class V2ManagedRunner(ManagedRunner):
             return CommandResult(cmd, cwd_path, json.dumps({"value": self.advertised_actor}), "", 0)
         if endpoint.startswith("repos/OWNER/REPO/contents/.github/workflows/ci.yml"):
             cmd, cwd_path = self._record_command(args, cwd)
-            return CommandResult(cmd, cwd_path, self.workflow, "", 0)
+            return CommandResult(
+                cmd,
+                cwd_path,
+                self.workflow if self.workflow_returncode == 0 else "",
+                self.workflow_stderr,
+                self.workflow_returncode,
+            )
         if endpoint == "repos/OWNER/REPO/pulls/7":
             cmd, cwd_path = self._record_command(args, cwd)
             return CommandResult(cmd, cwd_path, json.dumps(self.rest_pr), "", 0)
@@ -253,6 +269,28 @@ def test_protection_assessment_distinguishes_private_free_plan_limit(tmp_path):
     )
 
     assert assessment.state == "plan_limited"
+
+
+def test_private_free_plan_limits_on_both_protection_endpoints_remain_override_eligible(tmp_path):
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        repo_payload={"private": True},
+        pr_branch_protection_returncode=1,
+        pr_branch_protection_stderr="HTTP 403: Upgrade to GitHub Pro or make this repository public",
+        pr_effective_rules_returncode=1,
+        pr_effective_rules_stderr="HTTP 403: Upgrade to GitHub Pro or make this repository public",
+    )
+
+    readiness = evaluate_managed_ci_readiness(
+        runner,
+        context=ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path),
+        base="main",
+        trusted_actor="agent-loop",
+    )
+
+    assert readiness.protection.state == "plan_limited"
+    assert readiness.state == "override_eligible"
+    assert any("/rules/branches/" in " ".join(command) for command, _ in runner.commands)
 
 
 def test_protection_assessment_accepts_array_rules_and_rejects_voluntary_rulesets(tmp_path):
@@ -325,6 +363,38 @@ def test_readiness_resolves_default_base_and_distinguishes_missing_actor_variabl
     assert missing.state == "ordinary_fallback"
     assert missing.advertised_actor is None
     assert missing.remediation
+
+
+def test_suppressing_v2_without_recovery_marker_is_invalid_and_cannot_create_managed_pr(tmp_path):
+    runner = V2ManagedRunner(workflow=SUPPRESSING_V2_WORKFLOW_WITHOUT_RECOVERY)
+    context = ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path)
+
+    readiness = evaluate_managed_ci_readiness(
+        runner, context=context, base="main", trusted_actor="agent-loop"
+    )
+
+    assert readiness.state == "invalid"
+    assert readiness.recovery_capable is False
+    assert preflight_managed_ci_creation(
+        runner,
+        config=make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop"),
+        issue_number=643,
+    ) is None
+
+
+def test_missing_workflow_is_a_deterministic_ordinary_ci_fallback(tmp_path):
+    readiness = evaluate_managed_ci_readiness(
+        V2ManagedRunner(
+            workflow_returncode=1,
+            workflow_stderr="HTTP 404: Not Found",
+        ),
+        context=ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path),
+        base="main",
+        trusted_actor="agent-loop",
+    )
+
+    assert readiness.state == "ordinary_fallback"
+    assert readiness.workflow_v2 is False
 
 
 def test_suppressing_v2_preflight_falls_back_without_override_and_uses_nonce_with_override(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -15,6 +15,8 @@ from coding_review_agent_loop.managed_ci import (
     MANAGED_OPT_OUT_LABEL,
     READINESS_CONTEXT,
     ManagedCiContract,
+    ManagedCiProbeContext,
+    assess_exact_head_protection,
     _dispatch_v2_qualification,
     _ensure_v2_intent,
     _v2_failed_jobs,
@@ -223,6 +225,21 @@ class V2ManagedRunner(ManagedRunner):
             cmd, cwd_path = self._record_command(args, cwd)
             return CommandResult(cmd, cwd_path, f"{self.pr_payload.get('headRefOid')}\n", "", 0)
         return super()._run_locked(args, cwd=cwd, check=check)
+
+
+def test_protection_assessment_distinguishes_private_free_plan_limit(tmp_path):
+    runner = FakeRunner(
+        pr_branch_protection_returncode=1,
+        pr_branch_protection_stderr="Upgrade to GitHub Pro or make this repository public",
+    )
+
+    assessment = assess_exact_head_protection(
+        runner,
+        context=ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path),
+        base="main",
+    )
+
+    assert assessment.state == "plan_limited"
 
 
 def metadata(*, base_branch="main"):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -16,12 +16,14 @@ from coding_review_agent_loop.managed_ci import (
     READINESS_CONTEXT,
     ManagedCiContract,
     ManagedCiProbeContext,
+    UNPROTECTED_OVERRIDE_TRAILER,
     assess_exact_head_protection,
     _dispatch_v2_qualification,
     _ensure_v2_intent,
     _v2_failed_jobs,
     activate_managed_ci,
     dispatch_final_qualification,
+    evaluate_managed_ci_readiness,
     intermediate_managed_checks,
     preflight_managed_ci_creation,
     prepare_v2_merge,
@@ -63,6 +65,13 @@ on:
 jobs:
   aggregate:
     name: final-ci/exact-head
+"""
+
+SUPPRESSING_V2_WORKFLOW = V2_WORKFLOW + """
+# AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1
+on:
+  pull_request:
+    types: [opened, unlabeled]
 """
 
 
@@ -130,6 +139,7 @@ class V2ManagedRunner(ManagedRunner):
         actor_login="agent-loop",
         actor_id=1,
         advertised_actor=None,
+        missing_advertised_actor=False,
         issue_events=None,
         unreadable_issue_events_after_label=False,
         **kwargs,
@@ -155,6 +165,7 @@ class V2ManagedRunner(ManagedRunner):
         self.actor_login = actor_login
         self.actor_id = actor_id
         self.advertised_actor = advertised_actor or actor_login
+        self.missing_advertised_actor = missing_advertised_actor
         self.issue_events = list(issue_events or [])
         self.unreadable_issue_events_after_label = unreadable_issue_events_after_label
         self.labels_posted = False
@@ -175,6 +186,8 @@ class V2ManagedRunner(ManagedRunner):
             )
         if endpoint.endswith("/actions/variables/AGENT_LOOP_MANAGED_ACTOR"):
             cmd, cwd_path = self._record_command(args, cwd)
+            if self.missing_advertised_actor:
+                return CommandResult(cmd, cwd_path, "", "HTTP 404: Not Found", 1)
             return CommandResult(cmd, cwd_path, json.dumps({"value": self.advertised_actor}), "", 0)
         if endpoint.startswith("repos/OWNER/REPO/contents/.github/workflows/ci.yml"):
             cmd, cwd_path = self._record_command(args, cwd)
@@ -242,6 +255,44 @@ def test_protection_assessment_distinguishes_private_free_plan_limit(tmp_path):
     assert assessment.state == "plan_limited"
 
 
+def test_protection_assessment_accepts_array_rules_and_rejects_voluntary_rulesets(tmp_path):
+    context = ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path)
+    rule = {"ruleset_id": 8}
+    required = {"contexts": []}
+    active_rule = {
+        "enforcement": "active", "bypass_actors": [],
+        "rules": [{"type": "required_status_checks", "parameters": {"required_status_checks": [{"context": FINAL_CONTEXT}]}}],
+    }
+    strict = assess_exact_head_protection(
+        FakeRunner(pr_branch_protection_payload=required, pr_effective_rules_payload=[rule], pr_rulesets_payload={8: active_rule}),
+        context=context, base="main",
+    )
+    assert strict.state == "strict"
+
+    bypassable = dict(active_rule, bypass_actors=[{"actor_id": 1}])
+    voluntary = assess_exact_head_protection(
+        FakeRunner(pr_branch_protection_payload=required, pr_effective_rules_payload=[rule], pr_rulesets_payload={8: bypassable}),
+        context=context, base="main",
+    )
+    assert voluntary.state == "voluntary"
+
+    evaluate_mode = dict(active_rule, enforcement="evaluate")
+    voluntary = assess_exact_head_protection(
+        FakeRunner(pr_branch_protection_payload=required, pr_effective_rules_payload=[rule], pr_rulesets_payload={8: evaluate_mode}),
+        context=context, base="main",
+    )
+    assert voluntary.state == "voluntary"
+
+
+def test_protection_assessment_never_treats_empty_admin_response_as_enforced(tmp_path):
+    assessment = assess_exact_head_protection(
+        FakeRunner(pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]}, pr_enforce_admins_payload={}),
+        context=ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path), base="main",
+    )
+
+    assert assessment.state == "indeterminate"
+
+
 def metadata(*, base_branch="main"):
     return PullRequestMetadata(
         number=7,
@@ -251,6 +302,77 @@ def metadata(*, base_branch="main"):
         base_branch=base_branch,
         head_sha="abc123",
         url="https://github.com/OWNER/REPO/pull/7",
+    )
+
+
+def test_readiness_resolves_default_base_and_distinguishes_missing_actor_variable(tmp_path):
+    context = ManagedCiProbeContext("OWNER/REPO", "gh", tmp_path)
+    ready = evaluate_managed_ci_readiness(
+        V2ManagedRunner(
+            workflow=SUPPRESSING_V2_WORKFLOW,
+            pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+        ),
+        context=context, base=None, trusted_actor=" agent-loop ",
+    )
+
+    assert ready.state == "strict_ready"
+    assert ready.base == "main"
+
+    missing = evaluate_managed_ci_readiness(
+        V2ManagedRunner(workflow=SUPPRESSING_V2_WORKFLOW, missing_advertised_actor=True),
+        context=context, base="main", trusted_actor="agent-loop",
+    )
+    assert missing.state == "ordinary_fallback"
+    assert missing.advertised_actor is None
+    assert missing.remediation
+
+
+def test_suppressing_v2_preflight_falls_back_without_override_and_uses_nonce_with_override(tmp_path):
+    runner = V2ManagedRunner(workflow=SUPPRESSING_V2_WORKFLOW)
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+
+    assert preflight_managed_ci_creation(runner, config=config, issue_number=643) is None
+
+    override_config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    intent = preflight_managed_ci_creation(runner, config=override_config, issue_number=643)
+
+    assert intent is not None
+    assert intent.audit_nonce
+
+
+def test_override_activation_requires_the_preflight_nonce_and_releases_label_on_mismatch(tmp_path):
+    nonce = "nonce-from-preflight"
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        rest_pr={"body": f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={nonce}"},
+    )
+    config = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True, managed_ci_expected_override_nonce=nonce,
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.audit_nonce == nonce
+    assert contract.audit_comment_id == 17
+    assert any(UNPROTECTED_OVERRIDE_TRAILER in " ".join(command) for command, _ in runner.commands)
+
+    mismatch = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        rest_pr={"body": f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={nonce}"},
+    )
+    rejected = make_config(
+        tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True, managed_ci_expected_override_nonce="different",
+    )
+    assert activate_managed_ci(mismatch, config=rejected, pr_number=7, metadata=metadata()) is None
+    assert any(
+        command[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
+        for command, _ in mismatch.commands
     )
 
 


### PR DESCRIPTION
Fixes #658\n\nAdds a read-only managed-CI readiness preflight, typed protection assessment, explicit per-invocation unprotected override for plan-first issue-created v2 work, no-check managed-label merge guard, tests, and operator documentation.