### PR TITLE
Resume unprotected managed drafts safely after interrupted qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,32 @@ repository that previously used issue-created v2 without non-bypassable GitHub
 protection now returns to ordinary CI unless that explicit per-run waiver is
 present.
 
+To resume an interrupted issue-created managed draft on an unprotected
+repository, rerun the explicit waiver in PR mode:
+
+```bash
+agent-loop pr <number> --auto-merge \
+  --managed-ci-trusted-actor <login> --allow-unprotected-managed-ci
+```
+
+This is supported resume, not retroactive adoption. The live PR must still be
+an open same-repository draft authored by the authenticated actor (matching
+its immutable ID), use the reserved `agent-loop/managed-*` ref and live
+base/head, and have an active `agent-loop-managed` label event made by that
+actor. A prior actor-owned override audit is provenance only: its editable
+body nonce is never reused or trusted. Missing, malformed, ambiguous, or
+mismatched history deliberately releases the label to ordinary CI. Successful
+resume writes a fresh audit and intent generation; prior dispatched runs,
+including rejected or failed runs, remain previous-invocation outcomes and are
+never attached to the new generation.
+
+When safe managed resume is unavailable, agent-loop waits for a new unlabeled
+recovery run on the exact current head and then requires the ordinary required
+checks. Only the draft released by that invocation may be made ready, and only
+with `--auto-merge`; unrelated drafts remain drafts. The head is revalidated
+before and after `gh pr ready`, and merge uses `--match-head-commit`. If that
+later merge fails, the PR remains ready and unmerged for a safe retry.
+
 For repositories without that contract, `--auto-merge` foreground-polls the
 complete check board after approval with
 `--ci-timeout-seconds` and

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1306,6 +1306,37 @@ comment cannot be written, agent-loop removes `agent-loop-managed` and waits
 for the workflow's `unlabeled` recovery CI instead of treating a `no_checks`
 board as mergeable.
 
+To retry an interrupted issue-created managed draft on an unprotected
+repository, use the explicit per-invocation PR-mode command:
+
+```bash
+agent-loop pr <number> --auto-merge \
+  --managed-ci-trusted-actor <login> --allow-unprotected-managed-ci
+```
+
+This is supported resume, not retroactive adoption. The live PR must still be
+open, a draft, same-repository, authored by the authenticated trusted actor
+(login and immutable ID), on the reserved `agent-loop/managed-*` ref, with the
+same live base/head and an active `agent-loop-managed` timeline event applied
+by that actor. A prior actor-owned override audit is only provenance; its
+editable body nonce never grants authority or gets reused. The audit's
+repository/base fields must match, and missing, malformed, ambiguous, or raced
+audit/timeline data fails closed to deliberate ordinary release.
+
+A successful resume records a fresh audit, nonce, and invocation intent
+generation. Earlier ledger entries and attached workflow runs remain history:
+even a queued, successful, failed, or rejected prior run is logged as the
+previous invocation's outcome and is never adopted by the new dispatch. If
+safe managed resume is unavailable, agent-loop removes the exact active
+managed label and waits for a new post-`unlabeled` workflow run on the exact
+head, then requires the ordinary current-head check board to pass. It does not
+accept pre-release green checks, `no_checks`, or a different SHA. Only the
+invocation-owned fallback draft can be made ready, only when `--auto-merge` is
+requested; unrelated or intentional drafts remain drafts. Agent-loop checks
+the exact head before and after `gh pr ready` and merges with
+`--match-head-commit`. If that merge fails after readiness, it logs that the PR
+remains ready and leaves it unmerged rather than restoring draft state.
+
 Suppression-capable v2 workflows must additionally advertise
 `AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1` and subscribe their
 `pull_request` trigger to `unlabeled`; when a managed label is released,

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -564,9 +564,10 @@ def build_parser() -> argparse.ArgumentParser:
     issue.add_argument(
         "--allow-unprotected-managed-ci", action="store_true",
         help=(
-            "Per-invocation waiver for plan-first issue-created managed CI when GitHub "
-            "cannot independently enforce final-ci/exact-head. Requires --auto-merge and "
-            "--managed-ci-trusted-actor; never applies to existing-PR adoption."
+            "Per-invocation waiver for issue-created managed CI, including a safe PR-mode "
+            "resume of its existing draft, when GitHub cannot independently enforce "
+            "final-ci/exact-head. Requires --auto-merge and --managed-ci-trusted-actor; "
+            "never applies to arbitrary PR adoption."
         ),
     )
     add_review_parallel(issue)
@@ -577,9 +578,9 @@ def build_parser() -> argparse.ArgumentParser:
     pr.add_argument(
         "--allow-unprotected-managed-ci", action="store_true",
         help=(
-            "Per-invocation waiver for plan-first issue-created managed CI when GitHub "
-            "cannot independently enforce final-ci/exact-head. Requires --auto-merge and "
-            "--managed-ci-trusted-actor; never applies to existing-PR adoption."
+            "Per-invocation waiver for issue-created managed CI resume when GitHub cannot "
+            "independently enforce final-ci/exact-head. Requires --auto-merge and "
+            "--managed-ci-trusted-actor; never authorizes arbitrary PR adoption."
         ),
     )
     pr.add_argument(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -188,6 +188,10 @@ class AgentLoopConfig:
     # It is intentionally not a CLI option: a later invocation must perform a
     # new preflight rather than accepting a PR-body token it did not create.
     managed_ci_expected_override_nonce: str | None = None
+    # True only for the public `agent-loop pr` entry point. Issue-mode
+    # implementation hands off to the PR loop too, but must retain the
+    # issue-created activation semantics for that first invocation.
+    managed_ci_pr_mode: bool = False
     invocation_argv: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -966,6 +970,7 @@ def config_from_args(
         managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
         managed_ci_adopt_existing_pr=getattr(args, "managed_ci_adopt_existing_pr", False),
         allow_unprotected_managed_ci=getattr(args, "allow_unprotected_managed_ci", False),
+        managed_ci_pr_mode=getattr(args, "command", None) == "pr",
         invocation_argv=invocation_argv,
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -7,7 +7,6 @@ import secrets
 import shlex
 import time
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
@@ -706,6 +705,46 @@ def _release_for_ordinary_recovery(
     )
 
 
+def refresh_ordinary_recovery_capability(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    capability: OrdinaryRecoveryCapability,
+) -> OrdinaryRecoveryCapability | None:
+    """Rebind ordinary recovery to the live draft head before finalization.
+
+    Review rounds may push commits after the managed label was released.  The
+    original capability must not reject that expected progress, nor may it
+    authorize a different PR or a relabeled PR.  A newly observed head is
+    newer than this invocation's release observation, so its run baseline
+    starts empty and only runs observed for that exact head are eligible.
+    """
+    pr = _api_json(
+        runner, config, f"repos/{config.repo}/pulls/{capability.pr_number}", quiet=True,
+    )
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+    head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+    live_head = head.get("sha") if isinstance(head.get("sha"), str) else None
+    if not live_head or not isinstance(head_repo.get("full_name"), str):
+        return None
+    if (
+        pr.get("state") not in {None, "open", "OPEN"}
+        or pr.get("draft") is not True
+        or base.get("ref") != capability.base_ref
+        or head_repo["full_name"].casefold() != capability.repository.casefold()
+        or _active_managed_label_event(runner, config=config, pr_number=capability.pr_number) is not None
+    ):
+        return None
+    if live_head == capability.expected_head_sha:
+        return capability
+    return replace(
+        capability,
+        expected_head_sha=live_head,
+        prior_run_ids=frozenset(),
+    )
+
+
 def _parse_override_audit(body: str) -> dict[str, str] | None:
     """Parse only the structured provenance fields of an old audit comment."""
     first = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
@@ -845,8 +884,6 @@ def _activate_v2_managed_ci(
     # still identify this trusted actor. The old body nonce is provenance, not
     # authorization; this invocation mints a new nonce and intent generation.
     active_event: tuple[int, str, int] | None = None
-    resume_audit_id: int | None = None
-    resume_provenance_head: str | None = None
     if config.managed_ci_pr_mode:
         active_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
         if (
@@ -863,19 +900,6 @@ def _activate_v2_managed_ci(
                 activation_path="ordinary_fallback",
                 ordinary_recovery=None,
             )
-        prior_audit = _find_resume_audit(
-            runner, config=config, pr_number=pr_number,
-            actor_login=actor_login, actor_id=actor_id, base_ref=base_ref,
-        )
-        if prior_audit is None:
-            recovery = _release_for_ordinary_recovery(
-                runner, config=config, pr_number=pr_number, base_ref=base_ref,
-                expected_head_sha=live_sha, active_event=active_event,
-                reason="no unambiguous actor-owned issue-created override audit exists",
-            )
-            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
-        resume_audit_id, prior_fields = prior_audit
-        resume_provenance_head = prior_fields.get("head")
 
     # Only workflows with a pull_request route can suppress an opening matrix.
     # Legacy dispatch-only v2 deployments remain compatible, while modern
@@ -883,6 +907,8 @@ def _activate_v2_managed_ci(
     # live, explicit waiver and its auditable PR trailer.
     protection = ProtectionAssessment("strict", "legacy", "dispatch-only legacy workflow")
     override_nonce: str | None = None
+    resume_audit_id: int | None = None
+    resume_provenance_head: str | None = None
     if "pull_request" in workflow_text:
         protection = assess_exact_head_protection(
             runner,
@@ -899,8 +925,19 @@ def _activate_v2_managed_ci(
                 return ManagedCiContract(
                     activation_path="ordinary_fallback", ordinary_recovery=recovery,
                 )
-            # The prior audit was already validated against immutable actor,
-            # repository, and base facts above. Its head remains history only.
+            prior_audit = _find_resume_audit(
+                runner, config=config, pr_number=pr_number,
+                actor_login=actor_login, actor_id=actor_id, base_ref=base_ref,
+            )
+            if prior_audit is None:
+                recovery = _release_for_ordinary_recovery(
+                    runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                    expected_head_sha=live_sha, active_event=active_event,
+                    reason="no unambiguous actor-owned issue-created override audit exists",
+                )
+                return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
+            resume_audit_id, prior_fields = prior_audit
+            resume_provenance_head = prior_fields.get("head")
         elif protection.state != "strict":
             body = pr.get("body") if isinstance(pr.get("body"), str) else ""
             marker_line = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
@@ -980,38 +1017,41 @@ def _activate_v2_managed_ci(
                 reason="the immutable resume tuple changed before activation",
             )
             return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
-        override_nonce = secrets.token_urlsafe(24)
-        resume_body = (
-            f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
-            f"base={base_ref} head={live_sha} protection={protection.state} "
-            f"active_label_event_id={active_event[0]} resume_from={resume_audit_id} "
-            f"provenance_head={resume_provenance_head or 'unknown'} generation={secrets.token_urlsafe(12)}\n\n"
-            "Resume provenance only: the prior issue-created audit is not an authorization token."
-        )
-        audit = runner.run(
-            [
-                config.gh_cmd, "api", "--method", "POST",
-                f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={resume_body}",
-            ], cwd=active_workdir(config), check=False,
-        )
-        if audit.returncode != 0:
-            recovery = _release_for_ordinary_recovery(
-                runner, config=config, pr_number=pr_number, base_ref=base_ref,
-                expected_head_sha=live_sha, active_event=active_event,
-                reason="the fresh resume audit could not be recorded",
+        if protection.state != "strict":
+            override_nonce = secrets.token_urlsafe(24)
+            resume_body = (
+                f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
+                f"base={base_ref} head={live_sha} protection={protection.state} "
+                f"active_label_event_id={active_event[0]} resume_from={resume_audit_id} "
+                f"provenance_head={resume_provenance_head or 'unknown'} generation={secrets.token_urlsafe(12)}\n\n"
+                "Resume provenance only: the prior issue-created audit is not an authorization token."
             )
-            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
-        try:
-            audit_id = json.loads(audit.stdout or "{}").get("id")
-        except json.JSONDecodeError:
+            audit = runner.run(
+                [
+                    config.gh_cmd, "api", "--method", "POST",
+                    f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={resume_body}",
+                ], cwd=active_workdir(config), check=False,
+            )
+            if audit.returncode != 0:
+                recovery = _release_for_ordinary_recovery(
+                    runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                    expected_head_sha=live_sha, active_event=active_event,
+                    reason="the fresh resume audit could not be recorded",
+                )
+                return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
+            try:
+                audit_id = json.loads(audit.stdout or "{}").get("id")
+            except json.JSONDecodeError:
+                audit_id = None
+            if not isinstance(audit_id, int):
+                recovery = _release_for_ordinary_recovery(
+                    runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                    expected_head_sha=live_sha, active_event=active_event,
+                    reason="the fresh resume audit response was malformed",
+                )
+                return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
+        else:
             audit_id = None
-        if not isinstance(audit_id, int):
-            recovery = _release_for_ordinary_recovery(
-                runner, config=config, pr_number=pr_number, base_ref=base_ref,
-                expected_head_sha=live_sha, active_event=active_event,
-                reason="the fresh resume audit response was malformed",
-            )
-            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
     workflow_revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True)
     revision = workflow_revision.get("sha") if isinstance(workflow_revision.get("sha"), str) else None
     generation = secrets.token_urlsafe(16) if config.managed_ci_pr_mode else None
@@ -1540,12 +1580,11 @@ def _ensure_v2_intent(
     if comments_result.returncode != 0:
         raise AgentLoopError("Unable to inspect managed-CI v2 intent history.")
     comments: list[object] = []
-    if comments_result.returncode == 0:
-        try:
-            parsed = json.loads(comments_result.stdout or "[]")
-            comments = parsed if isinstance(parsed, list) else []
-        except json.JSONDecodeError as exc:
-            raise AgentLoopError("Managed-CI intent comments response was invalid JSON.") from exc
+    try:
+        parsed = json.loads(comments_result.stdout or "[]")
+        comments = parsed if isinstance(parsed, list) else []
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError("Managed-CI intent comments response was invalid JSON.") from exc
     matching: list[tuple[int, dict[str, object]]] = []
     for raw in comments:
         if not isinstance(raw, dict):
@@ -2003,16 +2042,6 @@ def wait_for_ordinary_recovery(
                 continue
             if isinstance(run.get("head_sha"), str) and run["head_sha"] != expected_head:
                 continue
-            created_at = run.get("created_at")
-            if isinstance(created_at, str):
-                try:
-                    created_timestamp = datetime.fromisoformat(
-                        created_at.replace("Z", "+00:00")
-                    ).astimezone(timezone.utc).timestamp()
-                except ValueError:
-                    continue
-                if created_timestamp <= capability.released_at:
-                    continue
             recovery_runs.append(run)
         latest = get_pr_checks(runner, config=config, metadata=metadata)
         if latest.state == "failing":

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -7,6 +7,7 @@ import secrets
 import shlex
 import time
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
@@ -114,6 +115,12 @@ class ManagedCiContract:
     protection_mode: str | None = None
     audit_nonce: str | None = None
     audit_comment_id: int | None = None
+    # A resumed invocation always gets a new generation. Historical intent
+    # comments remain diagnostic history and are never adopted as this run's
+    # dispatch authorization.
+    intent_generation: str | None = None
+    activation_path: Literal["managed", "ordinary_fallback"] = "managed"
+    ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
 
 
 @dataclass(frozen=True)
@@ -124,6 +131,19 @@ class ManagedCiCreationIntent:
     trusted_actor: str
     protection_mode: str = "strict"
     audit_nonce: str | None = None
+
+
+@dataclass(frozen=True)
+class OrdinaryRecoveryCapability:
+    """Invocation-owned proof that this run deliberately released managed CI."""
+
+    pr_number: int
+    repository: str
+    base_ref: str
+    expected_head_sha: str
+    released_label_event_id: int | None
+    released_at: int
+    prior_run_ids: frozenset[int] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -632,6 +652,116 @@ def _restore_ordinary_ci_after_v2_fallback(
     log(config, f"PR #{pr_number}: removed `{MANAGED_LABEL}`; continuing with ordinary CI ({reason})")
 
 
+def _release_for_ordinary_recovery(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    base_ref: str,
+    expected_head_sha: str,
+    active_event: tuple[int, str, int] | None,
+    reason: str,
+) -> OrdinaryRecoveryCapability | None:
+    """Release the exact active label and return a narrowly scoped capability.
+
+    The capability is deliberately unusable when timeline ownership cannot be
+    proven. We still remove the suppression label where possible so ordinary
+    current-head CI can run, but the orchestrator will not ready or merge such
+    a PR automatically.
+    """
+    prior_run_ids: set[int] = set()
+    try:
+        prior_run_ids = _workflow_run_ids(runner, config=config, head_sha=expected_head_sha)
+    except AgentLoopError:
+        log(config, f"PR #{pr_number}: could not baseline ordinary recovery runs ({reason})")
+    if active_event is not None:
+        current_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        if current_event != active_event:
+            raise AgentLoopError(
+                f"PR #{pr_number} managed-label ownership changed before ordinary release; "
+                "leaving the label untouched and no merge will be attempted."
+            )
+    result = runner.run(
+        [
+            config.gh_cmd, "api", "--method", "DELETE",
+            f"repos/{config.repo}/issues/{pr_number}/labels/{MANAGED_LABEL}",
+        ],
+        cwd=active_workdir(config), check=False,
+    )
+    if result.returncode != 0:
+        raise AgentLoopError(
+            f"Managed-CI v2 could not activate ({reason}) and `{MANAGED_LABEL}` could not be removed."
+        )
+    log(config, f"PR #{pr_number}: selected ordinary unlabeled recovery ({reason})")
+    if active_event is None:
+        return None
+    return OrdinaryRecoveryCapability(
+        pr_number=pr_number,
+        repository=config.repo,
+        base_ref=base_ref,
+        expected_head_sha=expected_head_sha,
+        released_label_event_id=active_event[0],
+        released_at=int(time.time()),
+        prior_run_ids=frozenset(prior_run_ids),
+    )
+
+
+def _parse_override_audit(body: str) -> dict[str, str] | None:
+    """Parse only the structured provenance fields of an old audit comment."""
+    first = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
+    if not first:
+        return None
+    fields: dict[str, str] = {}
+    for token in first.split()[1:]:
+        key, separator, value = token.partition("=")
+        if not separator or key not in {
+            "nonce", "repo", "base", "head", "protection", "active_label_event_id",
+            "resume_from", "provenance_head", "generation",
+        } or not value:
+            return None
+        if key in fields:
+            return None
+        fields[key] = value
+    if not {"repo", "base", "head", "protection"}.issubset(fields):
+        return None
+    return fields
+
+
+def _find_resume_audit(
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, actor_login: str, actor_id: int,
+    base_ref: str,
+) -> tuple[int, dict[str, str]] | None:
+    """Find exactly one actor-owned old issue audit for resume provenance."""
+    comments = _api_list(runner, config, f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100")
+    if comments is None:
+        return None
+    candidates: list[tuple[int, dict[str, str]]] = []
+    malformed = False
+    for comment in comments:
+        body = comment.get("body") if isinstance(comment.get("body"), str) else ""
+        if UNPROTECTED_OVERRIDE_TRAILER not in body:
+            continue
+        parsed = _parse_override_audit(body)
+        user = comment.get("user") if isinstance(comment.get("user"), dict) else {}
+        if parsed is None or user.get("login") != actor_login or user.get("id") != actor_id:
+            malformed = True
+            continue
+        if parsed["repo"].casefold() != config.repo.casefold() or parsed["base"] != base_ref:
+            malformed = True
+            continue
+        cid = comment.get("id")
+        if not isinstance(cid, int):
+            malformed = True
+            continue
+        candidates.append((cid, parsed))
+    if malformed or not candidates:
+        return None
+    # Multiple valid audits are normal after a safe retry. The newest actor-
+    # owned record is the latest provenance, while all malformed/mismatched
+    # records still fail closed above.
+    return sorted(candidates, key=lambda item: item[0])[-1]
+
+
 def _activate_v2_managed_ci(
     runner: Runner,
     *,
@@ -710,6 +840,43 @@ def _activate_v2_managed_ci(
     )
     if not managed_tuple:
         return None
+    # A direct `pr` retry has a separate, deliberately narrower contract. It
+    # may resume only an issue-created draft whose immutable timeline facts
+    # still identify this trusted actor. The old body nonce is provenance, not
+    # authorization; this invocation mints a new nonce and intent generation.
+    active_event: tuple[int, str, int] | None = None
+    resume_audit_id: int | None = None
+    resume_provenance_head: str | None = None
+    if config.managed_ci_pr_mode:
+        active_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        if (
+            active_event is None
+            or active_event[1].casefold() != actor_login.casefold()
+            or active_event[2] != actor_id
+        ):
+            _release_for_ordinary_recovery(
+                runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                expected_head_sha=live_sha, active_event=active_event,
+                reason="the active managed-label event is missing or not actor-owned",
+            )
+            return ManagedCiContract(
+                activation_path="ordinary_fallback",
+                ordinary_recovery=None,
+            )
+        prior_audit = _find_resume_audit(
+            runner, config=config, pr_number=pr_number,
+            actor_login=actor_login, actor_id=actor_id, base_ref=base_ref,
+        )
+        if prior_audit is None:
+            recovery = _release_for_ordinary_recovery(
+                runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                expected_head_sha=live_sha, active_event=active_event,
+                reason="no unambiguous actor-owned issue-created override audit exists",
+            )
+            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
+        resume_audit_id, prior_fields = prior_audit
+        resume_provenance_head = prior_fields.get("head")
+
     # Only workflows with a pull_request route can suppress an opening matrix.
     # Legacy dispatch-only v2 deployments remain compatible, while modern
     # suppression-capable workflows must retain strict protection or supply a
@@ -722,7 +889,19 @@ def _activate_v2_managed_ci(
             context=ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config)),
             base=base_ref,
         )
-        if protection.state != "strict":
+        if protection.state != "strict" and config.managed_ci_pr_mode:
+            if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"}:
+                recovery = _release_for_ordinary_recovery(
+                    runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                    expected_head_sha=live_sha, active_event=active_event,
+                    reason="strict protection is unavailable and the explicit waiver is absent",
+                )
+                return ManagedCiContract(
+                    activation_path="ordinary_fallback", ordinary_recovery=recovery,
+                )
+            # The prior audit was already validated against immutable actor,
+            # repository, and base facts above. Its head remains history only.
+        elif protection.state != "strict":
             body = pr.get("body") if isinstance(pr.get("body"), str) else ""
             marker_line = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
             if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"} or not marker_line:
@@ -776,9 +955,72 @@ def _activate_v2_managed_ci(
             audit_id = None
     else:
         audit_id = None
+
+    if config.managed_ci_pr_mode:
+        # Re-read both the PR and the active timeline event immediately before
+        # the audit write. A successful earlier probe cannot authorize a raced
+        # head/base/draft/label transition.
+        live_pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+        live_head = live_pr.get("head") if isinstance(live_pr.get("head"), dict) else {}
+        live_base = live_pr.get("base") if isinstance(live_pr.get("base"), dict) else {}
+        live_author = live_pr.get("user") if isinstance(live_pr.get("user"), dict) else {}
+        live_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        if (
+            live_pr.get("draft") is not True
+            or live_base.get("ref") != base_ref
+            or live_head.get("sha") != live_sha
+            or live_head.get("repo", {}).get("full_name", "").casefold() != config.repo.casefold()
+            or live_author.get("login") != actor_login
+            or live_author.get("id") != actor_id
+            or live_event != active_event
+        ):
+            recovery = _release_for_ordinary_recovery(
+                runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                expected_head_sha=live_sha, active_event=live_event,
+                reason="the immutable resume tuple changed before activation",
+            )
+            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
+        override_nonce = secrets.token_urlsafe(24)
+        resume_body = (
+            f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
+            f"base={base_ref} head={live_sha} protection={protection.state} "
+            f"active_label_event_id={active_event[0]} resume_from={resume_audit_id} "
+            f"provenance_head={resume_provenance_head or 'unknown'} generation={secrets.token_urlsafe(12)}\n\n"
+            "Resume provenance only: the prior issue-created audit is not an authorization token."
+        )
+        audit = runner.run(
+            [
+                config.gh_cmd, "api", "--method", "POST",
+                f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={resume_body}",
+            ], cwd=active_workdir(config), check=False,
+        )
+        if audit.returncode != 0:
+            recovery = _release_for_ordinary_recovery(
+                runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                expected_head_sha=live_sha, active_event=active_event,
+                reason="the fresh resume audit could not be recorded",
+            )
+            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
+        try:
+            audit_id = json.loads(audit.stdout or "{}").get("id")
+        except json.JSONDecodeError:
+            audit_id = None
+        if not isinstance(audit_id, int):
+            recovery = _release_for_ordinary_recovery(
+                runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                expected_head_sha=live_sha, active_event=active_event,
+                reason="the fresh resume audit response was malformed",
+            )
+            return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
     workflow_revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True)
     revision = workflow_revision.get("sha") if isinstance(workflow_revision.get("sha"), str) else None
-    log(config, f"PR #{pr_number}: activated authenticated managed exact-head CI v2")
+    generation = secrets.token_urlsafe(16) if config.managed_ci_pr_mode else None
+    log(
+        config,
+        f"PR #{pr_number}: selected managed resume (fresh generation)"
+        if config.managed_ci_pr_mode
+        else f"PR #{pr_number}: activated authenticated managed exact-head CI v2",
+    )
     return ManagedCiContract(
         protocol_version=2,
         base_ref=base_ref,
@@ -788,6 +1030,8 @@ def _activate_v2_managed_ci(
         protection_mode=protection.state,
         audit_nonce=override_nonce,
         audit_comment_id=audit_id if isinstance(audit_id, int) else None,
+        intent_generation=generation,
+        active_label_event_id=active_event[0] if active_event is not None else None,
     )
 
 
@@ -1208,9 +1452,23 @@ def _dispatch_v2_qualification(
         raise AgentLoopError(
             "The managed-CI base workflow revision changed after activation; rerun review before dispatch."
         )
-    _ensure_v2_intent(
-        runner, config=config, pr_number=pr_number, expected_head_sha=expected_head_sha, contract=contract
-    )
+    try:
+        _ensure_v2_intent(
+            runner, config=config, pr_number=pr_number, expected_head_sha=expected_head_sha, contract=contract
+        )
+    except AgentLoopError as exc:
+        if not config.managed_ci_pr_mode:
+            raise
+        event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        recovery = _release_for_ordinary_recovery(
+            runner, config=config, pr_number=pr_number, base_ref=contract.base_ref,
+            expected_head_sha=expected_head_sha, active_event=event,
+            reason=f"fresh intent ledger could not be reconciled ({exc})",
+        )
+        contract.activation_path = "ordinary_fallback"
+        contract.ordinary_recovery = recovery
+        log(config, f"PR #{pr_number}: managed resume ledger failed; selected ordinary recovery")
+        return
     attached = _discover_v2_run(runner, config=config, contract=contract, retries=3)
     if attached is None:
         _patch_intent(runner, config=config, contract=contract, state="dispatch-requested")
@@ -1259,6 +1517,7 @@ def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_s
         "expected_head_sha": expected_head_sha,
         "base_ref": contract.base_ref,
         "workflow_revision": contract.workflow_revision,
+        "generation": contract.intent_generation,
         "nonce": contract.nonce,
         "created_at": contract.created_at,
         "state": state,
@@ -1278,6 +1537,8 @@ def _ensure_v2_intent(
         [config.gh_cmd, "api", "--paginate", f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100"],
         cwd=active_workdir(config), check=False,
     )
+    if comments_result.returncode != 0:
+        raise AgentLoopError("Unable to inspect managed-CI v2 intent history.")
     comments: list[object] = []
     if comments_result.returncode == 0:
         try:
@@ -1303,6 +1564,15 @@ def _ensure_v2_intent(
         if not isinstance(intent, dict):
             continue
         if intent.get("repository") != config.repo:
+            continue
+        if contract.intent_generation is not None and intent.get("generation") != contract.intent_generation:
+            prior_run = intent.get("run_id")
+            if isinstance(prior_run, int):
+                log(
+                    config,
+                    f"PR #{pr_number}: superseding prior managed-CI generation run {prior_run}; "
+                    "it will not be attached to this invocation",
+                )
             continue
         if intent.get("pr") == pr_number and intent.get("expected_head_sha") == expected_head_sha:
             cid = raw.get("id")
@@ -1702,6 +1972,101 @@ def _workflow_runs_payload(
     if not isinstance(runs, list):
         raise AgentLoopError("Managed-CI workflow-run response omitted `workflow_runs`.")
     return runs
+
+
+def wait_for_ordinary_recovery(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    capability: OrdinaryRecoveryCapability,
+    metadata: PullRequestMetadata,
+) -> ManagedCiOutcome:
+    """Wait for a post-unlabel current-head run and a complete ordinary board."""
+    expected_head = capability.expected_head_sha
+    attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
+    latest: PullRequestChecks | None = None
+    for attempt in range(attempts):
+        live_head = get_pr_head_sha(runner, config, capability.pr_number)
+        if live_head != expected_head:
+            return ManagedCiOutcome(status="head_changed", checks=latest, head_sha=live_head)
+        mergeability = get_pr_mergeability(runner, config=config, pr_number=capability.pr_number)
+        if mergeability.state == "conflicted":
+            return ManagedCiOutcome(
+                status="merge_conflict", checks=latest, mergeability=mergeability, head_sha=live_head,
+            )
+        runs = _workflow_runs_payload(runner, config=config, head_sha=expected_head)
+        recovery_runs = []
+        for run in runs:
+            if not isinstance(run, dict) or run.get("id") in capability.prior_run_ids:
+                continue
+            if run.get("event") not in {None, "pull_request"}:
+                continue
+            if isinstance(run.get("head_sha"), str) and run["head_sha"] != expected_head:
+                continue
+            created_at = run.get("created_at")
+            if isinstance(created_at, str):
+                try:
+                    created_timestamp = datetime.fromisoformat(
+                        created_at.replace("Z", "+00:00")
+                    ).astimezone(timezone.utc).timestamp()
+                except ValueError:
+                    continue
+                if created_timestamp <= capability.released_at:
+                    continue
+            recovery_runs.append(run)
+        latest = get_pr_checks(runner, config=config, metadata=metadata)
+        if latest.state == "failing":
+            return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
+        if is_wholly_infrastructure_blocked(latest):
+            return ManagedCiOutcome(
+                status="infrastructure_stall", checks=latest, head_sha=live_head,
+                stall=CiInfrastructureStall(checks=latest.infrastructure_stalls),
+            )
+        completed = [run for run in recovery_runs if run.get("status") == "completed"]
+        if completed and any(run.get("conclusion") not in {"success", "neutral", "skipped"} for run in completed):
+            return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
+        reliable = latest.check_query_status == "ok" and latest.branch_protection_status in {
+            "configured", "not_found", "forbidden",
+        }
+        if (
+            recovery_runs
+            and any(run.get("status") == "completed" and run.get("conclusion") in {"success", "neutral", "skipped"} for run in completed)
+            and latest.state == "passing"
+            and reliable
+            and not latest.pending
+            and not latest.missing_required
+        ):
+            log(config, f"PR #{capability.pr_number}: ordinary unlabeled recovery passed at {expected_head}")
+            return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
+        if attempt < attempts - 1:
+            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
+    return ManagedCiOutcome(status="timeout", checks=latest, head_sha=expected_head)
+
+
+def validate_ordinary_recovery_capability(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    capability: OrdinaryRecoveryCapability,
+    require_draft: bool | None = True,
+) -> bool:
+    """Revalidate the invocation-owned fallback tuple before readiness/merge."""
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{capability.pr_number}", quiet=True)
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+    head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+    event = _active_managed_label_event(
+        runner, config=config, pr_number=capability.pr_number,
+    )
+    return bool(
+        pr.get("state") in {None, "open"}
+        and (require_draft is None or pr.get("draft") is require_draft)
+        and base.get("ref") == capability.base_ref
+        and isinstance(head_repo.get("full_name"), str)
+        and head_repo["full_name"].casefold() == capability.repository.casefold()
+        and head.get("sha") == capability.expected_head_sha
+        and event is None
+    )
 
 
 def _wait_for_label_handoff(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -110,6 +110,7 @@ from .managed_ci import (
     preflight_managed_ci_creation,
     prepare_v2_merge,
     publish_round_readiness,
+    refresh_ordinary_recovery_capability,
     release_adopted_managed_ci,
     revalidate_adopted_managed_ci,
     validate_ordinary_recovery_capability,
@@ -5668,6 +5669,14 @@ def _finalize_ordinary_recovery_merge(
     capability: OrdinaryRecoveryCapability,
 ) -> None:
     """Ready and merge only the draft released by this invocation."""
+    refreshed = refresh_ordinary_recovery_capability(
+        runner, config=config, capability=capability,
+    )
+    if refreshed is None:
+        raise AgentLoopError(
+            f"PR #{pr_number} ordinary recovery provenance changed before finalization; no merge attempted."
+        )
+    capability = refreshed
     outcome = wait_for_ordinary_recovery(
         runner, config=config, capability=capability,
         metadata=get_pr_review_context(runner, config=config, pr_number=pr_number).metadata,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -102,6 +102,7 @@ from .evidence_reconciliation import (
 from .memory import AgentMemoryContext, prepare_agent_memory
 from .managed_ci import (
     MANAGED_LABEL,
+    OrdinaryRecoveryCapability,
     activate_managed_ci,
     dispatch_final_qualification,
     intermediate_managed_checks,
@@ -111,6 +112,8 @@ from .managed_ci import (
     publish_round_readiness,
     release_adopted_managed_ci,
     revalidate_adopted_managed_ci,
+    validate_ordinary_recovery_capability,
+    wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
 from .migrations import validate_pr_migration_topology
@@ -5657,6 +5660,49 @@ def _extract_structured_coder_tests_run(text: str | None) -> tuple[str, ...] | N
         return None
 
 
+def _finalize_ordinary_recovery_merge(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    capability: OrdinaryRecoveryCapability,
+) -> None:
+    """Ready and merge only the draft released by this invocation."""
+    outcome = wait_for_ordinary_recovery(
+        runner, config=config, capability=capability,
+        metadata=get_pr_review_context(runner, config=config, pr_number=pr_number).metadata,
+    )
+    if outcome.status != "passed":
+        raise AgentLoopError(
+            f"PR #{pr_number} ordinary recovery did not qualify the exact head "
+            f"({outcome.status}); the draft was left unmerged."
+        )
+    if not validate_ordinary_recovery_capability(runner, config=config, capability=capability):
+        raise AgentLoopError(
+            f"PR #{pr_number} ordinary recovery provenance changed before readiness; no merge attempted."
+        )
+    ready = runner.run(
+        [config.gh_cmd, "pr", "ready", str(pr_number), "--repo", config.repo],
+        cwd=active_workdir(config), check=False,
+    )
+    if ready.returncode != 0:
+        raise AgentLoopError(f"Unable to mark recovered PR #{pr_number} ready for review.")
+    if not validate_ordinary_recovery_capability(
+        runner, config=config, capability=capability, require_draft=None,
+    ):
+        raise AgentLoopError(
+            f"PR #{pr_number} head or provenance changed after `gh pr ready`; "
+            "the PR remains ready and was not merged."
+        )
+    try:
+        merge_pr(runner, config, pr_number, expected_head_sha=capability.expected_head_sha)
+    except Exception:
+        # Do not convert a successfully readied PR back into a draft. A safe
+        # rerun can now inspect the ready exact head and retry the merge gate.
+        log(config, f"PR #{pr_number}: merge failed after ordinary recovery readiness; PR remains ready")
+        raise
+
+
 def run_pr_loop(
     runner: Runner,
     *,
@@ -5672,6 +5718,8 @@ def run_pr_loop(
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
     managed_ci = None
+    ordinary_recovery: OrdinaryRecoveryCapability | None = None
+    ordinary_recovery_selected = False
     managed_ci_qualified = False
     try:
         bootstrap_cwd = github_bootstrap_cwd(config)
@@ -5717,12 +5765,23 @@ def run_pr_loop(
             _ensure_parallel_reviewer_workdirs(config, flag_name="--review-parallel", role_label="reviewer")
         log(config, f"Validating PR #{pr_number}")
         validate_open_pr(runner, config=config, pr_number=pr_number)
-        managed_ci = activate_managed_ci(
+        activation = activate_managed_ci(
             runner,
             config=config,
             pr_number=pr_number,
             metadata=initial_pr_context.metadata,
         )
+        if activation is not None and activation.activation_path == "ordinary_fallback":
+            ordinary_recovery_selected = True
+            ordinary_recovery = activation.ordinary_recovery
+            managed_ci = None
+            log(
+                config,
+                f"PR #{pr_number}: ordinary recovery selected; "
+                "the previous managed activation is not being resumed",
+            )
+        else:
+            managed_ci = activation
 
         def managed_ci_active(metadata: PullRequestMetadata) -> bool:
             """Drop adopted filtering immediately when its live handshake changes."""
@@ -6842,6 +6901,20 @@ def run_pr_loop(
                     )
                     return 0
                 if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
+                    if ordinary_recovery_selected:
+                        if ordinary_recovery is None:
+                            raise AgentLoopError(
+                                f"PR #{pr_number} was released to ordinary CI, but recovery provenance "
+                                "could not be correlated; no merge attempted."
+                            )
+                        _finalize_ordinary_recovery_merge(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            capability=ordinary_recovery,
+                        )
+                        print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
+                        return 0
                     if watch_deadline is None:
                         watch_deadline = time.monotonic() + config.ci_timeout_seconds
                         watch_attempts_remaining = max(
@@ -6899,7 +6972,10 @@ def run_pr_loop(
                         )
                         run_optional_tests(runner, config)
                         if config.auto_merge:
-                            merge_pr(runner, config, pr_number)
+                            merge_pr(
+                                runner, config, pr_number,
+                                expected_head_sha=pr_metadata.head_sha,
+                            )
                             print(f"PR #{pr_number} merged after CI watch completed.")
                         else:
                             print(f"PR #{pr_number} is merge-ready after CI watch completed.")
@@ -7111,6 +7187,23 @@ def run_pr_loop(
                                 head_ref=pr_metadata.head_branch,
                                 contract=managed_ci,
                             )
+                            if managed_ci.activation_path == "ordinary_fallback":
+                                ordinary_recovery_selected = True
+                                ordinary_recovery = managed_ci.ordinary_recovery
+                                managed_ci = None
+                                if ordinary_recovery is None:
+                                    raise AgentLoopError(
+                                        f"PR #{pr_number} managed resume could not be correlated to ordinary "
+                                        "recovery CI; no merge attempted."
+                                    )
+                                _finalize_ordinary_recovery_merge(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    capability=ordinary_recovery,
+                                )
+                                print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
+                                return 0
                             managed_outcome = wait_for_final_qualification(
                                 runner,
                                 config=config,
@@ -7233,6 +7326,19 @@ def run_pr_loop(
                                 if item.status in {"blocking", "same-pr"}
                             ]
                             wait_outcome = None
+                        elif ordinary_recovery_selected:
+                            if ordinary_recovery is None:
+                                raise AgentLoopError(
+                                    f"PR #{pr_number} ordinary recovery provenance is unavailable; "
+                                    "no merge attempted."
+                                )
+                            _finalize_ordinary_recovery_merge(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                capability=ordinary_recovery,
+                            )
+                            wait_outcome = None
                         else:
                             wait_outcome = wait_for_ci(
                                 runner, config, pr_number, metadata=pr_metadata
@@ -7286,7 +7392,10 @@ def run_pr_loop(
                                 "during the CI wait; no merge attempted",
                             )
                         else:
-                            merge_pr(runner, config, pr_number)
+                            merge_pr(
+                                runner, config, pr_number,
+                                expected_head_sha=pr_metadata.head_sha,
+                            )
                     if not must_fix_items:
                         print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")
                         return 0

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1266,6 +1266,7 @@ def test_config_enables_ci_watch_with_auto_merge_without_rebuilding_antigravity_
         invocation_argv=("agent-loop", "pr", "77"),
     )
     assert config.watch_pending_ci is True
+    assert config.managed_ci_pr_mode is True
     assert config.invocation_argv[-1] == "77"
     assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
 

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -127,6 +127,16 @@ def test_managed_ci_docs_describe_explicit_existing_pr_adoption_and_opt_out():
     assert "triage/write collaborators" in text
 
 
+def test_managed_ci_docs_describe_safe_issue_draft_resume_and_fallback():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    assert "agent-loop pr <number> --auto-merge" in text
+    assert "supported resume, not retroactive adoption" in text
+    assert "editable body nonce never grants authority" in text
+    assert "previous invocation's outcome" in text
+    assert "invocation-owned fallback draft" in text
+    assert "remains ready" in text
+
+
 def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert f"### {LOCAL_TEST_SCOPE_HEADING_TEXT}" in text

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -2,6 +2,8 @@ import json
 
 import pytest
 
+import coding_review_agent_loop.managed_ci as managed_ci
+
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import (
     PullRequestCheck,
@@ -30,6 +32,8 @@ from coding_review_agent_loop.managed_ci import (
     publish_round_readiness,
     release_adopted_managed_ci,
     revalidate_adopted_managed_ci,
+    OrdinaryRecoveryCapability,
+    wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
 from coding_review_agent_loop.runner import CommandResult
@@ -444,6 +448,100 @@ def test_override_activation_requires_the_preflight_nonce_and_releases_label_on_
         command[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
         for command, _ in mismatch.commands
     )
+
+
+def _resume_audit(*, head="old-head", repo="OWNER/REPO", base="main"):
+    return {
+        "id": 41,
+        "user": {"login": "agent-loop", "id": 1},
+        "body": (
+            f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=old-nonce repo={repo} "
+            f"base={base} head={head} protection=voluntary"
+        ),
+    }
+
+
+def test_pr_mode_resumes_only_from_immutable_issue_draft_facts_and_mints_fresh_audit(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        rest_pr={"draft": True},
+        issue_events=[label_event()],
+        intent_comments=[_resume_audit()],
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.activation_path == "managed"
+    assert contract.audit_nonce and contract.audit_nonce != "old-nonce"
+    assert contract.audit_comment_id == 17
+    assert contract.intent_generation
+    assert any("active_label_event_id=101" in " ".join(cmd) for cmd, _ in runner.commands)
+
+
+def test_pr_mode_treats_edited_or_missing_audit_as_ordinary_fallback(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        issue_events=[label_event()],
+        intent_comments=[_resume_audit(repo="EVIL/REPO")],
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.activation_path == "ordinary_fallback"
+    assert contract.ordinary_recovery is not None
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
+        for cmd, _ in runner.commands
+    )
+
+
+def test_resume_intent_generation_ignores_historical_same_head_ledger_and_run(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    historical = v2_intent_comment(run_id=100, run_attempt=1)
+    contract = v2_contract(intent_generation="fresh-generation")
+    runner = V2ManagedRunner(
+        intent_comments=[historical],
+        workflow_runs=[v2_run(run_id=100)],
+    )
+
+    _ensure_v2_intent(runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract)
+
+    assert contract.nonce != "nonce-1"
+    assert contract.attached_run_id is None
+    assert any("issues/7/comments" in " ".join(cmd) and "POST" in cmd for cmd, _ in runner.commands)
+
+
+def test_ordinary_recovery_rejects_green_checks_without_post_release_run(monkeypatch, tmp_path):
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1)
+    capability = OrdinaryRecoveryCapability(
+        pr_number=7, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=100, prior_run_ids=frozenset({2}),
+    )
+    passing = checks(passing=(PullRequestCheck("test", "check_run", "success"),), required=("test",))
+    monkeypatch.setattr(managed_ci, "get_pr_head_sha", lambda *args, **kwargs: "abc123")
+    monkeypatch.setattr(managed_ci, "get_pr_mergeability", lambda *args, **kwargs: type("M", (), {"state": "mergeable"})())
+    monkeypatch.setattr(managed_ci, "_workflow_runs_payload", lambda *args, **kwargs: [{"id": 2, "status": "completed", "conclusion": "success"}])
+    monkeypatch.setattr(managed_ci, "get_pr_checks", lambda *args, **kwargs: passing)
+
+    outcome = wait_for_ordinary_recovery(runner=FakeRunner(), config=config, capability=capability, metadata=metadata())
+
+    assert outcome.status == "timeout"
 
 
 def v2_contract(**overrides):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -33,6 +33,7 @@ from coding_review_agent_loop.managed_ci import (
     release_adopted_managed_ci,
     revalidate_adopted_managed_ci,
     OrdinaryRecoveryCapability,
+    refresh_ordinary_recovery_capability,
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
@@ -486,6 +487,33 @@ def test_pr_mode_resumes_only_from_immutable_issue_draft_facts_and_mints_fresh_a
     assert any("active_label_event_id=101" in " ".join(cmd) for cmd, _ in runner.commands)
 
 
+def test_pr_mode_strict_resume_does_not_require_or_write_unprotected_audit(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        issue_events=[label_event()],
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+        pr_enforce_admins_payload={"enabled": True},
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.activation_path == "managed"
+    assert contract.audit_nonce is None
+    assert not any(
+        cmd[:3] == ["gh", "api", "--method"]
+        and "issues/7/comments" in " ".join(cmd)
+        and "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1" in " ".join(cmd)
+        for cmd, _cwd in runner.commands
+    )
+
+
 def test_pr_mode_treats_edited_or_missing_audit_as_ordinary_fallback(tmp_path):
     config = make_config(
         tmp_path,
@@ -542,6 +570,54 @@ def test_ordinary_recovery_rejects_green_checks_without_post_release_run(monkeyp
     outcome = wait_for_ordinary_recovery(runner=FakeRunner(), config=config, capability=capability, metadata=metadata())
 
     assert outcome.status == "timeout"
+
+
+def test_ordinary_recovery_accepts_current_head_run_without_local_clock_filter(monkeypatch, tmp_path):
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1)
+    capability = OrdinaryRecoveryCapability(
+        pr_number=7, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=2_000, prior_run_ids=frozenset(),
+    )
+    passing = checks(passing=(PullRequestCheck("test", "check_run", "success"),), required=("test",))
+    monkeypatch.setattr(managed_ci, "get_pr_head_sha", lambda *args, **kwargs: "abc123")
+    monkeypatch.setattr(managed_ci, "get_pr_mergeability", lambda *args, **kwargs: type("M", (), {"state": "mergeable"})())
+    monkeypatch.setattr(
+        managed_ci,
+        "_workflow_runs_payload",
+        lambda *args, **kwargs: [{
+            "id": 3, "status": "completed", "conclusion": "success",
+            "created_at": "1970-01-01T00:00:00Z",
+        }],
+    )
+    monkeypatch.setattr(managed_ci, "get_pr_checks", lambda *args, **kwargs: passing)
+
+    outcome = wait_for_ordinary_recovery(
+        runner=FakeRunner(), config=config, capability=capability, metadata=metadata(),
+    )
+
+    assert outcome.status == "passed"
+
+
+def test_refresh_ordinary_recovery_rebinds_changed_head_and_resets_run_baseline(tmp_path):
+    capability = OrdinaryRecoveryCapability(
+        pr_number=7, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=100, prior_run_ids=frozenset({2}),
+    )
+    runner = V2ManagedRunner(
+        rest_pr={
+            "head": {"repo": {"full_name": "OWNER/REPO"}, "sha": "new-head", "ref": "feature"},
+            "labels": [],
+        },
+        issue_events=[label_event(), label_event(event="unlabeled")],
+    )
+
+    refreshed = refresh_ordinary_recovery_capability(
+        runner, config=make_config(tmp_path), capability=capability,
+    )
+
+    assert refreshed is not None
+    assert refreshed.expected_head_sha == "new-head"
+    assert refreshed.prior_run_ids == frozenset()
 
 
 def v2_contract(**overrides):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import re
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,7 +29,11 @@ from coding_review_agent_loop.github import (
     get_pr_checks,
 )
 from coding_review_agent_loop.migrations import MigrationValidationResult
-from coding_review_agent_loop.managed_ci import ManagedCiContract, ManagedCiOutcome
+from coding_review_agent_loop.managed_ci import (
+    ManagedCiContract,
+    ManagedCiOutcome,
+    OrdinaryRecoveryCapability,
+)
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     PostedRoundMetadata,
@@ -204,6 +209,147 @@ def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
         "repos/OWNER/REPO/branches/main/protection/required_status_checks",
     ] in commands
     assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge", "--match-head-commit", "abc123"] in commands
+
+
+def test_ordinary_recovery_readies_and_merges_exact_head(monkeypatch, tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, auto_merge=True)
+    capability = OrdinaryRecoveryCapability(
+        pr_number=77, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=100,
+    )
+    validations = []
+    merged = []
+    monkeypatch.setattr(orchestrator, "refresh_ordinary_recovery_capability", lambda *args, **kwargs: capability)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_ordinary_recovery",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed"),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "get_pr_review_context",
+        lambda *args, **kwargs: SimpleNamespace(metadata=PullRequestMetadata(
+            number=77, repo="OWNER/REPO", title="draft", head_branch="feature",
+            base_branch="main", head_sha="abc123", url=None,
+        )),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "validate_ordinary_recovery_capability",
+        lambda *args, **kwargs: validations.append(kwargs.get("require_draft", True)) or True,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "merge_pr",
+        lambda *args, **kwargs: merged.append(kwargs["expected_head_sha"]),
+    )
+
+    orchestrator._finalize_ordinary_recovery_merge(
+        runner, config=config, pr_number=77, capability=capability,
+    )
+
+    assert validations == [True, None]
+    assert merged == ["abc123"]
+    assert ["gh", "pr", "ready", "77", "--repo", "OWNER/REPO"] in [
+        command for command, _cwd in runner.commands
+    ]
+
+
+def test_ordinary_recovery_refuses_head_changed_before_ready(monkeypatch, tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, auto_merge=True)
+    capability = OrdinaryRecoveryCapability(
+        pr_number=77, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=100,
+    )
+    monkeypatch.setattr(orchestrator, "refresh_ordinary_recovery_capability", lambda *args, **kwargs: capability)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_ordinary_recovery",
+        lambda *args, **kwargs: ManagedCiOutcome(status="head_changed", head_sha="new-head"),
+    )
+
+    with pytest.raises(AgentLoopError, match="head_changed"):
+        orchestrator._finalize_ordinary_recovery_merge(
+            runner, config=config, pr_number=77, capability=capability,
+        )
+
+    assert not any(command[:3] == ["gh", "pr", "ready"] for command, _cwd in runner.commands)
+
+
+def test_ordinary_recovery_refuses_provenance_change_after_ready(monkeypatch, tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, auto_merge=True)
+    capability = OrdinaryRecoveryCapability(
+        pr_number=77, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=100,
+    )
+    validations = iter([True, False])
+    monkeypatch.setattr(orchestrator, "refresh_ordinary_recovery_capability", lambda *args, **kwargs: capability)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_ordinary_recovery",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed"),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "get_pr_review_context",
+        lambda *args, **kwargs: SimpleNamespace(metadata=PullRequestMetadata(
+            number=77, repo="OWNER/REPO", title="draft", head_branch="feature",
+            base_branch="main", head_sha="abc123", url=None,
+        )),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "validate_ordinary_recovery_capability",
+        lambda *args, **kwargs: next(validations),
+    )
+
+    with pytest.raises(AgentLoopError, match="after `gh pr ready`"):
+        orchestrator._finalize_ordinary_recovery_merge(
+            runner, config=config, pr_number=77, capability=capability,
+        )
+
+    assert any(command[:3] == ["gh", "pr", "ready"] for command, _cwd in runner.commands)
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command, _cwd in runner.commands)
+
+
+def test_ordinary_recovery_merge_failure_leaves_pr_ready(monkeypatch, tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, auto_merge=True)
+    capability = OrdinaryRecoveryCapability(
+        pr_number=77, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=101, released_at=100,
+    )
+    monkeypatch.setattr(orchestrator, "refresh_ordinary_recovery_capability", lambda *args, **kwargs: capability)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_ordinary_recovery",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed"),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "get_pr_review_context",
+        lambda *args, **kwargs: SimpleNamespace(metadata=PullRequestMetadata(
+            number=77, repo="OWNER/REPO", title="draft", head_branch="feature",
+            base_branch="main", head_sha="abc123", url=None,
+        )),
+    )
+    monkeypatch.setattr(orchestrator, "validate_ordinary_recovery_capability", lambda *args, **kwargs: True)
+
+    def fail_merge(*args, **kwargs):
+        raise AgentLoopError("merge failed")
+
+    monkeypatch.setattr(orchestrator, "merge_pr", fail_merge)
+
+    with pytest.raises(AgentLoopError, match="merge failed"):
+        orchestrator._finalize_ordinary_recovery_merge(
+            runner, config=config, pr_number=77, capability=capability,
+        )
+
+    assert any(command[:3] == ["gh", "pr", "ready"] for command, _cwd in runner.commands)
+    assert not any("convert-to-draft" in command for command, _cwd in runner.commands)
 
 def test_pr_loop_does_not_post_gemini_diagnostics_without_agent_state(tmp_path):
     diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -203,7 +203,7 @@ def test_pr_loop_runs_tests_and_merge_only_after_codex_approval(tmp_path):
         "api",
         "repos/OWNER/REPO/branches/main/protection/required_status_checks",
     ] in commands
-    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge", "--match-head-commit", "abc123"] in commands
 
 def test_pr_loop_does_not_post_gemini_diagnostics_without_agent_state(tmp_path):
     diagnostic = "[ERROR] Invalid stream: The model returned an empty response or malformed tool call."
@@ -2485,7 +2485,7 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
     ]
     assert len(metadata_fetches) == 1
     assert ["pytest", "tests/test_agent_loop.py"] in commands
-    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge", "--match-head-commit", "abc123"] in commands
 
 
 def test_pr_loop_skips_prior_approval_when_pr_head_is_unchanged(tmp_path):
@@ -5300,7 +5300,7 @@ def test_claude_review_loop_runs_tests_and_merge_only_after_approval(tmp_path):
 
     commands = [cmd for cmd, _cwd in runner.commands]
     assert ["pytest", "tests/test_agent_loop.py"] in commands
-    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge"] in commands
+    assert ["gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge", "--match-head-commit", "abc123"] in commands
 
 def test_claude_review_loop_does_not_run_codex_after_final_blocking_round(tmp_path):
     runner = FakeRunner(


### PR DESCRIPTION
Fixes #663\n\nSummary:\n- authorize PR-mode resume only from immutable actor, author, draft, reserved-ref, base/head, active-label, and audit provenance facts\n- mint fresh resume audit and invocation intent generations; never adopt historical runs\n- release unsafe managed drafts into exact-head ordinary unlabeled recovery and gate draft readiness/merge with --match-head-commit\n- document the supported retry command and add focused regression coverage\n\nTests:\n- timeout 1800s python3 -m pytest -q tests/test_managed_ci.py tests/test_agent_loop.py tests/test_orchestrator_pr.py tests/test_ci_watch.py tests/test_mergeability.py tests/test_merge_conflict.py tests/test_docs_guidance.py\n- timeout 1800s python3 -m pytest (2068 passed)