### PR TITLE
Fix managed CI GitHub CLI pagination durability

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1497,6 +1497,31 @@ selected independently of `--watch-pending-ci`; neither that flag nor
 `--no-watch-pending-ci` replaces exact-head qualification with an ordinary
 full-board or named-check wait.
 
+#### Managed-CI GitHub CLI compatibility
+
+The managed-CI API calls use the GitHub CLI 2.45-compatible pagination
+behavior. Paginated array endpoints are decoded as one flat JSON array;
+concatenated object pages (such as workflow jobs) are decoded page by page. A
+malformed page or entry is unavailable and is never treated as an empty or
+absent timeline. The managed-label timeline is therefore unreadable-is-not-absent,
+and every ownership, readiness, and merge gate fails closed when it cannot be
+revalidated.
+
+Ordinary fallback is authorized only by the centralized release path. Before
+removing the managed label it records the IDs of existing workflow runs for
+the exact head. Recovery accepts only a newly observed `pull_request` run for
+that same head, together with a passing and complete ordinary check board.
+There is deliberately no local-clock or timestamp ordering claim: GitHub run
+IDs and the exact-head check are the available provenance, and no run observed
+is not treated as a successful recovery.
+
+Reconstructed reserved drafts require the authenticated user, the configured
+CLI trusted actor, and the current `AGENT_LOOP_MANAGED_ACTOR` repository
+variable to agree. Readiness and merge remain fail-closed, with `gh pr ready`
+and `--match-head-commit` guarded by a fresh exact-head and inactive-label
+provenance check. The workflow must advertise the `pull_request: unlabeled`
+recovery trigger for this path.
+
 ### Watch pending CI
 
 For repositories not using managed exact-head CI, `--watch-pending-ci` is
@@ -2083,28 +2108,3 @@ when only some counters are available. When a backend exposes no usable usage
 data, the orchestrator records an `estimated` fallback based on prompt and
 public-response size, along with raw character and byte counts. `--dry-run`
 does not invent token usage records.
-
-#### Managed-CI GitHub CLI compatibility
-
-The managed-CI API calls use the GitHub CLI 2.45-compatible pagination
-behavior. Paginated array endpoints are decoded as one flat JSON array;
-concatenated object pages (such as workflow jobs) are decoded page by page. A
-malformed page or entry is unavailable and is never treated as an empty or
-absent timeline. The managed-label timeline is therefore unreadable-is-not-
-absent, and every ownership, readiness, and merge gate fails closed when it
-cannot be revalidated.
-
-Ordinary fallback is authorized only by the centralized release path. Before
-removing the managed label it records the IDs of existing workflow runs for
-the exact head. Recovery accepts only a newly observed `pull_request` run for
-that same head, together with a passing and complete ordinary check board.
-There is deliberately no local-clock or timestamp ordering claim: GitHub run
-IDs and the exact-head check are the available provenance, and no run observed
-is not treated as a successful recovery.
-
-Reconstructed reserved drafts require the authenticated user, the configured
-CLI trusted actor, and the current `AGENT_LOOP_MANAGED_ACTOR` repository
-variable to agree. Readiness and merge remain fail-closed, with `gh pr ready`
-and `--match-head-commit` guarded by a fresh exact-head and inactive-label
-provenance check. The workflow must advertise the `pull_request: unlabeled`
-recovery trigger for this path.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -2083,3 +2083,27 @@ when only some counters are available. When a backend exposes no usable usage
 data, the orchestrator records an `estimated` fallback based on prompt and
 public-response size, along with raw character and byte counts. `--dry-run`
 does not invent token usage records.
+
+# Managed-CI GitHub CLI compatibility
+
+Managed-CI uses GitHub CLI 2.45.0 or newer. Paginated array endpoints are
+decoded as one flat JSON array; concatenated object pages (such as workflow
+jobs) are decoded page by page. A malformed page or entry is unavailable and
+is never treated as an empty or absent timeline. The managed-label timeline is
+therefore unreadable-is-not-absent, and every ownership, readiness, and merge
+gate fails closed when it cannot be revalidated.
+
+Ordinary fallback is authorized only by the centralized release path. It
+records the GitHub `unlabeled.created_at` instant in UTC and separate
+pre-release and post-release exact-head run snapshots. Earlier run timestamps
+fail; equal-second timestamps require clock-free proof that the run was absent
+from the post-release snapshot and first observed during recovery; malformed
+timestamps fail. Operators should distinguish no run observed from a run that
+appeared but cannot prove post-release ordering.
+
+Reconstructed reserved drafts require the authenticated user, the configured
+CLI trusted actor, and the current `AGENT_LOOP_MANAGED_ACTOR` repository
+variable to agree. Readiness and merge remain fail-closed, with `gh pr ready`
+and `--match-head-commit` guarded by a fresh exact-head and inactive-label
+provenance check. The workflow must advertise the `pull_request: unlabeled`
+recovery trigger for this path.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -2084,22 +2084,23 @@ data, the orchestrator records an `estimated` fallback based on prompt and
 public-response size, along with raw character and byte counts. `--dry-run`
 does not invent token usage records.
 
-# Managed-CI GitHub CLI compatibility
+#### Managed-CI GitHub CLI compatibility
 
-Managed-CI uses GitHub CLI 2.45.0 or newer. Paginated array endpoints are
-decoded as one flat JSON array; concatenated object pages (such as workflow
-jobs) are decoded page by page. A malformed page or entry is unavailable and
-is never treated as an empty or absent timeline. The managed-label timeline is
-therefore unreadable-is-not-absent, and every ownership, readiness, and merge
-gate fails closed when it cannot be revalidated.
+The managed-CI API calls use the GitHub CLI 2.45-compatible pagination
+behavior. Paginated array endpoints are decoded as one flat JSON array;
+concatenated object pages (such as workflow jobs) are decoded page by page. A
+malformed page or entry is unavailable and is never treated as an empty or
+absent timeline. The managed-label timeline is therefore unreadable-is-not-
+absent, and every ownership, readiness, and merge gate fails closed when it
+cannot be revalidated.
 
-Ordinary fallback is authorized only by the centralized release path. It
-records the GitHub `unlabeled.created_at` instant in UTC and separate
-pre-release and post-release exact-head run snapshots. Earlier run timestamps
-fail; equal-second timestamps require clock-free proof that the run was absent
-from the post-release snapshot and first observed during recovery; malformed
-timestamps fail. Operators should distinguish no run observed from a run that
-appeared but cannot prove post-release ordering.
+Ordinary fallback is authorized only by the centralized release path. Before
+removing the managed label it records the IDs of existing workflow runs for
+the exact head. Recovery accepts only a newly observed `pull_request` run for
+that same head, together with a passing and complete ordinary check board.
+There is deliberately no local-clock or timestamp ordering claim: GitHub run
+IDs and the exact-head check are the available provenance, and no run observed
+is not treated as a successful recovery.
 
 Reconstructed reserved drafts require the authenticated user, the configured
 CLI trusted actor, and the current `AGENT_LOOP_MANAGED_ACTOR` repository

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -48,6 +48,8 @@ V2_ADOPTION_MARKER = "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION"
 V2_ADOPTION_FEATURE_MARKERS = (V2_ADOPTION_MARKER,)
 RECOVERY_MARKER = "AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1"
 UNPROTECTED_OVERRIDE_TRAILER = "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1"
+GH_MIN_VERSION = (2, 45, 0)
+GH_MIN_VERSION_TEXT = "2.45.0"
 
 
 @dataclass(frozen=True)
@@ -1088,7 +1090,7 @@ def _activate_v2_managed_ci(
 def _api_list(runner: Runner, config: AgentLoopConfig, endpoint: str) -> list[dict[str, object]] | None:
     """Fetch a paginated GitHub list, returning None for an uninspectable response."""
     result = runner.run(
-        [config.gh_cmd, "api", "--paginate", "--slurp", endpoint], cwd=active_workdir(config), check=False
+        [config.gh_cmd, "api", "--paginate", endpoint], cwd=active_workdir(config), check=False
     )
     if result.returncode != 0:
         return None
@@ -1098,11 +1100,12 @@ def _api_list(runner: Runner, config: AgentLoopConfig, endpoint: str) -> list[di
         return None
     if not isinstance(payload, list):
         return None
-    # `gh api --paginate --slurp` returns one array per page.  Accept a plain
-    # list too so single-page API implementations remain compatible.
-    if all(isinstance(item, list) for item in payload):
-        return [entry for page in payload for entry in page if isinstance(entry, dict)]
-    return [item for item in payload if isinstance(item, dict)]
+    # GitHub CLI 2.45 emits one flat array for paginated array endpoints.
+    # Never silently discard malformed entries: doing so could turn an
+    # incomplete timeline into an apparently complete ownership record.
+    if not all(isinstance(item, dict) for item in payload):
+        return None
+    return payload
 
 
 def _active_managed_label_event(
@@ -1933,11 +1936,31 @@ def _v2_failed_jobs(runner: Runner, *, config: AgentLoopConfig, run_id: int | No
     )
     if result.returncode != 0:
         return (f"Managed CI run {run_id} failed; job details were unavailable.",)
+    raw = result.stdout or ""
+    # Without --slurp, gh 2.45 concatenates object pages. Decode every object
+    # instead of accepting only the first page (or treating the stream as bad).
+    decoder = json.JSONDecoder()
+    pages: list[dict[str, object]] = []
+    offset = 0
     try:
-        payload = json.loads(result.stdout or "{}")
-    except json.JSONDecodeError:
+        while offset < len(raw):
+            while offset < len(raw) and raw[offset].isspace():
+                offset += 1
+            if offset == len(raw):
+                break
+            page, end = decoder.raw_decode(raw, offset)
+            if not isinstance(page, dict):
+                raise ValueError("jobs page is not an object")
+            pages.append(page)
+            offset = end
+    except (json.JSONDecodeError, ValueError):
         return (f"Managed CI run {run_id} failed; job details were unavailable.",)
-    jobs = payload.get("jobs") if isinstance(payload, dict) else None
+    jobs: list[object] = []
+    for payload in pages:
+        page_jobs = payload.get("jobs")
+        if not isinstance(page_jobs, list):
+            return (f"Managed CI run {run_id} failed; job details were unavailable.",)
+        jobs.extend(page_jobs)
     terminal = {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
     details = []
     for job in jobs if isinstance(jobs, list) else []:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -48,8 +48,6 @@ V2_ADOPTION_MARKER = "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION"
 V2_ADOPTION_FEATURE_MARKERS = (V2_ADOPTION_MARKER,)
 RECOVERY_MARKER = "AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1"
 UNPROTECTED_OVERRIDE_TRAILER = "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1"
-GH_MIN_VERSION = (2, 45, 0)
-GH_MIN_VERSION_TEXT = "2.45.0"
 
 
 @dataclass(frozen=True)
@@ -1586,22 +1584,13 @@ def _ensure_v2_intent(
     contract.pr_number = pr_number
     contract.expected_head_sha = expected_head_sha
     contract.repository = config.repo
-    comments_result = runner.run(
-        [config.gh_cmd, "api", "--paginate", f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100"],
-        cwd=active_workdir(config), check=False,
+    comments = _api_list(
+        runner, config, f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100"
     )
-    if comments_result.returncode != 0:
+    if comments is None:
         raise AgentLoopError("Unable to inspect managed-CI v2 intent history.")
-    comments: list[object] = []
-    try:
-        parsed = json.loads(comments_result.stdout or "[]")
-        comments = parsed if isinstance(parsed, list) else []
-    except json.JSONDecodeError as exc:
-        raise AgentLoopError("Managed-CI intent comments response was invalid JSON.") from exc
     matching: list[tuple[int, dict[str, object]]] = []
     for raw in comments:
-        if not isinstance(raw, dict):
-            continue
         body = raw.get("body")
         author = raw.get("user") if isinstance(raw.get("user"), dict) else {}
         if not isinstance(body, str) or INTENT_MARKER not in body:

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -666,7 +666,62 @@ class FakeRunner(Runner):
 
     def run(self, args, *, cwd, input_text=None, check=True, env=None):
         with self._scripted_lock:
+            cmd = [str(arg) for arg in args]
+            error = self._gh_argv_error(cmd)
+            if error is not None:
+                cmd, cwd_path = self._record_command(cmd, cwd)
+                return CommandResult(cmd, cwd_path, "", error, 1)
             return self._run_locked(args, cwd=cwd, check=check)
+
+    @staticmethod
+    def _gh_argv_error(cmd):
+        """Model the pinned gh 2.45 parser so tests catch unsupported flags."""
+        if len(cmd) < 2 or cmd[0] != "gh":
+            return None
+        if cmd[1] == "api":
+            value_flags = {"--method", "-H", "-f", "-F", "--input", "--hostname", "--jq"}
+            flags = {"--paginate", "--silent", "--verbose"}
+            index = 2
+            saw_endpoint = False
+            while index < len(cmd):
+                token = cmd[index]
+                if token == "--slurp":
+                    return "unknown flag: --slurp (unsupported by gh 2.45.0)"
+                if token in value_flags:
+                    if index + 1 >= len(cmd):
+                        return f"flag {token} requires a value"
+                    index += 2
+                    continue
+                if token in flags:
+                    index += 1
+                    continue
+                if token.startswith("-"):
+                    return f"unknown flag: {token}"
+                if saw_endpoint:
+                    return "gh api accepts one endpoint"
+                saw_endpoint = True
+                index += 1
+            if not saw_endpoint:
+                return "gh api requires an endpoint"
+            return None
+        allowed = {
+            "ready": {"--repo"},
+            "view": {"--repo", "--json", "--jq", "--comments"},
+            "list": {"--repo", "--state", "--search", "--json", "--limit"},
+            "comment": {"--repo", "--body", "--body-file"},
+            "checks": {"--repo", "--required", "--watch", "--fail-fast"},
+            "create": {"--repo", "--title", "--body", "--body-file", "--label"},
+            "clone": {"--", "--depth"},
+            "repo": {"--json", "--jq", "--repo"},
+            "issue": {"--repo", "--body", "--body-file", "--title", "--search", "--json"},
+        }
+        if len(cmd) < 3 or cmd[2] not in allowed:
+            return None
+        accepted = allowed[cmd[2]]
+        for token in cmd[3:]:
+            if token.startswith("-") and token not in accepted and not token.startswith("--inputs"):
+                return f"unknown flag: {token}"
+        return None
 
     def _run_locked(self, args, *, cwd, check):
         cmd, cwd_path = self._record_command(args, cwd)

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -670,6 +670,11 @@ class FakeRunner(Runner):
             error = self._gh_argv_error(cmd)
             if error is not None:
                 cmd, cwd_path = self._record_command(cmd, cwd)
+                if check:
+                    raise AgentLoopError(
+                        f"Command failed with exit 1: {' '.join(cmd)}\n"
+                        f"stdout:\n\n\nstderr:\n{error}"
+                    )
                 return CommandResult(cmd, cwd_path, "", error, 1)
             return self._run_locked(args, cwd=cwd, check=check)
 

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1,10 +1,12 @@
 import ast
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import coding_review_agent_loop.managed_ci as managed_ci
+import coding_review_agent_loop.orchestrator as orchestrator
 
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import (
@@ -40,6 +42,7 @@ from coding_review_agent_loop.managed_ci import (
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
+from coding_review_agent_loop.orchestrator import _finalize_ordinary_recovery_merge
 from coding_review_agent_loop.runner import CommandResult
 
 from agent_loop_helpers import FakeRunner, make_config
@@ -603,6 +606,57 @@ def test_resume_intent_generation_ignores_historical_same_head_ledger_and_run(tm
     assert contract.nonce != "nonce-1"
     assert contract.attached_run_id is None
     assert any("issues/7/comments" in " ".join(cmd) and "POST" in cmd for cmd, _ in runner.commands)
+
+
+def test_intent_history_malformed_page_fails_closed_instead_of_minting_nonce(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    contract = v2_contract(intent_generation="fresh-generation")
+    runner = V2ManagedRunner(intent_comments=[{"id": 17}, "malformed-entry"])
+
+    with pytest.raises(AgentLoopError, match="Unable to inspect managed-CI v2 intent history"):
+        _ensure_v2_intent(
+            runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract,
+        )
+
+
+def test_ordinary_fallback_readies_draft_then_merges_same_exact_head(tmp_path, monkeypatch):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = V2ManagedRunner(issue_events=[])
+    capability = OrdinaryRecoveryCapability(
+        pr_number=7, repository="OWNER/REPO", base_ref="main", expected_head_sha="abc123",
+        released_label_event_id=None, released_at=100, prior_run_ids=frozenset({2}),
+    )
+    monkeypatch.setattr(orchestrator, "refresh_ordinary_recovery_capability", lambda *args, **kwargs: capability)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_ordinary_recovery",
+        lambda *args, **kwargs: SimpleNamespace(status="passed"),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "get_pr_review_context",
+        lambda *args, **kwargs: SimpleNamespace(metadata=metadata()),
+    )
+    merged: list[tuple[int, str | None]] = []
+    monkeypatch.setattr(
+        orchestrator,
+        "merge_pr",
+        lambda _runner, _config, number, *, expected_head_sha: merged.append((number, expected_head_sha)),
+    )
+
+    _finalize_ordinary_recovery_merge(
+        runner, config=config, pr_number=7, capability=capability,
+    )
+
+    assert any(command[:3] == ["gh", "pr", "ready"] for command, _ in runner.commands)
+    assert merged == [(7, "abc123")]
+
+
+def test_fake_runner_models_gh_parser_failure_when_check_is_true(tmp_path):
+    runner = FakeRunner()
+
+    with pytest.raises(AgentLoopError, match="unknown flag: --slurp"):
+        runner.run(["gh", "api", "--paginate", "--slurp", "repos/OWNER/REPO/issues/7/events"], cwd=tmp_path)
 
 
 def test_ordinary_recovery_rejects_green_checks_without_post_release_run(monkeypatch, tmp_path):
@@ -1491,7 +1545,10 @@ def test_v2_failed_jobs_decodes_concatenated_cli_pages(tmp_path):
 
 
 def test_managed_ci_gh_invocations_obey_the_245_floor():
-    allowed_api_flags = {"--paginate", "--method", "-H", "-f"}
+    allowed_api_flags = {
+        "--paginate", "--method", "-H", "-f", "-F", "--input", "--hostname", "--jq",
+        "--silent", "--verbose",
+    }
     for filename in ("managed_ci.py", "orchestrator.py"):
         path = Path(__file__).parents[1] / "src" / "coding_review_agent_loop" / filename
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -1505,9 +1562,8 @@ def test_managed_ci_gh_invocations_obey_the_245_floor():
                 continue
             values = {elt.value for elt in command.elts if isinstance(elt, ast.Constant) and isinstance(elt.value, str)}
             if "api" in values:
-                assert "--slurp" not in values
-                assert values.isdisjoint({"--hostname", "--cache"})
-                assert values.intersection(allowed_api_flags | {"api"})
+                api_flags = {value for value in values if value.startswith("-")}
+                assert api_flags.issubset(allowed_api_flags)
 
 
 def test_merge_pr_uses_expected_head_guard(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1,4 +1,6 @@
+import ast
 import json
+from pathlib import Path
 
 import pytest
 
@@ -23,6 +25,7 @@ from coding_review_agent_loop.managed_ci import (
     _dispatch_v2_qualification,
     _ensure_v2_intent,
     _v2_failed_jobs,
+    _api_list,
     activate_managed_ci,
     dispatch_final_qualification,
     evaluate_managed_ci_readiness,
@@ -1458,6 +1461,53 @@ def test_v2_failed_jobs_and_ready_merge_recovery(tmp_path):
     )
 
     assert not any(cmd[:3] == ["gh", "pr", "ready"] for cmd, _cwd in runner.commands)
+
+
+def test_paginated_array_response_is_flat_and_malformed_entries_are_unavailable(tmp_path):
+    config = make_config(tmp_path)
+    runner = V2ManagedRunner(issue_events=[label_event()])
+
+    assert _api_list(runner, config, "repos/OWNER/REPO/issues/7/events?per_page=100") == [label_event()]
+    runner.issue_events = [label_event(), ["not an event"]]
+    assert _api_list(runner, config, "repos/OWNER/REPO/issues/7/events?per_page=100") is None
+    assert all("--slurp" not in command for command, _cwd in runner.commands)
+
+
+def test_v2_failed_jobs_decodes_concatenated_cli_pages(tmp_path):
+    class PagedJobsRunner(FakeRunner):
+        def _run_locked(self, args, *, cwd, check):
+            if args and str(args[-1]).endswith("/jobs?filter=latest&per_page=100"):
+                cmd, cwd_path = self._record_command(args, cwd)
+                return CommandResult(
+                    cmd, cwd_path,
+                    '{"jobs":[{"name":"unit","conclusion":"failure"}]}'
+                    '{"jobs":[{"name":"lint","conclusion":"timed_out"}]}',
+                    "", 0,
+                )
+            return super()._run_locked(args, cwd=cwd, check=check)
+
+    details = _v2_failed_jobs(PagedJobsRunner(), config=make_config(tmp_path), run_id=100)
+    assert details == ("unit: failure", "lint: timed_out")
+
+
+def test_managed_ci_gh_invocations_obey_the_245_floor():
+    allowed_api_flags = {"--paginate", "--method", "-H", "-f"}
+    for filename in ("managed_ci.py", "orchestrator.py"):
+        path = Path(__file__).parents[1] / "src" / "coding_review_agent_loop" / filename
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in {"run", "run_with_log"} or not node.args:
+                continue
+            command = node.args[0]
+            if not isinstance(command, ast.List) or not command.elts:
+                continue
+            values = {elt.value for elt in command.elts if isinstance(elt, ast.Constant) and isinstance(elt.value, str)}
+            if "api" in values:
+                assert "--slurp" not in values
+                assert values.isdisjoint({"--hostname", "--cache"})
+                assert values.intersection(allowed_api_flags | {"api"})
 
 
 def test_merge_pr_uses_expected_head_guard(tmp_path):


### PR DESCRIPTION
Fixes #667

## Summary

- Restore GitHub CLI 2.45-compatible managed-CI pagination by removing the unsupported `--slurp` flag and strictly validating flat array responses.
- Decode concatenated workflow-job pages and fail closed on malformed pages or entries.
- Add a shared FakeRunner argv compatibility guard and static audit coverage for managed-CI/orchestrator GitHub CLI calls.
- Document the CLI floor, pagination shapes, and fail-closed recovery ordering semantics.

## Tests

- `timeout 1800s python3 -m pytest tests/test_managed_ci.py tests/test_orchestrator_pr.py` — passed (239 tests)
- `timeout 1800s python3 -m pytest` — passed (2089 tests)
