### PR TITLE
Decouple managed exact-head CI from auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ still-computing (`UNKNOWN`) GitHub mergeability result is re-checked before
 being treated as unresolved. See
 [Merge conflicts](docs/local_agent_loop.md#merge-conflicts) for details.
 
-With `--auto-merge`, repositories that advertise the managed exact-head CI
+With `--auto-merge`, or with explicit `--managed-ci`, repositories that advertise the managed exact-head CI
 contract use a dedicated flow. The v2 rollout atomically opens a trusted draft
 with `agent-loop-managed`, dispatches qualification from the base workflow,
 and accepts only nonce/run/attempt-correlated statuses; v1 keeps its post-open
@@ -660,6 +660,20 @@ qualified SHA with `--match-head-commit`. `--watch-pending-ci` and
 `--no-watch-pending-ci` do not alter this managed flow. See
 [Managed exact-head CI](docs/local_agent_loop.md#managed-exact-head-ci) for the
 repository contract and failure behavior.
+
+To qualify a protected exact head while retaining a human merge decision, use:
+
+```bash
+agent-loop issue <number> --managed-ci --managed-ci-trusted-actor <login>
+```
+
+The successful terminal result names the qualified SHA and prints a guarded
+`gh pr merge --match-head-commit <sha>` command; the merge API is not called.
+For an existing issue-created PR left ready and unlabeled after a successful
+manual run, rerun `agent-loop pr <number> --managed-ci
+--managed-ci-trusted-actor <login>`. Re-entry first makes that PR a draft, so
+the previous manual-merge command is suspended until a fresh review and
+qualification succeeds. A changed head always needs a new cycle.
 
 Already-open PRs remain ordinary CI by default. A repository can separately
 advertise safe adoption and an operator can explicitly request it only with
@@ -689,7 +703,7 @@ To resume an interrupted issue-created managed draft on an unprotected
 repository, rerun the explicit waiver in PR mode:
 
 ```bash
-agent-loop pr <number> --auto-merge \
+agent-loop pr <number> --managed-ci \
   --managed-ci-trusted-actor <login> --allow-unprotected-managed-ci
 ```
 

--- a/README.md
+++ b/README.md
@@ -655,8 +655,10 @@ matches both the authenticated GitHub CLI user and the repository Actions
 variable `AGENT_LOOP_MANAGED_ACTOR`; without that explicit trust configuration,
 the normal CI path remains in effect. Agent-loop may
 publish local round readiness after a configured pre-review test succeeds,
-dispatches final CI for the reviewers' exact approved SHA, and merges only that
-qualified SHA with `--match-head-commit`. `--watch-pending-ci` and
+dispatches final CI for the reviewers' exact approved SHA. With `--auto-merge`,
+it merges only that qualified SHA with `--match-head-commit`; with explicit
+`--managed-ci`, it publishes the qualified SHA and leaves merging to the human.
+`--watch-pending-ci` and
 `--no-watch-pending-ci` do not alter this managed flow. See
 [Managed exact-head CI](docs/local_agent_loop.md#managed-exact-head-ci) for the
 repository contract and failure behavior.
@@ -700,14 +702,17 @@ protection now returns to ordinary CI unless that explicit per-run waiver is
 present.
 
 To resume an interrupted issue-created managed draft on an unprotected
-repository, rerun the explicit waiver in PR mode:
+repository while retaining the historical automatic merge, rerun the explicit
+waiver in PR mode:
 
 ```bash
-agent-loop pr <number> --managed-ci \
+agent-loop pr <number> --auto-merge \
   --managed-ci-trusted-actor <login> --allow-unprotected-managed-ci
 ```
 
-This is supported resume, not retroactive adoption. The live PR must still be
+For a manual-merge resume, use the same command with `--managed-ci` instead of
+`--auto-merge`; it publishes a fresh SHA-bound qualification and does not
+merge. This is supported resume, not retroactive adoption. The live PR must still be
 an open same-repository draft authored by the authenticated actor (matching
 its immutable ID), use the reserved `agent-loop/managed-*` ref and live
 base/head, and have an active `agent-loop-managed` label event made by that

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,8 +18,9 @@ mechanical Python code, while skill mode also spends host-session context and ou
 interpreting and executing the orchestration workflow. Actual quota use varies. The CLI also
 supports hands-off automation and externally scheduled resume after quota reset — optionally a
 `--test-command` gate and, with
-`--auto-merge`, CI-wait + merge (both are configuration-dependent; without them the CLI
-runs no gate and won't poll/merge). The skill never auto-merges (merge stays a human
+`--auto-merge`, CI-wait + merge, or explicit `--managed-ci` exact-head qualification
+with a printed head-guarded manual merge command (all are configuration-dependent;
+without them the CLI runs no gate and won't poll/merge). The skill never auto-merges (merge stays a human
 decision), cannot continue or schedule its own restart after the host session exhausts
 quota, and may still encounter Claude Code tool-approval prompts. Keeping the skill also
 reduces reliance on

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,8 @@ supports hands-off automation and externally scheduled resume after quota reset 
 `--test-command` gate and, with
 `--auto-merge`, CI-wait + merge, or explicit `--managed-ci` exact-head qualification
 with a printed head-guarded manual merge command (all are configuration-dependent;
-without them the CLI runs no gate and won't poll/merge). The skill never auto-merges (merge stays a human
+without `--test-command`, `--auto-merge`, or `--managed-ci`, the CLI runs no gate
+and does not poll or merge). The skill never auto-merges (merge stays a human
 decision), cannot continue or schedule its own restart after the host session exhausts
 quota, and may still encounter Claude Code tool-approval prompts. Keeping the skill also
 reduces reliance on

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1302,7 +1302,7 @@ changes before reviewer rounds, so reviewers are less likely to spend rounds
 on code that already fails the configured local test command. Use
 `--no-pre-review-tests` to keep `--test-command` as a post-approval gate only.
 
-Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps watching until checks resolve before merging.
+Failing GitHub checks always block approval and can route back to the coder. Pending or unavailable GitHub checks are treated as an external wait state rather than actionable coder feedback: if every reviewer approves the code and only GitHub checks are pending/unavailable, the loop posts a comment and stops with a clear message instead of erroring or starting another coder/reviewer round. If those checks later pass, manual merge is fine and rerunning is optional unless you want agent-loop to re-check or automate the final step. With `--auto-merge`, the loop instead keeps watching until checks resolve before merging. With active `--managed-ci`, the informational comment is retained but the loop falls through to dispatch the final exact-head workflow; ordinary pending/unavailable checks are not qualification.
 
 ### Managed exact-head CI
 
@@ -1354,7 +1354,7 @@ To retry an interrupted issue-created managed draft on an unprotected
 repository, use the explicit per-invocation PR-mode command:
 
 ```bash
-agent-loop pr <number> --auto-merge \
+agent-loop pr <number> --managed-ci \
   --managed-ci-trusted-actor <login> --allow-unprotected-managed-ci
 ```
 
@@ -1375,8 +1375,8 @@ safe managed resume is unavailable, agent-loop removes the exact active
 managed label and waits for a new post-`unlabeled` workflow run on the exact
 head, then requires the ordinary current-head check board to pass. It does not
 accept pre-release green checks, `no_checks`, or a different SHA. Only the
-invocation-owned fallback draft can be made ready, only when `--auto-merge` is
-requested; unrelated or intentional drafts remain drafts. Agent-loop checks
+invocation-owned fallback draft can be made ready, only when managed
+qualification is explicitly requested; unrelated or intentional drafts remain drafts. Agent-loop checks
 the exact head before and after `gh pr ready` and merges with
 `--match-head-commit`. If that merge fails after readiness, it logs that the PR
 remains ready and leaves it unmerged rather than restoring draft state.
@@ -1501,10 +1501,25 @@ accepts neither green nor red same-context statuses unless publisher, nonce,
 attached run, and latest attempt all correlate. A failure is reported from the
 validated run's failing jobs, not base-ref PR checks.
 
-After correlated success, agent-loop applies `agent-loop-exact-head-qualified`,
-marks the PR ready, rechecks its head, and merges with `--match-head-commit`.
-Interrupted labeled drafts remain non-mergeable; rerun the issue loop to resume
-the intent, or remove the managed label to deliberately release ordinary CI.
+After correlated success, auto-merge applies the short-lived
+`agent-loop-exact-head-qualified` label, marks the PR ready, rechecks its head,
+and merges with `--match-head-commit`. Explicit `--managed-ci` never applies
+that bare label and never calls the merge API: it releases the managed label,
+marks an issue-created draft ready, writes a SHA-bearing
+`AGENT_LOOP_MANAGED_CI_QUALIFIED_V2` audit comment, and prints:
+
+```bash
+gh pr merge <number> --repo OWNER/REPO --merge --match-head-commit <qualified-sha>
+```
+
+The PR stays open for a human. A later head change invalidates the result. A
+rerun of a successful issue-created manual result first makes the PR draft
+again, suspending the earlier manual command; if reconstruction fails, rerun
+managed qualification or restore readiness manually and use the old guarded
+command only after confirming that exact SHA is still live. For an explicitly
+unprotected run, the audit and terminal warning state that GitHub cannot force
+the human to use the qualified SHA after agent-loop exits. Explicit mode
+requires complete v2; it rejects v1 instead of silently claiming qualification.
 
 A v2 issue-created PR has zero billed routing jobs at opening, zero hosted
 minutes per intermediate revision, one final matrix, and one rounded
@@ -1579,8 +1594,10 @@ For repositories not using managed exact-head CI, `--watch-pending-ci` is
 enabled by default whenever `--auto-merge` is set;
 pass `--no-watch-pending-ci` to fall back to the legacy single
 `--ci-check-name` waiter described above. It can also be passed explicitly
-without `--auto-merge`, in which case it watches checks after approval and
-reports merge-ready without merging.
+without `--auto-merge`, in which case it watches ordinary checks after approval
+and reports merge-ready without merging. It does not activate suppression or
+replace managed exact-head qualification; when `--managed-ci` is active it is
+inert for that managed route.
 
 When active, it foreground-polls the full PR check/status/required-check board
 using the existing timeout and poll interval controls. It does not call

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1351,13 +1351,16 @@ for the workflow's `unlabeled` recovery CI instead of treating a `no_checks`
 board as mergeable.
 
 To retry an interrupted issue-created managed draft on an unprotected
-repository, use the explicit per-invocation PR-mode command:
+repository and preserve automatic merging, use the explicit per-invocation
+PR-mode command:
 
 ```bash
-agent-loop pr <number> --managed-ci \
+agent-loop pr <number> --auto-merge \
   --managed-ci-trusted-actor <login> --allow-unprotected-managed-ci
 ```
 
+For a manual-merge resume, replace `--auto-merge` with `--managed-ci`; that
+mode publishes a fresh SHA-bound qualification and never calls the merge API.
 This is supported resume, not retroactive adoption. The live PR must still be
 open, a draft, same-repository, authored by the authenticated trusted actor
 (login and immutable ID), on the reserved `agent-loop/managed-*` ref, with the
@@ -1375,8 +1378,10 @@ safe managed resume is unavailable, agent-loop removes the exact active
 managed label and waits for a new post-`unlabeled` workflow run on the exact
 head, then requires the ordinary current-head check board to pass. It does not
 accept pre-release green checks, `no_checks`, or a different SHA. Only the
-invocation-owned fallback draft can be made ready, only when managed
-qualification is explicitly requested; unrelated or intentional drafts remain drafts. Agent-loop checks
+invocation-owned fallback draft can be made ready, and only an auto-merge
+invocation can take this deliberate ordinary-recovery path; explicit managed
+manual mode fails closed instead. Unrelated or intentional drafts remain
+drafts. Agent-loop checks
 the exact head before and after `gh pr ready` and merges with
 `--match-head-commit`. If that merge fails after readiness, it logs that the PR
 remains ready and leaves it unmerged rather than restoring draft state.

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -355,8 +355,9 @@ def build_parser() -> argparse.ArgumentParser:
             dest="watch_pending_ci",
             default=None,
             help=(
-                "With --auto-merge, foreground-poll the full GitHub check board after approval "
-                "and resume the coder if CI fails (enabled by default with --auto-merge)."
+                "For ordinary CI, foreground-poll the full GitHub check board after approval "
+                "and resume the coder if CI fails (enabled by default with --auto-merge). "
+                "Managed exact-head qualification remains its own gate."
             ),
         )
         subparser.add_argument(
@@ -572,11 +573,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_common(issue)
     issue.add_argument(
+        "--managed-ci",
+        action="store_true",
+        help=(
+            "Explicitly activate managed exact-head CI and qualify the approved head. "
+            "Without --auto-merge, leave a successfully qualified PR ready for manual "
+            "head-guarded merging. Requires --managed-ci-trusted-actor."
+        ),
+    )
+    issue.add_argument(
         "--allow-unprotected-managed-ci", action="store_true",
         help=(
             "Per-invocation waiver for issue-created managed CI, including a safe PR-mode "
             "resume of its existing draft, when GitHub cannot independently enforce "
-            "final-ci/exact-head. Requires --auto-merge and --managed-ci-trusted-actor; "
+            "final-ci/exact-head. Requires an effective managed-CI request and "
+            "--managed-ci-trusted-actor; "
             "never applies to arbitrary PR adoption."
         ),
     )
@@ -586,10 +597,20 @@ def build_parser() -> argparse.ArgumentParser:
     pr.add_argument("pr_number", type=int)
     add_common(pr)
     pr.add_argument(
+        "--managed-ci",
+        action="store_true",
+        help=(
+            "Explicitly activate managed exact-head CI without implying a merge. "
+            "A successful run leaves the live qualified head ready for manual "
+            "head-guarded merging. Requires --managed-ci-trusted-actor."
+        ),
+    )
+    pr.add_argument(
         "--allow-unprotected-managed-ci", action="store_true",
         help=(
             "Per-invocation waiver for issue-created managed CI resume when GitHub cannot "
-            "independently enforce final-ci/exact-head. Requires --auto-merge and "
+            "independently enforce final-ci/exact-head. Requires an effective managed-CI "
+            "request and "
             "--managed-ci-trusted-actor; never authorizes arbitrary PR adoption."
         ),
     )
@@ -598,7 +619,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Explicitly adopt an eligible already-open PR into the separately advertised "
-            "v2 managed-CI protocol. Requires --auto-merge and --managed-ci-trusted-actor."
+            "v2 managed-CI protocol. Requires an effective managed-CI request and "
+            "--managed-ci-trusted-actor."
         ),
     )
     add_review_parallel(pr)
@@ -774,6 +796,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         # Preserve tokens (rather than a rendered command) so timeout guidance can
         # be safely shell-quoted locally. Programmatic callers have no sys.argv.
         invocation = tuple([sys.argv[0], *sys.argv[1:]]) if argv is None else tuple(["agent-loop", *argv])
+        explicit_managed_ci = bool(getattr(args, "managed_ci", False))
+        if explicit_managed_ci:
+            if args.command not in {"issue", "pr"}:
+                raise AgentLoopError("--managed-ci is only supported with issue or pr.")
+            if not (args.managed_ci_trusted_actor or "").strip():
+                raise AgentLoopError("--managed-ci requires --managed-ci-trusted-actor.")
         config = config_from_args(args, runner, invocation_argv=invocation)
         implementation_override_requested = (
             args.implementation_coder is not None
@@ -785,8 +813,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if getattr(args, "managed_ci_adopt_existing_pr", False):
             if args.command != "pr":
                 raise AgentLoopError("--managed-ci-adopt-existing-pr is only supported with `agent-loop pr <n>`.")
-            if not args.auto_merge:
-                raise AgentLoopError("--managed-ci-adopt-existing-pr requires --auto-merge.")
+            if not (args.auto_merge or getattr(args, "managed_ci", False)):
+                raise AgentLoopError("--managed-ci-adopt-existing-pr requires --managed-ci or --auto-merge.")
             if not (args.managed_ci_trusted_actor or "").strip():
                 raise AgentLoopError(
                     "--managed-ci-adopt-existing-pr requires --managed-ci-trusted-actor."
@@ -794,8 +822,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if getattr(args, "allow_unprotected_managed_ci", False):
             if args.command not in {"issue", "pr"}:
                 raise AgentLoopError("--allow-unprotected-managed-ci is only supported with issue or pr.")
-            if not args.auto_merge:
-                raise AgentLoopError("--allow-unprotected-managed-ci requires --auto-merge.")
+            if not (args.auto_merge or getattr(args, "managed_ci", False)):
+                raise AgentLoopError("--allow-unprotected-managed-ci requires --managed-ci or --auto-merge.")
             if not (args.managed_ci_trusted_actor or "").strip():
                 raise AgentLoopError("--allow-unprotected-managed-ci requires --managed-ci-trusted-actor.")
             if getattr(args, "managed_ci_adopt_existing_pr", False):

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -179,6 +179,10 @@ class AgentLoopConfig:
     # invocations enable this automatically with --auto-merge; direct config
     # constructions remain conservative unless they set it explicitly.
     watch_pending_ci: bool = False
+    # Explicit request to activate managed exact-head CI without requesting a
+    # merge. `auto_merge` remains an implicit managed-CI eligibility signal so
+    # existing invocations retain their behavior.
+    managed_ci: bool = False
     # Optional v2 managed-CI identity. A repository must independently opt in
     # with its Actions variable before this can suppress any automatic matrix.
     managed_ci_trusted_actor: str | None = None
@@ -197,6 +201,11 @@ class AgentLoopConfig:
     # issue-created activation semantics for that first invocation.
     managed_ci_pr_mode: bool = False
     invocation_argv: tuple[str, ...] = ()
+
+    @property
+    def effective_managed_ci(self) -> bool:
+        """Whether this invocation requested the managed-CI protocol."""
+        return self.managed_ci or self.auto_merge
 
     def __post_init__(self) -> None:
         if isinstance(self.reviewer, str):
@@ -998,6 +1007,7 @@ def config_from_args(
             else bool(args.watch_pending_ci)
         ),
         managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
+        managed_ci=getattr(args, "managed_ci", False),
         managed_ci_adopt_existing_pr=getattr(args, "managed_ci_adopt_existing_pr", False),
         allow_unprotected_managed_ci=getattr(args, "allow_unprotected_managed_ci", False),
         managed_ci_pr_mode=getattr(args, "command", None) == "pr",

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -35,6 +35,7 @@ from .workdirs import active_workdir
 MANAGED_LABEL = "agent-loop-managed"
 MANAGED_OPT_OUT_LABEL = "agent-loop-managed-opt-out"
 QUALIFIED_LABEL = "agent-loop-exact-head-qualified"
+QUALIFICATION_MARKER = "AGENT_LOOP_MANAGED_CI_QUALIFIED_V2"
 FINAL_CONTEXT = "final-ci/exact-head"
 READINESS_CONTEXT = "agent-loop/round-readiness"
 WORKFLOW_FILE = "ci.yml"
@@ -113,6 +114,7 @@ class ManagedCiContract:
     repository: str | None = None
     created_at: int | None = None
     adopted_existing_pr: bool = False
+    issue_created_pr: bool = False
     guard_head_sha: str | None = None
     active_label_event_id: int | None = None
     invocation_applied_label: bool = False
@@ -191,13 +193,13 @@ def activate_managed_ci(
     pr_number: int,
     metadata: PullRequestMetadata,
 ) -> ManagedCiContract | None:
-    """Activate a repository-advertised managed-CI contract for auto-merge runs.
+    """Activate a repository-advertised managed-CI contract.
 
     Repositories without any contract markers retain legacy behavior. A partial
     contract fails closed because applying its suppression label could otherwise
     disable hosted tests without a usable final qualification path.
     """
-    if not config.auto_merge or config.dry_run:
+    if not config.effective_managed_ci or config.dry_run:
         return None
 
     workflow_ref = metadata.base_branch or config.base
@@ -220,6 +222,11 @@ def activate_managed_ci(
     workflow = result.stdout or ""
     present = tuple(marker for marker in _CONTRACT_MARKERS if marker in workflow)
     if not present:
+        if config.managed_ci:
+            raise AgentLoopError(
+                "--managed-ci requested managed exact-head qualification, but the base workflow "
+                "does not advertise a complete v2 managed-CI contract."
+            )
         return None
     missing = tuple(marker for marker in _CONTRACT_MARKERS if marker not in workflow)
     if missing:
@@ -246,15 +253,31 @@ def activate_managed_ci(
             metadata=metadata,
         )
         if contract is not None or not config.managed_ci_adopt_existing_pr:
+            if contract is None and config.managed_ci:
+                raise AgentLoopError(
+                    f"PR #{pr_number} does not match the authenticated issue-created managed-CI "
+                    "tuple; use --managed-ci-adopt-existing-pr for an eligible existing PR."
+                )
             return contract
         # A complete ordinary v2 workflow is not an adoption contract.  This
         # path is intentionally quiet/fallback-compatible when the optional
         # marker has not been deployed.
-        return _activate_v2_existing_pr_adoption(
+        adopted = _activate_v2_existing_pr_adoption(
             runner,
             config=config,
             pr_number=pr_number,
             metadata=metadata,
+        )
+        if adopted is None and config.managed_ci:
+            raise AgentLoopError(
+                f"--managed-ci-adopt-existing-pr could not safely adopt PR #{pr_number}; "
+                "no suppression or qualification was claimed."
+            )
+        return adopted
+
+    if config.managed_ci:
+        raise AgentLoopError(
+            "--managed-ci is unsupported for the legacy v1 managed-CI contract; deploy the complete v2 workflow."
         )
 
     pr_result = runner.run(
@@ -607,11 +630,16 @@ def preflight_managed_ci_creation(
     This happens before the coder is prompted, avoiding the opened-event race:
     the PR is born as a draft with its managed label, or it is ordinary CI.
     """
-    if not config.auto_merge or config.dry_run or not config.managed_ci_trusted_actor or not config.base:
+    if not config.effective_managed_ci or config.dry_run or not config.managed_ci_trusted_actor or not config.base:
         return None
     source_context = ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config))
     source_workflow, _ = _probe_raw_workflow(runner, source_context, config.base)
     if source_workflow is None or V2_MARKER not in source_workflow:
+        if config.managed_ci:
+            raise AgentLoopError(
+                "--managed-ci requires a complete v2 workflow on the resolved base branch; "
+                "v1 or ordinary CI cannot qualify a managed head."
+            )
         return None
     if any(marker not in source_workflow for marker in V2_FEATURE_MARKERS):
         raise AgentLoopError("Repository CI advertises an incomplete managed-CI v2 contract.")
@@ -623,6 +651,11 @@ def preflight_managed_ci_creation(
         trusted_actor=config.managed_ci_trusted_actor,
     )
     if readiness.state == "indeterminate" and not legacy_non_suppressing:
+        if config.managed_ci:
+            raise AgentLoopError(
+                "--managed-ci could not determine the repository's exact-head protection; "
+                "no PR was created."
+            )
         log(config, "Managed-CI readiness could not be determined; continuing with ordinary CI.")
         return None
     if readiness.state == "indeterminate":
@@ -635,16 +668,30 @@ def preflight_managed_ci_creation(
             actor.casefold() != config.managed_ci_trusted_actor.casefold()
             or actor.casefold() != advertised.casefold()
         ):
+            if config.managed_ci:
+                raise AgentLoopError(
+                    "--managed-ci authentication does not match the configured trusted actor; no PR was created."
+                )
             return None
         readiness = ManagedCiReadiness(
             "override_eligible", None, actor, advertised, True, True,
             ProtectionAssessment("voluntary", "legacy", "legacy non-suppressing workflow"), (), (),
         )
     if readiness.state == "override_eligible" and not (config.allow_unprotected_managed_ci or legacy_non_suppressing):
+        if config.managed_ci:
+            raise AgentLoopError(
+                "--managed-ci requires protected final-ci/exact-head or "
+                "--allow-unprotected-managed-ci; no PR was created."
+            )
         return None
     if readiness.state != "strict_ready" and not (
         readiness.state == "override_eligible" and (config.allow_unprotected_managed_ci or legacy_non_suppressing)
     ):
+        if config.managed_ci:
+            raise AgentLoopError(
+                "--managed-ci repository readiness is not sufficient for suppression and exact-head qualification; "
+                "no PR was created."
+            )
         return None
     return ManagedCiCreationIntent(
         branch=f"agent-loop/managed-{issue_number}",
@@ -671,6 +718,12 @@ def _restore_ordinary_ci_after_v2_fallback(
             "Remove the label before relying on ordinary CI."
         )
     log(config, f"PR #{pr_number}: removed `{MANAGED_LABEL}`; continuing with ordinary CI ({reason})")
+    if config.managed_ci:
+        raise AgentLoopError(
+            f"--managed-ci requested qualification, but activation failed ({reason}). "
+            f"PR #{pr_number} is now draft and unlabeled; this run did NOT qualify its head. "
+            "Rerun the same managed-CI command to start a fresh cycle."
+        )
 
 
 def _release_for_ordinary_recovery(
@@ -720,6 +773,13 @@ def _release_for_ordinary_recovery(
             f"Managed-CI v2 could not activate ({reason}) and `{MANAGED_LABEL}` could not be removed."
         )
     log(config, f"PR #{pr_number}: selected ordinary unlabeled recovery ({reason})")
+    if config.managed_ci:
+        raise AgentLoopError(
+            f"--managed-ci requested qualification, but activation failed ({reason}). "
+            f"PR #{pr_number} is now draft and unlabeled; this run did NOT qualify its head. "
+            "The previously advertised manual-merge state is suspended. Rerun the same "
+            "managed-CI command to qualify a fresh live head."
+        )
     return OrdinaryRecoveryCapability(
         pr_number=pr_number,
         repository=config.repo,
@@ -893,24 +953,90 @@ def _activate_v2_managed_ci(
     author_id = author.get("id") if isinstance(author.get("id"), int) else None
     # Reserved branches are generated by the typed creation prompt. A mere
     # lookalike branch cannot pass without all the other authenticated fields.
-    managed_tuple = (
+    immutable_tuple = (
         head_repo_name is not None and head_repo_name.casefold() == config.repo.casefold()
         and author_login is not None and author_login.casefold() == actor_login.casefold()
         and author_id == actor_id
         and isinstance(head_ref, str) and head_ref.startswith("agent-loop/managed-")
-        and MANAGED_LABEL in labels
-        and pr.get("draft") is True
         and base.get("ref") == base_ref
         and live_sha is not None and live_sha == metadata.head_sha
+        and pr.get("state") not in {"closed", "CLOSED"}
     )
-    if not managed_tuple:
+    if not immutable_tuple:
         return None
+
+    # A successful explicit manual run leaves an issue-created PR ready and
+    # unlabeled. Re-entry deliberately suspends that prior manual-merge
+    # affordance before reconstructing suppression, so every invocation gets a
+    # fresh exact-head qualification ledger.
+    if pr.get("draft") is not True:
+        if not (config.managed_ci and config.managed_ci_pr_mode and MANAGED_LABEL not in labels):
+            return None
+        undo = runner.run(
+            [config.gh_cmd, "pr", "ready", "--undo", str(pr_number), "--repo", config.repo],
+            cwd=active_workdir(config), check=False,
+        )
+        refreshed = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+        if undo.returncode != 0 and refreshed.get("draft") is not True:
+            raise AgentLoopError(
+                f"--managed-ci re-entry could not make PR #{pr_number} a draft; its prior "
+                "qualified/manual-merge state remains suspended until the PR is safely reconstructed."
+            )
+        pr = refreshed
+        head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+        base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+        author = pr.get("user") if isinstance(pr.get("user"), dict) else {}
+        head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+        labels = {
+            item.get("name") for item in (pr.get("labels") or [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        live_sha = head.get("sha") if isinstance(head.get("sha"), str) else None
+        if (
+            pr.get("draft") is not True
+            or pr.get("state") in {"closed", "CLOSED"}
+            or base.get("ref") != base_ref
+            or live_sha != metadata.head_sha
+            or head.get("ref") != head_ref
+            or head_repo.get("full_name", "").casefold() != config.repo.casefold()
+            or author.get("login") != actor_login
+            or author.get("id") != actor_id
+        ):
+            # There is no trusted active label to remove in the unlabeled
+            # re-entry case. Report the draft/unlabeled state without claiming
+            # qualification; the next invocation can retry reconstruction.
+            raise AgentLoopError(
+                f"--managed-ci re-entry reconstruction for PR #{pr_number} failed after "
+                "the ready-to-draft transition; the head is NOT qualified by this run. "
+                "The PR must be draft and unlabeled before rerunning managed qualification."
+            )
+    if MANAGED_LABEL not in labels:
+        # Implicit auto-merge keeps the historical existing-PR behavior: only
+        # an already authenticated issue-created managed draft is resumable.
+        if not config.managed_ci:
+            return None
+        if not _ensure_managed_label(runner, config=config):
+            raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
+        applied_label = runner.run(
+            [
+                config.gh_cmd, "api", "--method", "POST",
+                f"repos/{config.repo}/issues/{pr_number}/labels",
+                "-f", f"labels[]={MANAGED_LABEL}",
+            ], cwd=active_workdir(config), check=False,
+        )
+        if applied_label.returncode != 0:
+            raise AgentLoopError(f"Unable to apply `{MANAGED_LABEL}` to PR #{pr_number}.")
+        label_applied = True
+        labels.add(MANAGED_LABEL)
+    else:
+        label_applied = False
+
     # A direct `pr` retry has a separate, deliberately narrower contract. It
     # may resume only an issue-created draft whose immutable timeline facts
     # still identify this trusted actor. The old body nonce is provenance, not
     # authorization; this invocation mints a new nonce and intent generation.
     active_event: tuple[int, str, int] | None = None
-    if config.managed_ci_pr_mode:
+    if config.managed_ci_pr_mode or config.managed_ci:
         active_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
         if active_event is None:
             recovery = _release_for_ordinary_recovery(
@@ -1086,7 +1212,7 @@ def _activate_v2_managed_ci(
             audit_id = None
     workflow_revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True)
     revision = workflow_revision.get("sha") if isinstance(workflow_revision.get("sha"), str) else None
-    generation = secrets.token_urlsafe(16) if config.managed_ci_pr_mode else None
+    generation = secrets.token_urlsafe(16) if (config.managed_ci_pr_mode or config.managed_ci) else None
     log(
         config,
         f"PR #{pr_number}: selected managed resume (fresh generation)"
@@ -1104,6 +1230,8 @@ def _activate_v2_managed_ci(
         audit_comment_id=audit_id if isinstance(audit_id, int) else None,
         intent_generation=generation,
         active_label_event_id=active_event[0] if active_event is not None else None,
+        issue_created_pr=True,
+        invocation_applied_label=label_applied,
     )
 
 
@@ -1301,6 +1429,11 @@ def _activate_v2_existing_pr_adoption(
         trusted_actor_id=actor_id, workflow_revision=revision if isinstance(revision, str) else None,
         adopted_existing_pr=True, guard_head_sha=live_sha, active_label_event_id=existing[0],
         invocation_applied_label=applied,
+        intent_generation=(
+            secrets.token_urlsafe(16)
+            if (config.managed_ci or config.managed_ci_pr_mode)
+            else None
+        ),
     )
 
 
@@ -1340,7 +1473,8 @@ def revalidate_adopted_managed_ci(
 
 
 def release_adopted_managed_ci(
-    runner: Runner, *, config: AgentLoopConfig, pr_number: int, contract: ManagedCiContract
+    runner: Runner, *, config: AgentLoopConfig, pr_number: int, contract: ManagedCiContract,
+    force: bool = False,
 ) -> bool:
     """Remove an invocation-owned adoption label without removing a later label.
 
@@ -1348,7 +1482,9 @@ def release_adopted_managed_ci(
     our claimed suppression.  It is then removed unconditionally; when an
     event ID was recorded, retain the normal fresh event-ID ownership check.
     """
-    if not contract.adopted_existing_pr or not contract.invocation_applied_label:
+    if not (contract.adopted_existing_pr or contract.issue_created_pr) or (
+        not contract.invocation_applied_label and not force
+    ):
         return True
     if contract.active_label_event_id is not None:
         event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
@@ -1359,6 +1495,147 @@ def release_adopted_managed_ci(
         cwd=active_workdir(config), check=False,
     )
     return result.returncode == 0
+
+
+def _release_managed_label_for_manual_qualification(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    contract: ManagedCiContract,
+) -> None:
+    """Release only the authenticated active suppression before manual exit."""
+    event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+    if (
+        event is None
+        or contract.active_label_event_id is None
+        or event[0] != contract.active_label_event_id
+        or event[1].casefold() != (contract.trusted_actor_login or "").casefold()
+        or event[2] != contract.trusted_actor_id
+    ):
+        raise AgentLoopError(
+            f"PR #{pr_number} managed-label provenance changed before manual qualification; "
+            "the head is not qualified and no manual merge command is safe."
+        )
+    result = runner.run(
+        [
+            config.gh_cmd, "api", "--method", "DELETE",
+            f"repos/{config.repo}/issues/{pr_number}/labels/{MANAGED_LABEL}",
+        ], cwd=active_workdir(config), check=False,
+    )
+    if result.returncode != 0:
+        raise AgentLoopError(
+            f"PR #{pr_number} qualified CI passed, but `{MANAGED_LABEL}` could not be removed; "
+            "the PR remains suppressed and must not be manually merged until the label is removed."
+        )
+
+
+def publish_manual_v2_qualification(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    expected_head_sha: str,
+    contract: ManagedCiContract,
+    reviewers: tuple[str, ...],
+) -> str:
+    """Publish a SHA-bound manual result, release suppression, and ready the PR."""
+    if contract.protocol_version != 2:
+        raise AgentLoopError("Explicit managed-CI manual qualification requires protocol v2.")
+    if get_pr_head_sha(runner, config, pr_number) != expected_head_sha:
+        raise AgentLoopError(
+            f"PR #{pr_number} head changed before manual qualification publication; no merge is safe."
+        )
+
+    # The bare qualified label is intentionally not used for a manual result.
+    # Remove a historical copy if one exists so it cannot outlive its SHA.
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
+    labels = {
+        item.get("name") for item in (pr.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    if QUALIFIED_LABEL in labels:
+        removed = runner.run(
+            [
+                config.gh_cmd, "api", "--method", "DELETE",
+                f"repos/{config.repo}/issues/{pr_number}/labels/{QUALIFIED_LABEL}",
+            ], cwd=active_workdir(config), check=False,
+        )
+        if removed.returncode != 0:
+            raise AgentLoopError(f"Unable to clear stale `{QUALIFIED_LABEL}` from PR #{pr_number}.")
+
+    _release_managed_label_for_manual_qualification(
+        runner, config=config, pr_number=pr_number, contract=contract,
+    )
+    after_release = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
+    after_head = after_release.get("head") if isinstance(after_release.get("head"), dict) else {}
+    after_labels = {
+        item.get("name") for item in (after_release.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    if (
+        after_head.get("sha") != expected_head_sha
+        or MANAGED_LABEL in after_labels
+        or (contract.adopted_existing_pr and after_release.get("draft") is True)
+    ):
+        raise AgentLoopError(
+            f"PR #{pr_number} changed while releasing managed CI; its exact head is not safely published."
+        )
+
+    if not contract.adopted_existing_pr:
+        ready = runner.run(
+            [config.gh_cmd, "pr", "ready", str(pr_number), "--repo", config.repo],
+            cwd=active_workdir(config), check=False,
+        )
+        if ready.returncode != 0:
+            raise AgentLoopError(f"Unable to mark qualified PR #{pr_number} ready for manual review.")
+        after_ready = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
+        ready_head = after_ready.get("head") if isinstance(after_ready.get("head"), dict) else {}
+        ready_labels = {
+            item.get("name") for item in (after_ready.get("labels") or [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        if ready_head.get("sha") != expected_head_sha or after_ready.get("draft") is True or MANAGED_LABEL in ready_labels:
+            raise AgentLoopError(
+                f"PR #{pr_number} changed while being made ready; the approved head is not safely published."
+            )
+
+    run_text = str(contract.attached_run_id) if contract.attached_run_id is not None else "unknown"
+    attempt_text = str(contract.run_attempt) if contract.run_attempt is not None else "unknown"
+    reviewer_text = ",".join(reviewers) or "unknown"
+    body = (
+        f"<!-- {QUALIFICATION_MARKER} repo={config.repo} pr={pr_number} base={contract.base_ref or config.base} "
+        f"protocol=2 qualified_head={expected_head_sha} reviewers={reviewer_text} "
+        f"protection={contract.protection_mode or 'unknown'} nonce={contract.nonce or 'unknown'} "
+        f"run_id={run_text} attempt={attempt_text} generation={contract.intent_generation or 'unknown'} -->\n\n"
+        f"Managed exact-head CI qualified `{expected_head_sha}` for manual merge. "
+        "The managed suppression label was released and this SHA is the only advertised merge target."
+    )
+    if contract.protection_mode != "strict":
+        body += (
+            " GitHub cannot force a human or other automation to use this SHA or the guarded command "
+            "after agent-loop exits."
+        )
+    posted = runner.run(
+        [
+            config.gh_cmd, "api", "--method", "POST",
+            f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={body}",
+        ], cwd=active_workdir(config), check=False,
+    )
+    if posted.returncode != 0:
+        raise AgentLoopError(f"Unable to publish the SHA-bound qualification audit for PR #{pr_number}.")
+    try:
+        audit_id = json.loads(posted.stdout or "{}").get("id")
+    except json.JSONDecodeError:
+        audit_id = None
+    if not isinstance(audit_id, int):
+        raise AgentLoopError(f"Qualification audit for PR #{pr_number} returned no comment ID.")
+    contract.audit_comment_id = audit_id
+    if get_pr_head_sha(runner, config, pr_number) != expected_head_sha:
+        raise AgentLoopError(
+            f"PR #{pr_number} head changed after qualification publication; rerun review and exact-head CI."
+        )
+    return expected_head_sha
 
 
 def _api_json(runner: Runner, config: AgentLoopConfig, endpoint: str, *, quiet: bool = False) -> dict[str, object]:

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -218,6 +218,11 @@ def activate_managed_ci(
         check=False,
     )
     if result.returncode != 0:
+        if config.managed_ci:
+            raise AgentLoopError(
+                "--managed-ci could not read the base workflow; managed exact-head qualification "
+                "is unavailable and no ordinary fallback was selected."
+            )
         return None
     workflow = result.stdout or ""
     present = tuple(marker for marker in _CONTRACT_MARKERS if marker in workflow)
@@ -1431,7 +1436,7 @@ def _activate_v2_existing_pr_adoption(
         invocation_applied_label=applied,
         intent_generation=(
             secrets.token_urlsafe(16)
-            if (config.managed_ci or config.managed_ci_pr_mode)
+            if config.managed_ci
             else None
         ),
     )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5809,11 +5809,8 @@ def _finalize_ordinary_recovery_merge(
     config: AgentLoopConfig,
     pr_number: int,
     capability: OrdinaryRecoveryCapability,
-    merge: bool | None = None,
 ) -> None:
-    """Qualify and ready only the draft released by this invocation."""
-    if merge is None:
-        merge = config.auto_merge
+    """Qualify, ready, and merge only the draft released by this invocation."""
     refreshed = refresh_ordinary_recovery_capability(
         runner, config=config, capability=capability,
     )
@@ -5848,14 +5845,6 @@ def _finalize_ordinary_recovery_merge(
             f"PR #{pr_number} head or provenance changed after `gh pr ready`; "
             "the PR remains ready and was not merged."
         )
-    if not merge:
-        print(
-            f"PR #{pr_number} approved and qualified; manual merge required. "
-            f"Qualified head: {capability.expected_head_sha}. "
-            f"Run `gh pr merge {pr_number} --repo {config.repo} --merge "
-            f"--match-head-commit {capability.expected_head_sha}` after confirming the live head."
-        )
-        return
     try:
         merge_pr(runner, config, pr_number, expected_head_sha=capability.expected_head_sha)
     except Exception:
@@ -7125,10 +7114,8 @@ def run_pr_loop(
                         config=config,
                         pr_number=pr_number,
                         capability=ordinary_recovery,
-                        merge=config.auto_merge,
                     )
-                    if config.auto_merge:
-                        print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
+                    print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
                     return 0
                 if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
                     if watch_deadline is None:
@@ -7311,7 +7298,7 @@ def run_pr_loop(
                 if not must_fix_items:
                     if pr_checks.state in {"pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)
-                        if not config.auto_merge and not managed_ci_active(pr_metadata):
+                        if not config.effective_managed_ci and not managed_ci_active(pr_metadata):
                             # Pending/unavailable checks are an external wait, not
                             # actionable coder feedback: stop cleanly instead of
                             # erroring or spending another coder/reviewer round.
@@ -7348,8 +7335,10 @@ def run_pr_loop(
                                 f"{_pending_ci_stop_guidance(pr_checks.state)}"
                             )
                             return 0
-                        # --auto-merge: post the informational comment, then fall
-                        # through to wait for CI before merging, as today.
+                        # Managed qualification and --auto-merge: post the
+                        # informational comment, then fall through to wait for
+                        # the final gate before merging or publishing a manual
+                        # result.
                         post_pr_comment(
                             runner,
                             config=config,
@@ -7896,6 +7885,7 @@ def run_pr_loop(
             f"Reached max rounds ({config.max_rounds}) for PR #{pr_number}; human review required."
         )
     finally:
+        cleanup_failure: AgentLoopError | None = None
         if (
             managed_ci is not None
             and not managed_ci_qualified
@@ -7910,12 +7900,21 @@ def run_pr_loop(
             ):
                 message = f"PR #{pr_number}: unable to release invocation-owned managed-CI label"
                 if config.managed_ci:
-                    raise AgentLoopError(
+                    cleanup_failure = AgentLoopError(
                         message + "; the PR remains suppressed and requires manual label removal."
                     )
                 log(config, message)
         if owned_usage_context:
             _persist_usage_summary(config, usage_context)
+        if cleanup_failure is not None:
+            active_exception = sys.exc_info()[1]
+            if active_exception is not None:
+                # Preserve the original failure while making cleanup failure
+                # visible in its traceback. Usage accounting above must run
+                # even when label cleanup also fails.
+                active_exception.add_note(str(cleanup_failure))
+            else:
+                raise cleanup_failure
 
 
 DISCUSS_CONSENSUS_MARKER_RE = re.compile(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -112,6 +112,7 @@ from .managed_ci import (
     intermediate_managed_checks,
     managed_label_present,
     preflight_managed_ci_creation,
+    publish_manual_v2_qualification,
     prepare_v2_merge,
     publish_round_readiness,
     refresh_ordinary_recovery_capability,
@@ -5492,6 +5493,20 @@ def run_issue_loop(
             )
 
         sync_coder_base_before_implementation(config, runner)
+        managed_ci_creation_intent = None
+        if config.managed_ci:
+            # Direct issue mode is intentionally the only new creation path.
+            # A plain `issue --auto-merge` invocation keeps its historical
+            # ordinary opening behavior unless it uses plan-first.
+            managed_ci_creation_intent = preflight_managed_ci_creation(
+                runner, config=config, issue_number=issue_number
+            )
+            if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
+                print(
+                    "WARNING: --allow-unprotected-managed-ci is active for this invocation. GitHub cannot "
+                    "prevent a manual merge, other automation, a compromised credential, or an agent-loop "
+                    "defect from bypassing the voluntary final-ci/exact-head gate."
+                )
         assigned_head_before = _read_assigned_workdir_head(runner, config)
         salvage_summary = latest_salvage_context(
             config.log_dir,
@@ -5511,6 +5526,7 @@ def run_issue_loop(
                 issue_context=issue_context,
                 salvage_summary=salvage_summary,
                 staged_parent_issue=staged_parent_issue,
+                managed_ci_creation_intent=managed_ci_creation_intent,
             ),
             marker_description="positive <!-- AGENT_PR: <number> -->, PR URL, blocking, or clarification",
             validate=_require_issue_implementation_result,
@@ -5597,6 +5613,11 @@ def run_issue_loop(
                 ),
             ),
         )
+        if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
+            config = dataclasses_replace(
+                config,
+                managed_ci_expected_override_nonce=managed_ci_creation_intent.audit_nonce,
+            )
         return run_pr_loop(
             runner,
             pr_number=pr_number,
@@ -5788,8 +5809,11 @@ def _finalize_ordinary_recovery_merge(
     config: AgentLoopConfig,
     pr_number: int,
     capability: OrdinaryRecoveryCapability,
+    merge: bool | None = None,
 ) -> None:
-    """Ready and merge only the draft released by this invocation."""
+    """Qualify and ready only the draft released by this invocation."""
+    if merge is None:
+        merge = config.auto_merge
     refreshed = refresh_ordinary_recovery_capability(
         runner, config=config, capability=capability,
     )
@@ -5824,6 +5848,14 @@ def _finalize_ordinary_recovery_merge(
             f"PR #{pr_number} head or provenance changed after `gh pr ready`; "
             "the PR remains ready and was not merged."
         )
+    if not merge:
+        print(
+            f"PR #{pr_number} approved and qualified; manual merge required. "
+            f"Qualified head: {capability.expected_head_sha}. "
+            f"Run `gh pr merge {pr_number} --repo {config.repo} --merge "
+            f"--match-head-commit {capability.expected_head_sha}` after confirming the live head."
+        )
+        return
     try:
         merge_pr(runner, config, pr_number, expected_head_sha=capability.expected_head_sha)
     except Exception:
@@ -5960,6 +5992,19 @@ def run_pr_loop(
             if revalidate_adopted_managed_ci(
                 runner, config=config, pr_number=pr_number, metadata=metadata, contract=managed_ci
             ):
+                if managed_ci.issue_created_pr:
+                    label_state = managed_label_present(
+                        runner, config=config, pr_number=pr_number,
+                    )
+                    if label_state is True:
+                        return True
+                    if config.managed_ci:
+                        raise AgentLoopError(
+                            f"PR #{pr_number} lost its authenticated `{MANAGED_LABEL}` suppression label; "
+                            "managed qualification is cancelled and the head is not qualified."
+                        )
+                    managed_ci = None
+                    return False
                 return True
             if managed_ci.adopted_existing_pr:
                 if not release_adopted_managed_ci(
@@ -7069,21 +7114,23 @@ def run_pr_loop(
                         "Actions runners recover."
                     )
                     return 0
-                if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
-                    if ordinary_recovery_selected:
-                        if ordinary_recovery is None:
-                            raise AgentLoopError(
-                                f"PR #{pr_number} was released to ordinary CI, but recovery provenance "
-                                "could not be correlated; no merge attempted."
-                            )
-                        _finalize_ordinary_recovery_merge(
-                            runner,
-                            config=config,
-                            pr_number=pr_number,
-                            capability=ordinary_recovery,
+                if not must_fix_items and ordinary_recovery_selected and not managed_ci_active(pr_metadata):
+                    if ordinary_recovery is None:
+                        raise AgentLoopError(
+                            f"PR #{pr_number} was released to ordinary CI, but recovery provenance "
+                            "could not be correlated; no merge attempted."
                         )
+                    _finalize_ordinary_recovery_merge(
+                        runner,
+                        config=config,
+                        pr_number=pr_number,
+                        capability=ordinary_recovery,
+                        merge=config.auto_merge,
+                    )
+                    if config.auto_merge:
                         print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
-                        return 0
+                    return 0
+                if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
                     if watch_deadline is None:
                         watch_deadline = time.monotonic() + config.ci_timeout_seconds
                         watch_attempts_remaining = max(
@@ -7264,7 +7311,7 @@ def run_pr_loop(
                 if not must_fix_items:
                     if pr_checks.state in {"pending", "unavailable"}:
                         details = _pr_check_details(pr_checks)
-                        if not config.auto_merge:
+                        if not config.auto_merge and not managed_ci_active(pr_metadata):
                             # Pending/unavailable checks are an external wait, not
                             # actionable coder feedback: stop cleanly instead of
                             # erroring or spending another coder/reviewer round.
@@ -7344,7 +7391,7 @@ def run_pr_loop(
                         followups=future_followups,
                     )
                     run_optional_tests(runner, config)
-                    if config.auto_merge:
+                    if config.auto_merge or managed_ci_active(pr_metadata):
                         if managed_ci_active(pr_metadata):
                             assert pr_metadata.head_sha is not None
                             assert pr_metadata.head_branch is not None
@@ -7381,24 +7428,49 @@ def run_pr_loop(
                                 contract=managed_ci,
                             )
                             if managed_outcome.status == "passed":
-                                managed_ci_qualified = True
-                                prepare_v2_merge(
-                                    runner,
-                                    config=config,
-                                    pr_number=pr_number,
-                                    expected_head_sha=pr_metadata.head_sha,
-                                    contract=managed_ci,
-                                )
-                                merge_pr(
-                                    runner,
-                                    config,
-                                    pr_number,
-                                    expected_head_sha=pr_metadata.head_sha,
-                                )
-                                print(
-                                    f"PR #{pr_number} approved by "
-                                    f"{format_agent_list(configured_reviewers)}."
-                                )
+                                if config.auto_merge:
+                                    managed_ci_qualified = True
+                                    prepare_v2_merge(
+                                        runner,
+                                        config=config,
+                                        pr_number=pr_number,
+                                        expected_head_sha=pr_metadata.head_sha,
+                                        contract=managed_ci,
+                                    )
+                                    merge_pr(
+                                        runner,
+                                        config,
+                                        pr_number,
+                                        expected_head_sha=pr_metadata.head_sha,
+                                    )
+                                    print(
+                                        f"PR #{pr_number} approved by "
+                                        f"{format_agent_list(configured_reviewers)}."
+                                    )
+                                else:
+                                    qualified_head = publish_manual_v2_qualification(
+                                        runner,
+                                        config=config,
+                                        pr_number=pr_number,
+                                        expected_head_sha=pr_metadata.head_sha,
+                                        contract=managed_ci,
+                                        reviewers=tuple(str(reviewer) for reviewer in configured_reviewers),
+                                    )
+                                    managed_ci_qualified = True
+                                    merge_command = (
+                                        f"gh pr merge {pr_number} --repo {shlex.quote(config.repo)} --merge "
+                                        f"--match-head-commit {shlex.quote(qualified_head)}"
+                                    )
+                                    risk = (
+                                        " GitHub cannot force a human or other automation to use that SHA."
+                                        if managed_ci.protection_mode != "strict"
+                                        else ""
+                                    )
+                                    print(
+                                        f"PR #{pr_number} approved and qualified; manual merge required. "
+                                        f"Qualified head: {qualified_head}. Run `{merge_command}` after "
+                                        f"confirming the live head.{risk}"
+                                    )
                                 return 0
                             if managed_outcome.status == "head_changed":
                                 log(
@@ -7826,13 +7898,22 @@ def run_pr_loop(
     finally:
         if (
             managed_ci is not None
-            and managed_ci.adopted_existing_pr
             and not managed_ci_qualified
-            and not release_adopted_managed_ci(
-                runner, config=config, pr_number=pr_number, contract=managed_ci
-            )
         ):
-            log(config, f"PR #{pr_number}: unable to release invocation-owned managed-CI label")
+            should_release = managed_ci.adopted_existing_pr or config.managed_ci
+            if should_release and not release_adopted_managed_ci(
+                runner,
+                config=config,
+                pr_number=pr_number,
+                contract=managed_ci,
+                force=config.managed_ci,
+            ):
+                message = f"PR #{pr_number}: unable to release invocation-owned managed-CI label"
+                if config.managed_ci:
+                    raise AgentLoopError(
+                        message + "; the PR remains suppressed and requires manual label removal."
+                    )
+                log(config, message)
         if owned_usage_context:
             _persist_usage_summary(config, usage_context)
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5996,6 +5996,11 @@ def run_pr_loop(
                     return False
                 return True
             if managed_ci.adopted_existing_pr:
+                if config.managed_ci:
+                    raise AgentLoopError(
+                        f"PR #{pr_number} managed-CI adoption provenance changed; "
+                        "managed qualification is cancelled and the head is not qualified."
+                    )
                 if not release_adopted_managed_ci(
                     runner, config=config, pr_number=pr_number, contract=managed_ci
                 ):

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1161,6 +1161,7 @@ def build_issue_prompt(
     issue_context: IssueContext | None = None,
     salvage_summary: str | None = None,
     staged_parent_issue: int | None = None,
+    managed_ci_creation_intent: ManagedCiCreationIntent | None = None,
 ) -> str:
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
@@ -1174,6 +1175,24 @@ def build_issue_prompt(
         if staged_parent_issue is not None
         else _issue_pr_reference_guidance(issue_number)
     )
+    managed_creation_guidance = ""
+    if managed_ci_creation_intent is not None:
+        branch = managed_ci_creation_intent.branch
+        override = ""
+        if managed_ci_creation_intent.audit_nonce:
+            override = (
+                " Include this exact PR-body trailer on its own line: "
+                f"`{UNPROTECTED_OVERRIDE_TRAILER} nonce={managed_ci_creation_intent.audit_nonce}`. "
+                "This is a voluntary gate: GitHub cannot force a later human merge to use "
+                "the qualified SHA."
+            )
+        managed_creation_guidance = (
+            "\nThis invocation has explicit authenticated managed-CI enabled. Create the PR "
+            f"on the reserved branch `{branch}` as a draft, ensure the `agent-loop-managed` "
+            "label exists, and create it with `gh pr create --draft --label "
+            f"agent-loop-managed`. Do not mark it ready; agent-loop will dispatch exact-head "
+            f"qualification after review.{override}\n"
+        )
     return f"""Fix GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the fix,
@@ -1182,6 +1201,7 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
+{managed_creation_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
     requirement_label="implementation requirements",

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1154,6 +1154,27 @@ selectively, and validate any reused changes yourself.
 """
 
 
+def _managed_ci_creation_guidance(
+    intent: ManagedCiCreationIntent | None,
+) -> str:
+    if intent is None:
+        return ""
+    override = ""
+    if intent.audit_nonce:
+        override = (
+            " This invocation uses the explicit unprotected override. Include this exact "
+            f"PR-body trailer on its own line: `{UNPROTECTED_OVERRIDE_TRAILER} nonce={intent.audit_nonce}`. "
+            "This is a voluntary gate: GitHub cannot force a later human merge, other automation, "
+            "a compromised credential, or an agent-loop defect to use the qualified SHA."
+        )
+    return (
+        "\nThis invocation has authenticated managed-CI v2 enabled. Create the PR atomically: "
+        f"use the reserved branch `{intent.branch}`, create or verify the `agent-loop-managed` "
+        "label, then run `gh pr create --draft --label agent-loop-managed`. Do not mark it ready; "
+        f"agent-loop will dispatch exact-head qualification after review.{override}\n"
+    )
+
+
 def build_issue_prompt(
     issue_number: int,
     config: AgentLoopConfig,
@@ -1175,24 +1196,7 @@ def build_issue_prompt(
         if staged_parent_issue is not None
         else _issue_pr_reference_guidance(issue_number)
     )
-    managed_creation_guidance = ""
-    if managed_ci_creation_intent is not None:
-        branch = managed_ci_creation_intent.branch
-        override = ""
-        if managed_ci_creation_intent.audit_nonce:
-            override = (
-                " Include this exact PR-body trailer on its own line: "
-                f"`{UNPROTECTED_OVERRIDE_TRAILER} nonce={managed_ci_creation_intent.audit_nonce}`. "
-                "This is a voluntary gate: GitHub cannot force a later human merge to use "
-                "the qualified SHA."
-            )
-        managed_creation_guidance = (
-            "\nThis invocation has explicit authenticated managed-CI enabled. Create the PR "
-            f"on the reserved branch `{branch}` as a draft, ensure the `agent-loop-managed` "
-            "label exists, and create it with `gh pr create --draft --label "
-            f"agent-loop-managed`. Do not mark it ready; agent-loop will dispatch exact-head "
-            f"qualification after review.{override}\n"
-        )
+    managed_creation_guidance = _managed_ci_creation_guidance(managed_ci_creation_intent)
     return f"""Fix GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the fix,
@@ -1763,23 +1767,7 @@ def build_issue_implementation_prompt(
         if staged_parent_issue is not None
         else _issue_pr_reference_guidance(issue_number)
     )
-    managed_creation_guidance = ""
-    if managed_ci_creation_intent is not None:
-        branch = managed_ci_creation_intent.branch
-        override = ""
-        if managed_ci_creation_intent.audit_nonce:
-            override = (
-                " This invocation is using the explicit unprotected override. Include this exact "
-                f"PR-body trailer on its own line: `{UNPROTECTED_OVERRIDE_TRAILER} nonce={managed_ci_creation_intent.audit_nonce}`. "
-                "GitHub cannot stop a manual merge, other automation, a compromised credential, "
-                "or an agent-loop defect from bypassing this voluntary gate."
-            )
-        managed_creation_guidance = (
-            "\nThis repository has authenticated managed-CI v2 enabled. Create the PR atomically: "
-            f"use the reserved branch `{branch}`, create/verify the `agent-loop-managed` label first, "
-            "then run `gh pr create --draft --label agent-loop-managed`. Do not mark it ready until "
-            f"agent-loop's final exact-head qualification succeeds.{override}\n"
-        )
+    managed_creation_guidance = _managed_ci_creation_guidance(managed_ci_creation_intent)
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 
 Use this local checkout as your workspace. Create a branch, implement the

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1287,6 +1287,26 @@ def test_config_enables_ci_watch_with_auto_merge_without_rebuilding_antigravity_
     assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
 
 
+def test_config_records_explicit_managed_ci_without_implying_auto_merge(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "77", "--repo", "OWNER/REPO", "--managed-ci",
+        "--managed-ci-trusted-actor", "agent-loop",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.managed_ci is True
+    assert config.auto_merge is False
+    assert config.effective_managed_ci is True
+    assert config.watch_pending_ci is False
+
+
+def test_explicit_managed_ci_requires_trusted_actor_before_agent_preflight(capsys):
+    assert main(["pr", "77", "--repo", "OWNER/REPO", "--managed-ci"]) == 1
+    assert "--managed-ci requires --managed-ci-trusted-actor" in capsys.readouterr().err
+
+
 def test_config_records_explicit_existing_pr_managed_ci_adoption(tmp_path):
     parser = build_parser()
     args = parser.parse_args([

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -19,6 +19,7 @@ from coding_review_agent_loop.managed_ci import (
     FINAL_CONTEXT,
     MANAGED_LABEL,
     MANAGED_OPT_OUT_LABEL,
+    QUALIFICATION_MARKER,
     READINESS_CONTEXT,
     ManagedCiContract,
     ManagedCiProbeContext,
@@ -35,6 +36,7 @@ from coding_review_agent_loop.managed_ci import (
     intermediate_managed_checks,
     preflight_managed_ci_creation,
     prepare_v2_merge,
+    publish_manual_v2_qualification,
     publish_round_readiness,
     release_adopted_managed_ci,
     revalidate_adopted_managed_ci,
@@ -272,6 +274,24 @@ class V2ManagedRunner(ManagedRunner):
         return super()._run_locked(args, cwd=cwd, check=check)
 
 
+class ManualQualificationRunner(V2ManagedRunner):
+    """Model GitHub's draft/ready transition for manual qualification tests."""
+
+    @staticmethod
+    def _gh_argv_error(cmd):
+        if cmd[:3] == ["gh", "pr", "ready"] and "--undo" in cmd:
+            return None
+        return FakeRunner._gh_argv_error(cmd)
+
+    def _run_locked(self, args, *, cwd, check):
+        cmd = list(args)
+        if cmd[:3] == ["gh", "pr", "ready"]:
+            cmd, cwd_path = self._record_command(args, cwd)
+            self.rest_pr["draft"] = "--undo" in cmd
+            return CommandResult(cmd, cwd_path, "", "", 0)
+        return super()._run_locked(args, cwd=cwd, check=check)
+
+
 def test_protection_assessment_distinguishes_private_free_plan_limit(tmp_path):
     runner = FakeRunner(
         pr_branch_protection_returncode=1,
@@ -496,6 +516,46 @@ def test_pr_mode_resumes_only_from_immutable_issue_draft_facts_and_mints_fresh_a
     assert contract.audit_comment_id == 17
     assert contract.intent_generation
     assert any("active_label_event_id=101" in " ".join(cmd) for cmd, _ in runner.commands)
+
+
+def test_explicit_manual_reentry_reconstructs_ready_pr_as_draft_before_labeling(tmp_path):
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+    )
+    runner = ManualQualificationRunner(
+        rest_pr={"draft": False, "labels": []},
+        issue_events=[],
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+
+    contract = activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
+
+    assert contract is not None
+    assert contract.issue_created_pr is True
+    assert contract.intent_generation
+    commands = [command for command, _cwd in runner.commands]
+    undo_index = next(index for index, command in enumerate(commands) if "--undo" in command)
+    label_index = next(
+        index for index, command in enumerate(commands)
+        if command[:5] == ["gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"]
+    )
+    assert undo_index < label_index
+
+
+def test_explicit_manual_reentry_fails_closed_when_ready_to_draft_transition_does_not_stick(tmp_path):
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+    )
+    runner = V2ManagedRunner(rest_pr={"draft": False, "labels": []})
+
+    with pytest.raises(AgentLoopError, match="re-entry could not make"):
+        activate_managed_ci(runner, config=config, pr_number=7, metadata=metadata())
 
 
 def test_pr_mode_strict_resume_does_not_require_or_write_unprotected_audit(tmp_path):
@@ -740,6 +800,126 @@ def v2_contract(**overrides):
     }
     fields.update(overrides)
     return ManagedCiContract(**fields)
+
+
+def test_publish_manual_v2_qualification_releases_label_readies_and_audits_sha(tmp_path):
+    config = make_config(
+        tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop",
+    )
+    runner = ManualQualificationRunner(issue_events=[label_event()])
+    contract = v2_contract(
+        issue_created_pr=True,
+        active_label_event_id=101,
+        invocation_applied_label=True,
+        protection_mode="strict",
+        attached_run_id=100,
+        run_attempt=2,
+        intent_generation="generation-1",
+    )
+
+    qualified = publish_manual_v2_qualification(
+        runner,
+        config=config,
+        pr_number=7,
+        expected_head_sha="abc123",
+        contract=contract,
+        reviewers=("Codex", "Claude"),
+    )
+
+    assert qualified == "abc123"
+    commands = [command for command, _cwd in runner.commands]
+    release_index = next(
+        index for index, command in enumerate(commands)
+        if command[:5] == [
+            "gh", "api", "--method", "DELETE",
+            f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}",
+        ]
+    )
+    ready_index = next(index for index, command in enumerate(commands) if command[:4] == ["gh", "pr", "ready", "7"])
+    assert release_index < ready_index
+    assert not any(
+        command[:5] == [
+            "gh", "api", "--method", "POST",
+            "repos/OWNER/REPO/issues/7/labels",
+        ] and QUALIFICATION_MARKER not in " ".join(command)
+        for command in commands
+    )
+    audit_commands = [command for command in commands if QUALIFICATION_MARKER in " ".join(command)]
+    assert len(audit_commands) == 1
+    assert "qualified_head=abc123" in " ".join(" ".join(command) for command in audit_commands)
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command in commands)
+
+
+def test_publish_manual_v2_qualification_publishes_unprotected_residual_risk(tmp_path):
+    config = make_config(tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop")
+    runner = ManualQualificationRunner(
+        rest_pr={"draft": False}, issue_events=[label_event()],
+    )
+    contract = v2_contract(
+        adopted_existing_pr=True,
+        active_label_event_id=101,
+        protection_mode="voluntary",
+    )
+
+    publish_manual_v2_qualification(
+        runner,
+        config=config,
+        pr_number=7,
+        expected_head_sha="abc123",
+        contract=contract,
+        reviewers=("Codex",),
+    )
+
+    audit = next(" ".join(command) for command, _cwd in runner.commands if QUALIFICATION_MARKER in " ".join(command))
+    assert "GitHub cannot force a human or other automation" in audit
+    assert not any(command[:3] == ["gh", "pr", "ready"] for command, _cwd in runner.commands)
+
+
+def test_publish_manual_v2_qualification_rejects_head_change_before_release(tmp_path, monkeypatch):
+    config = make_config(tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop")
+    runner = ManualQualificationRunner(issue_events=[label_event()])
+    contract = v2_contract(
+        issue_created_pr=True, active_label_event_id=101, invocation_applied_label=True,
+        protection_mode="strict",
+    )
+    monkeypatch.setattr(managed_ci, "get_pr_head_sha", lambda *args, **kwargs: "new-head")
+
+    with pytest.raises(AgentLoopError, match="head changed before"):
+        publish_manual_v2_qualification(
+            runner,
+            config=config,
+            pr_number=7,
+            expected_head_sha="abc123",
+            contract=contract,
+            reviewers=("Codex",),
+        )
+
+    assert not any(command[:3] == ["gh", "pr", "ready"] for command, _cwd in runner.commands)
+    assert not any(command[:4] == ["gh", "api", "--method", "DELETE"] for command, _cwd in runner.commands)
+
+
+def test_publish_manual_v2_qualification_rejects_head_change_after_audit(tmp_path, monkeypatch):
+    config = make_config(tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop")
+    runner = ManualQualificationRunner(issue_events=[label_event()])
+    contract = v2_contract(
+        issue_created_pr=True, active_label_event_id=101, invocation_applied_label=True,
+        protection_mode="strict",
+    )
+    heads = iter(("abc123", "new-head"))
+    monkeypatch.setattr(managed_ci, "get_pr_head_sha", lambda *args, **kwargs: next(heads))
+
+    with pytest.raises(AgentLoopError, match="after qualification publication"):
+        publish_manual_v2_qualification(
+            runner,
+            config=config,
+            pr_number=7,
+            expected_head_sha="abc123",
+            contract=contract,
+            reviewers=("Codex",),
+        )
+
+    assert any(QUALIFICATION_MARKER in " ".join(command) for command, _cwd in runner.commands)
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command, _cwd in runner.commands)
 
 
 def v2_run(
@@ -1593,6 +1773,7 @@ def test_existing_pr_adoption_reuses_trusted_label_and_revalidates(tmp_path):
     assert contract is not None
     assert contract.adopted_existing_pr is True
     assert contract.invocation_applied_label is False
+    assert contract.intent_generation is None
     assert revalidate_adopted_managed_ci(
         runner, config=config, pr_number=7, metadata=metadata(), contract=contract
     )

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -40,6 +40,7 @@ from coding_review_agent_loop.managed_ci import (
     revalidate_adopted_managed_ci,
     OrdinaryRecoveryCapability,
     refresh_ordinary_recovery_capability,
+    _release_for_ordinary_recovery,
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
@@ -1702,6 +1703,40 @@ def test_v2_preflight_fails_closed_for_incomplete_markers(tmp_path):
 
     with pytest.raises(AgentLoopError, match="incomplete managed-CI v2 contract"):
         preflight_managed_ci_creation(runner, config=config, issue_number=643)
+
+
+def test_explicit_managed_mode_rejects_legacy_v1_contract(tmp_path):
+    config = make_config(tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop")
+
+    with pytest.raises(AgentLoopError, match="legacy v1"):
+        activate_managed_ci(
+            ManagedRunner(workflow=WORKFLOW), config=config, pr_number=7, metadata=metadata()
+        )
+
+
+def test_explicit_activation_release_is_terminal_and_unqualified(tmp_path):
+    config = make_config(
+        tmp_path, managed_ci=True, managed_ci_trusted_actor="agent-loop",
+    )
+    runner = V2ManagedRunner(issue_events=[])
+
+    with pytest.raises(AgentLoopError, match="did NOT qualify"):
+        _release_for_ordinary_recovery(
+            runner,
+            config=config,
+            pr_number=7,
+            base_ref="main",
+            expected_head_sha="abc123",
+            active_event=None,
+            reason="timeline unavailable",
+        )
+    assert any(
+        command[:5] == [
+            "gh", "api", "--method", "DELETE",
+            f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}",
+        ]
+        for command, _cwd in runner.commands
+    )
 
 
 def test_v2_intent_resumes_matching_comment_and_rejects_competing_nonce(tmp_path):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1173,6 +1173,62 @@ def test_managed_ci_failure_routes_back_to_coder_and_uses_failure_extension(
     assert merges == [{"expected_head_sha": "abc123-coder-1"}]
 
 
+def test_managed_manual_success_publishes_result_without_merge_even_with_pending_intermediate_ci(
+    tmp_path, monkeypatch, capsys
+):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")],
+        pr_check_runs_payload={
+            "check_runs": [
+                {"name": "test", "status": "completed", "conclusion": "success"},
+                {"name": "lint", "status": "in_progress"},
+            ]
+        },
+        pr_status_payload={"state": "pending", "statuses": []},
+    )
+    config = make_config(tmp_path, managed_ci=True, max_rounds=1)
+    contract = ManagedCiContract(protocol_version=2, protection_mode="strict")
+    published = []
+
+    monkeypatch.setattr(orchestrator, "activate_managed_ci", lambda *args, **kwargs: contract)
+    monkeypatch.setattr(orchestrator, "dispatch_final_qualification", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        orchestrator,
+        "wait_for_final_qualification",
+        lambda *args, **kwargs: ManagedCiOutcome(status="passed", head_sha="abc123"),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "publish_manual_v2_qualification",
+        lambda *args, **kwargs: published.append(kwargs["expected_head_sha"]) or "abc123",
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "merge_pr",
+        lambda *args, **kwargs: pytest.fail("manual managed-CI success must not merge"),
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert published == ["abc123"]
+    assert "approved and qualified; manual merge required" in capsys.readouterr().out
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command, _cwd in runner.commands)
+
+
+def test_managed_manual_issue_created_label_loss_cancels_qualification(tmp_path, monkeypatch):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")],
+    )
+    config = make_config(tmp_path, managed_ci=True, max_rounds=1)
+    contract = ManagedCiContract(protocol_version=2, issue_created_pr=True)
+    monkeypatch.setattr(orchestrator, "activate_managed_ci", lambda *args, **kwargs: contract)
+
+    with pytest.raises(AgentLoopError, match="lost its authenticated"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command, _cwd in runner.commands)
+
+
 def test_managed_ci_head_change_restarts_review_without_coder(tmp_path, monkeypatch):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1229,6 +1229,31 @@ def test_managed_manual_issue_created_label_loss_cancels_qualification(tmp_path,
     assert not any(command[:3] == ["gh", "pr", "merge"] for command, _cwd in runner.commands)
 
 
+def test_managed_manual_adopted_provenance_loss_cancels_qualification(tmp_path, monkeypatch):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")],
+    )
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_adopt_existing_pr=True,
+        managed_ci_trusted_actor="agent-loop",
+        max_rounds=1,
+    )
+    contract = ManagedCiContract(
+        protocol_version=2,
+        base_ref="main",
+        adopted_existing_pr=True,
+    )
+    monkeypatch.setattr(orchestrator, "activate_managed_ci", lambda *args, **kwargs: contract)
+    monkeypatch.setattr(orchestrator, "revalidate_adopted_managed_ci", lambda *args, **kwargs: False)
+
+    with pytest.raises(AgentLoopError, match="adoption provenance changed"):
+        run_pr_loop(runner, pr_number=77, config=config)
+
+    assert not any(command[:3] == ["gh", "pr", "merge"] for command, _cwd in runner.commands)
+
+
 def test_managed_ci_head_change_restarts_review_without_coder(tmp_path, monkeypatch):
     runner = FakeRunner(
         codex_outputs=[

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,6 +2,7 @@ import pytest
 
 from agent_loop_helpers import *  # noqa: F403
 from coding_review_agent_loop.github import PullRequestCheck, PullRequestChecks
+from coding_review_agent_loop.managed_ci import ManagedCiCreationIntent
 from coding_review_agent_loop.prompts import build_task_clarification_prompt, format_pr_checks
 from coding_review_agent_loop.protocol import (
     validate_structured_coder_followup,
@@ -2877,3 +2878,17 @@ def test_build_discuss_final_analysis_prompt_excludes_prior_context(tmp_path):
     assert "Accept concession checks." in prompt
     assert "Your previous agenda" not in prompt
     assert "Complete debate transcript so far" not in prompt
+
+
+def test_build_issue_prompt_carries_explicit_managed_creation_contract(tmp_path):
+    intent = ManagedCiCreationIntent(
+        branch="agent-loop/managed-56",
+        trusted_actor="agent-loop",
+        protection_mode="strict",
+    )
+
+    prompt = build_issue_prompt(56, make_config(tmp_path, managed_ci=True), managed_ci_creation_intent=intent)
+
+    assert "agent-loop/managed-56" in prompt
+    assert "gh pr create --draft --label agent-loop-managed" in prompt
+    assert "Do not mark it ready" in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,7 +3,12 @@ import pytest
 from agent_loop_helpers import *  # noqa: F403
 from coding_review_agent_loop.github import PullRequestCheck, PullRequestChecks
 from coding_review_agent_loop.managed_ci import ManagedCiCreationIntent
-from coding_review_agent_loop.prompts import build_task_clarification_prompt, format_pr_checks
+from coding_review_agent_loop.prompts import (
+    build_issue_implementation_prompt,
+    build_issue_prompt,
+    build_task_clarification_prompt,
+    format_pr_checks,
+)
 from coding_review_agent_loop.protocol import (
     validate_structured_coder_followup,
     validate_structured_human_requirements_acknowledgement,
@@ -2887,8 +2892,15 @@ def test_build_issue_prompt_carries_explicit_managed_creation_contract(tmp_path)
         protection_mode="strict",
     )
 
-    prompt = build_issue_prompt(56, make_config(tmp_path, managed_ci=True), managed_ci_creation_intent=intent)
+    config = make_config(tmp_path, managed_ci=True)
+    prompt = build_issue_prompt(56, config, managed_ci_creation_intent=intent)
+    plan_prompt = build_issue_implementation_prompt(
+        56, "1. Implement it.", config, managed_ci_creation_intent=intent,
+    )
 
     assert "agent-loop/managed-56" in prompt
     assert "gh pr create --draft --label agent-loop-managed" in prompt
     assert "Do not mark it ready" in prompt
+    guidance = prompt[prompt.index("This invocation has authenticated managed-CI v2 enabled."):]
+    assert guidance.split("\n", 1)[0] in plan_prompt
+    assert "agent-loop will dispatch exact-head qualification after review." in plan_prompt


### PR DESCRIPTION
## Summary

- add explicit `--managed-ci` activation with trusted-actor validation, independent of `--auto-merge`
- qualify exact heads synchronously for protected or explicitly waived issue-created and adopted PRs
- leave successful manual runs ready, unlabeled, SHA-audited, and guarded by a printed `--match-head-commit` command without calling the merge API
- preserve ordinary auto-merge and `--watch-pending-ci` behavior, including fail-closed release and re-entry safeguards
- document the manual workflow, rerun lifecycle, v1 rejection, and unprotected residual risk

## Verification

- `timeout 1800s python3 -m pytest tests/test_managed_ci.py tests/test_agent_loop.py tests/test_orchestrator_issue.py tests/test_orchestrator_pr.py tests/test_prompts.py tests/test_docs_guidance.py`
- `timeout 1800s python3 -m pytest`

Fixes #683
