### PR TITLE
Stop managed-CI polling after cancelled attempts

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1488,14 +1488,25 @@ pre-review `--test-command` passes, agent-loop also publishes the non-required
 without running that command.
 
 After every required reviewer approves one live head, agent-loop dispatches the
-repository's `CI` workflow with the PR number and that exact expected SHA. It
-polls `final-ci/exact-head`, routes a real failure back to the coder, and
-restarts review if the head moves. A passing aggregate is merged with
-`--match-head-commit`, so a different head cannot inherit the approval or CI
-result. The managed label remains in place through merge. The managed route is
-selected independently of `--watch-pending-ci`; neither that flag nor
-`--no-watch-pending-ci` replaces exact-head qualification with an ordinary
-full-board or named-check wait.
+repository's `CI` workflow with the PR number and that exact expected SHA. In
+v2 it polls the exact-head status and the validated nonce/run/attempt together.
+A correlated terminal status is authoritative; a completed workflow without
+that publisher status is confirmed by an immediate re-read and one bounded
+subsequent poll, then stops resumably without synthesizing a status. This
+applies to every workflow conclusion, including cancellation, timeout,
+action-required, success, neutral, skipped, failure, and unknown values—workflow
+success alone never qualifies the head. A real correlated failure routes back
+to the coder, and a moved head restarts review. A passing aggregate is merged
+with `--match-head-commit`, so a different head cannot inherit the approval or
+CI result. The terminal-without-status stop records
+`state=terminal-no-status` and the exact run attempt in the intent ledger; a
+later higher-attempt rerun is accepted, while an unchanged head can also
+dispatch a fresh same-nonce run. If an adopted PR stops this way, its
+invocation-owned managed label is released and the next invocation
+re-adopts/reapplies managed mode. A corrected head requires a fresh exact-head
+review. The managed route is selected independently of `--watch-pending-ci`;
+neither that flag nor `--no-watch-pending-ci` replaces exact-head
+qualification with an ordinary full-board or named-check wait.
 
 #### Managed-CI GitHub CLI compatibility
 

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -125,6 +125,7 @@ class ManagedCiContract:
     intent_state: str | None = None
     terminal_run_id: int | None = None
     terminal_run_attempt: int | None = None
+    terminal_attempts: tuple[tuple[int, int | None], ...] = ()
     activation_path: Literal["managed", "ordinary_fallback"] = "managed"
     ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
 
@@ -1596,6 +1597,10 @@ def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_s
         "run_attempt": contract.run_attempt,
         "terminal_run_id": contract.terminal_run_id,
         "terminal_run_attempt": contract.terminal_run_attempt,
+        "terminal_attempts": [
+            {"run_id": run_id, "run_attempt": run_attempt}
+            for run_id, run_attempt in contract.terminal_attempts
+        ],
     }
     return f"<!-- {INTENT_MARKER} {json.dumps(payload, separators=(',', ':'), sort_keys=True)} -->"
 
@@ -1656,15 +1661,35 @@ def _ensure_v2_intent(
         contract.intent_state = intent.get("state") if isinstance(intent.get("state"), str) else None
         terminal_run_id = intent.get("terminal_run_id")
         terminal_run_attempt = intent.get("terminal_run_attempt")
-        if contract.intent_state == "terminal-no-status":
-            contract.terminal_run_id = (
-                terminal_run_id if isinstance(terminal_run_id, int) else contract.attached_run_id
-            )
-            contract.terminal_run_attempt = (
-                terminal_run_attempt
-                if isinstance(terminal_run_attempt, int)
-                else contract.run_attempt
-            )
+        encoded_attempts = intent.get("terminal_attempts")
+        terminal_attempts: list[tuple[int, int | None]] = []
+        if isinstance(encoded_attempts, list):
+            for encoded in encoded_attempts:
+                if not isinstance(encoded, dict) or not isinstance(encoded.get("run_id"), int):
+                    continue
+                encoded_attempt = encoded.get("run_attempt")
+                terminal_attempts.append(
+                    (encoded["run_id"], encoded_attempt if isinstance(encoded_attempt, int) else None)
+                )
+        if isinstance(terminal_run_id, int) and isinstance(terminal_run_attempt, int):
+            contract.terminal_run_id = terminal_run_id
+            contract.terminal_run_attempt = terminal_run_attempt
+        if contract.intent_state == "terminal-no-status" and not terminal_attempts:
+            if contract.attached_run_id is not None:
+                contract.terminal_run_id = contract.attached_run_id
+                contract.terminal_run_attempt = contract.run_attempt
+        legacy_key = (contract.terminal_run_id, contract.terminal_run_attempt)
+        if legacy_key[0] is not None and legacy_key not in terminal_attempts:
+            terminal_attempts.append((legacy_key[0], legacy_key[1]))
+        contract.terminal_attempts = tuple(terminal_attempts)
+        if (
+            contract.intent_state == "terminal-no-status"
+            and (contract.attached_run_id, contract.run_attempt) in contract.terminal_attempts
+        ):
+            # The attached attempt is the one that already stopped. Leave
+            # discovery responsible for finding a rerun or fresh dispatch.
+            contract.attached_run_id = None
+            contract.run_attempt = None
         return
     contract.nonce = secrets.token_urlsafe(24)
     contract.created_at = int(time.time())
@@ -1727,18 +1752,18 @@ def _discover_v2_snapshot(
                 for run in runs
                 if isinstance(run, dict) and _is_v2_intent_run(run, contract=contract, run_name=run_name)
             ]
-            excluded = None
-            if contract.terminal_run_id is not None:
-                excluded = (contract.terminal_run_id, contract.terminal_run_attempt)
             survivors = [
                 run for run in candidates
                 if include_terminal or run.get("status") != "completed"
                 or run.get("conclusion") != "cancelled"
             ]
-            if excluded is not None:
+            excluded_attempts = set(contract.terminal_attempts)
+            if contract.terminal_run_id is not None:
+                excluded_attempts.add((contract.terminal_run_id, contract.terminal_run_attempt))
+            if excluded_attempts:
                 survivors = [
                     run for run in survivors
-                    if (run.get("id"), run.get("run_attempt")) != excluded
+                    if (run.get("id"), run.get("run_attempt")) not in excluded_attempts
                 ]
             if survivors:
                 newest = sorted(survivors, key=lambda run: (str(run.get("created_at") or ""), int(run.get("id") or 0)))[-1]
@@ -1923,6 +1948,9 @@ def wait_for_final_qualification(
             elif terminal_confirmation_seen:
                 contract.terminal_run_id = run_snapshot.run_id
                 contract.terminal_run_attempt = run_snapshot.run_attempt
+                terminal_key = (run_snapshot.run_id, run_snapshot.run_attempt)
+                if terminal_key not in contract.terminal_attempts:
+                    contract.terminal_attempts += (terminal_key,)
                 _patch_intent(runner, config=config, contract=contract, state="terminal-no-status")
                 return ManagedCiOutcome(
                     status="terminal_without_status", checks=latest, head_sha=live_head,

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -48,6 +48,10 @@ V2_ADOPTION_MARKER = "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION"
 V2_ADOPTION_FEATURE_MARKERS = (V2_ADOPTION_MARKER,)
 RECOVERY_MARKER = "AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1"
 UNPROTECTED_OVERRIDE_TRAILER = "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1"
+_TERMINAL_CI_STATUSES = frozenset({
+    "success", "failure", "error", "cancelled", "timed_out",
+    "action_required", "startup_failure", "stale",
+})
 
 
 @dataclass(frozen=True)
@@ -119,6 +123,8 @@ class ManagedCiContract:
     # dispatch authorization.
     intent_generation: str | None = None
     intent_state: str | None = None
+    terminal_run_id: int | None = None
+    terminal_run_attempt: int | None = None
     activation_path: Literal["managed", "ordinary_fallback"] = "managed"
     ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
 
@@ -1588,6 +1594,8 @@ def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_s
         "state": state,
         "run_id": contract.attached_run_id,
         "run_attempt": contract.run_attempt,
+        "terminal_run_id": contract.terminal_run_id,
+        "terminal_run_attempt": contract.terminal_run_attempt,
     }
     return f"<!-- {INTENT_MARKER} {json.dumps(payload, separators=(',', ':'), sort_keys=True)} -->"
 
@@ -1646,6 +1654,17 @@ def _ensure_v2_intent(
         contract.attached_run_id = intent.get("run_id") if isinstance(intent.get("run_id"), int) else None
         contract.run_attempt = intent.get("run_attempt") if isinstance(intent.get("run_attempt"), int) else None
         contract.intent_state = intent.get("state") if isinstance(intent.get("state"), str) else None
+        terminal_run_id = intent.get("terminal_run_id")
+        terminal_run_attempt = intent.get("terminal_run_attempt")
+        if contract.intent_state == "terminal-no-status":
+            contract.terminal_run_id = (
+                terminal_run_id if isinstance(terminal_run_id, int) else contract.attached_run_id
+            )
+            contract.terminal_run_attempt = (
+                terminal_run_attempt
+                if isinstance(terminal_run_attempt, int)
+                else contract.run_attempt
+            )
         return
     contract.nonce = secrets.token_urlsafe(24)
     contract.created_at = int(time.time())
@@ -1709,8 +1728,8 @@ def _discover_v2_snapshot(
                 if isinstance(run, dict) and _is_v2_intent_run(run, contract=contract, run_name=run_name)
             ]
             excluded = None
-            if contract.intent_state == "terminal-no-status":
-                excluded = (contract.attached_run_id, contract.run_attempt)
+            if contract.terminal_run_id is not None:
+                excluded = (contract.terminal_run_id, contract.terminal_run_attempt)
             survivors = [
                 run for run in candidates
                 if include_terminal or run.get("status") != "completed"
@@ -1780,17 +1799,10 @@ def _refresh_v2_attached_run(
     attempt = run.get("run_attempt")
     return ManagedCiRunSnapshot(
         contract.attached_run_id,
-        attempt if isinstance(attempt, int) else None,
+        attempt if isinstance(attempt, int) else contract.run_attempt,
         run.get("status") if isinstance(run.get("status"), str) else None,
         run.get("conclusion") if isinstance(run.get("conclusion"), str) else None,
     )
-
-
-def _refresh_v2_attached_run_attempt(
-    runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract
-) -> int | None:
-    snapshot = _refresh_v2_attached_run(runner, config=config, contract=contract)
-    return snapshot.run_attempt if snapshot is not None else None
 
 
 def _v2_run_name(contract: ManagedCiContract) -> str:
@@ -1869,10 +1881,9 @@ def wait_for_final_qualification(
                     runner, config=config, contract=contract
                 )
                 if run_snapshot is not None and (
-                    run_snapshot.run_id != contract.attached_run_id
-                    or run_snapshot.run_attempt != contract.run_attempt
+                    run_snapshot.run_attempt is not None
+                    and run_snapshot.run_attempt != contract.run_attempt
                 ):
-                    contract.attached_run_id = run_snapshot.run_id
                     contract.run_attempt = run_snapshot.run_attempt
                     _patch_intent(runner, config=config, contract=contract, state="attached")
             final = _v2_correlated_status(
@@ -1886,10 +1897,7 @@ def wait_for_final_qualification(
             if contract is not None and contract.protocol_version == 2:
                 _patch_intent(runner, config=config, contract=contract, state="completed")
             return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
-        correlated_terminal = final is not None and final.status.lower() in {
-            "success", "failure", "error", "cancelled", "timed_out",
-            "action_required", "startup_failure", "stale",
-        }
+        correlated_terminal = final is not None and final.status.lower() in _TERMINAL_CI_STATUSES
         if (
             contract is not None and contract.protocol_version == 2
             and run_snapshot is not None
@@ -1905,37 +1913,23 @@ def wait_for_final_qualification(
                 final = _v2_correlated_status(
                     runner, config=config, expected_head=expected_head, contract=contract
                 )
-                if final is not None and final.status.lower() in {
-                    "success", "failure", "error", "cancelled", "timed_out",
-                    "action_required", "startup_failure", "stale",
-                }:
+                if final is not None and final.status.lower() in _TERMINAL_CI_STATUSES:
                     status = final.status.lower()
                     if status == "success":
                         _patch_intent(runner, config=config, contract=contract, state="completed")
                         return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
                 else:
                     terminal_confirmation_seen = True
-                if final is not None and final.status.lower() not in {
-                    "success", "failure", "error", "cancelled", "timed_out",
-                    "action_required", "startup_failure", "stale",
-                }:
-                    terminal_confirmation_seen = True
             elif terminal_confirmation_seen:
+                contract.terminal_run_id = run_snapshot.run_id
+                contract.terminal_run_attempt = run_snapshot.run_attempt
                 _patch_intent(runner, config=config, contract=contract, state="terminal-no-status")
                 return ManagedCiOutcome(
                     status="terminal_without_status", checks=latest, head_sha=live_head,
                     run_id=run_snapshot.run_id, run_attempt=run_snapshot.run_attempt,
                     workflow_status=run_snapshot.status, workflow_conclusion=run_snapshot.conclusion,
                 )
-        if status in {
-            "failure",
-            "error",
-            "cancelled",
-            "timed_out",
-            "action_required",
-            "startup_failure",
-            "stale",
-        }:
+        if status in _TERMINAL_CI_STATUSES - {"success"}:
             details = ()
             if contract is not None and contract.protocol_version == 2:
                 _patch_intent(runner, config=config, contract=contract, state="completed")

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -118,6 +118,7 @@ class ManagedCiContract:
     # comments remain diagnostic history and are never adopted as this run's
     # dispatch authorization.
     intent_generation: str | None = None
+    intent_state: str | None = None
     activation_path: Literal["managed", "ordinary_fallback"] = "managed"
     ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
 
@@ -154,12 +155,25 @@ class ManagedCiOutcome:
         "head_changed",
         "merge_conflict",
         "infrastructure_stall",
+        "terminal_without_status",
     ]
     checks: PullRequestChecks | None = None
     mergeability: PullRequestMergeability | None = None
     head_sha: str | None = None
     stall: CiInfrastructureStall | None = None
     failure_details: tuple[str, ...] = ()
+    run_id: int | None = None
+    run_attempt: int | None = None
+    workflow_status: str | None = None
+    workflow_conclusion: str | None = None
+
+
+@dataclass(frozen=True)
+class ManagedCiRunSnapshot:
+    run_id: int
+    run_attempt: int | None
+    status: str | None
+    conclusion: str | None
 
 
 def activate_managed_ci(
@@ -1631,6 +1645,7 @@ def _ensure_v2_intent(
         contract.created_at = intent.get("created_at") if isinstance(intent.get("created_at"), int) else None
         contract.attached_run_id = intent.get("run_id") if isinstance(intent.get("run_id"), int) else None
         contract.run_attempt = intent.get("run_attempt") if isinstance(intent.get("run_attempt"), int) else None
+        contract.intent_state = intent.get("state") if isinstance(intent.get("state"), str) else None
         return
     contract.nonce = secrets.token_urlsafe(24)
     contract.created_at = int(time.time())
@@ -1648,6 +1663,7 @@ def _ensure_v2_intent(
     if not isinstance(payload.get("id"), int):
         raise AgentLoopError("Managed-CI intent comment was created without an ID.")
     contract.intent_comment_id = payload["id"]
+    contract.intent_state = "prepared"
 
 
 def _patch_intent(runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract, state: str) -> None:
@@ -1667,9 +1683,13 @@ def _patch_intent(runner: Runner, *, config: AgentLoopConfig, contract: ManagedC
     )
     if updated.returncode != 0:
         raise AgentLoopError("Unable to persist managed-CI v2 intent state.")
+    contract.intent_state = state
 
 
-def _discover_v2_run(runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract, retries: int) -> tuple[int, int | None] | None:
+def _discover_v2_snapshot(
+    runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract,
+    retries: int, include_terminal: bool = False,
+) -> ManagedCiRunSnapshot | None:
     if not contract.nonce:
         return None
     run_name = _v2_run_name(contract)
@@ -1688,21 +1708,47 @@ def _discover_v2_run(runner: Runner, *, config: AgentLoopConfig, contract: Manag
                 for run in runs
                 if isinstance(run, dict) and _is_v2_intent_run(run, contract=contract, run_name=run_name)
             ]
-            survivors = [run for run in candidates if run.get("status") != "completed" or run.get("conclusion") != "cancelled"]
+            excluded = None
+            if contract.intent_state == "terminal-no-status":
+                excluded = (contract.attached_run_id, contract.run_attempt)
+            survivors = [
+                run for run in candidates
+                if include_terminal or run.get("status") != "completed"
+                or run.get("conclusion") != "cancelled"
+            ]
+            if excluded is not None:
+                survivors = [
+                    run for run in survivors
+                    if (run.get("id"), run.get("run_attempt")) != excluded
+                ]
             if survivors:
                 newest = sorted(survivors, key=lambda run: (str(run.get("created_at") or ""), int(run.get("id") or 0)))[-1]
                 rid = newest.get("id")
                 if isinstance(rid, int):
                     attempt_no = newest.get("run_attempt")
-                    return rid, attempt_no if isinstance(attempt_no, int) else None
+                    return ManagedCiRunSnapshot(
+                        rid,
+                        attempt_no if isinstance(attempt_no, int) else None,
+                        newest.get("status") if isinstance(newest.get("status"), str) else None,
+                        newest.get("conclusion") if isinstance(newest.get("conclusion"), str) else None,
+                    )
         if attempt < retries - 1:
             runner.run(["sleep", str(min(config.ci_poll_interval_seconds, 2))], cwd=active_workdir(config))
     return None
 
 
-def _refresh_v2_attached_run_attempt(
+def _discover_v2_run(
+    runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract, retries: int,
+) -> tuple[int, int | None] | None:
+    snapshot = _discover_v2_snapshot(
+        runner, config=config, contract=contract, retries=retries, include_terminal=False
+    )
+    return (snapshot.run_id, snapshot.run_attempt) if snapshot is not None else None
+
+
+def _refresh_v2_attached_run(
     runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract
-) -> int | None:
+) -> ManagedCiRunSnapshot | None:
     """Read the current attempt for the already-attached workflow run.
 
     GitHub increments ``run_attempt`` when a run is re-run.  The run ID remains
@@ -1732,7 +1778,19 @@ def _refresh_v2_attached_run_attempt(
     if not _is_v2_intent_run(run, contract=contract, run_name=run_name):
         return None
     attempt = run.get("run_attempt")
-    return attempt if isinstance(attempt, int) else None
+    return ManagedCiRunSnapshot(
+        contract.attached_run_id,
+        attempt if isinstance(attempt, int) else None,
+        run.get("status") if isinstance(run.get("status"), str) else None,
+        run.get("conclusion") if isinstance(run.get("conclusion"), str) else None,
+    )
+
+
+def _refresh_v2_attached_run_attempt(
+    runner: Runner, *, config: AgentLoopConfig, contract: ManagedCiContract
+) -> int | None:
+    snapshot = _refresh_v2_attached_run(runner, config=config, contract=contract)
+    return snapshot.run_attempt if snapshot is not None else None
 
 
 def _v2_run_name(contract: ManagedCiContract) -> str:
@@ -1782,6 +1840,8 @@ def wait_for_final_qualification(
         raise AgentLoopError(f"PR #{pr_number} has no approved head SHA.")
     attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
     latest: PullRequestChecks | None = None
+    terminal_confirmation: tuple[int, int | None] | None = None
+    terminal_confirmation_seen = False
     for attempt in range(attempts):
         live_head = get_pr_head_sha(runner, config, pr_number)
         if live_head != expected_head:
@@ -1795,18 +1855,25 @@ def wait_for_final_qualification(
                 head_sha=live_head,
             )
         latest = get_pr_checks(runner, config=config, metadata=metadata)
+        run_snapshot: ManagedCiRunSnapshot | None = None
         if contract is not None and contract.protocol_version == 2:
             if contract.attached_run_id is None:
-                attached = _discover_v2_run(runner, config=config, contract=contract, retries=1)
-                if attached is not None:
-                    contract.attached_run_id, contract.run_attempt = attached
+                run_snapshot = _discover_v2_snapshot(
+                    runner, config=config, contract=contract, retries=1, include_terminal=True
+                )
+                if run_snapshot is not None:
+                    contract.attached_run_id, contract.run_attempt = run_snapshot.run_id, run_snapshot.run_attempt
                     _patch_intent(runner, config=config, contract=contract, state="attached")
             else:
-                current_attempt = _refresh_v2_attached_run_attempt(
+                run_snapshot = _refresh_v2_attached_run(
                     runner, config=config, contract=contract
                 )
-                if current_attempt is not None and current_attempt != contract.run_attempt:
-                    contract.run_attempt = current_attempt
+                if run_snapshot is not None and (
+                    run_snapshot.run_id != contract.attached_run_id
+                    or run_snapshot.run_attempt != contract.run_attempt
+                ):
+                    contract.attached_run_id = run_snapshot.run_id
+                    contract.run_attempt = run_snapshot.run_attempt
                     _patch_intent(runner, config=config, contract=contract, state="attached")
             final = _v2_correlated_status(
                 runner, config=config, expected_head=expected_head, contract=contract
@@ -1819,6 +1886,47 @@ def wait_for_final_qualification(
             if contract is not None and contract.protocol_version == 2:
                 _patch_intent(runner, config=config, contract=contract, state="completed")
             return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
+        correlated_terminal = final is not None and final.status.lower() in {
+            "success", "failure", "error", "cancelled", "timed_out",
+            "action_required", "startup_failure", "stale",
+        }
+        if (
+            contract is not None and contract.protocol_version == 2
+            and run_snapshot is not None
+            and (run_snapshot.status or "").lower() == "completed"
+            and not correlated_terminal
+        ):
+            key = (run_snapshot.run_id, run_snapshot.run_attempt)
+            if key != terminal_confirmation:
+                terminal_confirmation = key
+                terminal_confirmation_seen = False
+                # A publisher may race the workflow's completed transition. Re-read
+                # immediately before starting the bounded confirmation window.
+                final = _v2_correlated_status(
+                    runner, config=config, expected_head=expected_head, contract=contract
+                )
+                if final is not None and final.status.lower() in {
+                    "success", "failure", "error", "cancelled", "timed_out",
+                    "action_required", "startup_failure", "stale",
+                }:
+                    status = final.status.lower()
+                    if status == "success":
+                        _patch_intent(runner, config=config, contract=contract, state="completed")
+                        return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
+                else:
+                    terminal_confirmation_seen = True
+                if final is not None and final.status.lower() not in {
+                    "success", "failure", "error", "cancelled", "timed_out",
+                    "action_required", "startup_failure", "stale",
+                }:
+                    terminal_confirmation_seen = True
+            elif terminal_confirmation_seen:
+                _patch_intent(runner, config=config, contract=contract, state="terminal-no-status")
+                return ManagedCiOutcome(
+                    status="terminal_without_status", checks=latest, head_sha=live_head,
+                    run_id=run_snapshot.run_id, run_attempt=run_snapshot.run_attempt,
+                    workflow_status=run_snapshot.status, workflow_conclusion=run_snapshot.conclusion,
+                )
         if status in {
             "failure",
             "error",

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -7314,16 +7314,6 @@ def run_pr_loop(
                                     "review so a new ledger is created/used."
                                 )
                                 post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-                                post_pr_comment(
-                                    runner,
-                                    config=config,
-                                    pr_number=pr_number,
-                                    body=(
-                                        f"PR #{pr_number} qualification stopped at terminal workflow state "
-                                        f"`{conclusion}` without `{FINAL_CONTEXT}` publication; rerun after a "
-                                        "legitimate higher-attempt rerun or fresh same-nonce dispatch."
-                                    ),
-                                )
                                 log(
                                     config,
                                     f"Round {round_number}: managed CI reached terminal state without "

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -101,6 +101,7 @@ from .evidence_reconciliation import (
 )
 from .memory import AgentMemoryContext, prepare_agent_memory
 from .managed_ci import (
+    FINAL_CONTEXT,
     MANAGED_LABEL,
     OrdinaryRecoveryCapability,
     activate_managed_ci,
@@ -7293,6 +7294,46 @@ def run_pr_loop(
                                     f"({'; '.join(_ci_infrastructure_details(managed_outcome.stall))}). "
                                     "No merge was attempted; rerun the same command once GitHub Actions "
                                     "runners recover."
+                                )
+                                return 0
+                            elif managed_outcome.status == "terminal_without_status":
+                                conclusion = managed_outcome.workflow_conclusion or "unknown"
+                                attempt_text = (
+                                    f"run `{managed_outcome.run_id}` attempt `{managed_outcome.run_attempt}`"
+                                    if managed_outcome.run_id is not None
+                                    else "the correlated managed-CI attempt"
+                                )
+                                body = (
+                                    f"PR #{pr_number} managed exact-head CI stopped because {attempt_text} "
+                                    f"reached terminal workflow state `{conclusion}` without publishing a "
+                                    f"correlated `{FINAL_CONTEXT}` status. No terminal status was synthesized "
+                                    "and no merge was attempted.\n\n"
+                                    "The round is resumable: for the unchanged head, rerun the command after "
+                                    "a legitimate GitHub rerun creates a higher attempt, or rerun it to dispatch "
+                                    "a fresh eligible same-nonce run. If the head was corrected, restart exact-head "
+                                    "review so a new ledger is created/used."
+                                )
+                                post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+                                post_pr_comment(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    body=(
+                                        f"PR #{pr_number} qualification stopped at terminal workflow state "
+                                        f"`{conclusion}` without `{FINAL_CONTEXT}` publication; rerun after a "
+                                        "legitimate higher-attempt rerun or fresh same-nonce dispatch."
+                                    ),
+                                )
+                                log(
+                                    config,
+                                    f"Round {round_number}: managed CI reached terminal state without "
+                                    "publishing the correlated exact-head status; no merge attempted",
+                                )
+                                print(
+                                    f"PR #{pr_number} managed exact-head CI reached terminal workflow state "
+                                    f"`{conclusion}` without publishing its correlated status. No merge was "
+                                    "attempted; rerun after a legitimate GitHub rerun or fresh same-nonce "
+                                    "dispatch (or restart review if the head changed)."
                                 )
                                 return 0
                             elif managed_outcome.status == "failed":

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -103,6 +103,7 @@ from .memory import AgentMemoryContext, prepare_agent_memory
 from .managed_ci import (
     FINAL_CONTEXT,
     MANAGED_LABEL,
+    ManagedCiOutcome,
     OrdinaryRecoveryCapability,
     activate_managed_ci,
     dispatch_final_qualification,
@@ -5713,6 +5714,45 @@ def _finalize_ordinary_recovery_merge(
         raise
 
 
+def _stop_on_terminal_without_status(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    round_number: int,
+    outcome: ManagedCiOutcome,
+) -> int:
+    conclusion = outcome.workflow_conclusion or "unknown"
+    attempt_text = (
+        f"run `{outcome.run_id}` attempt `{outcome.run_attempt}`"
+        if outcome.run_id is not None
+        else "the correlated managed-CI attempt"
+    )
+    body = (
+        f"PR #{pr_number} managed exact-head CI stopped because {attempt_text} "
+        f"reached terminal workflow state `{conclusion}` without publishing a "
+        f"correlated `{FINAL_CONTEXT}` status. No terminal status was synthesized "
+        "and no merge was attempted.\n\n"
+        "The round is resumable: for the unchanged head, rerun the command after "
+        "a legitimate GitHub rerun creates a higher attempt, or rerun it to dispatch "
+        "a fresh eligible same-nonce run. If the head was corrected, restart exact-head "
+        "review so a new ledger is created/used."
+    )
+    post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+    log(
+        config,
+        f"Round {round_number}: managed CI reached terminal state without "
+        "publishing the correlated exact-head status; no merge attempted",
+    )
+    print(
+        f"PR #{pr_number} managed exact-head CI reached terminal workflow state "
+        f"`{conclusion}` without publishing its correlated status. No merge was "
+        "attempted; rerun after a legitimate GitHub rerun or fresh same-nonce "
+        "dispatch (or restart review if the head changed)."
+    )
+    return 0
+
+
 def run_pr_loop(
     runner: Runner,
     *,
@@ -7297,35 +7337,13 @@ def run_pr_loop(
                                 )
                                 return 0
                             elif managed_outcome.status == "terminal_without_status":
-                                conclusion = managed_outcome.workflow_conclusion or "unknown"
-                                attempt_text = (
-                                    f"run `{managed_outcome.run_id}` attempt `{managed_outcome.run_attempt}`"
-                                    if managed_outcome.run_id is not None
-                                    else "the correlated managed-CI attempt"
+                                return _stop_on_terminal_without_status(
+                                    runner,
+                                    config=config,
+                                    pr_number=pr_number,
+                                    round_number=round_number,
+                                    outcome=managed_outcome,
                                 )
-                                body = (
-                                    f"PR #{pr_number} managed exact-head CI stopped because {attempt_text} "
-                                    f"reached terminal workflow state `{conclusion}` without publishing a "
-                                    f"correlated `{FINAL_CONTEXT}` status. No terminal status was synthesized "
-                                    "and no merge was attempted.\n\n"
-                                    "The round is resumable: for the unchanged head, rerun the command after "
-                                    "a legitimate GitHub rerun creates a higher attempt, or rerun it to dispatch "
-                                    "a fresh eligible same-nonce run. If the head was corrected, restart exact-head "
-                                    "review so a new ledger is created/used."
-                                )
-                                post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
-                                log(
-                                    config,
-                                    f"Round {round_number}: managed CI reached terminal state without "
-                                    "publishing the correlated exact-head status; no merge attempted",
-                                )
-                                print(
-                                    f"PR #{pr_number} managed exact-head CI reached terminal workflow state "
-                                    f"`{conclusion}` without publishing its correlated status. No merge was "
-                                    "attempted; rerun after a legitimate GitHub rerun or fresh same-nonce "
-                                    "dispatch (or restart review if the head changed)."
-                                )
-                                return 0
                             elif managed_outcome.status == "failed":
                                 details = (
                                     list(managed_outcome.failure_details)

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1273,7 +1273,7 @@ def test_v2_later_legitimate_rerun_attempt_is_accepted_after_terminal_stop(tmp_p
     runner = V2ManagedRunner(
         workflow_runs=[
             v2_run(run_id=100, attempt=2, status="completed", conclusion="success"),
-            v2_run(run_id=100, attempt=1, status="completed", conclusion="cancelled"),
+            v2_run(run_id=100, attempt=1, status="completed", conclusion="timed_out"),
         ],
         intent_comments=[v2_intent_comment(
             run_id=100, run_attempt=1, state="terminal-no-status",
@@ -1300,6 +1300,28 @@ def test_v2_later_legitimate_rerun_attempt_is_accepted_after_terminal_stop(tmp_p
     assert outcome.status == "passed"
     assert (contract.attached_run_id, contract.run_attempt) == (100, 2)
     assert contract.terminal_run_attempt == 1
+
+
+def test_v2_waiter_excludes_prior_non_cancelled_terminal_attempt(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1)
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(run_id=100, attempt=1, status="completed", conclusion="timed_out")],
+        pr_status_payload={"statuses": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = v2_contract(
+        terminal_run_id=100,
+        terminal_run_attempt=1,
+        terminal_attempts=((100, 1),),
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "timeout"
+    assert contract.attached_run_id is None
+    assert not any('"state":"attached"' in " ".join(command) for command, _cwd in runner.commands)
 
 
 def test_v2_refresh_keeps_known_attempt_when_payload_omits_run_attempt(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -42,7 +42,10 @@ from coding_review_agent_loop.managed_ci import (
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
-from coding_review_agent_loop.orchestrator import _finalize_ordinary_recovery_merge
+from coding_review_agent_loop.orchestrator import (
+    _finalize_ordinary_recovery_merge,
+    _stop_on_terminal_without_status,
+)
 from coding_review_agent_loop.runner import CommandResult
 
 from agent_loop_helpers import FakeRunner, make_config
@@ -764,6 +767,7 @@ def v2_run(
 def v2_intent_comment(
     *, nonce="nonce-1", run_id=None, run_attempt=None, state=None,
     terminal_run_id=None, terminal_run_attempt=None,
+    terminal_attempts=None,
 ):
     payload = {
         "repository": "OWNER/REPO",
@@ -780,6 +784,11 @@ def v2_intent_comment(
         payload["terminal_run_id"] = terminal_run_id
     if terminal_run_attempt is not None:
         payload["terminal_run_attempt"] = terminal_run_attempt
+    if terminal_attempts is not None:
+        payload["terminal_attempts"] = [
+            {"run_id": run_id, "run_attempt": attempt}
+            for run_id, attempt in terminal_attempts
+        ]
     return {
         "id": 17,
         "user": {"login": "agent-loop", "id": 1},
@@ -1146,6 +1155,26 @@ def test_v2_completed_run_without_publisher_status_stops_and_records_ledger(tmp_
     )
 
 
+def test_orchestrator_terminal_without_status_posts_resumable_diagnostic(tmp_path, capsys):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = V2ManagedRunner()
+    outcome = managed_ci.ManagedCiOutcome(
+        status="terminal_without_status",
+        run_id=100,
+        run_attempt=1,
+        workflow_conclusion="cancelled",
+    )
+
+    assert _stop_on_terminal_without_status(
+        runner, config=config, pr_number=7, round_number=2, outcome=outcome
+    ) == 0
+    assert len(runner.comments) == 1
+    assert "terminal workflow state `cancelled`" in runner.comments[0]
+    assert "No terminal status was synthesized" in runner.comments[0]
+    assert "higher attempt" in runner.comments[0]
+    assert "terminal workflow state `cancelled`" in capsys.readouterr().out
+
+
 def test_v2_cancelled_run_during_candidate_jobs_stops_without_publishing_status(tmp_path, monkeypatch):
     config = make_config(
         tmp_path, auto_merge=True, ci_timeout_seconds=2, ci_poll_interval_seconds=1
@@ -1192,6 +1221,50 @@ def test_v2_terminal_exclusion_does_not_attach_stale_cancelled_run(tmp_path):
 
     assert (contract.attached_run_id, contract.run_attempt) == (101, 1)
     assert contract.intent_state == "attached"
+    assert not any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
+
+
+def test_v2_terminal_ledger_clears_old_attachment_before_fresh_dispatch(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(run_id=100, attempt=1, status="completed", conclusion="cancelled")],
+        intent_comments=[v2_intent_comment(
+            run_id=100, run_attempt=1, state="terminal-no-status",
+            terminal_run_id=100, terminal_run_attempt=1,
+        )],
+    )
+    contract = v2_contract()
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert contract.attached_run_id is None
+    assert contract.run_attempt is None
+    assert any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
+
+
+def test_v2_terminal_ledger_excludes_all_prior_cancelled_attempts(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(
+        workflow_runs=[
+            v2_run(run_id=100, attempt=2, status="completed", conclusion="cancelled"),
+            v2_run(run_id=100, attempt=1, status="completed", conclusion="cancelled"),
+            v2_run(run_id=101, attempt=1, status="in_progress", conclusion=None),
+        ],
+        intent_comments=[v2_intent_comment(
+            run_id=100, run_attempt=2, state="terminal-no-status",
+            terminal_run_id=100, terminal_run_attempt=2,
+            terminal_attempts=((100, 1), (100, 2)),
+        )],
+    )
+    contract = v2_contract()
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert (contract.attached_run_id, contract.run_attempt) == (101, 1)
     assert not any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
 
 

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1100,6 +1100,69 @@ def test_v2_qualification_accepts_only_attached_run_status(tmp_path):
     assert outcome.status == "passed"
 
 
+def test_v2_completed_run_without_publisher_status_stops_and_records_ledger(tmp_path, monkeypatch):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=2, ci_poll_interval_seconds=1
+    )
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(status="completed", conclusion="cancelled")],
+        pr_payload={"headRefOid": "abc123", "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+        pr_status_payload={"statuses": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = v2_contract(
+        attached_run_id=100, run_attempt=1, intent_comment_id=17,
+        pr_number=7, expected_head_sha="abc123",
+    )
+    monkeypatch.setattr(
+        managed_ci, "_v2_correlated_status", lambda *args, **kwargs: None
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "terminal_without_status"
+    assert (outcome.run_id, outcome.run_attempt) == (100, 1)
+    assert outcome.workflow_conclusion == "cancelled"
+    assert contract.intent_state == "terminal-no-status"
+    assert any(
+        '"state":"terminal-no-status"' in " ".join(command)
+        for command, _cwd in runner.commands
+        if "/issues/comments/17" in " ".join(command)
+    )
+    assert not any(
+        "/statuses/abc123" in " ".join(command) and "POST" in command
+        for command, _cwd in runner.commands
+    )
+
+
+def test_v2_completed_run_failure_race_accepts_late_correlated_status(tmp_path, monkeypatch):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=2, ci_poll_interval_seconds=1
+    )
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(status="completed", conclusion="failure")],
+        jobs=[{"name": "unit", "conclusion": "failure"}],
+        pr_payload={"headRefOid": "abc123", "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+    )
+    contract = v2_contract(attached_run_id=100, run_attempt=1)
+    failure = PullRequestCheck(
+        name=FINAL_CONTEXT, kind="status_context", status="failure",
+        run_id="100", description="nonce=nonce-1;run_id=100;attempt=1",
+    )
+    responses = iter([None, failure])
+    monkeypatch.setattr(
+        managed_ci, "_v2_correlated_status", lambda *args, **kwargs: next(responses)
+    )
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "failed"
+
+
 def test_v2_qualification_rejects_numeric_prefix_tokens_and_run_url(tmp_path):
     config = make_config(
         tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -761,7 +761,10 @@ def v2_run(
     }
 
 
-def v2_intent_comment(*, nonce="nonce-1", run_id=None, run_attempt=None):
+def v2_intent_comment(
+    *, nonce="nonce-1", run_id=None, run_attempt=None, state=None,
+    terminal_run_id=None, terminal_run_attempt=None,
+):
     payload = {
         "repository": "OWNER/REPO",
         "pr": 7,
@@ -771,6 +774,12 @@ def v2_intent_comment(*, nonce="nonce-1", run_id=None, run_attempt=None):
         "run_id": run_id,
         "run_attempt": run_attempt,
     }
+    if state is not None:
+        payload["state"] = state
+    if terminal_run_id is not None:
+        payload["terminal_run_id"] = terminal_run_id
+    if terminal_run_attempt is not None:
+        payload["terminal_run_attempt"] = terminal_run_attempt
     return {
         "id": 17,
         "user": {"login": "agent-loop", "id": 1},
@@ -1135,6 +1144,114 @@ def test_v2_completed_run_without_publisher_status_stops_and_records_ledger(tmp_
         "/statuses/abc123" in " ".join(command) and "POST" in command
         for command, _cwd in runner.commands
     )
+
+
+def test_v2_cancelled_run_during_candidate_jobs_stops_without_publishing_status(tmp_path, monkeypatch):
+    config = make_config(
+        tmp_path, auto_merge=True, ci_timeout_seconds=2, ci_poll_interval_seconds=1
+    )
+    runner = V2ManagedRunner(
+        workflow_runs=[v2_run(status="completed", conclusion="cancelled")],
+        jobs=[{"name": "candidate", "conclusion": "cancelled"}],
+        pr_payload={"headRefOid": "abc123", "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+        pr_status_payload={"statuses": []},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = v2_contract(
+        attached_run_id=100, run_attempt=1, intent_comment_id=17,
+        pr_number=7, expected_head_sha="abc123",
+    )
+    monkeypatch.setattr(managed_ci, "_v2_correlated_status", lambda *args, **kwargs: None)
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "terminal_without_status"
+    assert outcome.workflow_conclusion == "cancelled"
+    assert (contract.terminal_run_id, contract.terminal_run_attempt) == (100, 1)
+
+
+def test_v2_terminal_exclusion_does_not_attach_stale_cancelled_run(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, managed_ci_trusted_actor="agent-loop")
+    runner = V2ManagedRunner(
+        workflow_runs=[
+            v2_run(run_id=100, attempt=1, status="completed", conclusion="cancelled"),
+            v2_run(run_id=101, attempt=1, status="in_progress", conclusion=None),
+        ],
+        intent_comments=[v2_intent_comment(
+            run_id=100, run_attempt=1, state="terminal-no-status",
+            terminal_run_id=100, terminal_run_attempt=1,
+        )],
+    )
+    contract = v2_contract()
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert (contract.attached_run_id, contract.run_attempt) == (101, 1)
+    assert contract.intent_state == "attached"
+    assert not any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
+
+
+def test_v2_later_legitimate_rerun_attempt_is_accepted_after_terminal_stop(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1)
+    runner = V2ManagedRunner(
+        workflow_runs=[
+            v2_run(run_id=100, attempt=2, status="completed", conclusion="success"),
+            v2_run(run_id=100, attempt=1, status="completed", conclusion="cancelled"),
+        ],
+        intent_comments=[v2_intent_comment(
+            run_id=100, run_attempt=1, state="terminal-no-status",
+            terminal_run_id=100, terminal_run_attempt=1,
+        )],
+        pr_status_payload={"statuses": [{
+            "context": FINAL_CONTEXT,
+            "state": "success",
+            "description": "nonce=nonce-1;run_id=100;attempt=2",
+            "target_url": "https://github.com/OWNER/REPO/actions/runs/100",
+            "creator": {"login": "github-actions[bot]", "id": 41898282},
+        }]},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = v2_contract()
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "passed"
+    assert (contract.attached_run_id, contract.run_attempt) == (100, 2)
+    assert contract.terminal_run_attempt == 1
+
+
+def test_v2_refresh_keeps_known_attempt_when_payload_omits_run_attempt(tmp_path):
+    config = make_config(tmp_path, auto_merge=True, ci_timeout_seconds=1, ci_poll_interval_seconds=1)
+    run = v2_run(run_id=100, attempt=1)
+    del run["run_attempt"]
+    runner = V2ManagedRunner(
+        workflow_runs=[run],
+        pr_status_payload={"statuses": [{
+            "context": FINAL_CONTEXT,
+            "state": "success",
+            "description": "nonce=nonce-1;run_id=100;attempt=1",
+            "target_url": "https://github.com/OWNER/REPO/actions/runs/100",
+            "creator": {"login": "github-actions[bot]", "id": 41898282},
+        }]},
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT], "checks": []},
+    )
+    contract = v2_contract(attached_run_id=100, run_attempt=1)
+
+    outcome = wait_for_final_qualification(
+        runner, config=config, pr_number=7, metadata=metadata(), contract=contract
+    )
+
+    assert outcome.status == "passed"
+    assert contract.run_attempt == 1
 
 
 def test_v2_completed_run_failure_race_accepts_late_correlated_status(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #666

## Summary
- correlate the latest validated managed-CI workflow attempt with exact-head publisher status
- stop resumably when a completed attempt has no correlated terminal status after bounded confirmation
- persist terminal-no-status ledger state and preserve rerun/fresh-dispatch correlation safeguards
- cover cancellation, publication races, orchestration stop behavior, and document recovery

## Tests
- `python3 -m pytest -q tests/test_managed_ci.py tests/test_orchestrator_pr.py`
- `timeout 1800s python3 -m pytest`