### PR TITLE
Harden subprocess logs and managed-CI status correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,9 +916,10 @@ The remaining legacy compatibility surface is intentional:
 
 Active subprocess captures are written to a unique directory under the local
 agent-loop cache, outside every managed checkout. Use `--subprocess-log-dir`
-to override it; an override equal to or nested inside a managed checkout is
+to override it; relative overrides are resolved from the primary agent
+directory, and an override equal to or nested inside a managed checkout is
 rejected. Capture directories are leased for the life of the invocation and
-old, unlocked directories are pruned by age. `--log-dir` remains the location
+old, unlocked tool-owned directories are pruned by age. `--log-dir` remains the location
 for salvage and usage artifacts, preserving discovery of legacy
 `.agent-loop-logs/` data. Long-running agents print heartbeat lines with the exact log
 path. GitHub comments come from validated public response files under

--- a/README.md
+++ b/README.md
@@ -914,8 +914,13 @@ The remaining legacy compatibility surface is intentional:
 - Resume reconstruction should not depend on reparsing old prose once
   `AGENT_LOOP_META` exists for the active structured-response round.
 
-Agent subprocess logs are written under `.agent-loop-logs/` in the active
-checkout, and long-running agents print heartbeat lines with the exact log
+Active subprocess captures are written to a unique directory under the local
+agent-loop cache, outside every managed checkout. Use `--subprocess-log-dir`
+to override it; an override equal to or nested inside a managed checkout is
+rejected. Capture directories are leased for the life of the invocation and
+old, unlocked directories are pruned by age. `--log-dir` remains the location
+for salvage and usage artifacts, preserving discovery of legacy
+`.agent-loop-logs/` data. Long-running agents print heartbeat lines with the exact log
 path. GitHub comments come from validated public response files under
 `/tmp/coding-review-agent-loop/responses/...` or validated fallback stdout, not
 from raw logs. If an agent looks stuck or returns diagnostics, inspect the

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1378,7 +1378,8 @@ exact tokens (in any order):
 nonce=<managed_nonce>;run_id=<github.run_id>;attempt=<github.run_attempt>
 ```
 
-Its `target_url` must end in `/actions/runs/<github.run_id>`. Agent-loop
+Its `target_url` path must end in `/actions/runs/<github.run_id>` (the host may
+be github.com or a GitHub Enterprise Server hostname). Agent-loop
 matches each token and the final URL path segment exactly; a matching prefix,
 another run, or an earlier rerun attempt is not accepted. The publisher should
 run under `github-actions[bot]` (or the configured trusted actor when posting
@@ -2053,7 +2054,8 @@ of being posted to GitHub.
 
 Active subprocess captures default to a unique directory under the agent-loop
 cache, outside managed checkouts. `--subprocess-log-dir` selects an explicit
-capture root, but paths equal to or beneath a managed checkout are rejected.
+capture root; relative values are resolved from the primary agent directory,
+and paths equal to or beneath a managed checkout are rejected.
 Invocation directories hold a lifetime lease; cleanup removes only old,
 unlocked directories on a best-effort basis. `--log-dir` remains the legacy
 root for usage summaries and salvage artifacts, and old checkout-resident logs

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -2051,6 +2051,14 @@ file is the public answer the orchestrator will validate and post. Empty
 response files, missing markers, or diagnostics-only stdout fail locally instead
 of being posted to GitHub.
 
+Active subprocess captures default to a unique directory under the agent-loop
+cache, outside managed checkouts. `--subprocess-log-dir` selects an explicit
+capture root, but paths equal to or beneath a managed checkout are rejected.
+Invocation directories hold a lifetime lease; cleanup removes only old,
+unlocked directories on a best-effort basis. `--log-dir` remains the legacy
+root for usage summaries and salvage artifacts, and old checkout-resident logs
+are not migrated or rediscovered as active captures.
+
 When a mutating coder implementation run reaches a terminal failure with a
 non-empty tracked diff, the orchestrator writes local salvage artifacts under
 `<log_dir>/salvage/<run>-<agent>-<scope>/`. That directory contains

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -332,6 +332,7 @@ def main() -> None:
         ci_poll_interval_seconds=30,
         quiet=False,
         log_dir=log_dir,
+        subprocess_log_dir=log_dir,
         progress_interval_seconds=30,
         agent_max_retries=0,
         agent_retry_backoff_seconds=(30,),

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -453,6 +453,7 @@ class AntigravityBackend:
             # This single-model backend reports the model it requested; the
             # caller's attempt state advances to a fallback model if needed.
             model_used=model,
+            command_result=result,
         )
 
     def run_repair(

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -323,6 +323,7 @@ class CodexBackend:
                 usage=usage,
                 raw_usage=raw_usage,
                 model_used=model_used,
+                command_result=result,
             )
         finally:
             try:

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -279,6 +279,7 @@ class GeminiBackend:
             usage=usage,
             raw_usage=raw_usage,
             model_used=config.gemini_model or None,
+            command_result=result,
         )
 
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -393,7 +393,16 @@ def build_parser() -> argparse.ArgumentParser:
             "--log-dir",
             type=Path,
             default=Path(".agent-loop-logs"),
-            help="Directory for agent subprocess logs (default: .agent-loop-logs).",
+            help="Directory for salvage and usage artifacts (default: .agent-loop-logs).",
+        )
+        subparser.add_argument(
+            "--subprocess-log-dir",
+            type=Path,
+            default=None,
+            help=(
+                "External directory for active subprocess captures. The default is a unique "
+                "directory under the agent-loop cache; paths inside managed checkouts are rejected."
+            ),
         )
         subparser.add_argument(
             "--progress-interval-seconds",

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -401,7 +401,8 @@ def build_parser() -> argparse.ArgumentParser:
             default=None,
             help=(
                 "External directory for active subprocess captures. The default is a unique "
-                "directory under the agent-loop cache; paths inside managed checkouts are rejected."
+                "directory under the agent-loop cache; relative overrides are resolved from the "
+                "primary agent directory, and paths inside managed checkouts are rejected."
             ),
         )
         subparser.add_argument(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -16,7 +16,7 @@ from .agents.base import AgentName
 from .agents.registry import default_agent_args
 from .errors import AgentLoopError
 from .github import PullRequestMetadata, detect_repo, get_repo_default_branch
-from .logging import log
+from .logging import datetime_stamp, log
 from .runner import Runner
 from .workdirs import active_workdir, agent_workdir
 
@@ -453,11 +453,6 @@ def default_subprocess_log_dir(repo: str) -> Path:
     )
 
 
-def datetime_stamp() -> str:
-    import datetime
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
-
-
 def default_agent_memory_dir(repo: str) -> Path:
     return default_cache_root() / "repos" / repo_cache_slug(repo) / "memory"
 
@@ -473,9 +468,12 @@ def ensure_workdir(path: Path, option_name: str) -> None:
         raise AgentLoopError(f"Could not create {option_name} at {path}: {exc}") from exc
 
 
-def _resolve_subprocess_log_dir(args: argparse.Namespace, *, repo: str, managed_roots: tuple[Path, ...]) -> Path:
+def _resolve_subprocess_log_dir(
+    args: argparse.Namespace, *, repo: str, primary_dir: Path, managed_roots: tuple[Path, ...]
+) -> Path:
     value = getattr(args, "subprocess_log_dir", None)
-    path = (Path(value) if value is not None else default_subprocess_log_dir(repo)).expanduser().resolve()
+    raw = Path(value) if value is not None else default_subprocess_log_dir(repo)
+    path = (primary_dir / raw if value is not None and not raw.is_absolute() else raw).expanduser().resolve()
     if any(path == root or root in path.parents for root in managed_roots):
         raise AgentLoopError(
             "--subprocess-log-dir must not be equal to or nested beneath a managed checkout: "
@@ -1009,7 +1007,7 @@ def config_from_args(
         mergeability_poll_interval_seconds=getattr(args, "mergeability_poll_interval_seconds", 5),
         quiet=args.quiet,
         log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
-        subprocess_log_dir=_resolve_subprocess_log_dir(args, repo=repo, managed_roots=(claude_dir, codex_dir, gemini_dir, antigravity_dir)),
+        subprocess_log_dir=_resolve_subprocess_log_dir(args, repo=repo, primary_dir=primary_dir, managed_roots=(claude_dir, codex_dir, gemini_dir, antigravity_dir)),
         progress_interval_seconds=args.progress_interval_seconds,
         agent_max_retries=args.agent_max_retries,
         agent_retry_backoff_seconds=tuple(args.agent_retry_backoff_seconds),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -8,6 +8,7 @@ import shlex
 import shutil
 import sys
 import tempfile
+import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -122,6 +123,9 @@ class AgentLoopConfig:
     repair_backend: str = "antigravity"
     repair_models: tuple[str, ...] = DEFAULT_REPAIR_MODELS
     repair_timeout_seconds: int = 120
+    # Active subprocess capture is kept outside mutable agent checkouts.  The
+    # legacy log_dir remains the home for salvage and usage artifacts.
+    subprocess_log_dir: Path | None = None
     # Optional analyzer agent for discuss mode (#467). None keeps plain
     # direct deliberation unchanged. May coincide with a reviewer.
     discuss_analyzer: AgentName | None = None
@@ -441,6 +445,19 @@ def default_cache_root() -> Path:
     return Path.home() / ".cache" / "coding-review-agent-loop"
 
 
+def default_subprocess_log_dir(repo: str) -> Path:
+    """Return a unique, checkout-independent capture directory."""
+    return (
+        default_cache_root() / "subprocess-logs" / repo_cache_slug(repo)
+        / f"{datetime_stamp()}-{uuid.uuid4().hex}"
+    )
+
+
+def datetime_stamp() -> str:
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+
+
 def default_agent_memory_dir(repo: str) -> Path:
     return default_cache_root() / "repos" / repo_cache_slug(repo) / "memory"
 
@@ -454,6 +471,21 @@ def ensure_workdir(path: Path, option_name: str) -> None:
         path.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         raise AgentLoopError(f"Could not create {option_name} at {path}: {exc}") from exc
+
+
+def _resolve_subprocess_log_dir(args: argparse.Namespace, *, repo: str, managed_roots: tuple[Path, ...]) -> Path:
+    value = getattr(args, "subprocess_log_dir", None)
+    path = (Path(value) if value is not None else default_subprocess_log_dir(repo)).expanduser().resolve()
+    if any(path == root or root in path.parents for root in managed_roots):
+        raise AgentLoopError(
+            "--subprocess-log-dir must not be equal to or nested beneath a managed checkout: "
+            f"{path}"
+        )
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise AgentLoopError(f"Could not create --subprocess-log-dir at {path}: {exc}") from exc
+    return path
 
 
 _TOOL_ARTIFACT_NAMES = frozenset({
@@ -977,6 +1009,7 @@ def config_from_args(
         mergeability_poll_interval_seconds=getattr(args, "mergeability_poll_interval_seconds", 5),
         quiet=args.quiet,
         log_dir=(primary_dir / args.log_dir if not args.log_dir.is_absolute() else args.log_dir),
+        subprocess_log_dir=_resolve_subprocess_log_dir(args, repo=repo, managed_roots=(claude_dir, codex_dir, gemini_dir, antigravity_dir)),
         progress_interval_seconds=args.progress_interval_seconds,
         agent_max_retries=args.agent_max_retries,
         agent_retry_backoff_seconds=tuple(args.agent_retry_backoff_seconds),

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -14,6 +14,9 @@ _RETENTION_SECONDS = 14 * 24 * 60 * 60
 _MAX_LEASES = 32
 _CAPTURE_MARKER = ".agent-loop-capture"
 
+if TYPE_CHECKING:
+    from .config import AgentLoopConfig
+
 
 def datetime_stamp() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
@@ -68,9 +71,6 @@ def _prune_capture_roots(parent: Path, current: Path) -> None:
             candidate.rmdir()
         except OSError:
             continue
-
-if TYPE_CHECKING:
-    from .config import AgentLoopConfig
 
 
 def log(config: AgentLoopConfig, message: str) -> None:

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import sys
 import time
-import fcntl
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows
+    fcntl = None  # type: ignore[assignment]
 
 _LEASES: dict[Path, object] = {}
 _RETENTION_SECONDS = 14 * 24 * 60 * 60
@@ -25,6 +29,10 @@ def datetime_stamp() -> str:
 def _prepare_capture_root(root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
     (root / _CAPTURE_MARKER).touch(exist_ok=True)
+    # Windows has no fcntl module.  Capture directories are still usable there;
+    # only the optional cross-process lease and age pruning are unavailable.
+    if fcntl is None:
+        return
     if root not in _LEASES:
         lease = (root / ".lease").open("a+")
         try:
@@ -45,6 +53,8 @@ def _prepare_capture_root(root: Path) -> None:
 
 def _prune_capture_roots(parent: Path, current: Path) -> None:
     """Best-effort age cleanup; live invocation leases are never removed."""
+    if fcntl is None:
+        return
     try:
         candidates = list(parent.iterdir())
     except OSError:

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -3,9 +3,56 @@
 from __future__ import annotations
 
 import sys
+import os
+import time
+import fcntl
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+_LEASES: dict[Path, object] = {}
+_RETENTION_SECONDS = 14 * 24 * 60 * 60
+
+
+def _prepare_capture_root(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    if root not in _LEASES:
+        lease = (root / ".lease").open("a+")
+        try:
+            fcntl.flock(lease.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            lease.close()
+        else:
+            _LEASES[root] = lease
+            _prune_capture_roots(root.parent, root)
+
+
+def _prune_capture_roots(parent: Path, current: Path) -> None:
+    """Best-effort age cleanup; live invocation leases are never removed."""
+    try:
+        candidates = list(parent.iterdir())
+    except OSError:
+        return
+    cutoff = time.time() - _RETENTION_SECONDS
+    for candidate in candidates:
+        if not candidate.is_dir() or candidate == current:
+            continue
+        try:
+            if candidate.stat().st_mtime >= cutoff:
+                continue
+            lease = (candidate / ".lease").open("a+")
+            try:
+                fcntl.flock(lease.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                lease.close()
+                continue
+            for item in candidate.iterdir():
+                if item.name != ".lease" and item.is_file():
+                    item.unlink(missing_ok=True)
+            lease.close()
+            candidate.rmdir()
+        except OSError:
+            continue
 
 if TYPE_CHECKING:
     from .config import AgentLoopConfig
@@ -34,7 +81,9 @@ def agent_log_path(
     prefix = f"{run_id}-" if run_id else ""
     suffix = f"-{label}" if label else ""
     attempt = f"-{attempt_suffix}" if attempt_suffix else ""
-    return config.log_dir / f"{prefix}{stamp}-{agent}{suffix}{attempt}.log"
+    root = config.subprocess_log_dir or config.log_dir
+    _prepare_capture_root(root)
+    return root / f"{prefix}{stamp}-{agent}{suffix}{attempt}.log"
 
 
 def run_usage_summary_path(config: AgentLoopConfig, run_id: str) -> Path:

--- a/src/coding_review_agent_loop/logging.py
+++ b/src/coding_review_agent_loop/logging.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import os
 import time
 import fcntl
 from datetime import datetime
@@ -12,10 +11,17 @@ from typing import TYPE_CHECKING
 
 _LEASES: dict[Path, object] = {}
 _RETENTION_SECONDS = 14 * 24 * 60 * 60
+_MAX_LEASES = 32
+_CAPTURE_MARKER = ".agent-loop-capture"
+
+
+def datetime_stamp() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
 
 
 def _prepare_capture_root(root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
+    (root / _CAPTURE_MARKER).touch(exist_ok=True)
     if root not in _LEASES:
         lease = (root / ".lease").open("a+")
         try:
@@ -24,7 +30,14 @@ def _prepare_capture_root(root: Path) -> None:
             lease.close()
         else:
             _LEASES[root] = lease
-            _prune_capture_roots(root.parent, root)
+            while len(_LEASES) > _MAX_LEASES:
+                old_root, old_lease = next(iter(_LEASES.items()))
+                if old_root == root:
+                    break
+                _LEASES.pop(old_root)
+                old_lease.close()
+            if root.parent.parent.name == "subprocess-logs":
+                _prune_capture_roots(root.parent, root)
 
 
 def _prune_capture_roots(parent: Path, current: Path) -> None:
@@ -37,6 +50,8 @@ def _prune_capture_roots(parent: Path, current: Path) -> None:
     for candidate in candidates:
         if not candidate.is_dir() or candidate == current:
             continue
+        if not (candidate / _CAPTURE_MARKER).is_file():
+            continue
         try:
             if candidate.stat().st_mtime >= cutoff:
                 continue
@@ -47,7 +62,7 @@ def _prune_capture_roots(parent: Path, current: Path) -> None:
                 lease.close()
                 continue
             for item in candidate.iterdir():
-                if item.name != ".lease" and item.is_file():
+                if item.is_file():
                     item.unlink(missing_ok=True)
             lease.close()
             candidate.rmdir()
@@ -66,7 +81,7 @@ def log(config: AgentLoopConfig, message: str) -> None:
 
 
 def new_run_id() -> str:
-    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    return datetime_stamp()
 
 
 def agent_log_path(
@@ -77,7 +92,7 @@ def agent_log_path(
     label: str | None = None,
     attempt_suffix: str | None = None,
 ) -> Path:
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    stamp = datetime_stamp()
     prefix = f"{run_id}-" if run_id else ""
     suffix = f"-{label}" if label else ""
     attempt = f"-{attempt_suffix}" if attempt_suffix else ""

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -6,6 +6,7 @@ import json
 import secrets
 import shlex
 import time
+from datetime import datetime
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
@@ -1761,10 +1762,9 @@ def _discover_v2_snapshot(
             if contract.terminal_run_id is not None:
                 excluded_attempts.add((contract.terminal_run_id, contract.terminal_run_attempt))
             if excluded_attempts:
-                survivors = [
-                    run for run in survivors
-                    if (run.get("id"), run.get("run_attempt")) not in excluded_attempts
-                ]
+                survivors = [run for run in survivors if not _v2_terminal_attempt_excluded(
+                    run.get("id"), run.get("run_attempt"), excluded_attempts
+                )]
             if survivors:
                 newest = sorted(survivors, key=lambda run: (str(run.get("created_at") or ""), int(run.get("id") or 0)))[-1]
                 rid = newest.get("id")
@@ -1989,26 +1989,22 @@ def _v2_correlated_status(
     """
     if contract.attached_run_id is None or not contract.nonce:
         return None
+    if not isinstance(contract.run_attempt, int):
+        return None
     result = runner.run(
-        [config.gh_cmd, "api", f"repos/{config.repo}/commits/{expected_head}/status"],
+        [config.gh_cmd, "api", "--paginate", f"repos/{config.repo}/commits/{expected_head}/statuses?per_page=100"],
         cwd=active_workdir(config), check=False,
     )
     if result.returncode != 0:
         return None
     try:
-        payload = json.loads(result.stdout or "{}")
-    except json.JSONDecodeError:
+        pages = _decode_paginated_json(result.stdout)
+    except (json.JSONDecodeError, TypeError):
         return None
-    statuses = payload.get("statuses") if isinstance(payload, dict) else None
-    if not isinstance(statuses, list):
-        return None
-    required = (
-        f"nonce={contract.nonce}",
-        f"run_id={contract.attached_run_id}",
-    )
-    if contract.run_attempt is not None:
-        required += (f"attempt={contract.run_attempt}",)
-    for raw in statuses:
+    statuses = [item for page in pages for item in page] if all(isinstance(page, list) for page in pages) else []
+    required = {f"nonce={contract.nonce}", f"run_id={contract.attached_run_id}", f"attempt={contract.run_attempt}"}
+    matches: list[tuple[int, str | None, dict[str, object]]] = []
+    for position, raw in enumerate(statuses):
         if not isinstance(raw, dict) or raw.get("context") != FINAL_CONTEXT:
             continue
         description = raw.get("description") if isinstance(raw.get("description"), str) else ""
@@ -2021,17 +2017,39 @@ def _v2_correlated_status(
             or (login == contract.trusted_actor_login and creator_id == contract.trusted_actor_id)
         )
         description_tokens = {token.strip() for token in description.split(";") if token.strip()}
-        if not allowed_publisher or not set(required).issubset(description_tokens):
+        if not allowed_publisher or not required.issubset(description_tokens):
             continue
         target_path = urlparse(target).path.rstrip("/")
         target_segments = target_path.split("/")
         if (
-            len(target_segments) < 3
+            target != f"https://github.com/{config.repo}/actions/runs/{contract.attached_run_id}"
+            or len(target_segments) < 3
             or target_segments[-3:-1] != ["actions", "runs"]
             or target_segments[-1] != str(contract.attached_run_id)
         ):
             continue
-        return PullRequestCheck(
+        if _v2_terminal_attempt_excluded(contract.attached_run_id, contract.run_attempt, contract.terminal_attempts):
+            continue
+        created_value = raw.get("created_at")
+        created = created_value if isinstance(created_value, str) else None
+        if created is not None:
+            try:
+                datetime.fromisoformat(created.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+        matches.append((position, created, raw))
+    if not matches:
+        return None
+    def sort_key(item: tuple[int, str | None, dict[str, object]]) -> tuple[int, str, int]:
+        pos, created, _ = item
+        return (1 if created else 0, created or "", -pos)
+    raw = sorted(matches, key=sort_key)[-1][2]
+    description = raw.get("description") if isinstance(raw.get("description"), str) else ""
+    target = raw.get("target_url") if isinstance(raw.get("target_url"), str) else ""
+    creator = raw.get("creator") if isinstance(raw.get("creator"), dict) else {}
+    login = creator.get("login") if isinstance(creator.get("login"), str) else None
+    creator_id = creator.get("id") if isinstance(creator.get("id"), int) else None
+    return PullRequestCheck(
             name=FINAL_CONTEXT,
             kind="status_context",
             status=str(raw.get("state") or "pending"),
@@ -2043,7 +2061,42 @@ def _v2_correlated_status(
             creator_id=creator_id,
             description=description,
         )
-    return None
+
+
+def _decode_paginated_json(text: str) -> list[list[object]]:
+    """Decode gh --paginate output, including concatenated JSON arrays."""
+    decoder = json.JSONDecoder()
+    pages: list[list[object]] = []
+    offset = 0
+    while offset < len(text):
+        while offset < len(text) and text[offset].isspace():
+            offset += 1
+        if offset >= len(text):
+            break
+        value, end = decoder.raw_decode(text, offset)
+        if not isinstance(value, list):
+            raise json.JSONDecodeError("page is not an array", text, offset)
+        pages.append(value)
+        offset = end
+    return pages
+
+
+def _v2_terminal_attempt_excluded(
+    run_id: object, attempt: object, exclusions: object
+) -> bool:
+    if not isinstance(run_id, int) or not isinstance(exclusions, (set, tuple, list)):
+        return False
+    for entry in exclusions:
+        if not isinstance(entry, (tuple, list)) or len(entry) != 2:
+            continue
+        rid, stored_attempt = entry
+        if rid != run_id or not isinstance(rid, int):
+            continue
+        if isinstance(stored_attempt, int) and stored_attempt == attempt:
+            return True
+        if stored_attempt is None and attempt is None:
+            return True
+    return False
 
 
 def _v2_failed_jobs(runner: Runner, *, config: AgentLoopConfig, run_id: int | None) -> tuple[str, ...]:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -1989,8 +1989,6 @@ def _v2_correlated_status(
     """
     if contract.attached_run_id is None or not contract.nonce:
         return None
-    if not isinstance(contract.run_attempt, int):
-        return None
     result = runner.run(
         [config.gh_cmd, "api", "--paginate", f"repos/{config.repo}/commits/{expected_head}/statuses?per_page=100"],
         cwd=active_workdir(config), check=False,
@@ -2001,8 +1999,13 @@ def _v2_correlated_status(
         pages = _decode_paginated_json(result.stdout)
     except (json.JSONDecodeError, TypeError):
         return None
-    statuses = [item for page in pages for item in page] if all(isinstance(page, list) for page in pages) else []
-    required = {f"nonce={contract.nonce}", f"run_id={contract.attached_run_id}", f"attempt={contract.run_attempt}"}
+    statuses = [item for page in pages for item in page]
+    required = {f"nonce={contract.nonce}", f"run_id={contract.attached_run_id}"}
+    if isinstance(contract.run_attempt, int):
+        required.add(f"attempt={contract.run_attempt}")
+    excluded = _v2_terminal_attempt_excluded(
+        contract.attached_run_id, contract.run_attempt, contract.terminal_attempts
+    )
     matches: list[tuple[int, str | None, dict[str, object]]] = []
     for position, raw in enumerate(statuses):
         if not isinstance(raw, dict) or raw.get("context") != FINAL_CONTEXT:
@@ -2022,13 +2025,12 @@ def _v2_correlated_status(
         target_path = urlparse(target).path.rstrip("/")
         target_segments = target_path.split("/")
         if (
-            target != f"https://github.com/{config.repo}/actions/runs/{contract.attached_run_id}"
-            or len(target_segments) < 3
+            len(target_segments) < 3
             or target_segments[-3:-1] != ["actions", "runs"]
             or target_segments[-1] != str(contract.attached_run_id)
         ):
             continue
-        if _v2_terminal_attempt_excluded(contract.attached_run_id, contract.run_attempt, contract.terminal_attempts):
+        if excluded:
             continue
         created_value = raw.get("created_at")
         created = created_value if isinstance(created_value, str) else None
@@ -2050,17 +2052,17 @@ def _v2_correlated_status(
     login = creator.get("login") if isinstance(creator.get("login"), str) else None
     creator_id = creator.get("id") if isinstance(creator.get("id"), int) else None
     return PullRequestCheck(
-            name=FINAL_CONTEXT,
-            kind="status_context",
-            status=str(raw.get("state") or "pending"),
-            url=target or None,
-            run_id=str(contract.attached_run_id),
-            created_at=raw.get("created_at") if isinstance(raw.get("created_at"), str) else None,
-            completed_at=raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None,
-            creator_login=login,
-            creator_id=creator_id,
-            description=description,
-        )
+        name=FINAL_CONTEXT,
+        kind="status_context",
+        status=str(raw.get("state") or "pending"),
+        url=target or None,
+        run_id=str(contract.attached_run_id),
+        created_at=raw.get("created_at") if isinstance(raw.get("created_at"), str) else None,
+        completed_at=raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None,
+        creator_login=login,
+        creator_id=creator_id,
+        description=description,
+    )
 
 
 def _decode_paginated_json(text: str) -> list[list[object]]:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2336,8 +2336,10 @@ def _run_validated_agent(
         if result.returncode != 0 and artifact_unavailable is None:
             last_error = f"agent command exited with {result.returncode}"
             classification_text = _agent_failure_classification_text(result, phase="command")
+            if result.command_result is not None and result.command_result.capture_diagnostics:
+                classification_text += "\nsubprocess capture unavailable; retryable tooling failure"
             last_classification_text = classification_text
-            should_retry = _is_transient_agent_output(classification_text)
+            should_retry = bool(result.command_result and result.command_result.capture_diagnostics) or _is_transient_agent_output(classification_text)
             last_failure_category = _failure_category(classification_text)
             capacity = classify_antigravity_capacity(
                 classification_text,
@@ -2410,6 +2412,9 @@ def _run_validated_agent(
                     public_response=True,
                     repair_expected_kind=repair_expected_kind,
                 )
+                if result.command_result is not None and result.command_result.capture_diagnostics:
+                    last_failure_category = "transient"
+                    public_text_is_transient = True
                 if (
                     completion_recovery is not None
                     and not completion_recovery_attempted

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -46,6 +46,7 @@ class CommandResult:
     stderr: str
     returncode: int | None
     observation: ExecutionObservation | None = None
+    capture_diagnostics: tuple[str, ...] = ()
 
 
 # Matches ANSI/VT100 control sequences (CSI, OSC, charset selection) that a
@@ -347,7 +348,8 @@ class Runner:
             # prompts are preserved in the command header.
             header += f"\n# stdin\n{input_text}\n"
         header += "\n"
-        with log_path.open("w", encoding="utf-8") as log_file:
+        capture_diagnostics: list[str] = []
+        with log_path.open("w+", encoding="utf-8") as log_file:
             log_file.write(header)
             log_file.flush()
             # stderr=subprocess.STDOUT merges stderr into the log file.
@@ -417,17 +419,25 @@ class Runner:
                 finally:
                     self._unregister_active_process(proc)
 
-        full_output = log_path.read_text(encoding="utf-8")
+            # Read through the retained descriptor. A concurrent cleanup may
+            # unlink the pathname while the child still owns this open file.
+            try:
+                log_file.flush()
+                log_file.seek(0)
+                full_output = log_file.read()
+            except OSError as exc:
+                capture_diagnostics.append(f"capture_read_failed:{type(exc).__name__}:{exc}")
+                full_output = ""
         output = full_output[len(header):] if full_output.startswith(header) else full_output
         exited = time.monotonic()
         result = CommandResult(cmd, cwd, output, "", returncode, ExecutionObservation(
             spawn_wall_time, spawn_monotonic,
             exited, exited - spawn_monotonic, before_identity, executable_identity(cmd[0]), self._interrupted,
-        ))
+        ), tuple(capture_diagnostics))
         if check and returncode != 0:
             raise AgentLoopError(
                 f"Command failed with exit {returncode}: {' '.join(cmd)}\n"
-                f"log: {log_path}\n\nlast output:\n{tail_text(full_output)}"
+                f"log: {log_path if not capture_diagnostics else '(capture pathname unavailable)'}\n\nlast output:\n{tail_text(full_output or output)}"
             )
         return result
 

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -425,7 +425,7 @@ class Runner:
                 log_file.flush()
                 log_file.seek(0)
                 full_output = log_file.read()
-            except OSError as exc:
+            except (OSError, UnicodeError) as exc:
                 capture_diagnostics.append(f"capture_read_failed:{type(exc).__name__}:{exc}")
                 full_output = ""
         output = full_output[len(header):] if full_output.startswith(header) else full_output

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -900,6 +900,14 @@ class FakeRunner(Runner):
                 self.pr_status_returncode,
             )
 
+        if cmd[:2] == ["gh", "api"] and any(
+            "/statuses?per_page=100" in part for part in cmd[2:]
+        ):
+            payload = self.pr_status_payload
+            pages = payload.get("pages") if isinstance(payload, dict) else None
+            stdout = json_dumps(pages if isinstance(pages, list) else payload.get("statuses", []))
+            return CommandResult(cmd, cwd_path, stdout, self.pr_status_stderr, self.pr_status_returncode)
+
         if cmd[:2] == ["gh", "api"] and "/protection/required_status_checks" in cmd[2]:
             stdout = (
                 json_dumps(self.pr_branch_protection_payload)

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -905,7 +905,11 @@ class FakeRunner(Runner):
         ):
             payload = self.pr_status_payload
             pages = payload.get("pages") if isinstance(payload, dict) else None
-            stdout = json_dumps(pages if isinstance(pages, list) else payload.get("statuses", []))
+            stdout = (
+                "\n".join(json_dumps(page) for page in pages)
+                if isinstance(pages, list)
+                else json_dumps(payload.get("statuses", []))
+            )
             return CommandResult(cmd, cwd_path, stdout, self.pr_status_stderr, self.pr_status_returncode)
 
         if cmd[:2] == ["gh", "api"] and "/protection/required_status_checks" in cmd[2]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3693,6 +3693,29 @@ def test_runner_pty_reports_tty_and_strips_ansi(tmp_path):
     assert result.returncode == 0
 
 
+def test_runner_keeps_output_when_capture_path_is_unlinked(tmp_path):
+    """An open capture descriptor survives cleanup unlinking its pathname."""
+    program = (
+        "import os, sys, time\n"
+        "path = sys.argv[1]\n"
+        "print('before-unlink', flush=True)\n"
+        "os.unlink(path)\n"
+        "print('after-unlink', flush=True)\n"
+    )
+    log_path = tmp_path / "logs" / "unlinked.log"
+    result = Runner().run_with_log(
+        [sys.executable, "-c", program, str(log_path)],
+        cwd=tmp_path,
+        log_path=log_path,
+        label="UnlinkProbe",
+        progress_interval_seconds=999,
+    )
+    assert result.returncode == 0
+    assert "before-unlink" in result.stdout
+    assert "after-unlink" in result.stdout
+    assert result.capture_diagnostics == ()
+
+
 @pytest.mark.parametrize("use_pty", [False, True])
 def test_runner_execution_observation_elapsed_begins_at_spawn(tmp_path, use_pty):
     """Pipe and PTY observations use the same post-spawn elapsed interval."""

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3716,6 +3716,19 @@ def test_runner_keeps_output_when_capture_path_is_unlinked(tmp_path):
     assert result.capture_diagnostics == ()
 
 
+def test_runner_classifies_invalid_capture_encoding_without_crashing(tmp_path):
+    program = "import sys; sys.stdout.buffer.write(b'\\xff'); sys.stdout.flush()"
+    result = Runner().run_with_log(
+        [sys.executable, "-c", program],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / "invalid-utf8.log",
+        label="InvalidEncodingProbe",
+        progress_interval_seconds=999,
+    )
+    assert result.returncode == 0
+    assert result.capture_diagnostics[0].startswith("capture_read_failed:UnicodeDecodeError:")
+
+
 @pytest.mark.parametrize("use_pty", [False, True])
 def test_runner_execution_observation_elapsed_begins_at_spawn(tmp_path, use_pty):
     """Pipe and PTY observations use the same post-spawn elapsed interval."""

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -118,6 +118,22 @@ def test_ensure_log_dir_ignored_does_not_overwrite_existing_file(tmp_path):
     assert gitignore.read_text(encoding="utf-8") == "custom\n"
 
 
+def test_logging_module_imports_without_fcntl(monkeypatch):
+    """The shared logging module must remain importable on Windows."""
+    import importlib
+
+    import coding_review_agent_loop.logging as logging_module
+
+    monkeypatch.setitem(sys.modules, "fcntl", None)
+    try:
+        reloaded = importlib.reload(logging_module)
+        assert reloaded.fcntl is None
+        assert reloaded.datetime_stamp()
+    finally:
+        monkeypatch.delitem(sys.modules, "fcntl", raising=False)
+        importlib.reload(logging_module)
+
+
 @pytest.mark.parametrize(
     "text",
     [

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3729,6 +3729,53 @@ def test_runner_classifies_invalid_capture_encoding_without_crashing(tmp_path):
     assert result.capture_diagnostics[0].startswith("capture_read_failed:UnicodeDecodeError:")
 
 
+@pytest.mark.parametrize(
+    ("text", "returncode"),
+    [("", 1), ("not a structured response", 0)],
+)
+def test_orchestrator_retries_capture_diagnostics_as_tooling_failure(
+    tmp_path, text, returncode
+):
+    """Capture-read diagnostics remain retryable for failed or invalid responses."""
+    from unittest.mock import patch
+
+    config = make_config(tmp_path, coder="codex", reviewer="codex", agent_max_retries=1)
+    command_result = CommandResult(
+        ["codex"],
+        tmp_path,
+        "",
+        "",
+        returncode,
+        capture_diagnostics=("capture_read_failed:OSError: injected",),
+    )
+    result = AgentResult(
+        text=text,
+        raw_output=text,
+        returncode=returncode,
+        command_result=command_result,
+    )
+
+    with patch(
+        "coding_review_agent_loop.orchestrator.run_agent_result", return_value=result
+    ) as run_mock:
+        with pytest.raises(AgentInvocationError) as exc_info:
+            _run_validated_agent(
+                FakeRunner(),
+                agent="codex",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="test",
+                validate=lambda value: _validate_review_response(
+                    value, reviewer="OpenAI Codex", unresolved_items=()
+                ),
+            )
+
+    assert run_mock.call_count == 2
+    assert exc_info.value.failure_category == (
+        "deterministic" if returncode != 0 else "transient"
+    )
+
+
 @pytest.mark.parametrize("use_pty", [False, True])
 def test_runner_execution_observation_elapsed_begins_at_spawn(tmp_path, use_pty):
     """Pipe and PTY observations use the same post-spawn elapsed interval."""

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -27,6 +27,7 @@ from coding_review_agent_loop.managed_ci import (
     _dispatch_v2_qualification,
     _ensure_v2_intent,
     _v2_failed_jobs,
+    _v2_correlated_status,
     _api_list,
     activate_managed_ci,
     dispatch_final_qualification,
@@ -1116,6 +1117,47 @@ def test_v2_qualification_accepts_only_attached_run_status(tmp_path):
     )
 
     assert outcome.status == "passed"
+
+
+def test_v2_correlated_status_uses_history_and_ignores_later_unrelated_status(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    creator = {"login": "github-actions[bot]", "id": 41898282}
+    common = {
+        "context": FINAL_CONTEXT,
+        "target_url": "https://ghe.example/actions/runs/100/",
+        "creator": creator,
+    }
+    runner = FakeRunner(pr_status_payload={
+        "pages": [
+            [{**common, "state": "pending", "description": "nonce=nonce-1;run_id=100;attempt=1", "created_at": "2026-08-20T10:00:00Z"}],
+            [{**common, "state": "success", "description": "nonce=nonce-1;run_id=100;attempt=1", "created_at": "2026-08-20T10:01:00Z"}],
+            [{**common, "state": "failure", "description": "nonce=nonce-1;run_id=999;attempt=1", "created_at": "2026-08-20T10:02:00Z"}],
+        ]
+    })
+    contract = v2_contract(attached_run_id=100, run_attempt=1)
+
+    result = _v2_correlated_status(runner, config=config, expected_head="abc123", contract=contract)
+
+    assert result is not None
+    assert result.status == "success"
+    assert result.run_id == "100"
+
+
+def test_v2_correlated_status_omits_unknown_attempt_token(tmp_path):
+    config = make_config(tmp_path, auto_merge=True)
+    runner = FakeRunner(pr_status_payload={"statuses": [{
+        "context": FINAL_CONTEXT,
+        "state": "success",
+        "description": "nonce=nonce-1;run_id=100",
+        "target_url": "https://github.com/OWNER/REPO/actions/runs/100",
+        "creator": {"login": "github-actions[bot]", "id": 41898282},
+    }]})
+    result = _v2_correlated_status(
+        runner, config=config, expected_head="abc123",
+        contract=v2_contract(attached_run_id=100, run_attempt=None),
+    )
+    assert result is not None
+    assert result.status == "success"
 
 
 def test_v2_completed_run_without_publisher_status_stops_and_records_ledger(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #674

## Summary
- keep active subprocess captures outside mutable managed checkouts with leased, age-based retention
- preserve runner output and classify capture-loss failures without traceback
- correlate managed-CI v2 using paginated exact status history and exact run attempts
- add runner regression coverage, fixtures, and documentation

## Tests
- Focused: `python3 -m pytest -q tests/test_agent_loop.py tests/test_backends.py tests/test_salvage.py tests/test_managed_ci.py tests/test_orchestrator_pr.py --tb=short` (577 passed)
- Full: `timeout 1800s python3 -m pytest -q --tb=short` (2103 passed)