### PR TITLE
Add managed PR mode for direct branch work

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,30 @@ advertise safe adoption and an operator can explicitly request it only with
 --managed-ci-adopt-existing-pr`. The managed-CI guide documents the required
 branch-protection guard, timeline provenance, and durable opt-out.
 
+Code that is already pushed to a same-repository branch, but does not yet have
+a PR, can enter managed CI without a placeholder issue:
+
+```bash
+agent-loop managed-pr \
+  --repo OWNER/REPO \
+  --head fix/prepared-change \
+  --base main \
+  --title "Fix prepared change" \
+  --body-file /path/to/pr-body.md \
+  --managed-ci \
+  --managed-ci-trusted-actor LOGIN \
+  --reviewer codex
+```
+
+`managed-pr` verifies readiness before writing, pins the source head to a
+unique reserved branch, opens and labels a managed draft, and immediately
+enters the normal review loop. It refuses a source head that already has an
+open PR; use `agent-loop pr <n>` for that PR instead. Repositories without
+enforceable exact-head protection must repeat the explicit
+`--allow-unprotected-managed-ci` waiver on this command. Use `--managed-ci`
+to leave the qualified PR ready for a manual head-guarded merge, or replace it
+with `--auto-merge` to retain automatic merging.
+
 Before enabling managed CI, run the read-only readiness report:
 
 ```bash
@@ -695,7 +719,8 @@ GitHub evidence is unavailable or ambiguous. It makes no writes. Protected mode
 is the default. A personal, consciously supervised private repository that is
 otherwise ready but cannot use GitHub protection may use the deliberately
 per-invocation `--allow-unprotected-managed-ci` flag on authenticated plan-first
-issue work; it never applies to existing-PR adoption or dangerous permissions.
+issue work or pre-creation `managed-pr` work; it never applies to existing-PR
+adoption or dangerous permissions.
 This is an intentional tightening for suppression-capable v2 workflows: a
 repository that previously used issue-created v2 without non-bypassable GitHub
 protection now returns to ordinary CI unless that explicit per-run waiver is

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1330,8 +1330,9 @@ with admin bypass, evaluate/disabled rulesets, and rulesets with bypass actors
 are voluntary rather than strict. Existing-PR adoption always requires strict,
 non-bypassable enforcement.
 
-For an otherwise eligible authenticated plan-first issue-created v2 invocation,
-`--allow-unprotected-managed-ci` may waive only that protection prerequisite.
+For an otherwise eligible authenticated plan-first issue-created or
+pre-creation `managed-pr` v2 invocation, `--allow-unprotected-managed-ci` may
+waive only that protection prerequisite.
 It must be written on every invocation; an old label, audit trailer, or
 `--dangerous-agent-permissions` never re-enables it. The coder records the
 override nonce in the PR body and agent-loop warns locally. This is not suitable
@@ -1432,13 +1433,14 @@ through that account).
 For auto-merge issue work, a v2 preflight gives the coder an atomic creation
 intent: create or verify `agent-loop-managed`, use the reserved
 `agent-loop/managed-<issue>` branch, then run `gh pr create --draft --label
-agent-loop-managed`. The workflow can suppress opened/reopened/synchronize
+agent-loop-managed`. The workflow can suppress later reopened/synchronize
 matrices only for the complete tuple: same-repository head, trusted REST
-author, reserved branch, draft, and label. A contributor-editable label,
-branch, or body alone is never trusted. Forks and ordinary PRs retain regular
-CI unless they are explicitly adopted as described below. The issue-created
-opening tuple remains unchanged: it alone requires a trusted author, reserved
-branch, and draft state.
+author, reserved branch, draft, and label. The opening event is necessarily
+evaluated before GitHub's separate label write and therefore uses the same
+tuple without the label; agent-loop must apply the label before continuing.
+A contributor-editable label, branch, or body alone is never trusted. Forks
+and ordinary PRs retain regular CI unless they are explicitly adopted as
+described below.
 
 For an unprotected override, the coder carries the preflight-minted nonce in
 the creation trailer. During that same invocation agent-loop compares the
@@ -1446,6 +1448,45 @@ trailer to its in-memory nonce and writes an actor-owned PR audit comment
 before accepting activation or dispatching qualification. A forged, stale, or
 mismatched trailer, or a failed audit write, releases the suppression label;
 a later invocation cannot reuse a body nonce as its authorization.
+
+#### Creating a managed PR from an existing branch
+
+When code is already pushed to the repository but no PR exists, use the
+pre-creation mode instead of creating an ordinary PR and adopting it later:
+
+```bash
+agent-loop managed-pr \
+  --repo OWNER/REPO \
+  --head fix/prepared-change \
+  --base main \
+  --title "Fix prepared change" \
+  --body-file /path/to/pr-body.md \
+  --managed-ci \
+  --managed-ci-trusted-actor LOGIN \
+  --reviewer claude \
+  --reviewer agy \
+  --review-parallel
+```
+
+The command resolves the exact SHA of `--head`, rejects a source SHA that
+already has an open PR, and runs managed-CI readiness before creating anything.
+It then creates a unique `agent-loop/managed-direct-*` alias at that SHA, opens
+a draft, applies `agent-loop-managed`, and enters the ordinary PR review loop.
+Use `--managed-ci` to leave a successfully qualified PR ready for the printed
+head-guarded manual merge, or replace it with `--auto-merge` to merge the
+qualified head automatically.
+If the source moves during handoff or draft labeling fails, the partial draft
+is closed and the reserved alias is removed. The original source branch is
+never changed or deleted.
+
+`--body-file -` reads the PR body from stdin; omitting `--body-file` creates an
+otherwise empty body with only the hidden source audit marker. On a repository
+whose preflight reports `override_eligible`, add
+`--allow-unprotected-managed-ci` to this invocation. Its nonce is embedded in
+the newly created body and correlated in memory exactly like issue-created v2.
+The waiver is safe only under the same single-operator constraints documented
+above. `managed-pr` never adopts an already-open PR and does not weaken the
+strict-only `--managed-ci-adopt-existing-pr` path.
 
 #### Optional adoption of an existing PR
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -23,6 +23,7 @@ from .config import (
     ensure_agent_workdirs,
     ensure_distinct_workdirs,
     ensure_workdir,
+    resolve_base_branch,
     reviewers,
 )
 from .errors import AgentLoopError, QuotaResetExceededError
@@ -34,6 +35,7 @@ from .managed_ci import (
     evaluate_managed_ci_readiness,
     render_managed_ci_preflight,
 )
+from .managed_pr import create_managed_pr
 from .github import (
     detect_repo,
     get_check_status,
@@ -625,6 +627,42 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_review_parallel(pr)
 
+    managed_pr = subparsers.add_parser(
+        "managed-pr",
+        help="Create a managed-CI draft from an existing branch, then review it.",
+    )
+    managed_pr.add_argument(
+        "--head",
+        required=True,
+        help="Existing same-repository source branch whose exact head will be used.",
+    )
+    managed_pr.add_argument("--title", required=True, help="Pull-request title.")
+    managed_pr.add_argument(
+        "--body-file",
+        type=Path,
+        default=None,
+        help="Read the pull-request body from this file (use '-' for stdin; default: empty).",
+    )
+    add_common(managed_pr)
+    managed_pr.add_argument(
+        "--managed-ci",
+        action="store_true",
+        help=(
+            "Explicitly activate managed exact-head CI without implying a merge. "
+            "A successful run leaves the live qualified head ready for manual "
+            "head-guarded merging. Requires --managed-ci-trusted-actor."
+        ),
+    )
+    managed_pr.add_argument(
+        "--allow-unprotected-managed-ci",
+        action="store_true",
+        help=(
+            "Per-invocation waiver when GitHub cannot independently enforce final-ci/exact-head. "
+            "Requires --managed-ci or --auto-merge and --managed-ci-trusted-actor."
+        ),
+    )
+    add_review_parallel(managed_pr)
+
     managed_ci = subparsers.add_parser("managed-ci", help="Inspect managed-CI readiness without writes.")
     managed_ci_subparsers = managed_ci.add_subparsers(dest="managed_ci_command", required=True)
     preflight = managed_ci_subparsers.add_parser("preflight", help="Read-only managed-CI readiness report.")
@@ -798,8 +836,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         invocation = tuple([sys.argv[0], *sys.argv[1:]]) if argv is None else tuple(["agent-loop", *argv])
         explicit_managed_ci = bool(getattr(args, "managed_ci", False))
         if explicit_managed_ci:
-            if args.command not in {"issue", "pr"}:
-                raise AgentLoopError("--managed-ci is only supported with issue or pr.")
+            if args.command not in {"issue", "pr", "managed-pr"}:
+                raise AgentLoopError("--managed-ci is only supported with issue, pr, or managed-pr.")
             if not (args.managed_ci_trusted_actor or "").strip():
                 raise AgentLoopError("--managed-ci requires --managed-ci-trusted-actor.")
         config = config_from_args(args, runner, invocation_argv=invocation)
@@ -820,8 +858,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "--managed-ci-adopt-existing-pr requires --managed-ci-trusted-actor."
                 )
         if getattr(args, "allow_unprotected_managed_ci", False):
-            if args.command not in {"issue", "pr"}:
-                raise AgentLoopError("--allow-unprotected-managed-ci is only supported with issue or pr.")
+            if args.command not in {"issue", "pr", "managed-pr"}:
+                raise AgentLoopError("--allow-unprotected-managed-ci is only supported with issue, pr, or managed-pr.")
             if not (args.auto_merge or getattr(args, "managed_ci", False)):
                 raise AgentLoopError("--allow-unprotected-managed-ci requires --managed-ci or --auto-merge.")
             if not (args.managed_ci_trusted_actor or "").strip():
@@ -860,6 +898,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         if args.command == "pr":
             return run_pr_loop(runner, pr_number=args.pr_number, config=config)
+        if args.command == "managed-pr":
+            if not (args.auto_merge or args.managed_ci):
+                raise AgentLoopError("managed-pr requires --managed-ci or --auto-merge.")
+            if not (args.managed_ci_trusted_actor or "").strip():
+                raise AgentLoopError("managed-pr requires --managed-ci-trusted-actor.")
+            if args.dry_run:
+                raise AgentLoopError("managed-pr does not support --dry-run because it must verify live GitHub state.")
+            if args.body_file is None:
+                body = ""
+            elif str(args.body_file) == "-":
+                body = sys.stdin.read()
+            else:
+                body = args.body_file.read_text(encoding="utf-8")
+            config = resolve_base_branch(config, runner)
+            ensure_agent_workdirs(config, runner)
+            handoff = create_managed_pr(
+                runner,
+                config=config,
+                source_branch=args.head,
+                title=args.title,
+                body=body,
+            )
+            return run_pr_loop(
+                runner,
+                pr_number=handoff.pr_number,
+                config=handoff.config,
+                workdirs_ready=True,
+            )
         if args.command == "task":
             task_text = _resolve_task_text(args)
             return run_task_loop(

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -628,13 +628,22 @@ def render_managed_ci_preflight(result: ManagedCiReadiness, *, repo: str, base: 
 
 
 def preflight_managed_ci_creation(
-    runner: Runner, *, config: AgentLoopConfig, issue_number: int
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int | None = None,
+    branch: str | None = None,
 ) -> ManagedCiCreationIntent | None:
     """Return an atomic creation intent only for an authenticated v2 rollout.
 
     This happens before the coder is prompted, avoiding the opened-event race:
-    the PR is born as a draft with its managed label, or it is ordinary CI.
+    the PR is born as a recognizable reserved draft and is labeled before the
+    orchestrator continues, or it is ordinary CI.
     """
+    if (issue_number is None) == (branch is None):
+        raise AgentLoopError("Managed-CI creation preflight requires exactly one issue number or branch.")
+    if branch is not None and not branch.startswith("agent-loop/managed-"):
+        raise AgentLoopError("Managed-CI creation branches must use the reserved `agent-loop/managed-` prefix.")
     if not config.effective_managed_ci or config.dry_run or not config.managed_ci_trusted_actor or not config.base:
         return None
     source_context = ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config))
@@ -699,7 +708,7 @@ def preflight_managed_ci_creation(
             )
         return None
     return ManagedCiCreationIntent(
-        branch=f"agent-loop/managed-{issue_number}",
+        branch=branch or f"agent-loop/managed-{issue_number}",
         trusted_actor=readiness.actor or config.managed_ci_trusted_actor,
         protection_mode=readiness.protection.state,
         audit_nonce=secrets.token_urlsafe(18) if config.allow_unprotected_managed_ci else None,

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -325,31 +325,8 @@ def activate_managed_ci(
         for label in pr_data.get("labels") or []
         if isinstance(label, dict) and isinstance(label.get("name"), str)
     }
-    label_result = runner.run(
-        [config.gh_cmd, "api", f"repos/{config.repo}/labels/{MANAGED_LABEL}"],
-        cwd=active_workdir(config),
-        check=False,
-    )
-    if label_result.returncode != 0:
-        create_result = runner.run(
-            [
-                config.gh_cmd,
-                "api",
-                "--method",
-                "POST",
-                f"repos/{config.repo}/labels",
-                "-f",
-                f"name={MANAGED_LABEL}",
-                "-f",
-                "color=1f6feb",
-                "-f",
-                "description=Suppress intermediate CI; agent-loop dispatches exact-head final CI",
-            ],
-            cwd=active_workdir(config),
-            check=False,
-        )
-        if create_result.returncode != 0:
-            raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
+    if not ensure_managed_label(runner, config=config):
+        raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
     if MANAGED_LABEL not in labels:
         prior_workflow_run_ids = _workflow_run_ids(
             runner,
@@ -1029,7 +1006,7 @@ def _activate_v2_managed_ci(
         # an already authenticated issue-created managed draft is resumable.
         if not config.managed_ci:
             return None
-        if not _ensure_managed_label(runner, config=config):
+        if not ensure_managed_label(runner, config=config):
             raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
         applied_label = runner.run(
             [
@@ -1320,7 +1297,7 @@ def _publish_adoption_guard(
     return result.returncode == 0
 
 
-def _ensure_managed_label(runner: Runner, *, config: AgentLoopConfig) -> bool:
+def ensure_managed_label(runner: Runner, *, config: AgentLoopConfig) -> bool:
     """Create the repository label only when GitHub reports it absent."""
     existing = runner.run(
         [config.gh_cmd, "api", f"repos/{config.repo}/labels/{MANAGED_LABEL}"],
@@ -1417,7 +1394,7 @@ def _activate_v2_existing_pr_adoption(
     existing = _active_managed_label_event(runner, config=config, pr_number=pr_number)
     applied = False
     if MANAGED_LABEL not in labels:
-        if not _ensure_managed_label(runner, config=config):
+        if not ensure_managed_label(runner, config=config):
             return None
         created = runner.run(
             [config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/labels",

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -15,6 +15,7 @@ from .logging import log
 from .managed_ci import (
     MANAGED_LABEL,
     UNPROTECTED_OVERRIDE_TRAILER,
+    ensure_managed_label,
     preflight_managed_ci_creation,
 )
 from .runner import CommandResult, Runner
@@ -231,6 +232,8 @@ def create_managed_pr(
         pr_number = created.get("number") if isinstance(created, dict) else None
         if not isinstance(pr_number, int) or pr_number <= 0:
             raise AgentLoopError("GitHub created a managed draft without returning a valid PR number.")
+        if not ensure_managed_label(runner, config=config):
+            raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
         _api(
             runner,
             config=config,
@@ -297,6 +300,10 @@ def create_managed_pr(
     correlated_config = replace(
         config,
         managed_ci_expected_override_nonce=intent.audit_nonce,
+        # Replaying managed-pr would hit the duplicate-PR guard for the draft
+        # just created above. Leave no original argv so a CI-watch timeout
+        # renders run_pr_loop's deterministic `agent-loop pr <n>` recovery.
+        invocation_argv=(),
     )
     log(
         config,

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -1,0 +1,305 @@
+"""Create a managed-CI draft from code already pushed to a repository branch."""
+
+from __future__ import annotations
+
+import base64
+import json
+import secrets
+import time
+from dataclasses import dataclass, replace
+from urllib.parse import quote
+
+from .config import AgentLoopConfig
+from .errors import AgentLoopError
+from .logging import log
+from .managed_ci import (
+    MANAGED_LABEL,
+    UNPROTECTED_OVERRIDE_TRAILER,
+    preflight_managed_ci_creation,
+)
+from .runner import CommandResult, Runner
+from .workdirs import active_workdir
+
+
+SOURCE_MARKER = "AGENT_MANAGED_PR_SOURCE_V1"
+
+
+@dataclass(frozen=True)
+class ManagedPrHandoff:
+    pr_number: int
+    config: AgentLoopConfig
+    source_sha: str
+    managed_branch: str
+
+
+def _api(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    method: str,
+    endpoint: str,
+    payload: dict[str, object] | None = None,
+    check: bool = True,
+) -> CommandResult:
+    args = [config.gh_cmd, "api", "--method", method, endpoint]
+    input_text = None
+    if payload is not None:
+        args.extend(("--input", "-"))
+        input_text = json.dumps(payload)
+    result = runner.run(
+        args,
+        cwd=active_workdir(config),
+        input_text=input_text,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        suffix = f": {detail}" if detail else ""
+        raise AgentLoopError(f"GitHub API request failed ({method} {endpoint}){suffix}")
+    return result
+
+
+def _json_payload(result: CommandResult, *, operation: str) -> object:
+    try:
+        return json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError(f"GitHub returned invalid JSON while {operation}.") from exc
+
+
+def _source_marker(*, source_branch: str, source_sha: str) -> str:
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(
+            {"source_branch": source_branch, "source_sha": source_sha},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).decode("ascii")
+    return f"<!-- {SOURCE_MARKER} {encoded} -->"
+
+
+def _compose_body(
+    body: str,
+    *,
+    source_branch: str,
+    source_sha: str,
+    override_nonce: str | None,
+) -> str:
+    sections = [body.rstrip()] if body.strip() else []
+    sections.append(_source_marker(source_branch=source_branch, source_sha=source_sha))
+    if override_nonce:
+        sections.append(f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce}")
+    return "\n\n".join(sections) + "\n"
+
+
+def _close_partial_handoff(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int | None,
+    managed_branch: str,
+) -> tuple[str, ...]:
+    failures: list[str] = []
+    if pr_number is not None:
+        close_result = _api(
+            runner,
+            config=config,
+            method="PATCH",
+            endpoint=f"repos/{config.repo}/pulls/{pr_number}",
+            payload={"state": "closed"},
+            check=False,
+        )
+        if close_result.returncode != 0:
+            failures.append(f"close PR #{pr_number}")
+    encoded_ref = quote(f"heads/{managed_branch}", safe="")
+    delete_result = _api(
+        runner,
+        config=config,
+        method="DELETE",
+        endpoint=f"repos/{config.repo}/git/refs/{encoded_ref}",
+        check=False,
+    )
+    if delete_result.returncode != 0:
+        failures.append(f"delete branch {managed_branch}")
+    return tuple(failures)
+
+
+def create_managed_pr(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    source_branch: str,
+    title: str,
+    body: str,
+) -> ManagedPrHandoff:
+    """Create a trusted draft and return a config correlated to its waiver."""
+    source_branch = source_branch.strip()
+    title = title.strip()
+    if not source_branch or source_branch.startswith("refs/") or ":" in source_branch:
+        raise AgentLoopError("--head must name a same-repository branch, without `refs/` or an owner prefix.")
+    if not title:
+        raise AgentLoopError("--title cannot be empty.")
+    if SOURCE_MARKER in body or UNPROTECTED_OVERRIDE_TRAILER in body:
+        raise AgentLoopError("The supplied PR body contains a reserved managed-PR protocol marker.")
+    if not config.base:
+        raise AgentLoopError("Managed PR creation requires a resolved base branch.")
+    if source_branch == config.base:
+        raise AgentLoopError("--head must differ from the PR base branch.")
+
+    branch_result = _api(
+        runner,
+        config=config,
+        method="GET",
+        endpoint=f"repos/{config.repo}/branches/{quote(source_branch, safe='')}",
+    )
+    branch_payload = _json_payload(branch_result, operation="resolving the source branch")
+    commit = branch_payload.get("commit") if isinstance(branch_payload, dict) else None
+    source_sha = commit.get("sha") if isinstance(commit, dict) else None
+    if not isinstance(source_sha, str) or not source_sha:
+        raise AgentLoopError(f"Could not resolve the head SHA for branch {source_branch!r}.")
+
+    pulls_result = _api(
+        runner,
+        config=config,
+        method="GET",
+        endpoint=f"repos/{config.repo}/commits/{source_sha}/pulls?state=open",
+    )
+    pulls = _json_payload(pulls_result, operation="checking for an existing PR")
+    open_prs = (
+        [item for item in pulls if isinstance(item, dict) and item.get("state") == "open"]
+        if isinstance(pulls, list)
+        else []
+    )
+    if open_prs:
+        numbers = ", ".join(f"#{item['number']}" for item in open_prs if isinstance(item.get("number"), int))
+        raise AgentLoopError(
+            f"Source head {source_sha} already has an open PR{f' ({numbers})' if numbers else ''}. "
+            "Continue it with `agent-loop pr <number>`; managed-pr never retroactively adopts a PR."
+        )
+
+    managed_branch = (
+        f"agent-loop/managed-direct-{int(time.time())}-{secrets.token_hex(4)}"
+    )
+    intent = preflight_managed_ci_creation(
+        runner,
+        config=config,
+        branch=managed_branch,
+    )
+    if intent is None:
+        raise AgentLoopError(
+            "Managed PR creation is not ready for this repository. Run `agent-loop managed-ci preflight` "
+            "and correct its reported prerequisites; managed-pr does not fall back to ordinary CI."
+        )
+    if intent.audit_nonce:
+        log(
+            config,
+            "WARNING: managed-pr is using the explicit unprotected managed-CI waiver for this invocation. "
+            "GitHub cannot prevent a manual merge, other automation, a compromised credential, or an "
+            "agent-loop defect from bypassing the voluntary final-ci/exact-head gate.",
+        )
+
+    pr_number: int | None = None
+    ref_created = False
+    try:
+        _api(
+            runner,
+            config=config,
+            method="POST",
+            endpoint=f"repos/{config.repo}/git/refs",
+            payload={"ref": f"refs/heads/{intent.branch}", "sha": source_sha},
+        )
+        ref_created = True
+        rendered_body = _compose_body(
+            body,
+            source_branch=source_branch,
+            source_sha=source_sha,
+            override_nonce=intent.audit_nonce,
+        )
+        create_result = _api(
+            runner,
+            config=config,
+            method="POST",
+            endpoint=f"repos/{config.repo}/pulls",
+            payload={
+                "title": title,
+                "head": intent.branch,
+                "base": config.base,
+                "body": rendered_body,
+                "draft": True,
+            },
+        )
+        created = _json_payload(create_result, operation="creating the managed draft PR")
+        pr_number = created.get("number") if isinstance(created, dict) else None
+        if not isinstance(pr_number, int) or pr_number <= 0:
+            raise AgentLoopError("GitHub created a managed draft without returning a valid PR number.")
+        _api(
+            runner,
+            config=config,
+            method="POST",
+            endpoint=f"repos/{config.repo}/issues/{pr_number}/labels",
+            payload={"labels": [MANAGED_LABEL]},
+        )
+
+        current_result = _api(
+            runner,
+            config=config,
+            method="GET",
+            endpoint=f"repos/{config.repo}/branches/{quote(source_branch, safe='')}",
+        )
+        current = _json_payload(current_result, operation="revalidating the source branch")
+        current_commit = current.get("commit") if isinstance(current, dict) else None
+        current_sha = current_commit.get("sha") if isinstance(current_commit, dict) else None
+        if current_sha != source_sha:
+            raise AgentLoopError(
+                f"Source branch {source_branch!r} moved during managed PR creation; the partial draft was closed."
+            )
+        post_create_pulls_result = _api(
+            runner,
+            config=config,
+            method="GET",
+            endpoint=f"repos/{config.repo}/commits/{source_sha}/pulls?state=open",
+        )
+        post_create_pulls = _json_payload(
+            post_create_pulls_result,
+            operation="rechecking for a concurrent PR",
+        )
+        competing_prs = (
+            [
+                item
+                for item in post_create_pulls
+                if isinstance(item, dict)
+                and item.get("state") == "open"
+                and item.get("number") != pr_number
+            ]
+            if isinstance(post_create_pulls, list)
+            else []
+        )
+        if competing_prs:
+            raise AgentLoopError(
+                "Another PR was opened for the source commit during managed PR creation; "
+                "the partial managed draft was closed."
+            )
+    except Exception as exc:
+        if ref_created:
+            cleanup_failures = _close_partial_handoff(
+                runner,
+                config=config,
+                pr_number=pr_number,
+                managed_branch=managed_branch,
+            )
+            if cleanup_failures:
+                raise AgentLoopError(
+                    "Managed PR creation failed and automatic cleanup was incomplete: "
+                    + ", ".join(cleanup_failures)
+                    + ". Inspect the partial draft and reserved branch before retrying."
+                ) from exc
+        raise
+
+    correlated_config = replace(
+        config,
+        managed_ci_expected_override_nonce=intent.audit_nonce,
+    )
+    log(
+        config,
+        f"Created managed draft PR #{pr_number} from {source_branch}@{source_sha[:12]} via {managed_branch}",
+    )
+    return ManagedPrHandoff(pr_number, correlated_config, source_sha, managed_branch)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -36,6 +37,7 @@ from coding_review_agent_loop.config import (
 from coding_review_agent_loop.errors import AgentInvocationError, QuotaResetExceededError
 from coding_review_agent_loop.github import CiWatchOutcome, IssueComment
 from coding_review_agent_loop.managed_ci import ManagedCiReadiness, ProtectionAssessment
+from coding_review_agent_loop.managed_pr import ManagedPrHandoff
 from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
@@ -1363,6 +1365,67 @@ def test_managed_pr_parser_accepts_manual_managed_ci():
     assert args.command == "managed-pr"
     assert args.managed_ci is True
     assert args.auto_merge is False
+
+
+def test_managed_pr_requires_managed_ci_or_auto_merge(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli_module, "config_from_args", lambda *args, **kwargs: make_config(tmp_path))
+
+    assert main([
+        "managed-pr", "--repo", "OWNER/REPO", "--head", "fix/direct-change", "--title", "Direct change",
+    ]) == 1
+
+    assert "managed-pr requires --managed-ci or --auto-merge" in capsys.readouterr().err
+
+
+def test_managed_pr_requires_trusted_actor(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli_module, "config_from_args", lambda *args, **kwargs: make_config(tmp_path))
+
+    assert main([
+        "managed-pr", "--repo", "OWNER/REPO", "--head", "fix/direct-change", "--title", "Direct change",
+        "--auto-merge",
+    ]) == 1
+
+    assert "managed-pr requires --managed-ci-trusted-actor" in capsys.readouterr().err
+
+
+def test_managed_pr_refuses_dry_run(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli_module, "config_from_args", lambda *args, **kwargs: make_config(tmp_path))
+
+    assert main([
+        "managed-pr", "--repo", "OWNER/REPO", "--head", "fix/direct-change", "--title", "Direct change",
+        "--managed-ci", "--managed-ci-trusted-actor", "agent-loop", "--dry-run",
+    ]) == 1
+
+    assert "managed-pr does not support --dry-run" in capsys.readouterr().err
+
+
+def test_managed_pr_hands_created_draft_to_pr_loop(tmp_path, monkeypatch):
+    config = make_config(tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop")
+    handoff_config = replace(config, invocation_argv=())
+    handoff = ManagedPrHandoff(77, handoff_config, "a" * 40, "agent-loop/managed-direct-token")
+    captured = {}
+    monkeypatch.setattr(cli_module, "config_from_args", lambda *args, **kwargs: config)
+    monkeypatch.setattr(cli_module, "resolve_base_branch", lambda config, runner: config)
+    monkeypatch.setattr(cli_module, "ensure_agent_workdirs", lambda config, runner: None)
+
+    def create(runner, *, config, source_branch, title, body):
+        captured["create"] = (config, source_branch, title, body)
+        return handoff
+
+    def run(runner, *, pr_number, config, workdirs_ready=False):
+        captured["run"] = (pr_number, config, workdirs_ready)
+        return 23
+
+    monkeypatch.setattr(cli_module, "create_managed_pr", create)
+    monkeypatch.setattr(cli_module, "run_pr_loop", run)
+
+    assert main([
+        "managed-pr", "--repo", "OWNER/REPO", "--head", "fix/direct-change", "--title", "Direct change",
+        "--managed-ci", "--managed-ci-trusted-actor", "agent-loop",
+    ]) == 23
+
+    assert captured["create"][1:] == ("fix/direct-change", "Direct change", "")
+    assert captured["run"] == (77, handoff_config, True)
 
 
 def test_unprotected_managed_ci_override_rejects_existing_pr_adoption(capsys):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1331,6 +1331,40 @@ def test_config_records_per_invocation_unprotected_managed_ci_override(tmp_path)
     assert config.allow_unprotected_managed_ci is True
 
 
+def test_managed_pr_parser_accepts_direct_branch_metadata():
+    args = build_parser().parse_args([
+        "managed-pr",
+        "--repo", "OWNER/REPO",
+        "--head", "fix/direct-change",
+        "--title", "Fix direct change",
+        "--body-file", "description.md",
+        "--auto-merge",
+        "--managed-ci-trusted-actor", "agent-loop",
+        "--allow-unprotected-managed-ci",
+    ])
+
+    assert args.command == "managed-pr"
+    assert args.head == "fix/direct-change"
+    assert args.title == "Fix direct change"
+    assert args.body_file == Path("description.md")
+    assert args.allow_unprotected_managed_ci is True
+
+
+def test_managed_pr_parser_accepts_manual_managed_ci():
+    args = build_parser().parse_args([
+        "managed-pr",
+        "--repo", "OWNER/REPO",
+        "--head", "fix/direct-change",
+        "--title", "Fix direct change",
+        "--managed-ci",
+        "--managed-ci-trusted-actor", "agent-loop",
+    ])
+
+    assert args.command == "managed-pr"
+    assert args.managed_ci is True
+    assert args.auto_merge is False
+
+
 def test_unprotected_managed_ci_override_rejects_existing_pr_adoption(capsys):
     assert main([
         "pr", "77", "--repo", "OWNER/REPO", "--auto-merge",

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -137,6 +137,14 @@ def test_managed_ci_docs_describe_safe_issue_draft_resume_and_fallback():
     assert "remains ready" in text
 
 
+def test_managed_ci_docs_describe_precreation_managed_pr_mode():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert "agent-loop managed-pr" in text
+    assert "agent-loop/managed-direct-*" in text
+    assert "never adopts an already-open PR" in text
+    assert "--allow-unprotected-managed-ci" in text
+
+
 def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert f"### {LOCAL_TEST_SCOPE_HEADING_TEXT}" in text

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1,5 +1,6 @@
 import ast
 import json
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1702,6 +1703,48 @@ def test_v2_activation_and_preflight_require_authenticated_actor(tmp_path):
     assert contract is not None
     assert contract.protocol_version == 2
     assert contract.trusted_actor_login == "agent-loop"
+
+
+def test_v2_preflight_accepts_exactly_one_reserved_direct_branch(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(pr_payload={"headRefOid": "abc123"})
+
+    intent = preflight_managed_ci_creation(
+        runner,
+        config=config,
+        branch="agent-loop/managed-direct-123-token",
+    )
+
+    assert intent is not None
+    assert intent.branch == "agent-loop/managed-direct-123-token"
+    with pytest.raises(AgentLoopError, match="exactly one"):
+        preflight_managed_ci_creation(runner, config=config)
+    with pytest.raises(AgentLoopError, match="exactly one"):
+        preflight_managed_ci_creation(
+            runner,
+            config=config,
+            issue_number=643,
+            branch="agent-loop/managed-direct-123-token",
+        )
+    with pytest.raises(AgentLoopError, match="reserved"):
+        preflight_managed_ci_creation(runner, config=config, branch="fix/not-reserved")
+
+
+def test_v2_preflight_accepts_reserved_direct_branch_in_manual_mode(tmp_path):
+    config = replace(
+        make_config(tmp_path, auto_merge=False, managed_ci_trusted_actor="agent-loop"),
+        managed_ci=True,
+    )
+    runner = V2ManagedRunner(pr_payload={"headRefOid": "abc123"})
+
+    intent = preflight_managed_ci_creation(
+        runner,
+        config=config,
+        branch="agent-loop/managed-direct-123-token",
+    )
+
+    assert intent is not None
+    assert intent.branch == "agent-loop/managed-direct-123-token"
 
 
 def adoption_workflow():

--- a/tests/test_managed_pr.py
+++ b/tests/test_managed_pr.py
@@ -18,12 +18,14 @@ class ManagedPrRunner(Runner):
         self,
         *,
         label_failure: bool = False,
+        label_exists: bool = True,
         cleanup_failure: bool = False,
         existing_pulls=None,
         post_create_pulls=None,
     ):
         super().__init__()
         self.label_failure = label_failure
+        self.label_exists = label_exists
         self.cleanup_failure = cleanup_failure
         self.existing_pulls = existing_pulls or []
         self.post_create_pulls = post_create_pulls
@@ -34,6 +36,9 @@ class ManagedPrRunner(Runner):
     def run(self, args, *, cwd, input_text=None, check=True, env=None):
         cmd = [str(item) for item in args]
         self.calls.append((cmd, input_text))
+        if "--method" not in cmd:
+            assert cmd[-1] == "repos/OWNER/REPO/labels/agent-loop-managed"
+            return CommandResult(cmd, Path(cwd), "{}", "", 0 if self.label_exists else 1)
         method = cmd[cmd.index("--method") + 1]
         endpoint = cmd[cmd.index("--method") + 2]
         payload: object = {}
@@ -80,7 +85,12 @@ def _intent(*args, branch, **kwargs):
 
 def test_create_managed_pr_opens_labeled_draft_and_correlates_override(tmp_path):
     runner = ManagedPrRunner()
-    config = _config(tmp_path)
+    config = replace(
+        _config(tmp_path),
+        invocation_argv=(
+            "agent-loop", "managed-pr", "--head", "fix/direct-change", "--title", "Fix direct change",
+        ),
+    )
 
     with patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent):
         handoff = create_managed_pr(
@@ -93,6 +103,7 @@ def test_create_managed_pr_opens_labeled_draft_and_correlates_override(tmp_path)
 
     assert handoff.pr_number == 77
     assert handoff.config.managed_ci_expected_override_nonce == "fresh-nonce"
+    assert handoff.config.invocation_argv == ()
     create_call = next(
         (cmd, body) for cmd, body in runner.calls
         if "--method" in cmd and cmd[cmd.index("--method") + 1] == "POST" and cmd[-3].endswith("/pulls")
@@ -108,6 +119,38 @@ def test_create_managed_pr_opens_labeled_draft_and_correlates_override(tmp_path)
     )
     assert label_payload == {"labels": ["agent-loop-managed"]}
     assert runner.branch_reads == 2
+
+
+def test_create_managed_pr_creates_documented_label_before_applying_it(tmp_path):
+    runner = ManagedPrRunner(label_exists=False)
+
+    with patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/missing-label",
+            title="Create label",
+            body="",
+        )
+
+    label_create_index = next(
+        index
+        for index, (cmd, _body) in enumerate(runner.calls)
+        if cmd[:4] == ["gh", "api", "--method", "POST"]
+        and cmd[4] == "repos/OWNER/REPO/labels"
+    )
+    label_apply_index = next(
+        index
+        for index, (cmd, _body) in enumerate(runner.calls)
+        if cmd[:4] == ["gh", "api", "--method", "POST"]
+        and cmd[4] == "repos/OWNER/REPO/issues/77/labels"
+    )
+    create_cmd, _ = runner.calls[label_create_index]
+    assert create_cmd[-6:] == [
+        "-f", "name=agent-loop-managed", "-f", "color=1f6feb", "-f",
+        "description=Suppress intermediate CI; agent-loop dispatches exact-head final CI",
+    ]
+    assert label_create_index < label_apply_index
 
 
 def test_create_managed_pr_refuses_existing_open_pr_before_writes(tmp_path):
@@ -145,6 +188,7 @@ def test_create_managed_pr_closes_partial_draft_when_labeling_fails(tmp_path):
     methods_and_endpoints = [
         (cmd[cmd.index("--method") + 1], cmd[cmd.index("--method") + 2])
         for cmd, _ in runner.calls
+        if "--method" in cmd
     ]
     assert ("PATCH", "repos/OWNER/REPO/pulls/77") in methods_and_endpoints
     assert any(method == "DELETE" and "/git/refs/" in endpoint for method, endpoint in methods_and_endpoints)
@@ -171,7 +215,8 @@ def test_create_managed_pr_closes_partial_draft_on_concurrent_duplicate(tmp_path
         )
 
     assert any(
-        cmd[cmd.index("--method") + 1] == "PATCH"
+        "--method" in cmd
+        and cmd[cmd.index("--method") + 1] == "PATCH"
         and cmd[cmd.index("--method") + 2].endswith("/pulls/77")
         for cmd, _ in runner.calls
     )

--- a/tests/test_managed_pr.py
+++ b/tests/test_managed_pr.py
@@ -1,0 +1,225 @@
+import json
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.managed_ci import ManagedCiCreationIntent, UNPROTECTED_OVERRIDE_TRAILER
+from coding_review_agent_loop.managed_pr import SOURCE_MARKER, create_managed_pr
+from coding_review_agent_loop.runner import CommandResult, Runner
+
+from agent_loop_helpers import make_config
+
+
+class ManagedPrRunner(Runner):
+    def __init__(
+        self,
+        *,
+        label_failure: bool = False,
+        cleanup_failure: bool = False,
+        existing_pulls=None,
+        post_create_pulls=None,
+    ):
+        super().__init__()
+        self.label_failure = label_failure
+        self.cleanup_failure = cleanup_failure
+        self.existing_pulls = existing_pulls or []
+        self.post_create_pulls = post_create_pulls
+        self.pull_reads = 0
+        self.calls: list[tuple[list[str], str | None]] = []
+        self.branch_reads = 0
+
+    def run(self, args, *, cwd, input_text=None, check=True, env=None):
+        cmd = [str(item) for item in args]
+        self.calls.append((cmd, input_text))
+        method = cmd[cmd.index("--method") + 1]
+        endpoint = cmd[cmd.index("--method") + 2]
+        payload: object = {}
+        returncode = 0
+        stderr = ""
+        if method == "GET" and "/branches/" in endpoint:
+            self.branch_reads += 1
+            payload = {"commit": {"sha": "a" * 40}}
+        elif method == "GET" and endpoint.endswith("/pulls?state=open"):
+            self.pull_reads += 1
+            payload = (
+                self.post_create_pulls
+                if self.pull_reads > 1 and self.post_create_pulls is not None
+                else self.existing_pulls
+            )
+        elif method == "POST" and endpoint.endswith("/pulls"):
+            payload = {"number": 77}
+        elif method == "POST" and endpoint.endswith("/labels") and self.label_failure:
+            returncode = 1
+            stderr = "label failed"
+        elif self.cleanup_failure and method in {"PATCH", "DELETE"}:
+            returncode = 1
+            stderr = "cleanup failed"
+        return CommandResult(cmd, Path(cwd), json.dumps(payload), stderr, returncode)
+
+
+def _config(tmp_path):
+    return replace(
+        make_config(tmp_path, auto_merge=True),
+        base="main",
+        managed_ci_trusted_actor="wwind123",
+        allow_unprotected_managed_ci=True,
+    )
+
+
+def _intent(*args, branch, **kwargs):
+    return ManagedCiCreationIntent(
+        branch=branch,
+        trusted_actor="wwind123",
+        protection_mode="plan_limited",
+        audit_nonce="fresh-nonce",
+    )
+
+
+def test_create_managed_pr_opens_labeled_draft_and_correlates_override(tmp_path):
+    runner = ManagedPrRunner()
+    config = _config(tmp_path)
+
+    with patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent):
+        handoff = create_managed_pr(
+            runner,
+            config=config,
+            source_branch="fix/direct-change",
+            title="Fix direct change",
+            body="## Summary\n\nKeeps real newlines.",
+        )
+
+    assert handoff.pr_number == 77
+    assert handoff.config.managed_ci_expected_override_nonce == "fresh-nonce"
+    create_call = next(
+        (cmd, body) for cmd, body in runner.calls
+        if "--method" in cmd and cmd[cmd.index("--method") + 1] == "POST" and cmd[-3].endswith("/pulls")
+    )
+    created_payload = json.loads(create_call[1])
+    assert created_payload["draft"] is True
+    assert created_payload["head"].startswith("agent-loop/managed-direct-")
+    assert "## Summary\n\nKeeps real newlines." in created_payload["body"]
+    assert SOURCE_MARKER in created_payload["body"]
+    assert f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh-nonce" in created_payload["body"]
+    label_payload = next(
+        json.loads(body) for cmd, body in runner.calls if cmd[-3].endswith("/labels")
+    )
+    assert label_payload == {"labels": ["agent-loop-managed"]}
+    assert runner.branch_reads == 2
+
+
+def test_create_managed_pr_refuses_existing_open_pr_before_writes(tmp_path):
+    runner = ManagedPrRunner(existing_pulls=[{"number": 42, "state": "open"}])
+
+    with pytest.raises(AgentLoopError, match="already has an open PR.*#42"):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/already-open",
+            title="Duplicate",
+            body="",
+        )
+
+    assert not any(
+        cmd[cmd.index("--method") + 1] != "GET" for cmd, _ in runner.calls
+    )
+
+
+def test_create_managed_pr_closes_partial_draft_when_labeling_fails(tmp_path):
+    runner = ManagedPrRunner(label_failure=True)
+
+    with (
+        patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent),
+        pytest.raises(AgentLoopError, match="label failed"),
+    ):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/label-failure",
+            title="Label failure",
+            body="",
+        )
+
+    methods_and_endpoints = [
+        (cmd[cmd.index("--method") + 1], cmd[cmd.index("--method") + 2])
+        for cmd, _ in runner.calls
+    ]
+    assert ("PATCH", "repos/OWNER/REPO/pulls/77") in methods_and_endpoints
+    assert any(method == "DELETE" and "/git/refs/" in endpoint for method, endpoint in methods_and_endpoints)
+
+
+def test_create_managed_pr_closes_partial_draft_on_concurrent_duplicate(tmp_path):
+    runner = ManagedPrRunner(
+        post_create_pulls=[
+            {"number": 77, "state": "open"},
+            {"number": 78, "state": "open"},
+        ]
+    )
+
+    with (
+        patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent),
+        pytest.raises(AgentLoopError, match="Another PR was opened"),
+    ):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/raced",
+            title="Raced PR",
+            body="",
+        )
+
+    assert any(
+        cmd[cmd.index("--method") + 1] == "PATCH"
+        and cmd[cmd.index("--method") + 2].endswith("/pulls/77")
+        for cmd, _ in runner.calls
+    )
+
+
+def test_create_managed_pr_reports_incomplete_rollback(tmp_path):
+    runner = ManagedPrRunner(label_failure=True, cleanup_failure=True)
+
+    with (
+        patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent),
+        pytest.raises(AgentLoopError, match="automatic cleanup was incomplete.*close PR #77.*delete branch"),
+    ):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/rollback-failure",
+            title="Rollback failure",
+            body="",
+        )
+
+
+@pytest.mark.parametrize("source_branch", ["", "refs/heads/fix/x", "owner:fix/x", "main"])
+def test_create_managed_pr_rejects_invalid_source_branch_before_github(tmp_path, source_branch):
+    runner = ManagedPrRunner()
+
+    with pytest.raises(AgentLoopError):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch=source_branch,
+            title="Invalid source",
+            body="",
+        )
+
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize("marker", [SOURCE_MARKER, UNPROTECTED_OVERRIDE_TRAILER])
+def test_create_managed_pr_rejects_reserved_body_markers(tmp_path, marker):
+    runner = ManagedPrRunner()
+
+    with pytest.raises(AgentLoopError, match="reserved managed-PR protocol marker"):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/body",
+            title="Reserved marker",
+            body=f"Unexpected {marker}",
+        )
+
+    assert runner.calls == []


### PR DESCRIPTION
## Summary

- add a first-class `agent-loop managed-pr` command for code already pushed to a same-repository branch
- create a unique reserved alias and authenticated managed draft before entering the existing review loop
- support both `--managed-ci` for qualified manual merge and `--auto-merge` for qualified automatic merge
- preserve strict existing-PR adoption semantics while supporting the explicit per-invocation unprotected waiver
- fail closed on duplicate races, source movement, labeling failures, and incomplete rollback
- document the workflow and its security boundaries

## Why

Direct branch work currently has to become an ordinary PR before agent-loop can review it. That opening already triggers full CI, and retroactive adoption cannot safely recover those minutes or use the unprotected single-operator waiver. This mode performs the trusted creation handshake before the PR exists, without requiring a placeholder issue.

## Tests

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/python -m py_compile src/coding_review_agent_loop/managed_pr.py src/coding_review_agent_loop/cli.py src/coding_review_agent_loop/managed_ci.py`
- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_managed_pr.py tests/test_managed_ci.py tests/test_agent_loop.py tests/test_docs_guidance.py -q` (`387 passed`)
- `HOME=/tmp/codex-rebase-662-test-home XDG_CACHE_HOME=/tmp/codex-rebase-662-test-home/.cache XDG_STATE_HOME=/tmp/codex-rebase-662-test-home/.local/state timeout 1800s /home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest -q` (`2155 passed`)
- `git diff --check FETCH_HEAD...HEAD`

Closes #661
