### PR TITLE
Validate closing references for multi-issue PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,47 @@ with cleanup guidance. Use `agent-loop pr <number>` when the PR is known, and
 see [Issue-to-PR association and recovery](docs/local_agent_loop.md#issue-to-pr-association-and-recovery)
 for plan-hash checks and operator recovery.
 
+### Expected closing issues
+
+When one implementation PR is intended to complete more than its primary issue,
+declare the complete closing set explicitly with the repeatable
+`--expected-closing-issue POSITIVE_ID` option:
+
+```bash
+agent-loop issue 847 --repo OWNER/REPO --expected-closing-issue 848
+agent-loop pr 900 --repo OWNER/REPO \
+  --expected-closing-issue 847 --expected-closing-issue 848
+agent-loop managed-pr --repo OWNER/REPO --head fix/multi-issue --base main \
+  --title "Complete related issues" --body-file /tmp/pr-body.md \
+  --expected-closing-issue 847 --expected-closing-issue 848
+```
+
+In issue mode the primary issue is always included, and approved-plan
+`additional_closing_issue_ids` declarations are unioned with the CLI additions.
+For direct `pr` and `managed-pr`, the CLI declaration is the complete contract.
+Without authoritative metadata, direct `pr` mode does not infer a contract from
+issue mentions, `Refs`, or related links. A staged child must close the child,
+reference an unfinished parent with `Refs`, and must not include the parent in
+the expected set. Split/decomposed parent workflows reject parent-scoped
+multi-issue declarations; invoke the child with a child-scoped contract.
+
+The expected set is stored in canonical issue handoff and PR metadata and is
+reused after interruption. A PR is checked after creation and before reviewer,
+qualification, or merge handoff. Each expected issue needs its own GitHub
+closing keyword/reference pair (`Closes`, `Fixes`, or `Resolves`, including
+same-repository qualified references and canonical issue URLs); `Closes #847,
+#848` is not treated as two closures. If the body is incomplete, edit the
+existing PR description and resume with `agent-loop pr <number>`—the loop will
+not create another PR. To deliberately widen a recovered contract, repeat the
+full desired set and add `--supersede-expected-closing-contract` on `issue` or
+`pr`; narrowing, replacement, or a missing declaration requires canonical
+metadata repair before resume.
+
+Protocol comments are canonical machine metadata. A bare mention of
+`AGENT_ISSUE_PR_HANDOFF` or `AGENT_PR_EXPECTED_CLOSING_ISSUES` in normal prose
+is allowed, but a well-formed forged marker is rejected before any comment,
+handoff, sidecar, or PR-body write.
+
 Evaluate a GitHub issue without writing any code using discuss mode. Reviewers
 first evaluate independently, then debate if their outcomes disagree:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1044,6 +1044,51 @@ that PR. Removing a marker alone is sufficient when the PR has only an
 incidental mention or contextual URL: that text cannot recreate the handoff.
 `agent-loop pr <number>` remains the explicit operator path for a known PR.
 
+### Expected closing issue contracts
+
+Use the repeatable `--expected-closing-issue POSITIVE_ID` option when a single
+PR intentionally completes multiple issues. Issue mode starts with the actual
+implementation issue and unions CLI additions with the approved plan's
+`additional_closing_issue_ids`; the plan field is optional, and an explicit
+empty list is different from omission. Direct `pr` and `managed-pr` use the
+explicit CLI IDs as the complete contract. Direct `pr` without a declaration or
+recovered contract remains contract-unknown and does not infer expected issues
+from linked-issue prose, `Refs`, or related URLs.
+
+The normalized set is persisted in the schema-version-1 issue handoff and in a
+canonical PR-side `AGENT_PR_EXPECTED_CLOSING_ISSUES` record. Recovery requires
+the issue and PR records to agree, while a validated one-sided write or
+supersession crash window can be completed idempotently. Omission on a rerun
+reuses the recovered set. A changed explicit declaration must match exactly;
+`--supersede-expected-closing-contract` is available only on `issue` and `pr`,
+requires a full declaration, and permits only a proper superset. The new record
+stores its contract hash and supersession hash, so narrowing or replacement is
+not silently accepted.
+
+After PR creation, and again after every body-edit round and immediately before
+reviewer dispatch, qualification, or merge, the loop fetches the current body
+and checks every expected ID. Each ID needs its own case-insensitive GitHub
+closing keyword (`Close(s|d)`, `Fix(es|ed)`, or `Resolve(s|d)`) paired with a
+same-repository `#N`, `OWNER/REPO#N`, or canonical issue URL. A keyword does not
+carry over to later bare targets, so `Closes #847, #848` satisfies only #847.
+`Refs`, cross-repository references, incidental links, comments, and code
+examples are not affirmative closure evidence. Blockquotes and nested list
+items remain active Markdown evidence because GitHub linkifies them.
+
+Staged and materialized topology is single-PR scoped: a child contract may
+include the child and child-scoped additions, but excludes the unfinished
+parent. The body must close the child and use non-closing `Refs #<parent>`; any
+parent closing keyword is rejected. Parent-scoped additions are rejected before
+child creation, stage handoff, or coder invocation, and the operator must rerun
+the actual child with its contract.
+
+If validation reports missing IDs, edit the existing PR description so every
+listed issue has its own closing keyword/reference pair, then resume with
+`agent-loop pr <number>`. No second PR is created. The reserved marker names
+may appear in ordinary coder or reviewer prose, but only an exactly well-formed
+canonical marker is trusted; such a forged marker aborts before the first
+durable write.
+
 If `--repo` is omitted, the tool runs `gh repo view` from the current working
 directory, or from `--codex-dir` when that flag is provided, and uses the
 detected `OWNER/REPO`. Pass `--repo` explicitly when running outside the target

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -525,6 +525,21 @@ def build_parser() -> argparse.ArgumentParser:
     issue = subparsers.add_parser("issue", help="Ask the coder to fix an issue, then review it.")
     issue.add_argument("issue_number", type=int)
     issue.add_argument(
+        "--expected-closing-issue",
+        action="append",
+        type=int,
+        metavar="POSITIVE_ID",
+        help=(
+            "Additional issue ID that this single implementation PR is authoritative to close. "
+            "Repeatable; values are sorted and deduplicated."
+        ),
+    )
+    issue.add_argument(
+        "--supersede-expected-closing-contract",
+        action="store_true",
+        help="Explicitly widen a recovered expected-closing contract with a proper superset.",
+    )
+    issue.add_argument(
         "--plan-first",
         action="store_true",
         help=(
@@ -597,6 +612,18 @@ def build_parser() -> argparse.ArgumentParser:
 
     pr = subparsers.add_parser("pr", help="Run the reviewer/coder loop on an existing PR.")
     pr.add_argument("pr_number", type=int)
+    pr.add_argument(
+        "--expected-closing-issue",
+        action="append",
+        type=int,
+        metavar="POSITIVE_ID",
+        help="Complete expected-closing issue set for this existing PR; repeatable.",
+    )
+    pr.add_argument(
+        "--supersede-expected-closing-contract",
+        action="store_true",
+        help="Explicitly widen a recovered expected-closing contract with a proper superset.",
+    )
     add_common(pr)
     pr.add_argument(
         "--managed-ci",
@@ -642,6 +669,13 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Read the pull-request body from this file (use '-' for stdin; default: empty).",
+    )
+    managed_pr.add_argument(
+        "--expected-closing-issue",
+        action="append",
+        type=int,
+        metavar="POSITIVE_ID",
+        help="Complete expected-closing issue set for this managed PR; repeatable.",
     )
     add_common(managed_pr)
     managed_pr.add_argument(
@@ -848,6 +882,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.command != "issue" and implementation_override_requested:
             raise AgentLoopError("--implementation-coder options are only supported with issue --plan-first.")
+        if getattr(args, "supersede_expected_closing_contract", False):
+            if args.command not in {"issue", "pr"}:
+                raise AgentLoopError(
+                    "--supersede-expected-closing-contract is only supported with `agent-loop issue` or `agent-loop pr`."
+                )
+            if getattr(args, "expected_closing_issue", None) is None:
+                raise AgentLoopError(
+                    "--supersede-expected-closing-contract requires an explicit full "
+                    "--expected-closing-issue declaration."
+                )
         if getattr(args, "managed_ci_adopt_existing_pr", False):
             if args.command != "pr":
                 raise AgentLoopError("--managed-ci-adopt-existing-pr is only supported with `agent-loop pr <n>`.")

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from .decomposition import _decode_json_payload, _encode_json_payload
 from .errors import AgentLoopError
+from .expected_closure import normalize_issue_ids
 from .agents.registry import agent_display_name, agent_signature
 from .protocol import (
     ANY_HEADING_RE,
@@ -42,6 +43,11 @@ if TYPE_CHECKING:
     from .config import AgentLoopConfig
 
 ITEM_SUMMARY_LIMIT = 100
+PLAN_EXPECTED_CLOSING_MARKER = "AGENT_PLAN_EXPECTED_CLOSING_ISSUES"
+PLAN_EXPECTED_CLOSING_MARKER_RE = re.compile(
+    rf"<!--\s*{PLAN_EXPECTED_CLOSING_MARKER}:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.IGNORECASE,
+)
 # Reverse map display-name -> agent. agent_display_name is config-independent, so
 # this is safe to build at import; the signature itself is resolved per-call via
 # agent_signature(agent, config) so it can reflect the configured model (#332).
@@ -238,6 +244,42 @@ def render_canonical_plan_steps(plan_steps: Sequence[str]) -> str:
     return "\n".join(f"{index}. {step}" for index, step in enumerate(plan_steps, start=1))
 
 
+def render_expected_closing_issue_declaration(
+    issue_ids: Sequence[int] | None,
+) -> str | None:
+    """Render an authoritative plan declaration, retaining omitted vs empty."""
+    if issue_ids is None:
+        return None
+    normalized = normalize_issue_ids(issue_ids, field_name="additional_closing_issue_ids")
+    assert normalized is not None
+    payload = {"issue_ids": list(normalized)}
+    encoded = _encode_json_payload(payload)
+    visible = ", ".join(f"#{item}" for item in normalized) or "none"
+    return "\n".join(
+        [
+            "### Additional issues completed by this implementation PR",
+            f"Only these additional same-repository issues are part of this single-PR closing contract: {visible}.",
+            "Incidental mentions, `Refs` links, related issues, staged parents, unselected stages, deferred work, and plan actions are not declarations.",
+            f"<!-- {PLAN_EXPECTED_CLOSING_MARKER}: {encoded} -->",
+        ]
+    )
+
+
+def decode_expected_closing_issue_declaration(encoded: str) -> tuple[int, ...]:
+    payload = _decode_json_payload(encoded, marker_name=PLAN_EXPECTED_CLOSING_MARKER)
+    if _encode_json_payload(payload) != encoded:
+        raise AgentLoopError(
+            f"Invalid {PLAN_EXPECTED_CLOSING_MARKER} payload: non-canonical encoding."
+        )
+    if set(payload) != {"issue_ids"}:
+        raise AgentLoopError(f"Invalid {PLAN_EXPECTED_CLOSING_MARKER} payload.")
+    normalized = normalize_issue_ids(
+        payload["issue_ids"], field_name=f"{PLAN_EXPECTED_CLOSING_MARKER}.issue_ids"
+    )
+    assert normalized is not None
+    return normalized
+
+
 def render_human_requirement_dispositions(
     dispositions: Sequence[HumanRequirementDisposition],
     *,
@@ -369,6 +411,11 @@ def render_canonical_plan_revision(
             ]
         )
     )
+    expected_section = render_expected_closing_issue_declaration(
+        parsed_revision.additional_closing_issue_ids
+    )
+    if expected_section:
+        sections.append(expected_section)
     human_section = render_human_requirement_dispositions(parsed_revision.human_requirement_dispositions)
     if human_section:
         sections.append(human_section)
@@ -670,6 +717,11 @@ def _render_public_plan_state_comment(
         parsed_plan.summary.strip(),
         "\n".join(["### Plan steps", render_canonical_plan_steps(parsed_plan.plan_steps)]),
     ]
+    expected_section = render_expected_closing_issue_declaration(
+        parsed_plan.additional_closing_issue_ids
+    )
+    if expected_section:
+        sections.append(expected_section)
     human_section = render_human_requirement_dispositions(parsed_plan.human_requirement_dispositions)
     if human_section:
         sections.append(human_section)

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from .agents.base import AgentName
 from .agents.registry import default_agent_args
 from .errors import AgentLoopError
+from .expected_closure import normalize_issue_ids
 from .github import PullRequestMetadata, detect_repo, get_repo_default_branch
 from .logging import datetime_stamp, log
 from .runner import Runner
@@ -201,6 +202,14 @@ class AgentLoopConfig:
     # issue-created activation semantics for that first invocation.
     managed_ci_pr_mode: bool = False
     invocation_argv: tuple[str, ...] = ()
+    # Optional authoritative issue-closing declaration. ``None`` means that
+    # this invocation made no declaration; an empty tuple is explicit and is
+    # intentionally preserved for reconciliation.
+    expected_closing_issue_ids: tuple[int, ...] | None = None
+    supersede_expected_closing_contract: bool = False
+    # Internal handoff bit: issue mode has already resolved CLI/plan additions
+    # into the complete immutable contract before entering the PR loop.
+    expected_closing_contract_resolved: bool = False
 
     @property
     def effective_managed_ci(self) -> bool:
@@ -267,6 +276,11 @@ class AgentLoopConfig:
             raise AgentLoopError("--discuss-debater-timeout must be greater than zero seconds.")
         if self.salvage_comment_patch_max_bytes <= 0:
             raise AgentLoopError("--salvage-comment-patch-max-bytes must be greater than zero.")
+        normalized_expected = normalize_issue_ids(
+            self.expected_closing_issue_ids,
+            field_name="expected_closing_issue_ids",
+        )
+        object.__setattr__(self, "expected_closing_issue_ids", normalized_expected)
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -1012,6 +1026,13 @@ def config_from_args(
         allow_unprotected_managed_ci=getattr(args, "allow_unprotected_managed_ci", False),
         managed_ci_pr_mode=getattr(args, "command", None) == "pr",
         invocation_argv=invocation_argv,
+        expected_closing_issue_ids=normalize_issue_ids(
+            getattr(args, "expected_closing_issue", None),
+            field_name="--expected-closing-issue",
+        ),
+        supersede_expected_closing_contract=getattr(
+            args, "supersede_expected_closing_contract", False
+        ),
         ci_queued_grace_seconds=getattr(args, "ci_queued_grace_seconds", 1200),
         mergeability_poll_attempts=getattr(args, "mergeability_poll_attempts", 3),
         mergeability_poll_interval_seconds=getattr(args, "mergeability_poll_interval_seconds", 5),

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -210,6 +210,9 @@ class AgentLoopConfig:
     # Internal handoff bit: issue mode has already resolved CLI/plan additions
     # into the complete immutable contract before entering the PR loop.
     expected_closing_contract_resolved: bool = False
+    # Origin for a contract created by the public direct/managed PR entry point.
+    # Issue-origin handoffs select their own flow when a linked issue exists.
+    pr_origin_flow: str = "direct-pr"
 
     @property
     def effective_managed_ci(self) -> bool:
@@ -281,6 +284,8 @@ class AgentLoopConfig:
             field_name="expected_closing_issue_ids",
         )
         object.__setattr__(self, "expected_closing_issue_ids", normalized_expected)
+        if self.pr_origin_flow not in {"direct-pr", "managed-pr"}:
+            raise AgentLoopError("pr_origin_flow must be 'direct-pr' or 'managed-pr'.")
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:

--- a/src/coding_review_agent_loop/expected_closure.py
+++ b/src/coding_review_agent_loop/expected_closure.py
@@ -1,0 +1,174 @@
+"""Construction and reconciliation of the expected issue-closing contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from collections.abc import Iterable
+
+from .errors import AgentLoopError
+
+
+def normalize_issue_ids(
+    value: Iterable[object] | None,
+    *,
+    field_name: str = "expected_closing_issue_ids",
+) -> tuple[int, ...] | None:
+    """Normalize an optional issue-id declaration without treating bool as int."""
+    if value is None:
+        return None
+    result: set[int] = set()
+    for index, raw in enumerate(value):
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+            raise AgentLoopError(
+                f"{field_name} item at index {index} must be a positive integer (not a bool)."
+            )
+        result.add(raw)
+    return tuple(sorted(result))
+
+
+def contract_hash(issue_ids: Iterable[int]) -> str:
+    normalized = normalize_issue_ids(issue_ids, field_name="contract") or ()
+    return hashlib.sha256(
+        json.dumps(list(normalized), separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class ExpectedClosingContract:
+    issue_ids: tuple[int, ...]
+    hash: str
+    supersedes_hash: str | None = None
+
+
+def make_contract(
+    issue_ids: Iterable[object], *, supersedes_hash: str | None = None
+) -> ExpectedClosingContract:
+    normalized = normalize_issue_ids(issue_ids, field_name="expected_closing_issue_ids")
+    assert normalized is not None
+    return ExpectedClosingContract(normalized, contract_hash(normalized), supersedes_hash)
+
+
+def _contract_conflict(
+    *,
+    recovered: tuple[int, ...],
+    current: tuple[int, ...],
+    supersede: bool,
+) -> AgentLoopError:
+    recovered_text = "{" + ", ".join(f"#{item}" for item in recovered) + "}"
+    current_text = "{" + ", ".join(f"#{item}" for item in current) + "}"
+    if supersede:
+        detail = (
+            "--supersede-expected-closing-contract only permits a proper superset; "
+            "narrowing, replacement, and equality require canonical-metadata correction "
+            "before resume."
+        )
+    else:
+        detail = (
+            "omit the explicit declaration to reuse the recovered contract, or use "
+            "--supersede-expected-closing-contract for a proper-superset widening."
+        )
+    return AgentLoopError(
+        "Expected closing contract conflict: recovered "
+        f"{recovered_text}, current {current_text}. No durable metadata changed; {detail}"
+    )
+
+
+def reconcile_contracts(
+    recovered: Iterable[object],
+    current: Iterable[object],
+    *,
+    supersede: bool = False,
+) -> ExpectedClosingContract:
+    """Reconcile a durable contract with a current explicit declaration."""
+    recovered_ids = normalize_issue_ids(recovered, field_name="recovered contract") or ()
+    current_ids = normalize_issue_ids(current, field_name="current contract") or ()
+    if recovered_ids == current_ids:
+        if supersede:
+            raise _contract_conflict(
+                recovered=recovered_ids, current=current_ids, supersede=True
+            )
+        return make_contract(current_ids)
+    if supersede and set(recovered_ids) < set(current_ids):
+        return make_contract(current_ids, supersedes_hash=contract_hash(recovered_ids))
+    raise _contract_conflict(
+        recovered=recovered_ids, current=current_ids, supersede=supersede
+    )
+
+
+def resolve_issue_contract(
+    *,
+    primary_issue: int,
+    cli_additions: Iterable[object] | None,
+    plan_additions: Iterable[object] | None,
+    recovered: Iterable[object] | None = None,
+    supersede: bool = False,
+) -> ExpectedClosingContract:
+    """Resolve issue-mode additions while retaining the primary issue."""
+    primary = normalize_issue_ids((primary_issue,), field_name="primary issue") or ()
+    cli = normalize_issue_ids(cli_additions, field_name="--expected-closing-issue")
+    plan = normalize_issue_ids(
+        plan_additions, field_name="additional_closing_issue_ids"
+    )
+    explicit = cli is not None or plan is not None
+    current = tuple(sorted(set(primary) | set(cli or ()) | set(plan or ())))
+    if recovered is None:
+        if supersede:
+            raise AgentLoopError(
+                "--supersede-expected-closing-contract requires an existing recovered "
+                "expected closing contract; no durable metadata changed."
+            )
+        return make_contract(current)
+    recovered_ids = normalize_issue_ids(recovered, field_name="recovered contract") or ()
+    if primary_issue not in recovered_ids:
+        raise AgentLoopError(
+            f"Recovered expected closing contract {recovered_ids!r} does not retain "
+            f"the actual primary issue #{primary_issue}. No durable metadata changed."
+        )
+    if not explicit:
+        if supersede:
+            raise AgentLoopError(
+                "--supersede-expected-closing-contract requires an explicit full "
+                "expected-closing declaration; no durable metadata changed."
+            )
+        return make_contract(recovered_ids)
+    return reconcile_contracts(recovered_ids, current, supersede=supersede)
+
+
+def resolve_direct_contract(
+    *,
+    explicit: Iterable[object] | None,
+    recovered: Iterable[object] | None = None,
+    supersede: bool = False,
+) -> ExpectedClosingContract | None:
+    """Resolve direct/managed PR mode without inferring from PR prose."""
+    if recovered is None:
+        if supersede:
+            raise AgentLoopError(
+                "--supersede-expected-closing-contract requires an existing recovered "
+                "expected closing contract; no durable metadata changed."
+            )
+        return make_contract(explicit) if explicit is not None else None
+    recovered_ids = normalize_issue_ids(recovered, field_name="recovered contract") or ()
+    if explicit is None:
+        if supersede:
+            raise AgentLoopError(
+                "--supersede-expected-closing-contract requires an explicit full "
+                "expected-closing declaration; no durable metadata changed."
+            )
+        return make_contract(recovered_ids)
+    return reconcile_contracts(recovered_ids, explicit, supersede=supersede)
+
+
+def reject_parent_from_contract(
+    contract: ExpectedClosingContract,
+    *,
+    parent_issue: int | None,
+) -> None:
+    if parent_issue is not None and parent_issue in contract.issue_ids:
+        raise AgentLoopError(
+            f"Expected closing contract includes staged parent issue #{parent_issue}. "
+            "Use a child-scoped contract containing the child and its additions only; "
+            "the parent must remain a non-closing `Refs` reference."
+        )

--- a/src/coding_review_agent_loop/expected_closure.py
+++ b/src/coding_review_agent_loop/expected_closure.py
@@ -18,8 +18,12 @@ def normalize_issue_ids(
     """Normalize an optional issue-id declaration without treating bool as int."""
     if value is None:
         return None
+    try:
+        iterator = iter(value)
+    except TypeError as exc:
+        raise AgentLoopError(f"{field_name} must be an iterable of issue IDs.") from exc
     result: set[int] = set()
-    for index, raw in enumerate(value):
+    for index, raw in enumerate(iterator):
         if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
             raise AgentLoopError(
                 f"{field_name} item at index {index} must be a positive integer (not a bool)."

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import datetime
 import json
 import os
@@ -22,6 +23,12 @@ from .ci_health import (
     is_wholly_infrastructure_blocked,
 )
 from .errors import AgentLoopError
+from .pr_contract import (
+    PR_EXPECTED_CLOSING_MARKER,
+    PR_EXPECTED_CLOSING_MARKER_RE,
+    decode_pr_contract,
+    encode_pr_contract,
+)
 from .logging import log
 from .round_transport import MAX_GITHUB_BODY_CHARS, prepare_round_comment
 from .protocol import parse_signed_human_requirement_body
@@ -136,6 +143,49 @@ _NON_CLOSING_ISSUE_REFERENCE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_AGENT_ISSUE_PR_HANDOFF_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_ISSUE_PR_HANDOFF:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.IGNORECASE,
+)
+
+
+def affirmative_markdown_view(body: str | None) -> str:
+    """Return active Markdown text that can count as affirmative issue evidence.
+
+    GitHub does not interpret code samples, inline code, or HTML comments as
+    closing instructions. List items are classified before indentation so a
+    nested list item remains active evidence, and blockquotes remain active
+    because GitHub linkifies their references.
+    """
+    if not body:
+        return ""
+    text = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+    output: list[str] = []
+    fenced = False
+    fence_char = ""
+    list_line_re = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
+    for line in text.splitlines():
+        stripped = line.lstrip(" \t")
+        fence = re.match(r"(`{3,}|~{3,})", stripped)
+        if fence:
+            token = fence.group(1)
+            if not fenced:
+                fenced = True
+                fence_char = token[0]
+            elif token[0] == fence_char:
+                fenced = False
+            continue
+        if fenced:
+            continue
+        is_list_item = bool(list_line_re.match(line))
+        if (line.startswith("    ") or line.startswith("\t")) and not is_list_item:
+            continue
+        # Inline code spans are non-rendered code, even when they are inside a
+        # list item or blockquote. Preserve surrounding prose and references.
+        line = re.sub(r"(`+)(.+?)\1", "", line)
+        output.append(line)
+    return "\n".join(output)
+
 
 @dataclass(frozen=True)
 class IssueReferenceEvidence:
@@ -207,6 +257,7 @@ def parse_issue_reference_evidence(
     *,
     repo: str,
     include_non_closing: bool = True,
+    affirmative: bool = True,
 ) -> tuple[IssueReferenceEvidence, ...]:
     """Parse closing and, optionally, explicit ``Refs`` issue evidence.
 
@@ -216,12 +267,13 @@ def parse_issue_reference_evidence(
     """
     if not body:
         return ()
+    searchable_body = affirmative_markdown_view(body) if affirmative else body
     matches: list[tuple[int, IssueReferenceEvidence]] = [
         (
             match.start(),
             _issue_reference_evidence_from_match(match, closing=True, default_repo=repo),
         )
-        for match in _CLOSING_ISSUE_REFERENCE_RE.finditer(body)
+        for match in _CLOSING_ISSUE_REFERENCE_RE.finditer(searchable_body)
     ]
     if include_non_closing:
         matches.extend(
@@ -229,7 +281,7 @@ def parse_issue_reference_evidence(
                 match.start(),
                 _issue_reference_evidence_from_match(match, closing=False, default_repo=repo),
             )
-            for match in _NON_CLOSING_ISSUE_REFERENCE_RE.finditer(body)
+            for match in _NON_CLOSING_ISSUE_REFERENCE_RE.finditer(searchable_body)
         )
     return tuple(evidence for _position, evidence in sorted(matches, key=lambda item: item[0]))
 
@@ -242,6 +294,22 @@ def parse_strong_issue_reference_evidence(
     return tuple(
         evidence
         for evidence in parse_issue_reference_evidence(body, repo=repo, include_non_closing=False)
+        if evidence.closing
+        and evidence.target_repo.casefold() == normalized_repo
+        and evidence.issue_number == issue_number
+    )
+
+
+def parse_raw_strong_issue_reference_evidence(
+    body: str | None, *, repo: str, issue_number: int
+) -> tuple[IssueReferenceEvidence, ...]:
+    """Return raw-body closing evidence for fail-closed safety prohibitions."""
+    normalized_repo = repo.casefold()
+    return tuple(
+        evidence
+        for evidence in parse_issue_reference_evidence(
+            body, repo=repo, include_non_closing=False, affirmative=False
+        )
         if evidence.closing
         and evidence.target_repo.casefold() == normalized_repo
         and evidence.issue_number == issue_number
@@ -398,10 +466,11 @@ def validate_pr_references_issue(
     pr_number: int,
     issue_number: int,
     staged_parent_issue: int | None = None,
+    body: str | None = None,
 ) -> None:
     if config.dry_run:
         return
-    body = _get_pr_body(runner, config=config, pr_number=pr_number)
+    body = _get_pr_body(runner, config=config, pr_number=pr_number) if body is None else body
     strong_evidence = parse_strong_issue_reference_evidence(
         body, repo=config.repo, issue_number=issue_number
     )
@@ -418,6 +487,50 @@ def validate_pr_references_issue(
         f"`agent-loop pr {pr_number}` to continue the review. Bare `#{issue_number}`, `Refs`, "
         "issue URLs used as context, and branch names are not implementation evidence."
     )
+
+
+def missing_expected_closing_issue_ids(
+    body: str | None,
+    *,
+    repo: str,
+    expected_issue_ids: Sequence[int],
+) -> tuple[int, ...]:
+    """Return expected IDs without their own affirmative closing pair."""
+    observed = {
+        evidence.issue_number
+        for evidence in parse_issue_reference_evidence(
+            body, repo=repo, include_non_closing=False, affirmative=True
+        )
+        if evidence.closing and evidence.target_repo.casefold() == repo.casefold()
+    }
+    return tuple(sorted(set(expected_issue_ids) - observed))
+
+
+def validate_pr_expected_closing_issues(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    expected_issue_ids: Sequence[int],
+    body: str | None = None,
+) -> tuple[int, ...]:
+    """Validate a known contract against one freshly fetched PR body."""
+    if config.dry_run:
+        return ()
+    current_body = _get_pr_body(runner, config=config, pr_number=pr_number) if body is None else body
+    missing = missing_expected_closing_issue_ids(
+        current_body, repo=config.repo, expected_issue_ids=expected_issue_ids
+    )
+    if missing:
+        rendered = ", ".join(f"#{issue}" for issue in missing)
+        expected = ", ".join(f"#{issue}" for issue in sorted(set(expected_issue_ids))) or "(none)"
+        raise AgentLoopError(
+            f"PR #{pr_number} is missing affirmative closing references for expected issue(s): {rendered}. "
+            f"The immutable expected set is {{{expected}}}. Edit the existing PR description so every "
+            "listed issue has its own `Closes`, `Fixes`, or `Resolves` keyword/reference pair, then "
+            f"resume with `agent-loop pr {pr_number}`; do not create another PR."
+        )
+    return missing
 
 
 def _get_pr_body(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> str:
@@ -443,7 +556,7 @@ def _get_pr_body(runner: Runner, *, config: AgentLoopConfig, pr_number: int) -> 
 def _validate_staged_parent_reference(
     body: str, *, config: AgentLoopConfig, pr_number: int, parent_issue: int
 ) -> None:
-    if parse_strong_issue_reference_evidence(
+    if parse_raw_strong_issue_reference_evidence(
         body, repo=config.repo, issue_number=parent_issue
     ):
         raise AgentLoopError(
@@ -476,7 +589,7 @@ def validate_pr_body_does_not_close_issue(
     `validate_pr_references_issue`.
     """
     body = _get_pr_body(runner, config=config, pr_number=pr_number)
-    if not parse_strong_issue_reference_evidence(
+    if not parse_raw_strong_issue_reference_evidence(
         body, repo=config.repo, issue_number=issue_number
     ):
         return
@@ -1217,6 +1330,7 @@ def post_pr_comment(
     pr_number: int,
     body: str,
 ) -> None:
+    reject_forged_protocol_markers(body)
     bodies = prepare_round_comment(body)
     if len(bodies) > 1:
         log(config, f"Posting round transport with {len(bodies) - 1} sidecars to PR #{pr_number}")
@@ -1232,12 +1346,143 @@ def post_issue_comment(
     issue_number: int,
     body: str,
 ) -> None:
+    reject_forged_protocol_markers(body)
     bodies = prepare_round_comment(body)
     if len(bodies) > 1:
         log(config, f"Posting round transport with {len(bodies) - 1} sidecars to issue #{issue_number}")
     log(config, f"Posting agent output to issue #{issue_number}")
     for prepared in bodies:
         _post_comment_body(runner, config=config, command=["issue", "comment", str(issue_number)], body=prepared)
+
+
+def reject_forged_protocol_markers(body: str) -> None:
+    """Reject only well-formed reserved metadata markers in untrusted prose."""
+    if _AGENT_ISSUE_PR_HANDOFF_MARKER_RE.search(body) or PR_EXPECTED_CLOSING_MARKER_RE.search(body):
+        raise AgentLoopError(
+            "Ordinary agent-authored comments may not contain a well-formed reserved "
+            "handoff or expected-closing protocol marker. Remove the marker from the "
+            "prose; a bare marker name is allowed."
+        )
+
+
+def _post_trusted_protocol_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    command: list[str],
+    body: str,
+) -> None:
+    """Post canonical protocol output after validating its marker encoding."""
+    _post_comment_body(runner, config=config, command=command, body=body)
+
+
+def _validate_canonical_json_marker_payload(
+    body: str,
+    *,
+    marker_re: re.Pattern[str],
+    marker_name: str,
+) -> None:
+    matches = tuple(marker_re.finditer(body))
+    if not matches:
+        raise AgentLoopError(
+            f"Trusted {marker_name} posting requires its canonical protocol marker."
+        )
+    for match in matches:
+        encoded = match.group("payload")
+        try:
+            value = json.loads(
+                base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8")
+            )
+        except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
+            raise AgentLoopError(f"Trusted {marker_name} payload is not valid JSON.") from exc
+        canonical = base64.urlsafe_b64encode(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        ).decode("ascii")
+        if canonical != encoded:
+            raise AgentLoopError(f"Trusted {marker_name} payload is not canonically encoded.")
+
+
+def post_trusted_pr_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    body: str,
+) -> None:
+    matches = tuple(PR_EXPECTED_CLOSING_MARKER_RE.finditer(body))
+    if not matches:
+        raise AgentLoopError(
+            f"Trusted PR protocol posting requires {PR_EXPECTED_CLOSING_MARKER}."
+        )
+    for match in matches:
+        encoded = match.group("payload")
+        contract = decode_pr_contract(encoded)
+        if encode_pr_contract(contract) != encoded:
+            raise AgentLoopError(
+                f"Trusted {PR_EXPECTED_CLOSING_MARKER} payload is not canonically encoded."
+            )
+    _post_trusted_protocol_comment(
+        runner, config=config, command=["pr", "comment", str(pr_number)], body=body
+    )
+
+
+def post_trusted_pr_contract_record(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    body: str,
+) -> None:
+    """Create a canonical PR contract record before issue-origin handoff."""
+    matches = tuple(PR_EXPECTED_CLOSING_MARKER_RE.finditer(body))
+    if not matches:
+        raise AgentLoopError(
+            f"Trusted PR protocol posting requires {PR_EXPECTED_CLOSING_MARKER}."
+        )
+    for match in matches:
+        encoded = match.group("payload")
+        contract = decode_pr_contract(encoded)
+        if encode_pr_contract(contract) != encoded:
+            raise AgentLoopError(
+                f"Trusted {PR_EXPECTED_CLOSING_MARKER} payload is not canonically encoded."
+            )
+    result = runner.run(
+        [
+            config.gh_cmd,
+            "api",
+            f"repos/{config.repo}/issues/{pr_number}/comments",
+            "--method",
+            "POST",
+            "--input",
+            "-",
+        ],
+        cwd=active_workdir(config),
+        input_text=json.dumps({"body": body}),
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise AgentLoopError(
+            f"Unable to persist the expected-closing PR contract for PR #{pr_number}."
+            + (f" {detail}" if detail else "")
+        )
+
+
+def post_trusted_issue_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    body: str,
+) -> None:
+    _validate_canonical_json_marker_payload(
+        body,
+        marker_re=_AGENT_ISSUE_PR_HANDOFF_MARKER_RE,
+        marker_name="AGENT_ISSUE_PR_HANDOFF",
+    )
+    _post_trusted_protocol_comment(
+        runner, config=config, command=["issue", "comment", str(issue_number)], body=body
+    )
 
 
 def _post_comment_body(runner: Runner, *, config: AgentLoopConfig, command: list[str], body: str) -> None:

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -163,6 +163,7 @@ def affirmative_markdown_view(body: str | None) -> str:
     output: list[str] = []
     fenced = False
     fence_char = ""
+    fence_length = 0
     list_line_re = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
     for line in text.splitlines():
         stripped = line.lstrip(" \t")
@@ -172,7 +173,12 @@ def affirmative_markdown_view(body: str | None) -> str:
             if not fenced:
                 fenced = True
                 fence_char = token[0]
-            elif token[0] == fence_char:
+                fence_length = len(token)
+            elif (
+                token[0] == fence_char
+                and len(token) >= fence_length
+                and not stripped[len(token) :].strip()
+            ):
                 fenced = False
             continue
         if fenced:

--- a/src/coding_review_agent_loop/issue_pr_handoff.py
+++ b/src/coding_review_agent_loop/issue_pr_handoff.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 
 from .config import AgentLoopConfig
 from .errors import AgentLoopError
+from .expected_closure import contract_hash, normalize_issue_ids
 from .github import (
     IssueContext,
     OpenPrClosingMatch,
@@ -29,7 +30,9 @@ from .github import (
     get_pr_state,
     get_pr_review_context,
     post_issue_comment,
+    post_trusted_issue_comment,
 )
+from .pr_contract import PrExpectedClosingContract, find_latest_pr_contract
 from .runner import Runner
 
 SCHEMA_VERSION = 1
@@ -50,6 +53,35 @@ class IssuePrHandoffMetadata:
     pr_head_sha: str
     flow: str
     plan_hash: str | None
+    expected_closing_issue_ids: tuple[int, ...] = ()
+    contract_hash: str | None = None
+    supersedes_hash: str | None = None
+
+    def __post_init__(self) -> None:
+        # Handoff records are issue-origin records, so the primary issue is
+        # always part of their contract. Preserve compatibility with callers
+        # that construct the pre-contract dataclass without the new fields.
+        if (
+            not self.expected_closing_issue_ids
+            and isinstance(self.issue_number, int)
+            and not isinstance(self.issue_number, bool)
+            and self.issue_number > 0
+        ):
+            object.__setattr__(self, "expected_closing_issue_ids", (self.issue_number,))
+        if not self.expected_closing_issue_ids:
+            return
+        normalized = normalize_issue_ids(
+            self.expected_closing_issue_ids,
+            field_name="expected_closing_issue_ids",
+        )
+        assert normalized is not None
+        if self.issue_number not in normalized:
+            raise AgentLoopError(
+                f"Issue handoff contract must retain primary issue #{self.issue_number}."
+            )
+        object.__setattr__(self, "expected_closing_issue_ids", normalized)
+        if self.contract_hash is None:
+            object.__setattr__(self, "contract_hash", contract_hash(normalized))
 
 
 @dataclass(frozen=True)
@@ -86,7 +118,7 @@ def _encode_json_payload(payload: dict[str, object]) -> str:
 def _decode_json_payload(encoded: str) -> dict[str, object]:
     try:
         payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
-    except (ValueError, json.JSONDecodeError) as exc:
+    except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_ISSUE_PR_HANDOFF payload.") from exc
     if not isinstance(payload, dict):
         raise AgentLoopError("Invalid AGENT_ISSUE_PR_HANDOFF payload.")
@@ -103,6 +135,9 @@ def _encode_issue_pr_handoff_metadata(metadata: IssuePrHandoffMetadata) -> str:
             "pr_head_sha": metadata.pr_head_sha,
             "flow": metadata.flow,
             "plan_hash": metadata.plan_hash,
+            "expected_closing_issue_ids": list(metadata.expected_closing_issue_ids),
+            "contract_hash": metadata.contract_hash,
+            "supersedes_hash": metadata.supersedes_hash,
         }
     )
 
@@ -163,6 +198,37 @@ def _decode_issue_pr_handoff_metadata(encoded: str) -> IssuePrHandoffMetadata:
             "Invalid AGENT_ISSUE_PR_HANDOFF payload: `plan_hash` must be absent for "
             "issue-implementation flow."
         )
+    raw_expected = payload.get("expected_closing_issue_ids")
+    if raw_expected is None:
+        expected_ids = (issue_number,)
+    else:
+        expected_ids = normalize_issue_ids(
+            raw_expected, field_name="AGENT_ISSUE_PR_HANDOFF.expected_closing_issue_ids"
+        )
+        assert expected_ids is not None
+        if issue_number not in expected_ids:
+            raise AgentLoopError(
+                "Invalid AGENT_ISSUE_PR_HANDOFF payload: expected closing IDs must retain "
+                f"the primary issue #{issue_number}."
+            )
+    raw_contract_hash = payload.get("contract_hash")
+    expected_contract_hash = contract_hash(expected_ids)
+    if raw_contract_hash is None:
+        handoff_contract_hash = expected_contract_hash
+    elif isinstance(raw_contract_hash, str) and raw_contract_hash == expected_contract_hash:
+        handoff_contract_hash = raw_contract_hash
+    else:
+        raise AgentLoopError(
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: `contract_hash` does not match "
+            "expected_closing_issue_ids."
+        )
+    supersedes_hash = payload.get("supersedes_hash")
+    if supersedes_hash is not None and (
+        not isinstance(supersedes_hash, str) or not supersedes_hash.strip()
+    ):
+        raise AgentLoopError(
+            "Invalid AGENT_ISSUE_PR_HANDOFF payload: `supersedes_hash` is invalid."
+        )
     return IssuePrHandoffMetadata(
         schema_version=schema_version,
         issue_number=issue_number,
@@ -171,6 +237,9 @@ def _decode_issue_pr_handoff_metadata(encoded: str) -> IssuePrHandoffMetadata:
         pr_head_sha=pr_head_sha,
         flow=str(flow),
         plan_hash=plan_hash if isinstance(plan_hash, str) else None,
+        expected_closing_issue_ids=expected_ids,
+        contract_hash=handoff_contract_hash,
+        supersedes_hash=supersedes_hash if isinstance(supersedes_hash, str) else None,
     )
 
 
@@ -199,10 +268,38 @@ def find_latest_issue_pr_handoff(
         if not isinstance(body, str):
             continue
         for match in AGENT_ISSUE_PR_HANDOFF_RE.finditer(body):
-            metadata = _decode_issue_pr_handoff_metadata(match.group("payload"))
+            encoded = match.group("payload")
+            metadata = _decode_issue_pr_handoff_metadata(encoded)
+            canonical_encoded = _encode_issue_pr_handoff_metadata(metadata)
+            if canonical_encoded != encoded:
+                legacy_keys = {
+                    "schema_version",
+                    "issue_number",
+                    "pr_number",
+                    "pr_url",
+                    "pr_head_sha",
+                    "flow",
+                    "plan_hash",
+                }
+                payload = _decode_json_payload(encoded)
+                if set(payload) != legacy_keys:
+                    raise AgentLoopError(
+                        "AGENT_ISSUE_PR_HANDOFF record is not canonically encoded."
+                    )
             if metadata.issue_number != issue_number:
                 continue
             _validate_issue_pr_handoff_url(metadata.pr_url, repo=repo, pr_number=metadata.pr_number)
+            if found is not None and found.pr_number == metadata.pr_number and found != metadata:
+                if (
+                    metadata.supersedes_hash == found.contract_hash
+                    and set(found.expected_closing_issue_ids) < set(metadata.expected_closing_issue_ids)
+                ):
+                    found = metadata
+                    continue
+                raise AgentLoopError(
+                    "Divergent AGENT_ISSUE_PR_HANDOFF records were found for "
+                    f"issue #{issue_number}."
+                )
             found = metadata
     return found
 
@@ -247,6 +344,29 @@ def resolve_canonical_pr_for_issue(
                 raise AgentLoopError(
                     f"recorded URL {canonical.pr_url!r} does not match GitHub URL "
                     f"{actual.url!r}"
+                )
+            pr_contract = find_latest_pr_contract(
+                pr_context.comments,
+                repository=config.repo,
+                pr_number=canonical.pr_number,
+            )
+            if pr_contract is not None and tuple(pr_contract.expected_closing_issue_ids) != tuple(
+                canonical.expected_closing_issue_ids
+            ):
+                raise AgentLoopError(
+                    "issue-side and PR-side expected closing contracts diverge: "
+                    f"issue side {canonical.expected_closing_issue_ids!r}, PR side "
+                    f"{pr_contract.expected_closing_issue_ids!r}."
+                )
+            if pr_contract is not None and (
+                pr_contract.primary_issue_number != canonical.issue_number
+                or pr_contract.origin_flow != canonical.flow
+                or pr_contract.contract_hash != canonical.contract_hash
+                or pr_contract.supersedes_hash != canonical.supersedes_hash
+            ):
+                raise AgentLoopError(
+                    "issue-side and PR-side expected closing contract metadata diverge: "
+                    "primary issue, origin flow, hash, or supersession lineage differs."
                 )
             state = get_pr_state(runner, config=config, pr_number=canonical.pr_number)
         except AgentLoopError as exc:
@@ -303,7 +423,18 @@ def format_issue_pr_handoff_comment(
     pr_head_sha: str,
     flow: str,
     plan_hash: str | None,
+    expected_closing_issue_ids: Sequence[int] | None = None,
+    supersedes_hash: str | None = None,
 ) -> str:
+    expected_ids = normalize_issue_ids(
+        expected_closing_issue_ids or (issue_number,),
+        field_name="expected_closing_issue_ids",
+    )
+    assert expected_ids is not None
+    if issue_number not in expected_ids:
+        raise AgentLoopError(
+            f"Issue handoff contract must retain primary issue #{issue_number}."
+        )
     metadata = IssuePrHandoffMetadata(
         schema_version=SCHEMA_VERSION,
         issue_number=issue_number,
@@ -312,7 +443,13 @@ def format_issue_pr_handoff_comment(
         pr_head_sha=pr_head_sha,
         flow=flow,
         plan_hash=plan_hash,
+        expected_closing_issue_ids=expected_ids,
+        contract_hash=contract_hash(expected_ids),
+        supersedes_hash=supersedes_hash,
     )
+    encoded_metadata = _encode_issue_pr_handoff_metadata(metadata)
+    if _encode_issue_pr_handoff_metadata(_decode_issue_pr_handoff_metadata(encoded_metadata)) != encoded_metadata:
+        raise AgentLoopError("Issue-to-PR handoff failed canonical rendering validation.")
     lines = [
         f"Issue #{issue_number} implementation handed off to PR #{pr_number}.",
         "",
@@ -322,13 +459,18 @@ def format_issue_pr_handoff_comment(
     ]
     if plan_hash:
         lines.append(f"Plan hash: {plan_hash}")
+    lines.append(
+        "Expected closing issues: "
+        + (", ".join(f"#{item}" for item in expected_ids) or "(none)")
+        + "."
+    )
     lines.extend(
         [
             "",
             "Reruns of `agent-loop issue` for this issue will resume review of this PR instead of "
             "invoking a coder again.",
             "",
-            f"<!-- AGENT_ISSUE_PR_HANDOFF: {_encode_issue_pr_handoff_metadata(metadata)} -->",
+            f"<!-- AGENT_ISSUE_PR_HANDOFF: {encoded_metadata} -->",
             "-- coding-review-agent-loop",
         ]
     )
@@ -345,8 +487,10 @@ def post_issue_pr_handoff_comment(
     pr_head_sha: str,
     flow: str,
     plan_hash: str | None,
+    expected_closing_issue_ids: Sequence[int] | None = None,
+    supersedes_hash: str | None = None,
 ) -> None:
-    post_issue_comment(
+    post_trusted_issue_comment(
         runner,
         config=config,
         issue_number=issue_number,
@@ -357,5 +501,7 @@ def post_issue_pr_handoff_comment(
             pr_head_sha=pr_head_sha,
             flow=flow,
             plan_hash=plan_hash,
+            expected_closing_issue_ids=expected_closing_issue_ids,
+            supersedes_hash=supersedes_hash,
         ),
     )

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -12,6 +12,7 @@ from urllib.parse import quote
 from .config import AgentLoopConfig
 from .errors import AgentLoopError
 from .logging import log
+from .github import reject_forged_protocol_markers
 from .managed_ci import (
     MANAGED_LABEL,
     UNPROTECTED_OVERRIDE_TRAILER,
@@ -139,6 +140,7 @@ def create_managed_pr(
         raise AgentLoopError("--head must name a same-repository branch, without `refs/` or an owner prefix.")
     if not title:
         raise AgentLoopError("--title cannot be empty.")
+    reject_forged_protocol_markers(body)
     if SOURCE_MARKER in body or UNPROTECTED_OVERRIDE_TRAILER in body:
         raise AgentLoopError("The supplied PR body contains a reserved managed-PR protocol marker.")
     if not config.base:

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -302,6 +302,7 @@ def create_managed_pr(
     correlated_config = replace(
         config,
         managed_ci_expected_override_nonce=intent.audit_nonce,
+        pr_origin_flow="managed-pr",
         # Replaying managed-pr would hit the duplicate-PR guard for the draft
         # just created above. Leave no original argv so a CI-watch timeout
         # renders run_pr_loop's deterministic `agent-loop pr <n>` recovery.

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -90,6 +90,7 @@ from .issue_pr_handoff import (
 )
 from .pr_contract import (
     PR_EXPECTED_CLOSING_MARKER_RE,
+    PrExpectedClosingContract,
     find_latest_pr_contract,
     format_pr_contract_comment,
     make_pr_contract,
@@ -342,14 +343,6 @@ from .round_state import (
     _serialize_unresolved_item,
     _strip_round_metadata,
 )
-
-
-def _embed_pr_contract_marker(body: str, contract) -> str:
-    marker = render_pr_contract_marker(contract)
-    if "\n-- " in body:
-        prefix, signature = body.rsplit("\n-- ", 1)
-        return f"{prefix}\n{marker}\n-- {signature}"
-    return f"{body.rstrip()}\n{marker}"
 from .round_transport import is_round_transport_sidecar
 from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
@@ -376,6 +369,14 @@ from .unresolved_items import (
     _validate_review_response,
     _validate_structured_coder_followup_items,
 )
+
+
+def _embed_pr_contract_marker(body: str, contract: PrExpectedClosingContract) -> str:
+    marker = render_pr_contract_marker(contract)
+    if "\n-- " in body:
+        prefix, signature = body.rsplit("\n-- ", 1)
+        return f"{prefix}\n{marker}\n-- {signature}"
+    return f"{body.rstrip()}\n{marker}"
 
 
 # TRANSIENT_AGENT_OUTPUT_RE / NON_RETRYABLE_AGENT_OUTPUT_RE / is_transient_agent_output
@@ -5622,6 +5623,7 @@ def run_issue_loop(
                     ),
                     primary_issue_number=issue_number,
                     expected_closing_issue_ids=closing_contract.issue_ids,
+                    supersedes_hash=closing_contract.supersedes_hash,
                 )
                 post_trusted_pr_comment(
                     runner,
@@ -5643,6 +5645,7 @@ def run_issue_loop(
                     ),
                     plan_hash=recovered_plan_hash if plan_first else None,
                     expected_closing_issue_ids=closing_contract.issue_ids,
+                    supersedes_hash=closing_contract.supersedes_hash,
                 )
             return run_pr_loop(
                 runner,
@@ -6149,7 +6152,11 @@ def run_pr_loop(
                 origin_flow=(
                     recorded_pr_contract.origin_flow
                     if recorded_pr_contract is not None
-                    else ("direct-pr" if issue_context is None else "issue-implementation")
+                    else (
+                        config.pr_origin_flow
+                        if issue_context is None
+                        else "issue-implementation"
+                    )
                 ),
                 primary_issue_number=(
                     recorded_pr_contract.primary_issue_number
@@ -6199,7 +6206,11 @@ def run_pr_loop(
                     origin_flow=(
                         recorded_pr_contract.origin_flow
                         if recorded_pr_contract is not None
-                        else ("direct-pr" if issue_context is None else "issue-implementation")
+                        else (
+                            config.pr_origin_flow
+                            if issue_context is None
+                            else "issue-implementation"
+                        )
                     ),
                     primary_issue_number=(
                         recorded_pr_contract.primary_issue_number
@@ -6207,7 +6218,13 @@ def run_pr_loop(
                         else None if issue_context is None else issue_context.number
                     ),
                     expected_closing_issue_ids=resolved_contract.issue_ids,
-                    supersedes_hash=resolved_contract.supersedes_hash,
+                    supersedes_hash=(
+                        recorded_pr_contract.supersedes_hash
+                        if recorded_pr_contract is not None
+                        and tuple(resolved_contract.issue_ids)
+                        == tuple(recorded_pr_contract.expected_closing_issue_ids)
+                        else resolved_contract.supersedes_hash
+                    ),
                 )
             )
         if issue_context is not None and recorded_pr_contract is None and config.expected_closing_contract_resolved:
@@ -6281,6 +6298,15 @@ def run_pr_loop(
                 issue_number=issue_context.number,
                 repo=config.repo,
             )
+            if (
+                issue_handoff_to_update is not None
+                and tuple(issue_handoff_to_update.expected_closing_issue_ids)
+                != tuple(recorded_pr_contract.expected_closing_issue_ids)
+            ):
+                raise AgentLoopError(
+                    "Issue-side and PR-side expected closing contracts disagree before "
+                    "supersession; no durable metadata changed."
+                )
         config = resolve_base_branch(
             config,
             runner,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -50,6 +50,12 @@ from .errors import (
     QuotaResetExceededError,
     UnknownPriorItemDispositionError,
 )
+from .expected_closure import (
+    ExpectedClosingContract,
+    reject_parent_from_contract,
+    resolve_direct_contract,
+    resolve_issue_contract,
+)
 from .github import (
     CiWatchOutcome,
     IssueContext,
@@ -65,17 +71,29 @@ from .github import (
     merge_pr,
     post_issue_comment,
     post_pr_comment,
+    post_trusted_pr_contract_record,
+    post_trusted_pr_comment,
+    reject_forged_protocol_markers,
     validate_open_issue,
     validate_open_pr,
     validate_pr_body_does_not_close_issue,
+    validate_pr_expected_closing_issues,
     validate_pr_references_issue,
     wait_for_ci,
     watch_pr_checks,
 )
 from .issue_pr_handoff import (
+    find_latest_issue_pr_handoff,
     post_issue_pr_handoff_comment,
     require_pr_metadata_for_handoff,
     resolve_canonical_pr_for_issue,
+)
+from .pr_contract import (
+    PR_EXPECTED_CLOSING_MARKER_RE,
+    find_latest_pr_contract,
+    format_pr_contract_comment,
+    make_pr_contract,
+    render_pr_contract_marker,
 )
 from .split_materialization import (
     DISCUSS_SPLIT_MARKER_RE,
@@ -274,6 +292,8 @@ from .comment_rendering import (
     render_agent_unavailable_comment,
     render_canonical_plan_revision,
     render_canonical_plan_steps,
+    PLAN_EXPECTED_CLOSING_MARKER_RE,
+    decode_expected_closing_issue_declaration,
     _render_discuss_agenda_lines,
 )
 from .followups import (
@@ -322,6 +342,14 @@ from .round_state import (
     _serialize_unresolved_item,
     _strip_round_metadata,
 )
+
+
+def _embed_pr_contract_marker(body: str, contract) -> str:
+    marker = render_pr_contract_marker(contract)
+    if "\n-- " in body:
+        prefix, signature = body.rsplit("\n-- ", 1)
+        return f"{prefix}\n{marker}\n-- {signature}"
+    return f"{body.rstrip()}\n{marker}"
 from .round_transport import is_round_transport_sidecar
 from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
@@ -3483,6 +3511,23 @@ def _extract_current_deferred_stages(current_plan: str) -> tuple[DeferredStage, 
     return tuple(stages)
 
 
+def _extract_current_expected_closing_issue_ids(
+    current_plan: str,
+) -> tuple[int, ...] | None:
+    """Recover the optional plan declaration from JSON or canonical Markdown."""
+    for validator in (validate_structured_plan_state, validate_structured_plan_revision):
+        try:
+            structured = validator(current_plan)
+        except AgentLoopError:
+            structured = None
+        if structured is not None:
+            return structured.additional_closing_issue_ids
+    marker = PLAN_EXPECTED_CLOSING_MARKER_RE.search(current_plan)
+    if marker is None:
+        return None
+    return decode_expected_closing_issue_declaration(marker.group("payload"))
+
+
 def _extract_current_child_stages(current_plan: str) -> tuple[ChildStage, ...]:
     """Return only explicitly typed child stages; legacy entries are record-only."""
     try:
@@ -3849,6 +3894,7 @@ def _implement_approved_issue(
     coder_name = agent_display_name(implementation_config.coder)
     implementation_session_id = coder_session_id if reuse_planning_session else None
     plan_hash = approved_plan_hash(approved_plan)
+    plan_additions = _extract_current_expected_closing_issue_ids(approved_plan)
 
     # A prior implementation attempt may have created a PR and then aborted
     # before recording any handoff marker/comment (e.g. the #493 test-report
@@ -3858,6 +3904,24 @@ def _implement_approved_issue(
     # (#495, #589).
     resolved_pr = resolve_canonical_pr_for_issue(
         runner, config=config, issue_number=issue_number, issue_context=issue_context
+    )
+    recovered_contract_ids = (
+        resolved_pr.metadata.expected_closing_issue_ids
+        if resolved_pr is not None and resolved_pr.metadata is not None
+        else (issue_number,) if resolved_pr is not None else None
+    )
+    closing_contract = resolve_issue_contract(
+        primary_issue=issue_number,
+        cli_additions=config.expected_closing_issue_ids,
+        plan_additions=plan_additions,
+        recovered=recovered_contract_ids,
+        supersede=config.supersede_expected_closing_contract,
+    )
+    reject_parent_from_contract(closing_contract, parent_issue=staged_parent_issue)
+    implementation_config = dataclasses_replace(
+        implementation_config,
+        expected_closing_issue_ids=closing_contract.issue_ids,
+        expected_closing_contract_resolved=True,
     )
     if resolved_pr is not None:
         existing_pr_number = resolved_pr.pr_number
@@ -3893,6 +3957,27 @@ def _implement_approved_issue(
             )
         if resolved_pr.source == "legacy-closing-reference":
             pr_url, pr_head_sha = require_pr_metadata_for_handoff(resumed_pr_context.metadata)
+            validate_pr_expected_closing_issues(
+                runner,
+                config=implementation_config,
+                pr_number=existing_pr_number,
+                expected_issue_ids=closing_contract.issue_ids,
+                body=resumed_pr_context.metadata.body,
+            )
+            pr_contract = make_pr_contract(
+                repository=implementation_config.repo,
+                pr_number=existing_pr_number,
+                origin_flow="approved-plan-implementation",
+                primary_issue_number=issue_number,
+                expected_closing_issue_ids=closing_contract.issue_ids,
+                supersedes_hash=closing_contract.supersedes_hash,
+            )
+            post_trusted_pr_comment(
+                runner,
+                config=implementation_config,
+                pr_number=existing_pr_number,
+                body=format_pr_contract_comment(pr_contract),
+            )
             post_issue_pr_handoff_comment(
                 runner,
                 config=implementation_config,
@@ -3902,6 +3987,8 @@ def _implement_approved_issue(
                 pr_head_sha=pr_head_sha,
                 flow="approved-plan-implementation",
                 plan_hash=plan_hash,
+                expected_closing_issue_ids=closing_contract.issue_ids,
+                supersedes_hash=closing_contract.supersedes_hash,
             )
         if one_shot_parent_issue is not None:
             post_one_shot_impl_handoff_comment(
@@ -4004,15 +4091,38 @@ def _implement_approved_issue(
     )
     log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
     validate_open_pr(runner, config=implementation_config, pr_number=pr_number)
+    initial_pr_context = get_pr_review_context(runner, config=implementation_config, pr_number=pr_number)
+    reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
     validate_pr_references_issue(
         runner,
         config=implementation_config,
         pr_number=pr_number,
         issue_number=issue_number,
         staged_parent_issue=staged_parent_issue,
+        body=initial_pr_context.metadata.body,
     )
-    initial_pr_context = get_pr_review_context(runner, config=implementation_config, pr_number=pr_number)
+    validate_pr_expected_closing_issues(
+        runner,
+        config=implementation_config,
+        pr_number=pr_number,
+        expected_issue_ids=closing_contract.issue_ids,
+        body=initial_pr_context.metadata.body,
+    )
     initial_pr_url, initial_pr_head_sha = require_pr_metadata_for_handoff(initial_pr_context.metadata)
+    pr_contract = make_pr_contract(
+        repository=implementation_config.repo,
+        pr_number=pr_number,
+        origin_flow="approved-plan-implementation",
+        primary_issue_number=issue_number,
+        expected_closing_issue_ids=closing_contract.issue_ids,
+        supersedes_hash=closing_contract.supersedes_hash,
+    )
+    post_trusted_pr_contract_record(
+        runner,
+        config=implementation_config,
+        pr_number=pr_number,
+        body=format_pr_contract_comment(pr_contract),
+    )
     post_issue_pr_handoff_comment(
         runner,
         config=implementation_config,
@@ -4022,6 +4132,8 @@ def _implement_approved_issue(
         pr_head_sha=initial_pr_head_sha,
         flow="approved-plan-implementation",
         plan_hash=plan_hash,
+        expected_closing_issue_ids=closing_contract.issue_ids,
+        supersedes_hash=closing_contract.supersedes_hash,
     )
     if one_shot_parent_issue is not None:
         post_one_shot_impl_handoff_comment(
@@ -4034,29 +4146,30 @@ def _implement_approved_issue(
             pr_number=pr_number,
             pr_head_sha=initial_pr_context.metadata.head_sha,
         )
-    post_pr_comment(
+    initial_coder_body = _attach_round_metadata(
+        normalize_freeform_signature(
+            coder_output,
+            agent=implementation_config.coder,
+            config=implementation_config,
+            model_used=coder_response.model_used,
+        ),
+        PostedRoundMetadata(
+            flow="pr",
+            role="coder",
+            agent=coder_name,
+            round_number=1,
+            subject=str(initial_pr_context.metadata.head_sha or "unknown"),
+            prior_items=(),
+            model_used=coder_response.model_used,
+            acquisition_outcome=coder_response.acquisition_outcome,
+            acquisition_returncode=coder_response.acquisition_returncode,
+        ),
+    )
+    post_trusted_pr_comment(
         runner,
         config=implementation_config,
         pr_number=pr_number,
-        body=_attach_round_metadata(
-            normalize_freeform_signature(
-                coder_output,
-                agent=implementation_config.coder,
-                config=implementation_config,
-                model_used=coder_response.model_used,
-            ),
-            PostedRoundMetadata(
-                flow="pr",
-                role="coder",
-                agent=coder_name,
-                round_number=1,
-                subject=str(initial_pr_context.metadata.head_sha or "unknown"),
-                prior_items=(),
-                model_used=coder_response.model_used,
-                acquisition_outcome=coder_response.acquisition_outcome,
-                acquisition_returncode=coder_response.acquisition_returncode,
-            ),
-        ),
+        body=_embed_pr_contract_marker(initial_coder_body, pr_contract),
     )
     if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
         implementation_config = dataclasses_replace(
@@ -4926,6 +5039,19 @@ def _run_plan_first_loop(
             mode = config.plan_execution_mode
             if implement_after_approval:
                 mode = "implement-one-shot"
+            plan_additions = _extract_current_expected_closing_issue_ids(current_plan)
+            split_topology = bool(
+                mode in {"decompose-only", "implement-by-phase"}
+                or config.materialize_split_issues
+                or _extract_current_child_stages(current_plan)
+                or _extract_current_deferred_stages(current_plan)
+            )
+            if split_topology and (config.expected_closing_issue_ids is not None or plan_additions is not None):
+                raise AgentLoopError(
+                    "Additional expected closing issue IDs are single-PR-only and cannot be "
+                    "carried through split/decomposition materialization. Invoke the actual "
+                    "child issue with a child-scoped --expected-closing-issue declaration."
+                )
             _publish_plan_approved_followups(
                 runner,
                 config=config,
@@ -5391,6 +5517,7 @@ def run_issue_loop(
         staged_parent_issue = _infer_staged_parent_issue(issue_context)
 
         recovered_plan_hash: str | None = None
+        recovered_plan_additions: tuple[int, ...] | None = None
         if plan_first:
             # This is a comment-only reconstruction.  It must happen before
             # memory preparation or any agent invocation so an existing
@@ -5400,6 +5527,9 @@ def run_issue_loop(
             )
             if recovered_plan_state is not None:
                 recovered_plan_hash = approved_plan_hash(recovered_plan_state[0])
+                recovered_plan_additions = _extract_current_expected_closing_issue_ids(
+                    recovered_plan_state[0]
+                )
 
         # Resolve the canonical AGENT_ISSUE_PR_HANDOFF record (or, failing
         # that, the legacy exactly-one-open-PR search) before invoking a
@@ -5410,6 +5540,23 @@ def run_issue_loop(
             runner, config=config, issue_number=issue_number, issue_context=issue_context
         )
         if resolved_pr is not None:
+            closing_contract = resolve_issue_contract(
+                primary_issue=issue_number,
+                cli_additions=config.expected_closing_issue_ids,
+                plan_additions=recovered_plan_additions,
+                recovered=(
+                    resolved_pr.metadata.expected_closing_issue_ids
+                    if resolved_pr.metadata is not None
+                    else (issue_number,)
+                ),
+                supersede=config.supersede_expected_closing_contract,
+            )
+            reject_parent_from_contract(closing_contract, parent_issue=staged_parent_issue)
+            config = dataclasses_replace(
+                config,
+                expected_closing_issue_ids=closing_contract.issue_ids,
+                expected_closing_contract_resolved=True,
+            )
             resolved_metadata = resolved_pr.metadata
             if plan_first and resolved_pr.source == "canonical" and resolved_metadata is not None:
                 if (
@@ -5457,7 +5604,31 @@ def run_issue_loop(
                 )
             if resolved_pr.source == "legacy-closing-reference":
                 pr_context = get_pr_review_context(runner, config=config, pr_number=resolved_pr.pr_number)
+                validate_pr_expected_closing_issues(
+                    runner,
+                    config=config,
+                    pr_number=resolved_pr.pr_number,
+                    expected_issue_ids=closing_contract.issue_ids,
+                    body=pr_context.metadata.body,
+                )
                 pr_url, pr_head_sha = require_pr_metadata_for_handoff(pr_context.metadata)
+                pr_contract = make_pr_contract(
+                    repository=config.repo,
+                    pr_number=resolved_pr.pr_number,
+                    origin_flow=(
+                        "approved-plan-implementation"
+                        if plan_first and recovered_plan_hash is not None
+                        else "issue-implementation"
+                    ),
+                    primary_issue_number=issue_number,
+                    expected_closing_issue_ids=closing_contract.issue_ids,
+                )
+                post_trusted_pr_comment(
+                    runner,
+                    config=config,
+                    pr_number=resolved_pr.pr_number,
+                    body=format_pr_contract_comment(pr_contract),
+                )
                 post_issue_pr_handoff_comment(
                     runner,
                     config=config,
@@ -5471,6 +5642,7 @@ def run_issue_loop(
                         else "issue-implementation"
                     ),
                     plan_hash=recovered_plan_hash if plan_first else None,
+                    expected_closing_issue_ids=closing_contract.issue_ids,
                 )
             return run_pr_loop(
                 runner,
@@ -5491,6 +5663,20 @@ def run_issue_loop(
                 implement_after_approval=implement_after_approval,
                 usage_context=usage_context,
             )
+
+        closing_contract = resolve_issue_contract(
+            primary_issue=issue_number,
+            cli_additions=config.expected_closing_issue_ids,
+            plan_additions=None,
+            recovered=None,
+            supersede=config.supersede_expected_closing_contract,
+        )
+        reject_parent_from_contract(closing_contract, parent_issue=staged_parent_issue)
+        config = dataclasses_replace(
+            config,
+            expected_closing_issue_ids=closing_contract.issue_ids,
+            expected_closing_contract_resolved=True,
+        )
 
         sync_coder_base_before_implementation(config, runner)
         managed_ci_creation_intent = None
@@ -5575,15 +5761,38 @@ def run_issue_loop(
         )
         log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
         validate_open_pr(runner, config=config, pr_number=pr_number)
+        initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
+        reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+        initial_pr_metadata = initial_pr_context.metadata
         validate_pr_references_issue(
             runner,
             config=config,
             pr_number=pr_number,
             issue_number=issue_number,
             staged_parent_issue=staged_parent_issue,
+            body=initial_pr_metadata.body,
         )
-        initial_pr_metadata = get_pr_review_context(runner, config=config, pr_number=pr_number).metadata
+        validate_pr_expected_closing_issues(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            expected_issue_ids=closing_contract.issue_ids,
+            body=initial_pr_metadata.body,
+        )
         initial_pr_url, initial_pr_head_sha = require_pr_metadata_for_handoff(initial_pr_metadata)
+        pr_contract = make_pr_contract(
+            repository=config.repo,
+            pr_number=pr_number,
+            origin_flow="issue-implementation",
+            primary_issue_number=issue_number,
+            expected_closing_issue_ids=closing_contract.issue_ids,
+        )
+        post_trusted_pr_contract_record(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            body=format_pr_contract_comment(pr_contract),
+        )
         post_issue_pr_handoff_comment(
             runner,
             config=config,
@@ -5593,25 +5802,32 @@ def run_issue_loop(
             pr_head_sha=initial_pr_head_sha,
             flow="issue-implementation",
             plan_hash=None,
+            expected_closing_issue_ids=closing_contract.issue_ids,
         )
-        post_pr_comment(
+        initial_coder_body = _attach_round_metadata(
+            normalize_freeform_signature(
+                coder_output,
+                agent=config.coder,
+                config=config,
+                model_used=coder_response.model_used,
+            ),
+            PostedRoundMetadata(
+                flow="pr",
+                role="coder",
+                agent=agent_display_name(config.coder),
+                round_number=1,
+                subject=str(initial_pr_metadata.head_sha or "unknown"),
+                prior_items=(),
+                model_used=coder_response.model_used,
+                acquisition_outcome=coder_response.acquisition_outcome,
+                acquisition_returncode=coder_response.acquisition_returncode,
+            ),
+        )
+        post_trusted_pr_comment(
             runner,
             config=config,
             pr_number=pr_number,
-            body=_attach_round_metadata(
-                normalize_freeform_signature(coder_output, agent=config.coder, config=config, model_used=coder_response.model_used),
-                PostedRoundMetadata(
-                    flow="pr",
-                    role="coder",
-                    agent=agent_display_name(config.coder),
-                    round_number=1,
-                    subject=str(initial_pr_metadata.head_sha or "unknown"),
-                    prior_items=(),
-                    model_used=coder_response.model_used,
-                    acquisition_outcome=coder_response.acquisition_outcome,
-                    acquisition_returncode=coder_response.acquisition_returncode,
-                ),
-            ),
+            body=_embed_pr_contract_marker(initial_coder_body, pr_contract),
         )
         if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
             config = dataclasses_replace(
@@ -5919,6 +6135,114 @@ def run_pr_loop(
             pr_number=pr_number,
             cwd=bootstrap_cwd,
         )
+        reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+        recorded_pr_contract = find_latest_pr_contract(
+            initial_pr_context.comments,
+            repository=config.repo,
+            pr_number=pr_number,
+        )
+        if config.expected_closing_contract_resolved:
+            assert config.expected_closing_issue_ids is not None
+            closing_contract = make_pr_contract(
+                repository=config.repo,
+                pr_number=pr_number,
+                origin_flow=(
+                    recorded_pr_contract.origin_flow
+                    if recorded_pr_contract is not None
+                    else ("direct-pr" if issue_context is None else "issue-implementation")
+                ),
+                primary_issue_number=(
+                    recorded_pr_contract.primary_issue_number
+                    if recorded_pr_contract is not None
+                    else None if issue_context is None else issue_context.number
+                ),
+                expected_closing_issue_ids=config.expected_closing_issue_ids,
+                supersedes_hash=(
+                    recorded_pr_contract.supersedes_hash
+                    if recorded_pr_contract is not None
+                    else None
+                ),
+            )
+            if recorded_pr_contract is not None and tuple(
+                recorded_pr_contract.expected_closing_issue_ids
+            ) != tuple(closing_contract.expected_closing_issue_ids):
+                closing_contract = resolve_direct_contract(
+                    explicit=closing_contract.expected_closing_issue_ids,
+                    recovered=recorded_pr_contract.expected_closing_issue_ids,
+                    supersede=config.supersede_expected_closing_contract,
+                )
+                assert closing_contract is not None
+                closing_contract = make_pr_contract(
+                    repository=config.repo,
+                    pr_number=pr_number,
+                    origin_flow=recorded_pr_contract.origin_flow,
+                    primary_issue_number=recorded_pr_contract.primary_issue_number,
+                    expected_closing_issue_ids=closing_contract.issue_ids,
+                    supersedes_hash=closing_contract.supersedes_hash,
+                )
+        else:
+            resolved_contract = resolve_direct_contract(
+                explicit=config.expected_closing_issue_ids,
+                recovered=(
+                    recorded_pr_contract.expected_closing_issue_ids
+                    if recorded_pr_contract is not None
+                    else None
+                ),
+                supersede=config.supersede_expected_closing_contract,
+            )
+            closing_contract = (
+                None
+                if resolved_contract is None
+                else make_pr_contract(
+                    repository=config.repo,
+                    pr_number=pr_number,
+                    origin_flow=(
+                        recorded_pr_contract.origin_flow
+                        if recorded_pr_contract is not None
+                        else ("direct-pr" if issue_context is None else "issue-implementation")
+                    ),
+                    primary_issue_number=(
+                        recorded_pr_contract.primary_issue_number
+                        if recorded_pr_contract is not None
+                        else None if issue_context is None else issue_context.number
+                    ),
+                    expected_closing_issue_ids=resolved_contract.issue_ids,
+                    supersedes_hash=resolved_contract.supersedes_hash,
+                )
+            )
+        if issue_context is not None and recorded_pr_contract is None and config.expected_closing_contract_resolved:
+            # A pre-contract canonical handoff is a legacy recovery record. Do
+            # not retroactively turn its old Refs-only body into a new durable
+            # contract; only newly persisted PR-side records activate the gate.
+            log(
+                config,
+                f"PR #{pr_number}: no PR-side expected-closing record found; retaining legacy "
+                "handoff recovery without inferring a contract from prose",
+            )
+            closing_contract = None
+        contract_needs_persisting = (
+            closing_contract is not None
+            and (recorded_pr_contract is None or recorded_pr_contract != closing_contract)
+        )
+        issue_handoff_to_update = None
+        if issue_context is not None and recorded_pr_contract is not None:
+            issue_handoff_to_update = find_latest_issue_pr_handoff(
+                issue_context.comments,
+                issue_number=issue_context.number,
+                repo=config.repo,
+            )
+            if (
+                contract_needs_persisting
+                and recorded_pr_contract.origin_flow
+                in {"issue-implementation", "approved-plan-implementation"}
+                and issue_handoff_to_update is not None
+                and tuple(issue_handoff_to_update.expected_closing_issue_ids)
+                != tuple(recorded_pr_contract.expected_closing_issue_ids)
+            ):
+                raise AgentLoopError(
+                    "Issue-side and PR-side expected closing contracts disagree before "
+                    "supersession; no durable metadata changed."
+                )
         if issue_context is None:
             linked_issue_numbers = parse_linked_issue_numbers(
                 initial_pr_context.metadata.body,
@@ -5943,6 +6267,20 @@ def run_pr_loop(
                 )
             else:
                 log(config, f"PR #{pr_number} has no linked issue context to include in review prompts")
+        if (
+            closing_contract is not None
+            and contract_needs_persisting
+            and recorded_pr_contract is not None
+            and recorded_pr_contract.origin_flow
+            in {"issue-implementation", "approved-plan-implementation"}
+            and issue_context is not None
+            and issue_handoff_to_update is None
+        ):
+            issue_handoff_to_update = find_latest_issue_pr_handoff(
+                issue_context.comments,
+                issue_number=issue_context.number,
+                repo=config.repo,
+            )
         config = resolve_base_branch(
             config,
             runner,
@@ -5955,6 +6293,47 @@ def run_pr_loop(
             _ensure_parallel_reviewer_workdirs(config, flag_name="--review-parallel", role_label="reviewer")
         log(config, f"Validating PR #{pr_number}")
         validate_open_pr(runner, config=config, pr_number=pr_number)
+        if closing_contract is not None:
+            validate_pr_expected_closing_issues(
+                runner,
+                config=config,
+                pr_number=pr_number,
+                expected_issue_ids=closing_contract.expected_closing_issue_ids,
+                body=initial_pr_context.metadata.body,
+            )
+            if contract_needs_persisting:
+                post_trusted_pr_comment(
+                    runner,
+                    config=config,
+                    pr_number=pr_number,
+                    body=format_pr_contract_comment(closing_contract),
+                )
+            if (
+                contract_needs_persisting
+                and recorded_pr_contract is not None
+                and recorded_pr_contract.origin_flow
+                in {"issue-implementation", "approved-plan-implementation"}
+                and issue_context is not None
+                and issue_handoff_to_update is not None
+            ):
+                if issue_context.number != recorded_pr_contract.primary_issue_number:
+                    raise AgentLoopError(
+                        "The linked issue context does not match the issue-origin PR contract; "
+                        "resume with the authoritative issue or PR metadata."
+                    )
+                pr_url, pr_head_sha = require_pr_metadata_for_handoff(initial_pr_context.metadata)
+                post_issue_pr_handoff_comment(
+                    runner,
+                    config=config,
+                    issue_number=issue_context.number,
+                    pr_number=pr_number,
+                    pr_url=pr_url,
+                    pr_head_sha=pr_head_sha,
+                    flow=recorded_pr_contract.origin_flow,
+                    plan_hash=issue_handoff_to_update.plan_hash,
+                    expected_closing_issue_ids=closing_contract.expected_closing_issue_ids,
+                    supersedes_hash=closing_contract.supersedes_hash,
+                )
         activation = activate_managed_ci(
             runner,
             config=config,
@@ -6074,6 +6453,14 @@ def run_pr_loop(
             initial_pr_context = pr_context
             pr_metadata = pr_context.metadata
             pr_comments = pr_context.comments
+            if closing_contract is not None:
+                validate_pr_expected_closing_issues(
+                    runner,
+                    config=config,
+                    pr_number=pr_number,
+                    expected_issue_ids=closing_contract.expected_closing_issue_ids,
+                    body=pr_metadata.body,
+                )
             if managed_ci_active(pr_metadata) and pre_review_tests_passed and pr_metadata.head_sha:
                 publish_round_readiness(
                     runner,

--- a/src/coding_review_agent_loop/pr_contract.py
+++ b/src/coding_review_agent_loop/pr_contract.py
@@ -1,0 +1,220 @@
+"""Canonical PR-side expected-closing contract records."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .errors import AgentLoopError
+from .expected_closure import contract_hash, normalize_issue_ids
+
+PR_EXPECTED_CLOSING_MARKER = "AGENT_PR_EXPECTED_CLOSING_ISSUES"
+PR_EXPECTED_CLOSING_MARKER_RE = re.compile(
+    rf"<!--\s*{PR_EXPECTED_CLOSING_MARKER}:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->"
+    ,
+    re.IGNORECASE,
+)
+
+_VALID_ORIGINS = {
+    "issue-implementation",
+    "approved-plan-implementation",
+    "direct-pr",
+    "managed-pr",
+}
+
+
+@dataclass(frozen=True)
+class PrExpectedClosingContract:
+    schema_version: int
+    repository: str
+    pr_number: int
+    origin_flow: str
+    primary_issue_number: int | None
+    expected_closing_issue_ids: tuple[int, ...]
+    contract_hash: str
+    supersedes_hash: str | None = None
+
+
+def _encode_payload(payload: dict[str, object]) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_payload(encoded: str) -> dict[str, object]:
+    try:
+        value = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8"))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload.") from exc
+    if not isinstance(value, dict):
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload.")
+    return value
+
+
+def encode_pr_contract(contract: PrExpectedClosingContract) -> str:
+    return _encode_payload(
+        {
+            "schema_version": contract.schema_version,
+            "repository": contract.repository,
+            "pr_number": contract.pr_number,
+            "origin_flow": contract.origin_flow,
+            "primary_issue_number": contract.primary_issue_number,
+            "expected_closing_issue_ids": list(contract.expected_closing_issue_ids),
+            "contract_hash": contract.contract_hash,
+            "supersedes_hash": contract.supersedes_hash,
+        }
+    )
+
+
+def decode_pr_contract(encoded: str) -> PrExpectedClosingContract:
+    payload = _decode_payload(encoded)
+    required = {
+        "schema_version",
+        "repository",
+        "pr_number",
+        "origin_flow",
+        "primary_issue_number",
+        "expected_closing_issue_ids",
+        "contract_hash",
+        "supersedes_hash",
+    }
+    if set(payload) != required:
+        raise AgentLoopError(
+            f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: expected exactly "
+            f"{', '.join(sorted(required))}."
+        )
+    version = payload["schema_version"]
+    pr_number = payload["pr_number"]
+    primary = payload["primary_issue_number"]
+    if isinstance(version, bool) or version != 1:
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: schema_version must be 1.")
+    if isinstance(pr_number, bool) or not isinstance(pr_number, int) or pr_number <= 0:
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: pr_number must be positive.")
+    if primary is not None and (
+        isinstance(primary, bool) or not isinstance(primary, int) or primary <= 0
+    ):
+        raise AgentLoopError(
+            f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: primary_issue_number is invalid."
+        )
+    repository = payload["repository"]
+    origin = payload["origin_flow"]
+    digest = payload["contract_hash"]
+    supersedes = payload["supersedes_hash"]
+    if not isinstance(repository, str) or not repository.strip():
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: repository is invalid.")
+    if origin not in _VALID_ORIGINS:
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: origin_flow is invalid.")
+    if supersedes is not None and (not isinstance(supersedes, str) or not supersedes.strip()):
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: supersedes_hash is invalid.")
+    ids = normalize_issue_ids(
+        payload["expected_closing_issue_ids"],
+        field_name=f"{PR_EXPECTED_CLOSING_MARKER}.expected_closing_issue_ids",
+    )
+    assert ids is not None
+    if not isinstance(digest, str) or digest != contract_hash(ids):
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} payload: contract_hash is invalid.")
+    return PrExpectedClosingContract(
+        schema_version=1,
+        repository=repository,
+        pr_number=pr_number,
+        origin_flow=str(origin),
+        primary_issue_number=primary,
+        expected_closing_issue_ids=ids,
+        contract_hash=digest,
+        supersedes_hash=supersedes,
+    )
+
+
+def make_pr_contract(
+    *,
+    repository: str,
+    pr_number: int,
+    origin_flow: str,
+    expected_closing_issue_ids: Sequence[int],
+    primary_issue_number: int | None = None,
+    supersedes_hash: str | None = None,
+) -> PrExpectedClosingContract:
+    if origin_flow not in _VALID_ORIGINS:
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} origin_flow.")
+    if isinstance(pr_number, bool) or not isinstance(pr_number, int) or pr_number <= 0:
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} pr_number.")
+    if primary_issue_number is not None and (
+        isinstance(primary_issue_number, bool)
+        or not isinstance(primary_issue_number, int)
+        or primary_issue_number <= 0
+    ):
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} primary_issue_number.")
+    if not isinstance(repository, str) or not repository.strip():
+        raise AgentLoopError(f"Invalid {PR_EXPECTED_CLOSING_MARKER} repository.")
+    ids = normalize_issue_ids(expected_closing_issue_ids, field_name="expected_closing_issue_ids")
+    assert ids is not None
+    return PrExpectedClosingContract(
+        schema_version=1,
+        repository=repository,
+        pr_number=pr_number,
+        origin_flow=origin_flow,
+        primary_issue_number=primary_issue_number,
+        expected_closing_issue_ids=ids,
+        contract_hash=contract_hash(ids),
+        supersedes_hash=supersedes_hash,
+    )
+
+
+def format_pr_contract_comment(contract: PrExpectedClosingContract) -> str:
+    if encode_pr_contract(decode_pr_contract(encode_pr_contract(contract))) != encode_pr_contract(contract):
+        raise AgentLoopError("PR expected-closing contract failed canonical rendering validation.")
+    issue_text = ", ".join(f"#{item}" for item in contract.expected_closing_issue_ids) or "(none)"
+    return "\n".join(
+        [
+            f"Expected closing issues for PR #{contract.pr_number}: {issue_text}.",
+            "",
+            f"Origin flow: {contract.origin_flow}",
+            f"Contract hash: {contract.contract_hash}",
+            f"<!-- {PR_EXPECTED_CLOSING_MARKER}: {encode_pr_contract(contract)} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+
+
+def render_pr_contract_marker(contract: PrExpectedClosingContract) -> str:
+    """Return only the canonical HTML marker for embedding in an existing post."""
+    encoded = encode_pr_contract(contract)
+    # Round-trip before exposing the marker so trusted callers cannot embed a
+    # hand-edited payload.
+    if encode_pr_contract(decode_pr_contract(encoded)) != encoded:
+        raise AgentLoopError("PR expected-closing contract failed canonical encoding validation.")
+    return f"<!-- {PR_EXPECTED_CLOSING_MARKER}: {encoded} -->"
+
+
+def find_latest_pr_contract(
+    comments: Sequence[object], *, repository: str, pr_number: int
+) -> PrExpectedClosingContract | None:
+    found: PrExpectedClosingContract | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in PR_EXPECTED_CLOSING_MARKER_RE.finditer(body):
+            contract = decode_pr_contract(match.group("payload"))
+            if contract.repository.casefold() != repository.casefold() or contract.pr_number != pr_number:
+                raise AgentLoopError(
+                    f"{PR_EXPECTED_CLOSING_MARKER} record does not belong to {repository} PR #{pr_number}."
+                )
+            if encode_pr_contract(contract) != match.group("payload"):
+                raise AgentLoopError(
+                    f"{PR_EXPECTED_CLOSING_MARKER} record is not canonically encoded."
+                )
+            if found is not None and found != contract:
+                if (
+                    contract.supersedes_hash == found.contract_hash
+                    and set(found.expected_closing_issue_ids) < set(contract.expected_closing_issue_ids)
+                ):
+                    found = contract
+                    continue
+                raise AgentLoopError(
+                    f"Divergent {PR_EXPECTED_CLOSING_MARKER} records were found for PR #{pr_number}."
+                )
+            found = contract
+    return found

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1243,11 +1243,17 @@ For a plan (rather than a clarification), respond with exactly one structured JS
   "state": "blocking",
   "summary": "<non-empty concise implementation summary>",
   "plan_steps": ["<non-empty step>"],
+  "additional_closing_issue_ids": [],
   "human_requirement_dispositions": []
 }}
 
 `plan_steps` must be a non-empty list of non-empty strings and should cover the
 intended approach, key files or areas to change, edge cases, and test strategy.
+`additional_closing_issue_ids` is optional. When present, it must be a unique
+array of positive integer issue IDs completed by this one approved implementation
+PR. Do not include ordinary mentions, `Refs` links, related issues, external
+dependencies, staged parents, unselected stages, deferred work, or plan actions.
+Absence means no declaration; an explicit empty array means no additional issue.
 When signed requirements are surfaced, the disposition array must contain every
 generated `Requirement N` exactly once; when none are surfaced, it must be empty.
 Use the optional typed `child_stages`, `external_dependencies`, `deferred_work`,
@@ -1649,13 +1655,19 @@ Use this mandatory structured JSON response format:
     "Update `src/coding_review_agent_loop/protocol.py` to hard-fail invalid structured plan payloads after JSON-prefix detection.",
     "Normalize structured plan rendering and metadata-backed resume behavior in `src/coding_review_agent_loop/orchestrator.py`.",
     "Extend prompts and targeted tests for structured planning flows."
-  ]
+  ],
+  "additional_closing_issue_ids": []
 }}
 <!-- AGENT_PLAN_STATE: blocking -->
 -- {coder_signature}
 
 The orchestrator will normalize structured plan revisions into canonical
 markdown for stored plan state, reviewer prompts, subject hashing, and resume.
+Preserve `additional_closing_issue_ids` when revising the plan. It covers only
+additional issues completed by this single implementation PR; do not infer it
+from issue mentions or PR prose, and do not add a staged parent, unselected
+stage, deferred work, or plan action. Omit it only when no declaration exists;
+use `[]` for an intentional explicit empty declaration.
 Your response must start with exactly one top-level JSON object, with no prose
 or code fences before it. If signed human requirements are present, put
 `<!-- HUMAN_REQUIREMENTS_ADDRESSED -->` and a `### Human requirements` section

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1111,16 +1111,42 @@ def _issue_human_requirements_prompt_context(
     )
 
 
-def _issue_pr_reference_guidance(issue_number: int) -> str:
+def _expected_closing_issue_ids(
+    issue_number: int, expected_closing_issue_ids: Sequence[int] | None
+) -> tuple[int, ...]:
+    ids = tuple(sorted(set(expected_closing_issue_ids or (issue_number,))))
+    return ids or (issue_number,)
+
+
+def _issue_pr_reference_guidance(
+    issue_number: int, *, expected_closing_issue_ids: Sequence[int] | None = None
+) -> str:
+    expected_ids = _expected_closing_issue_ids(issue_number, expected_closing_issue_ids)
+    if len(expected_ids) == 1:
+        issue_id = expected_ids[0]
+        return (
+            f"In the pull request body, include a GitHub closing phrase targeting issue "
+            f"#{issue_id}: use `Fixes #{issue_id}`, `Closes #{issue_id}`, or "
+            f"`Resolves #{issue_id}`. A bare `#{issue_id}`, `Refs` reference, contextual "
+            "issue URL, title, or branch name is not sufficient implementation evidence.\n"
+        )
+    else:
+        issue_text = "every expected issue"
+        examples = ", ".join(f"`Closes #{issue_id}`" for issue_id in expected_ids)
     return (
-        f"In the pull request body, include a GitHub closing phrase targeting issue "
-        f"#{issue_number}: use `Fixes #{issue_number}`, `Closes #{issue_number}`, or "
-        f"`Resolves #{issue_number}`. A bare `#{issue_number}`, `Refs` reference, contextual "
+        f"In the pull request body, include a separate GitHub closing phrase/reference pair "
+        f"for {issue_text}: use {examples}. A single keyword/reference pair must not be "
+        "shared across multiple issues. A bare issue reference, `Refs` reference, contextual "
         "issue URL, title, or branch name is not sufficient implementation evidence.\n"
     )
 
 
-def _staged_issue_pr_reference_guidance(issue_number: int, *, staged_parent_issue: int) -> str:
+def _staged_issue_pr_reference_guidance(
+    issue_number: int,
+    *,
+    staged_parent_issue: int,
+    expected_closing_issue_ids: Sequence[int] | None = None,
+) -> str:
     """PR-reference guidance for a staged implementation (#476).
 
     Used when `issue_number` is one split/deferred stage of `staged_parent_issue`
@@ -1128,11 +1154,13 @@ def _staged_issue_pr_reference_guidance(issue_number: int, *, staged_parent_issu
     stage issue, and must NOT use a closing keyword against the parent, or the
     parent would auto-close while the other stages are still outstanding.
     """
+    expected_ids = _expected_closing_issue_ids(issue_number, expected_closing_issue_ids)
+    closing_pairs = ", ".join(f"`Closes #{issue_id}`" for issue_id in expected_ids)
     return (
         f"This PR implements one stage (#{issue_number}) split out of parent issue "
         f"#{staged_parent_issue}; other stages may remain unfiled or unimplemented. In the pull "
-        f"request body, include a GitHub closing phrase targeting only the child issue "
-        f"(for example `Closes #{issue_number}`), plus the explicit non-closing reference "
+        f"request body, include a separate GitHub closing phrase/reference pair for every "
+        f"expected child/additional issue ({closing_pairs}), plus the explicit non-closing reference "
         f"`Refs #{staged_parent_issue}`. Do NOT use a closing keyword "
         f"(Fixes/Closes/Resolves) against #{staged_parent_issue} — that would auto-close the "
         "parent while other stages remain outstanding.\n"
@@ -1192,9 +1220,16 @@ def build_issue_prompt(
         full_omission_fallback="Fetch the issue discussion directly before implementing.",
     )
     pr_reference_guidance = (
-        _staged_issue_pr_reference_guidance(issue_number, staged_parent_issue=staged_parent_issue)
+        _staged_issue_pr_reference_guidance(
+            issue_number,
+            staged_parent_issue=staged_parent_issue,
+            expected_closing_issue_ids=config.expected_closing_issue_ids,
+        )
         if staged_parent_issue is not None
-        else _issue_pr_reference_guidance(issue_number)
+        else _issue_pr_reference_guidance(
+            issue_number,
+            expected_closing_issue_ids=config.expected_closing_issue_ids,
+        )
     )
     managed_creation_guidance = _managed_ci_creation_guidance(managed_ci_creation_intent)
     return f"""Fix GitHub issue #{issue_number} in {config.repo}.
@@ -1775,9 +1810,16 @@ def build_issue_implementation_prompt(
         full_omission_fallback="Fetch the issue discussion directly before implementing.",
     )
     pr_reference_guidance = (
-        _staged_issue_pr_reference_guidance(issue_number, staged_parent_issue=staged_parent_issue)
+        _staged_issue_pr_reference_guidance(
+            issue_number,
+            staged_parent_issue=staged_parent_issue,
+            expected_closing_issue_ids=config.expected_closing_issue_ids,
+        )
         if staged_parent_issue is not None
-        else _issue_pr_reference_guidance(issue_number)
+        else _issue_pr_reference_guidance(
+            issue_number,
+            expected_closing_issue_ids=config.expected_closing_issue_ids,
+        )
     )
     managed_creation_guidance = _managed_ci_creation_guidance(managed_ci_creation_intent)
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -283,6 +283,9 @@ class StructuredPlanRevision:
     summary: str
     prior_plan_item_dispositions: tuple[ReviewItemDisposition, ...]
     plan_steps: tuple[str, ...]
+    # None means the plan made no declaration. An empty tuple is an explicit
+    # declaration that the single PR completes no additional issues.
+    additional_closing_issue_ids: tuple[int, ...] | None = None
     deferred_stages: tuple[DeferredStage, ...] = ()
     typed_stages: TypedPlanStages = TypedPlanStages()
     human_requirement_dispositions: tuple[HumanRequirementDisposition, ...] = ()
@@ -295,6 +298,9 @@ class StructuredPlanState:
     state: str
     summary: str
     plan_steps: tuple[str, ...]
+    # Presence is preserved so an explicit empty declaration cannot be confused
+    # with an omitted declaration during contract reconciliation.
+    additional_closing_issue_ids: tuple[int, ...] | None = None
     deferred_stages: tuple[DeferredStage, ...] = ()
     typed_stages: TypedPlanStages = TypedPlanStages()
     human_requirement_dispositions: tuple[HumanRequirementDisposition, ...] = ()
@@ -943,6 +949,29 @@ def _expect_optional_string_list(
         item_context=item_context,
         min_length=min_length,
     )
+
+
+def _expect_optional_issue_id_list(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> tuple[int, ...] | None:
+    if field_name not in payload:
+        return None
+    value = payload[field_name]
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    ids: set[int] = set()
+    for index, item in enumerate(value):
+        if isinstance(item, bool) or not isinstance(item, int) or item <= 0:
+            raise AgentLoopError(
+                f"{context} item at index {index} must be a unique positive integer (not a bool)."
+            )
+        if item in ids:
+            raise AgentLoopError(f"{context} contains duplicate issue ID #{item}.")
+        ids.add(item)
+    return tuple(sorted(ids))
 
 
 def _expect_deferred_stage_list(
@@ -1933,6 +1962,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
             "plan_steps",
         },
         optional={
+            "additional_closing_issue_ids",
             "deferred_stages",
             "child_stages",
             "external_dependencies",
@@ -1958,6 +1988,11 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         item_context="plan_revision.plan_steps",
         min_length=1,
     )
+    additional_closing_issue_ids = _expect_optional_issue_id_list(
+        payload,
+        "additional_closing_issue_ids",
+        context="plan_revision.additional_closing_issue_ids",
+    )
     deferred_stages = _expect_deferred_stage_list(
         payload, "deferred_stages", context="plan_revision.deferred_stages"
     )
@@ -1972,6 +2007,7 @@ def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | Non
         summary=summary,
         prior_plan_item_dispositions=dispositions,
         plan_steps=plan_steps,
+        additional_closing_issue_ids=additional_closing_issue_ids,
         deferred_stages=deferred_stages,
         typed_stages=_expect_typed_plan_stages(payload, context="plan_revision"),
         human_requirement_dispositions=human_requirement_dispositions,
@@ -1991,6 +2027,7 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
         context="plan_state",
         required={"schema_version", "kind", "state", "summary", "plan_steps"},
         optional={
+            "additional_closing_issue_ids",
             "deferred_stages",
             "child_stages",
             "external_dependencies",
@@ -2012,6 +2049,11 @@ def validate_structured_plan_state(text: str) -> StructuredPlanState | None:
             context="plan_state.plan_steps",
             item_context="plan_state.plan_steps",
             min_length=1,
+        ),
+        additional_closing_issue_ids=_expect_optional_issue_id_list(
+            payload,
+            "additional_closing_issue_ids",
+            context="plan_state.additional_closing_issue_ids",
         ),
         deferred_stages=_expect_deferred_stage_list(
             payload, "deferred_stages", context="plan_state.deferred_stages"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -109,6 +109,164 @@ def test_pre_review_tests_can_be_disabled(tmp_path):
     assert commands.count(["pytest", "tests/test_agent_loop.py"]) == 1
 
 
+def test_issue_mode_passes_complete_expected_closing_set_to_coder(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"body": "Fixes #56\nFixes #847"},
+    )
+    config = make_config(tmp_path, expected_closing_issue_ids=(847,))
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    coder_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "separate GitHub closing phrase/reference pair" in coder_prompt
+    assert "Closes #847" in coder_prompt
+
+
+def test_approved_plan_additional_closing_issue_reaches_implementation_flow(tmp_path):
+    plan_output = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_state",
+                "state": "blocking",
+                "summary": "Implement the change.",
+                "plan_steps": ["Implement the change."],
+                "additional_closing_issue_ids": [847],
+                "human_requirement_dispositions": [],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude"
+    )
+    runner = FakeRunner(
+        claude_outputs=[
+            plan_output,
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=[
+            structured_plan_review(summary="Plan approved."),
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={"body": "Fixes #56\nFixes #847"},
+    )
+    config = make_config(tmp_path, plan_execution_mode="implement-one-shot")
+
+    assert run_issue_loop(
+        runner,
+        issue_number=56,
+        config=config,
+        plan_first=True,
+        implement_after_approval=True,
+    ) == 0
+
+    implementation_prompt = next(
+        cmd[-1]
+        for cmd, _cwd in runner.commands
+        if cmd[:1] == ["claude"] and "Implement the approved plan" in cmd[-1]
+    )
+    assert "Closes #847" in implementation_prompt
+
+
+def test_staged_child_closes_child_and_refs_parent(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->",
+        ],
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        issue_payload={
+            "body": "<!-- AGENT_SPLIT_CHILD: parent=12 key=" + "a" * 64 + " -->",
+        },
+        pr_payload={"body": "Fixes #56\nRefs #12"},
+    )
+    config = make_config(tmp_path)
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    coder_prompt = next(cmd[-1] for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
+    assert "Closes #56" in coder_prompt
+    assert "Refs #12" in coder_prompt
+    assert "Do NOT use a closing keyword" in coder_prompt
+
+
+def test_direct_pr_without_metadata_remains_contract_unknown(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"body": "Fixes #56"},
+    )
+    config = make_config(tmp_path)
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    assert not any(
+        "AGENT_PR_EXPECTED_CLOSING_ISSUES" in comment
+        for comment in runner.pr_payload["comments"]
+    )
+
+
+def test_direct_pr_explicit_metadata_uses_managed_origin_and_all_ids(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={"body": "Closes #847\nCloses #848"},
+    )
+    config = make_config(
+        tmp_path,
+        expected_closing_issue_ids=(847, 848),
+        pr_origin_flow="managed-pr",
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    contract_comments = [
+        comment
+        for comment in runner.pr_payload["comments"]
+        if "AGENT_PR_EXPECTED_CLOSING_ISSUES" in comment["body"]
+    ]
+    assert len(contract_comments) == 1
+    assert "Origin flow: managed-pr" in contract_comments[0]["body"]
+
+
+def test_direct_pr_supersession_lineage_survives_plain_reruns(tmp_path):
+    runner = FakeRunner(
+        codex_outputs=[
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+            "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
+        ],
+        pr_payload={"body": "Closes #847\nCloses #848"},
+    )
+
+    assert run_pr_loop(
+        runner,
+        pr_number=77,
+        config=make_config(tmp_path, expected_closing_issue_ids=(847,)),
+    ) == 0
+    assert sum(
+        "AGENT_PR_EXPECTED_CLOSING_ISSUES" in comment["body"]
+        for comment in runner.pr_payload["comments"]
+    ) == 1
+
+    assert run_pr_loop(
+        runner,
+        pr_number=77,
+        config=make_config(
+            tmp_path,
+            expected_closing_issue_ids=(847, 848),
+            supersede_expected_closing_contract=True,
+        ),
+    ) == 0
+    assert sum(
+        "AGENT_PR_EXPECTED_CLOSING_ISSUES" in comment["body"]
+        for comment in runner.pr_payload["comments"]
+    ) == 2
+
+    assert run_pr_loop(runner, pr_number=77, config=make_config(tmp_path)) == 0
+    assert sum(
+        "AGENT_PR_EXPECTED_CLOSING_ISSUES" in comment["body"]
+        for comment in runner.pr_payload["comments"]
+    ) == 2
+
+
 def test_ensure_log_dir_ignored_does_not_overwrite_existing_file(tmp_path):
     log_dir = tmp_path / "logs"
     log_dir.mkdir()

--- a/tests/test_expected_closure.py
+++ b/tests/test_expected_closure.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -11,6 +12,8 @@ from coding_review_agent_loop.comment_rendering import (
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.expected_closure import (
     contract_hash,
+    make_contract,
+    reject_parent_from_contract,
     reconcile_contracts,
     resolve_direct_contract,
     resolve_issue_contract,
@@ -25,6 +28,7 @@ from coding_review_agent_loop.pr_contract import (
     decode_pr_contract,
     encode_pr_contract,
     format_pr_contract_comment,
+    find_latest_pr_contract,
     make_pr_contract,
 )
 from coding_review_agent_loop.protocol import (
@@ -94,6 +98,8 @@ def test_direct_pr_without_metadata_does_not_infer_contract_from_prose():
         ("Closes #847\nFixes #848", ()),
         ("Closes #847\nRefs #848", (848,)),
         ("```\nCloses #847\n```", (847, 848)),
+        ("````\n```\nCloses #847\n```\n````", (847, 848)),
+        ("~~~\n~~~ info\nCloses #847\n~~~\n", (847, 848)),
         ("- outer\n  - Closes #847", (848,)),
         ("> Closes #847", (848,)),
     ],
@@ -112,6 +118,39 @@ def test_markdown_view_removes_code_but_preserves_list_and_blockquote_evidence()
     assert "Closes #847" in view
     assert "Closes #848" in view
     assert "Closes #849" not in view
+
+
+def test_staged_parent_is_rejected_but_child_scoped_contract_is_allowed():
+    with pytest.raises(AgentLoopError, match="staged parent issue #12"):
+        reject_parent_from_contract(make_contract((11, 12)), parent_issue=12)
+    reject_parent_from_contract(make_contract((11,)), parent_issue=12)
+
+
+def test_pr_contract_supersession_is_recovered_as_the_latest_record():
+    first = make_pr_contract(
+        repository="OWNER/REPO",
+        pr_number=900,
+        origin_flow="direct-pr",
+        expected_closing_issue_ids=(847,),
+    )
+    second = make_pr_contract(
+        repository="OWNER/REPO",
+        pr_number=900,
+        origin_flow="direct-pr",
+        expected_closing_issue_ids=(847, 848),
+        supersedes_hash=first.contract_hash,
+    )
+
+    found = find_latest_pr_contract(
+        [
+            SimpleNamespace(body=format_pr_contract_comment(first)),
+            SimpleNamespace(body=format_pr_contract_comment(second)),
+        ],
+        repository="OWNER/REPO",
+        pr_number=900,
+    )
+
+    assert found == second
 
 
 def test_protocol_markers_allow_token_name_prose_but_reject_well_formed_forgery():

--- a/tests/test_expected_closure.py
+++ b/tests/test_expected_closure.py
@@ -1,0 +1,178 @@
+import json
+
+import pytest
+
+from coding_review_agent_loop.cli import build_parser
+from coding_review_agent_loop.comment_rendering import (
+    PLAN_EXPECTED_CLOSING_MARKER_RE,
+    render_canonical_plan_revision,
+    render_canonical_plan_steps,
+)
+from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.expected_closure import (
+    contract_hash,
+    reconcile_contracts,
+    resolve_direct_contract,
+    resolve_issue_contract,
+)
+from coding_review_agent_loop.github import (
+    affirmative_markdown_view,
+    missing_expected_closing_issue_ids,
+    reject_forged_protocol_markers,
+)
+from coding_review_agent_loop.pr_contract import (
+    PR_EXPECTED_CLOSING_MARKER_RE,
+    decode_pr_contract,
+    encode_pr_contract,
+    format_pr_contract_comment,
+    make_pr_contract,
+)
+from coding_review_agent_loop.protocol import (
+    StructuredPlanRevision,
+    validate_structured_plan_revision,
+    validate_structured_plan_state,
+)
+
+
+def _plan_state(additional=None):
+    payload = {
+        "schema_version": 1,
+        "kind": "plan_state",
+        "state": "blocking",
+        "summary": "Plan",
+        "plan_steps": ["Implement"],
+        "human_requirement_dispositions": [],
+    }
+    if additional is not None:
+        payload["additional_closing_issue_ids"] = additional
+    return json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Coder"
+
+
+def test_cli_scope_and_normalization_preserve_explicit_empty():
+    parser = build_parser()
+    args = parser.parse_args(["pr", "77", "--expected-closing-issue", "849", "--expected-closing-issue", "848"])
+    assert args.expected_closing_issue == [849, 848]
+    assert not hasattr(parser.parse_args(["task", "do work"]), "expected_closing_issue")
+
+
+def test_issue_contract_unions_primary_cli_and_plan_and_retains_primary():
+    contract = resolve_issue_contract(
+        primary_issue=847,
+        cli_additions=[848, 848],
+        plan_additions=[849],
+    )
+    assert contract.issue_ids == (847, 848, 849)
+
+
+def test_recovered_contract_is_reused_or_requires_monotonic_supersession():
+    recovered = (847, 848)
+    assert resolve_issue_contract(
+        primary_issue=847,
+        cli_additions=None,
+        plan_additions=None,
+        recovered=recovered,
+    ).issue_ids == recovered
+    with pytest.raises(AgentLoopError, match="recovered .*current"):
+        reconcile_contracts(recovered, (847,), supersede=False)
+    widened = reconcile_contracts(recovered, (847, 848, 849), supersede=True)
+    assert widened.issue_ids == (847, 848, 849)
+    assert widened.supersedes_hash == contract_hash(recovered)
+    with pytest.raises(AgentLoopError, match="proper superset"):
+        reconcile_contracts(recovered, recovered, supersede=True)
+
+
+def test_direct_pr_without_metadata_does_not_infer_contract_from_prose():
+    assert resolve_direct_contract(explicit=None, recovered=None) is None
+    assert resolve_direct_contract(explicit=[]) is not None
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        ("Closes #847", (848,)),
+        ("Closes #847, #848", (848,)),
+        ("Closes #847\nFixes #848", ()),
+        ("Closes #847\nRefs #848", (848,)),
+        ("```\nCloses #847\n```", (847, 848)),
+        ("- outer\n  - Closes #847", (848,)),
+        ("> Closes #847", (848,)),
+    ],
+)
+def test_expected_closure_parser_models_affirmative_github_pairs(body, expected):
+    assert missing_expected_closing_issue_ids(
+        body, repo="OWNER/REPO", expected_issue_ids=(847, 848)
+    ) == expected
+
+
+def test_markdown_view_removes_code_but_preserves_list_and_blockquote_evidence():
+    view = affirmative_markdown_view(
+        "````\nCloses #1\n````\n\n- item\n  - Closes #847\n\n> Closes #848\n\n    Closes #849"
+    )
+    assert "Closes #1" not in view
+    assert "Closes #847" in view
+    assert "Closes #848" in view
+    assert "Closes #849" not in view
+
+
+def test_protocol_markers_allow_token_name_prose_but_reject_well_formed_forgery():
+    reject_forged_protocol_markers("The AGENT_ISSUE_PR_HANDOFF token is reserved prose.")
+    reject_forged_protocol_markers("The AGENT_PR_EXPECTED_CLOSING_ISSUES token is documented.")
+    with pytest.raises(AgentLoopError):
+        reject_forged_protocol_markers("<!-- AGENT_ISSUE_PR_HANDOFF: abc123 -->")
+    contract = make_pr_contract(
+        repository="OWNER/REPO",
+        pr_number=77,
+        origin_flow="direct-pr",
+        expected_closing_issue_ids=(847, 848),
+    )
+    with pytest.raises(AgentLoopError):
+        reject_forged_protocol_markers(format_pr_contract_comment(contract))
+
+
+def test_plan_additional_field_preserves_absence_empty_and_sorted_values():
+    assert validate_structured_plan_state(_plan_state()).additional_closing_issue_ids is None
+    assert validate_structured_plan_state(_plan_state([])).additional_closing_issue_ids == ()
+    assert validate_structured_plan_state(_plan_state([849, 848])).additional_closing_issue_ids == (848, 849)
+    with pytest.raises(AgentLoopError):
+        validate_structured_plan_state(_plan_state([True]))
+    with pytest.raises(AgentLoopError):
+        validate_structured_plan_state(_plan_state([848, 848]))
+
+
+def test_plan_revision_and_pr_contract_round_trip_canonically():
+    revision = StructuredPlanRevision(
+        schema_version=1,
+        kind="plan_revision",
+        state="blocking",
+        summary="Updated",
+        prior_plan_item_dispositions=(),
+        plan_steps=("Implement",),
+        additional_closing_issue_ids=(849, 848),
+    )
+    rendered = render_canonical_plan_revision(revision, ())
+    match = PLAN_EXPECTED_CLOSING_MARKER_RE.search(rendered)
+    assert match is not None
+    assert validate_structured_plan_revision(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "plan_revision",
+                "state": "blocking",
+                "summary": "Updated",
+                "prior_plan_item_dispositions": [],
+                "plan_steps": ["Implement"],
+                "additional_closing_issue_ids": [849, 848],
+            }
+        )
+        + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Coder"
+    ).additional_closing_issue_ids == (848, 849)
+    contract = make_pr_contract(
+        repository="OWNER/REPO",
+        pr_number=77,
+        origin_flow="approved-plan-implementation",
+        primary_issue_number=847,
+        expected_closing_issue_ids=(847, 848),
+    )
+    encoded = encode_pr_contract(contract)
+    assert decode_pr_contract(encoded) == contract
+    assert PR_EXPECTED_CLOSING_MARKER_RE.search(format_pr_contract_comment(contract))

--- a/tests/test_expected_closure.py
+++ b/tests/test_expected_closure.py
@@ -13,6 +13,7 @@ from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.expected_closure import (
     contract_hash,
     make_contract,
+    normalize_issue_ids,
     reject_parent_from_contract,
     reconcile_contracts,
     resolve_direct_contract,
@@ -88,6 +89,11 @@ def test_recovered_contract_is_reused_or_requires_monotonic_supersession():
 def test_direct_pr_without_metadata_does_not_infer_contract_from_prose():
     assert resolve_direct_contract(explicit=None, recovered=None) is None
     assert resolve_direct_contract(explicit=[]) is not None
+
+
+def test_normalize_issue_ids_rejects_non_iterable_values_as_agent_loop_errors():
+    with pytest.raises(AgentLoopError, match="expected_closing_issue_ids must be an iterable"):
+        normalize_issue_ids(847)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_pr_handoff.py
+++ b/tests/test_issue_pr_handoff.py
@@ -45,6 +45,28 @@ def test_round_trips_approved_plan_flow_with_plan_hash():
     assert _decode_issue_pr_handoff_metadata(encoded) == metadata
 
 
+def test_round_trips_complete_expected_closing_set_and_supersession_lineage():
+    metadata = _metadata(
+        expected_closing_issue_ids=(56, 57),
+        supersedes_hash="a" * 64,
+    )
+
+    encoded = _encode_issue_pr_handoff_metadata(metadata)
+
+    assert _decode_issue_pr_handoff_metadata(encoded) == metadata
+    rendered = format_issue_pr_handoff_comment(
+        issue_number=56,
+        pr_number=77,
+        pr_url="https://github.com/OWNER/REPO/pull/77",
+        pr_head_sha="abc123",
+        flow="issue-implementation",
+        plan_hash=None,
+        expected_closing_issue_ids=(56, 57),
+        supersedes_hash="a" * 64,
+    )
+    assert "Expected closing issues: #56, #57." in rendered
+
+
 def test_find_latest_issue_pr_handoff_returns_newest_when_multiple_markers_present():
     older = format_issue_pr_handoff_comment(
         issue_number=56,

--- a/tests/test_managed_pr.py
+++ b/tests/test_managed_pr.py
@@ -103,6 +103,7 @@ def test_create_managed_pr_opens_labeled_draft_and_correlates_override(tmp_path)
 
     assert handoff.pr_number == 77
     assert handoff.config.managed_ci_expected_override_nonce == "fresh-nonce"
+    assert handoff.config.pr_origin_flow == "managed-pr"
     assert handoff.config.invocation_argv == ()
     create_call = next(
         (cmd, body) for cmd, body in runner.calls


### PR DESCRIPTION
Implements the approved expected-closing contract plan across issue, approved-plan, staged, direct PR, and managed PR flows.

Adds durable issue/PR contract metadata, explicit CLI and plan declarations, complete GitHub closing-reference validation, supersession and resume handling, marker trust-boundary checks, focused regressions, and documentation.

Fixes #677