### PR TITLE
Fix ordinary recovery and report path validation

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1090,9 +1090,14 @@ The orchestrator validates coder-reported test commands before posting normal
 coder progress. For `Tests:` reports and structured `tests_run` entries, it is
 role-aware rather than pattern-only: an explicit working directory (`cd
 <path>`, `-C <path>`, `--directory[=]<path>`, `--chdir[=]`, `--cwd[=]`,
-`--rootdir[=]`) is always validated, and so is any ordinary target, checkout,
-or artifact path (a positional test path, a redirect target, an `--rootdir`
-value, and so on). An absolute interpreter, runner, or package-manager
+`--rootdir[=]<path>`) is always validated, and so is any ordinary target,
+checkout, or artifact path (a positional test path, a redirect target, an
+`--rootdir` value, and so on). The values of the explicitly recognized report
+flags `--output`, `--output-dir`, `--output-file`, `--report`, and
+`--report-file` are the narrow exception: they are treated as report
+destinations and may name paths outside the checkout. This exemption is
+flag-gated only; a shell redirect to an outside path such as `pytest tests/ >
+/tmp/out.log` is still rejected. An absolute interpreter, runner, or package-manager
 executable in *program position* -- for example `/usr/bin/python3`, a venv's
 `.venv/bin/pytest`, or a wrapper like `sudo`/`env` in front of one -- is not
 treated as a test location, and neither is the value of a narrow set of
@@ -1106,8 +1111,8 @@ are likewise consumed only for their defined options such as `timeout -k`/`-s`,
 `xargs -n`/`-P`/`-I`. These exemptions
 are gated on command position or on a specific interpreter-valued construct,
 not on path components: wrapper operands, option values, workdirs,
-test/script targets, outputs, remote targets, malformed commands, and
-arbitrary `/tmp` paths receive no blanket exemption, so a toolchain-shaped path
+test/script targets, unrecognized outputs, remote targets, malformed commands,
+and arbitrary `/tmp` paths receive no blanket exemption, so a toolchain-shaped path
 used as an ordinary argument (`pytest /outside/bin/tests/test_foo.py`) still
 fails containment. Package acquisition (`pip install ...`, including the
 `python -m pip install ...` form) is exempted from the separate live-target

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -663,10 +663,13 @@ def _release_for_ordinary_recovery(
 ) -> OrdinaryRecoveryCapability | None:
     """Release the exact active label and return a narrowly scoped capability.
 
-    The capability is deliberately unusable when timeline ownership cannot be
-    proven. We still remove the suppression label where possible so ordinary
-    current-head CI can run, but the orchestrator will not ready or merge such
-    a PR automatically.
+    The capability is created only after the caller has already authenticated
+    the managed draft tuple (same-repository branch, trusted author, draft,
+    label, base, and exact head). The timeline event is useful provenance, but
+    it is not the sole proof of this invocation's ownership: GitHub can return
+    an incomplete event history immediately after a label transition. The
+    later exact-head ordinary-CI gate remains mandatory before readiness or
+    merge.
     """
     prior_run_ids: set[int] = set()
     try:
@@ -692,14 +695,12 @@ def _release_for_ordinary_recovery(
             f"Managed-CI v2 could not activate ({reason}) and `{MANAGED_LABEL}` could not be removed."
         )
     log(config, f"PR #{pr_number}: selected ordinary unlabeled recovery ({reason})")
-    if active_event is None:
-        return None
     return OrdinaryRecoveryCapability(
         pr_number=pr_number,
         repository=config.repo,
         base_ref=base_ref,
         expected_head_sha=expected_head_sha,
-        released_label_event_id=active_event[0],
+        released_label_event_id=active_event[0] if active_event is not None else None,
         released_at=int(time.time()),
         prior_run_ids=frozenset(prior_run_ids),
     )
@@ -891,14 +892,14 @@ def _activate_v2_managed_ci(
             or active_event[1].casefold() != actor_login.casefold()
             or active_event[2] != actor_id
         ):
-            _release_for_ordinary_recovery(
+            recovery = _release_for_ordinary_recovery(
                 runner, config=config, pr_number=pr_number, base_ref=base_ref,
                 expected_head_sha=live_sha, active_event=active_event,
                 reason="the active managed-label event is missing or not actor-owned",
             )
             return ManagedCiContract(
                 activation_path="ordinary_fallback",
-                ordinary_recovery=None,
+                ordinary_recovery=recovery,
             )
 
     # Only workflows with a pull_request route can suppress an opening matrix.

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -665,9 +665,12 @@ def _release_for_ordinary_recovery(
 
     The capability is created only after the caller has already authenticated
     the managed draft tuple (same-repository branch, trusted author, draft,
-    label, base, and exact head). The timeline event is useful provenance, but
-    it is not the sole proof of this invocation's ownership: GitHub can return
-    an incomplete event history immediately after a label transition. The
+    label, base, and exact head) and the caller is handling a temporarily
+    missing timeline event. GitHub can return an incomplete event history
+    immediately after a label transition, so that specific race may still use
+    the authenticated tuple as provenance. A readable event owned by another
+    identity remains fail-closed: the label can be removed to restore ordinary
+    CI, but the caller must not receive a capability to ready or merge. The
     later exact-head ordinary-CI gate remains mandatory before readiness or
     merge.
     """
@@ -887,19 +890,25 @@ def _activate_v2_managed_ci(
     active_event: tuple[int, str, int] | None = None
     if config.managed_ci_pr_mode:
         active_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
-        if (
-            active_event is None
-            or active_event[1].casefold() != actor_login.casefold()
-            or active_event[2] != actor_id
-        ):
+        if active_event is None:
             recovery = _release_for_ordinary_recovery(
                 runner, config=config, pr_number=pr_number, base_ref=base_ref,
                 expected_head_sha=live_sha, active_event=active_event,
-                reason="the active managed-label event is missing or not actor-owned",
+                reason="the active managed-label event is temporarily unreadable",
             )
             return ManagedCiContract(
                 activation_path="ordinary_fallback",
                 ordinary_recovery=recovery,
+            )
+        if active_event[1].casefold() != actor_login.casefold() or active_event[2] != actor_id:
+            _release_for_ordinary_recovery(
+                runner, config=config, pr_number=pr_number, base_ref=base_ref,
+                expected_head_sha=live_sha, active_event=active_event,
+                reason="the active managed-label event is not actor-owned",
+            )
+            return ManagedCiContract(
+                activation_path="ordinary_fallback",
+                ordinary_recovery=None,
             )
 
     # Only workflows with a pull_request route can suppress an opening matrix.

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import re
 import shutil
@@ -183,6 +184,14 @@ class Runner:
             f"Retry shortly or pass {override_flag} <path>."
         )
 
+    def _command_non_executable_after_preflight_error(self, command: str) -> AgentLoopError:
+        override_flag = self._override_flag_for(command)
+        return AgentLoopError(
+            f"{command} CLI remained temporarily non-executable after "
+            f"{_SPAWN_ATTEMPTS} spawn attempts and may be updating; "
+            f"retry shortly or pass {override_flag} <path>."
+        )
+
     @staticmethod
     def _is_dangling_symlink(path: str | None) -> bool:
         return bool(path and os.path.islink(path) and not os.path.exists(path))
@@ -219,6 +228,20 @@ class Runner:
                     if saw_preflight_disappearance and not dangling_symlink:
                         raise self._command_disappeared_after_preflight_error(command) from exc
                     raise self._missing_command_error(command) from exc
+                time.sleep(_SPAWN_RETRY_BACKOFF_SECONDS)
+            except OSError as exc:
+                # Claude Code can briefly leave its bare command pointing at
+                # an incomplete native install during an auto-update. Treat
+                # only ENOEXEC for a preflighted bare command as retryable;
+                # permission errors and explicit paths remain fail-closed.
+                if exc.errno != errno.ENOEXEC or os.path.isabs(command):
+                    raise
+                with self._commands_lock:
+                    preflighted = command in self._preflighted_commands
+                if not preflighted:
+                    raise
+                if attempt == _SPAWN_ATTEMPTS:
+                    raise self._command_non_executable_after_preflight_error(command) from exc
                 time.sleep(_SPAWN_RETRY_BACKOFF_SECONDS)
 
         raise AssertionError("spawn retry loop exited unexpectedly")

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -71,6 +71,18 @@ WORKDIR_FLAG_PREFIXES = ("--directory=", "--chdir=", "--cwd=", "--rootdir=")
 INTERPRETER_VALUE_FLAGS = {"--python", "--interpreter", "--with-python", "--python-executable"}
 INTERPRETER_VALUE_ENV_VARS = {"PYTHONPATH", "VIRTUAL_ENV", "NODE_PATH", "JAVA_HOME", "PATH"}
 
+# Report destinations are not execution inputs.  Keep this vocabulary
+# deliberately explicit so an arbitrary outside path cannot be hidden behind
+# a generic option.
+OUTPUT_VALUE_FLAGS = {
+    "--output",
+    "--output-dir",
+    "--output-file",
+    "--report",
+    "--report-file",
+}
+OUTPUT_VALUE_FLAG_PREFIXES = tuple(f"{flag}=" for flag in OUTPUT_VALUE_FLAGS)
+
 # ---------------------------------------------------------------------------
 # Package acquisition (URL pass exclusion).
 # ---------------------------------------------------------------------------
@@ -498,6 +510,15 @@ def _path_roles(clause: _Clause) -> list[tuple[str, str]]:
             idx += 1
             continue
 
+        for prefix in OUTPUT_VALUE_FLAG_PREFIXES:
+            if token.startswith(prefix):
+                results.append((token[len(prefix) :], "output"))
+                matched_prefix = True
+                break
+        if matched_prefix:
+            idx += 1
+            continue
+
         env_match = VAR_ASSIGNMENT_RE.match(token)
         if env_match:
             eq_idx = token.index("=")
@@ -521,6 +542,11 @@ def _path_roles(clause: _Clause) -> list[tuple[str, str]]:
             idx += 2
             continue
 
+        if token in OUTPUT_VALUE_FLAGS and idx + 1 < n:
+            results.append((tokens[idx + 1], "output"))
+            idx += 2
+            continue
+
         if _is_path_shaped(token):
             if idx in program_positions or idx == promoted_idx:
                 results.append((token, "program"))
@@ -540,6 +566,8 @@ def _check_path_role(raw_path: str, role: str, *, command: str, assigned: Path) 
     if role == "program" and _is_toolchain_executable(raw_path):
         return
     if role == "interpreter_value":
+        return
+    if role == "output":
         return
     raise AgentLoopError(
         "Coder reported tests from outside the assigned checkout: "

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3958,7 +3958,7 @@ def test_runner_preflighted_command_permission_error_does_not_retry(
     tmp_path,
     use_pty,
 ):
-    """Only FileNotFoundError can use the preflighted-command retry."""
+    """Only FileNotFoundError and preflighted bare-command ENOEXEC can retry."""
     import coding_review_agent_loop.runner as runner_module
 
     command_name = "bare-agent"
@@ -4027,6 +4027,45 @@ def test_runner_preflighted_exec_format_error_retries(monkeypatch, tmp_path, use
 
     assert len(popen_calls) == 3
     assert sleep_calls == [2, 2]
+
+
+@pytest.mark.parametrize("command", ["bare-agent", "/tmp/bare-agent"])
+def test_runner_unpreflighted_or_absolute_exec_format_error_does_not_retry(
+    monkeypatch,
+    tmp_path,
+    command,
+):
+    """ENOEXEC is fail-closed for unpreflighted and absolute commands."""
+    import errno
+    import coding_review_agent_loop.runner as runner_module
+
+    runner = Runner()
+    popen_calls = []
+    sleep_calls = []
+
+    def invalid_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        raise OSError(errno.ENOEXEC, "Exec format error")
+
+    monkeypatch.setattr(runner_module.subprocess, "Popen", invalid_popen)
+    monkeypatch.setattr(
+        runner_module.time,
+        "sleep",
+        lambda delay: sleep_calls.append(delay),
+    )
+
+    with pytest.raises(OSError) as exc_info:
+        runner.run_with_log(
+            [command, "--version"],
+            cwd=tmp_path,
+            log_path=tmp_path / "logs" / "exec-format-no-retry.log",
+            label="Exec format no-retry probe",
+            progress_interval_seconds=999,
+        )
+
+    assert exc_info.value.errno == errno.ENOEXEC
+    assert len(popen_calls) == 1
+    assert sleep_calls == []
 
 
 def test_runner_missing_command_without_dangling_evidence_does_not_retry(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3992,6 +3992,43 @@ def test_runner_preflighted_command_permission_error_does_not_retry(
     assert sleep_calls == []
 
 
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_preflighted_exec_format_error_retries(monkeypatch, tmp_path, use_pty):
+    """A bare preflighted CLI may be briefly non-executable during auto-update."""
+    import errno
+    import coding_review_agent_loop.runner as runner_module
+
+    command_name = "bare-agent"
+    runner = Runner()
+    runner.remember_agent_command(command_name, "/tmp/bare-agent", "--claude-cmd")
+    popen_calls = []
+    sleep_calls = []
+
+    def invalid_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        raise OSError(errno.ENOEXEC, "Exec format error")
+
+    monkeypatch.setattr(runner_module.subprocess, "Popen", invalid_popen)
+    monkeypatch.setattr(
+        runner_module.time,
+        "sleep",
+        lambda delay: sleep_calls.append(delay),
+    )
+
+    with pytest.raises(AgentLoopError, match="remained temporarily non-executable"):
+        runner.run_with_log(
+            [command_name, "--version"],
+            cwd=tmp_path,
+            log_path=tmp_path / "logs" / f"exec-format-retry-{use_pty}.log",
+            label="Exec format retry probe",
+            progress_interval_seconds=999,
+            use_pty=use_pty,
+        )
+
+    assert len(popen_calls) == 3
+    assert sleep_calls == [2, 2]
+
+
 def test_runner_missing_command_without_dangling_evidence_does_not_retry(
     monkeypatch,
     tmp_path,

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -539,6 +539,29 @@ def test_pr_mode_treats_edited_or_missing_audit_as_ordinary_fallback(tmp_path):
     )
 
 
+def test_pr_mode_keeps_ordinary_recovery_capability_when_label_event_is_temporarily_unreadable(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        # The PR API still proves the managed draft tuple, but the timeline
+        # has not yielded the label event yet.
+        issue_events=[],
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.activation_path == "ordinary_fallback"
+    assert contract.ordinary_recovery is not None
+    assert contract.ordinary_recovery.released_label_event_id is None
+
+
 def test_resume_intent_generation_ignores_historical_same_head_ledger_and_run(tmp_path):
     config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
     historical = v2_intent_comment(run_id=100, run_attempt=1)

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -562,6 +562,30 @@ def test_pr_mode_keeps_ordinary_recovery_capability_when_label_event_is_temporar
     assert contract.ordinary_recovery.released_label_event_id is None
 
 
+def test_pr_mode_keeps_readable_non_owned_label_event_fail_closed(tmp_path):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        issue_events=[label_event(login="collaborator", actor_id=2)],
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.activation_path == "ordinary_fallback"
+    assert contract.ordinary_recovery is None
+    assert any(
+        cmd[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
+        for cmd, _ in runner.commands
+    )
+
+
 def test_resume_intent_generation_ignores_historical_same_head_ledger_and_run(tmp_path):
     config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
     historical = v2_intent_comment(run_id=100, run_attempt=1)

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -216,6 +216,24 @@ def test_rejects_timeout_wrapped_outside_paths(tmp_path, command):
 
 
 @pytest.mark.parametrize("command", [
+    "python scripts/qualify_localization.py --output-dir /tmp/localization-report",
+    "python scripts/qualify_localization.py --output=/tmp/localization-report",
+    "python scripts/qualify_localization.py --report-file /tmp/localization-report.json",
+])
+def test_accepts_explicit_report_outputs_outside_checkout(tmp_path, command):
+    validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+@pytest.mark.parametrize("command", [
+    "python /outside/checkout/scripts/qualify.py --output-dir /tmp/report",
+    "python tests/test_foo.py --rootdir /outside/checkout",
+])
+def test_report_output_exemption_does_not_allow_outside_execution_or_workdir(tmp_path, command):
+    with pytest.raises(AgentLoopError, match="outside the assigned checkout"):
+        validate_test_commands_within_workdir((command,), assigned_workdir=_assigned(tmp_path))
+
+
+@pytest.mark.parametrize("command", [
     "timeout curl https://live.example",
     "timeout badduration curl https://live.example",
     "timeout -k",


### PR DESCRIPTION
## Summary

- Accept explicit report destinations such as `--output-dir` outside the assigned checkout without weakening execution/workdir/input validation.
- Preserve an invocation-owned ordinary-CI recovery capability when GitHub's label timeline is temporarily incomplete.
- Require the existing exact-head ordinary-CI gate before readiness and merge.
- Retry a preflighted bare CLI when an auto-update briefly produces `ENOEXEC`.

## Fixes

- A localization qualification command could pass all tests but be rejected because its report directory was under `/tmp`.
- A managed draft released to ordinary CI could pass every exact-head check but stop with "recovery provenance could not be correlated" when the label event was unavailable.
- Claude Code could briefly leave its command pointing at an incomplete native install during auto-update, causing `Exec format error` before review started.

## Verification

- `647 passed` across `tests/test_agent_loop.py`, `tests/test_workdir_guard.py`, `tests/test_managed_ci.py`, and `tests/test_orchestrator_pr.py`.

Related incident: `llm-dialectic#849`.
