### PR TITLE
Recover Codex turns interrupted by executable replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,6 +1025,30 @@ early with rerun guidance, while narrower transient failures retry according to
 are also visible in the log as schema-validation failure, repair attempt, and
 recovered-or-invalid repair messages.
 
+Claude and Codex also have evidence-gated recovery for an executable that is
+replaced after spawn. The runner records the resolved PATH entry, symlink target,
+and executable identity immediately around each invocation and only considers a
+replacement when that identity changed or disappeared during the invocation.
+Codex replay is deliberately conservative: an outputless failed `codex exec
+--json` may contain no parsed events or only one `thread.started` setup event;
+any item, tool, command, error, or `turn.completed` event prevents a fresh
+replay. A usable public response or Codex last-message artifact always wins,
+even if executable metadata changes after completion, and a malformed artifact
+continues through normal validation. Absolute command overrides require direct
+identity evidence; ordinary unchanged-identity Codex failures are not treated
+as replacement interruptions.
+
+After Codex identity evidence, the loop waits for executable stability for at
+most six seconds independently of the interrupted turn's timeout, then makes
+one fresh replay with the full configured timeout. This replay does not consume
+the ordinary retry allowance. Ordinary Codex logs keep their existing names;
+only the dedicated replay is suffixed `executable-replacement-attempt2`.
+Claude retains its invocation deadline and replays only with the remaining
+budget, using `self-update-attempt2`. If stability or replay/retry exhaustion
+leaves a failure, the error retains a specific executable-replacement/self-update
+diagnostic. A genuine long quota reset remains the primary exit-code-3 result,
+with any earlier replacement context appended.
+
 For trusted local automation that must run without approval prompts:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -2060,6 +2060,32 @@ narrow and intended for stream/tool-call failures, empty responses, network
 timeouts/resets, and provider 5xx errors. Auth, credit, quota, dirty workdir,
 and normal missing-marker responses are not retried.
 
+Claude and Codex have a separate, evidence-gated post-spawn executable
+replacement path. The runner samples the resolved command entry, symlink target,
+and executable identity for the successful spawn attempt and again after exit.
+A replay is considered only when direct identity-change or disappearance evidence
+falls within the invocation window. Codex has no elapsed-time cap, but it may be
+replayed only when its failed `--json` stream parsed as empty or as exactly one
+setup-only `thread.started` dictionary. Any other dictionary event—including
+item, tool, command, error, or `turn.completed` activity—means work may have
+started and prevents a fresh replay. A public response file or last-message
+artifact suppresses replacement classification even when metadata changes after
+completion; a malformed present artifact remains on ordinary validation.
+
+The Codex stability wait is independent and bounded to six seconds. Once stable,
+the loop performs at most one fresh `codex exec` replay with the full configured
+timeout (or no timeout when unconfigured), without consuming ordinary retry
+budget. Ordinary Codex invocation and discuss-round log names are unchanged; only
+the dedicated replay uses `executable-replacement-attempt2`. An unstable or
+exhausted path retains a specific Codex executable-replacement diagnostic. Bare
+commands compare PATH entry, symlink, and target identities; an absolute override
+requires direct evidence that its exact entry or target changed or disappeared.
+Claude's existing 30-second eligibility cap, updater diagnostics, deadline-
+bounded stability wait, remaining-time replay, and `self-update-attempt2` suffix
+remain unchanged. If a genuine long quota reset occurs after replacement
+context was recorded, quota remains primary and exit code 3 is preserved with
+the earlier replacement detail appended.
+
 Unsupported model/provider-auth compatibility errors are reported separately
 with failure category `unsupported_model`. These diagnostics name the agent and
 requested model when available and suggest choosing a compatible model or

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -46,6 +46,9 @@ class AgentResult:
     # antigravity fallback chain (#333) sets this to the model that answered.
     model_used: str | None = None
     command_result: CommandResult | None = None
+    # Provider-neutral evidence that the configured executable was replaced or
+    # disappeared during this invocation. Claude uses the historical field name;
+    # Codex sets it for the same bounded recovery signal.
     self_update_reason: str | None = None
 
 

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -17,7 +17,7 @@ from .base import (
     with_public_response_file_instruction,
 )
 from ..logging import agent_log_path, log
-from ..runner import CommandResult, ExecutableIdentity, Runner
+from ..runner import CommandResult, Runner, executable_identity_changed
 from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
@@ -101,16 +101,6 @@ _UPDATER_DIAGNOSTIC_RE = re.compile(
 )
 
 
-def _identity_changed(before: ExecutableIdentity, after: ExecutableIdentity, *, spawn_wall: float, exit_wall: float) -> bool:
-    changed = (before.path, before.target, before.entry_identity, before.target_identity) != (
-        after.path, after.target, after.entry_identity, after.target_identity
-    )
-    if not changed:
-        return False
-    mtimes = [identity[2] / 1_000_000_000 for identity in (after.entry_identity, after.target_identity) if identity]
-    return not mtimes or any(spawn_wall - 5 <= mtime <= exit_wall + 2 for mtime in mtimes)
-
-
 def _has_updater_diagnostic(output: str) -> bool:
     lines = [line.strip() for line in output.splitlines() if line.strip()][-8:]
     return bool(_UPDATER_DIAGNOSTIC_RE.search("\n".join(lines)[-2048:]))
@@ -143,7 +133,12 @@ def classify_self_update_interruption(
     # race through an identity change while it was running.
     if os.path.isabs(command):
         return None
-    if _identity_changed(observation.before, observation.after, spawn_wall=observation.spawn_wall_time, exit_wall=observation.spawn_wall_time + observation.elapsed_seconds):
+    if executable_identity_changed(
+        observation.before,
+        observation.after,
+        spawn_wall_time=observation.spawn_wall_time,
+        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
+    ):
         return "Claude executable changed during invocation"
     return None
 

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -18,7 +18,7 @@ from .base import (
     with_public_response_file_instruction,
 )
 from ..logging import agent_log_path, log
-from ..runner import Runner
+from ..runner import CommandResult, Runner, executable_identity_changed
 from ..usage import UsageMetadata, coerce_int, first_present
 
 if TYPE_CHECKING:
@@ -219,6 +219,62 @@ def _read_codex_message_file(output_path: Path) -> str | None:
     return text or None
 
 
+def _codex_stream_is_setup_only(raw: str) -> bool:
+    """Allow replay only when --json produced no work-progress events."""
+    events: list[object] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            events.append(json.loads(stripped))
+        except json.JSONDecodeError:
+            # Updater diagnostics and other plain-text startup output are not
+            # Codex work events. They remain eligible only if no JSON event was
+            # parsed at all.
+            continue
+    if not events:
+        return True
+    return (
+        len(events) == 1
+        and isinstance(events[0], dict)
+        and events[0].get("type") == "thread.started"
+    )
+
+
+def classify_executable_replacement_interruption(
+    result: CommandResult,
+    *,
+    command: str,
+    response_file_text: str | None,
+    last_message_artifact: str | None,
+) -> str | None:
+    """Return direct Codex executable-replacement evidence, if safely replayable."""
+    observation = result.observation
+    if not isinstance(result.returncode, int) or observation is None:
+        return None
+    has_public_response = bool(response_file_text and response_file_text.strip())
+    has_last_message = bool(last_message_artifact and last_message_artifact.strip())
+    if result.returncode == 0 and has_last_message:
+        return None
+    if has_public_response or has_last_message:
+        return None
+    if observation.interrupted or result.capture_diagnostics:
+        return None
+    identity_changed = executable_identity_changed(
+        observation.before,
+        observation.after,
+        command=command,
+        spawn_wall_time=observation.spawn_wall_time,
+        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
+    )
+    if not _codex_stream_is_setup_only(result.stdout):
+        return None
+    if identity_changed:
+        return "Codex executable changed during invocation"
+    return None
+
+
 class CodexBackend:
     name: AgentName = "codex"
     display_name = "Codex"
@@ -307,7 +363,8 @@ class CodexBackend:
                 timeout_seconds=timeout_seconds,
             )
             response_file_text = read_public_response_file(response_path)
-            message_text = _read_codex_message_file(Path(output_path)) or result.stdout
+            last_message_artifact = _read_codex_message_file(Path(output_path))
+            message_text = last_message_artifact or result.stdout
             usage, raw_usage = _extract_codex_usage(result.stdout)
             model_used = _codex_model_label(config) or _detect_codex_model(result.stdout)
             log(config, f"Codex finished; log: {log_path}")
@@ -324,6 +381,12 @@ class CodexBackend:
                 raw_usage=raw_usage,
                 model_used=model_used,
                 command_result=result,
+                self_update_reason=classify_executable_replacement_interruption(
+                    result,
+                    command=config.codex_cmd,
+                    response_file_text=response_file_text,
+                    last_message_artifact=last_message_artifact,
+                ),
             )
         finally:
             try:

--- a/src/coding_review_agent_loop/agents/codex.py
+++ b/src/coding_review_agent_loop/agents/codex.py
@@ -255,8 +255,6 @@ def classify_executable_replacement_interruption(
         return None
     has_public_response = bool(response_file_text and response_file_text.strip())
     has_last_message = bool(last_message_artifact and last_message_artifact.strip())
-    if result.returncode == 0 and has_last_message:
-        return None
     if has_public_response or has_last_message:
         return None
     if observation.interrupted or result.capture_diagnostics:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1312,6 +1312,29 @@ def _unsupported_model_suggestion(diagnostic: _UnsupportedModelDiagnostic | None
     )
 
 
+def _executable_replacement_failure_detail(
+    *,
+    provider: AgentName | None,
+    reason: str | None,
+    stability_error: str | None,
+) -> str:
+    """Render sticky replacement evidence without losing the terminal cause."""
+    if provider is None:
+        return ""
+    if stability_error:
+        return stability_error
+    if provider == "claude":
+        label = "Claude self-update"
+    elif provider == "codex":
+        label = "Codex executable replacement"
+    else:
+        label = "agent executable replacement"
+    detail = f"likely {label} interruption"
+    if reason:
+        detail += f" ({reason})"
+    return f"{detail}; dedicated replay and ordinary retries were exhausted."
+
+
 def _failure_suggestion(
     category: str | None,
     reason: str,
@@ -1330,7 +1353,11 @@ def _failure_suggestion(
             "or switch that agent/model before re-running."
         )
     if category == "self-update-interruption":
-        return "Suggestion: wait for the Claude Code self-update to finish, then re-run."
+        if agent_name.lower() == "claude":
+            return "Suggestion: wait for the Claude Code self-update to finish, then re-run."
+        return "Suggestion: wait for the agent executable replacement to finish, then re-run."
+    if category == "executable-replacement":
+        return "Suggestion: wait for the Codex executable replacement to finish, then re-run."
     if category == "transient":
         if _QUOTA_RATE_LIMIT_RE.search(combined):
             return (
@@ -1419,7 +1446,12 @@ def _format_invalid_agent_response_error(
     elif category == "timeout":
         category_hint = " Failure category: timeout (the agent exceeded the configured time limit)."
     elif category == "self-update-interruption":
-        category_hint = " Failure category: self-update-interruption (Claude Code updated during startup)."
+        if agent_name.lower() == "claude":
+            category_hint = " Failure category: self-update-interruption (Claude Code updated during startup)."
+        else:
+            category_hint = " Failure category: self-update-interruption (the agent executable changed during invocation)."
+    elif category == "executable-replacement":
+        category_hint = " Failure category: executable-replacement (Codex changed during invocation)."
     elif category == "agent-unavailable":
         category_hint = " Failure category: agent-unavailable (the agent explicitly could not continue)."
     if not classification_text:
@@ -2198,7 +2230,7 @@ def _run_validated_agent(
     max_attempts = (
         len(config.antigravity_models) + config.agent_max_retries
         if antigravity_attempts is not None
-        else config.agent_max_retries + 2 if agent == "claude" else config.agent_max_retries + 1
+        else config.agent_max_retries + 2 if agent in {"claude", "codex"} else config.agent_max_retries + 1
     )
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
@@ -2213,8 +2245,10 @@ def _run_validated_agent(
     completion_recovery_attempted = False
     # Keep the detection guard separate from the replay marker: a failed
     # stability check must not make the next ordinary retry look like a replay.
-    updater_replay_considered = False
-    updater_replay_pending = False
+    executable_replacement_considered = False
+    executable_replacement_replay_pending = False
+    executable_replacement_provider: AgentName | None = None
+    executable_replacement_reason: str | None = None
     ordinary_retries_used = 0
     self_update_deadline: float | None = None
     self_update_stability_error: str | None = None
@@ -2227,13 +2261,15 @@ def _run_validated_agent(
             else config
         )
         invocation_kwargs: dict[str, object] = {}
-        is_self_update_replay = updater_replay_pending
+        is_executable_replacement_replay = executable_replacement_replay_pending
         if agent == "claude":
             invocation_kwargs["attempt_suffix"] = (
                 "self-update-attempt2"
-                if is_self_update_replay
+                if is_executable_replacement_replay
                 else f"attempt{ordinary_retries_used + 1}"
             )
+        elif agent == "codex" and is_executable_replacement_replay:
+            invocation_kwargs["attempt_suffix"] = "executable-replacement-attempt2"
         result = run_agent_result(
             runner,
             agent=agent,
@@ -2248,8 +2284,8 @@ def _run_validated_agent(
         )
         # The bounded deadline belongs only to the interrupted invocation and
         # its dedicated replay. A later ordinary retry has its normal budget.
-        if is_self_update_replay:
-            updater_replay_pending = False
+        if is_executable_replacement_replay:
+            executable_replacement_replay_pending = False
             next_timeout_seconds = timeout_seconds
         last_result = result
         if result.log_path is not None:
@@ -2312,46 +2348,81 @@ def _run_validated_agent(
                 # envelope, even when the command itself failed.
                 text = artifact
 
-        # A Claude process can be replaced by its self-updater after it spawned.
-        # This is exclusive with ordinary transient classification and gets one
-        # full replay only after the bare executable is stable.
+        # Claude or Codex can be replaced after spawning. This is exclusive with
+        # ordinary transient classification and gets one full replay only after
+        # the configured executable is stable.
         if (
-            agent == "claude"
+            agent in {"claude", "codex"}
             and result.self_update_reason is not None
-            and not updater_replay_considered
+            and not executable_replacement_considered
             and result.command_result is not None
         ):
-            updater_replay_considered = True
+            executable_replacement_considered = True
+            executable_replacement_provider = agent
+            executable_replacement_reason = result.self_update_reason
             observation = result.command_result.observation
-            self_update_deadline = (
-                observation.spawn_monotonic + timeout_seconds
-                if timeout_seconds is not None and observation is not None
-                else None
-            )
-            stable = runner.wait_for_executable_stability(
-                config.claude_cmd, deadline=self_update_deadline
-            )
-            remaining = (
-                self_update_deadline - time.monotonic()
-                if self_update_deadline is not None else None
-            )
-            if not stable or (remaining is not None and remaining <= 0):
+            if agent == "claude":
+                self_update_deadline = (
+                    observation.spawn_monotonic + timeout_seconds
+                    if timeout_seconds is not None and observation is not None
+                    else None
+                )
+                stable = runner.wait_for_executable_stability(
+                    config.claude_cmd, deadline=self_update_deadline
+                )
+                remaining = (
+                    self_update_deadline - time.monotonic()
+                    if self_update_deadline is not None else None
+                )
+                replay_timeout = remaining
+                deadline_exhausted = remaining is not None and remaining <= 0
+            else:
+                # Codex replacement recovery has its own bounded six-second
+                # stability observation. The replay is a fresh invocation and
+                # receives the full configured timeout, if any.
+                stable = runner.wait_for_executable_stability(
+                    config.codex_cmd, deadline=None
+                )
+                replay_timeout = timeout_seconds
+                deadline_exhausted = False
+            if not stable or deadline_exhausted:
+                provider_label = (
+                    "Claude self-update"
+                    if agent == "claude"
+                    else "Codex executable replacement"
+                )
+                deadline_label = (
+                    "within the invocation deadline"
+                    if agent == "claude"
+                    else "within the bounded stability window"
+                )
                 self_update_stability_error = (
-                    f"likely Claude self-update interruption ({result.self_update_reason}); "
-                    "executable did not stabilize within the invocation deadline"
+                    f"likely {provider_label} interruption ({result.self_update_reason}); "
+                    f"executable did not stabilize {deadline_label}"
                 )
                 if usage_record is not None:
-                    usage_record.outcome = "self_update_interruption"
+                    usage_record.outcome = (
+                        "self_update_interruption"
+                        if agent == "claude"
+                        else "executable_replacement_interruption"
+                    )
                     usage_record.log_path = str(result.log_path) if result.log_path else None
-                # Preserve any ordinary transient retry allowance: a failed
-                # stability observation does not make provider errors final.
+                # Preserve the ordinary retry allowance: a failed stability
+                # observation does not make provider errors final.
             else:
-                updater_replay_pending = True
+                executable_replacement_replay_pending = True
                 if usage_record is not None:
-                    usage_record.outcome = "self_update_interruption"
+                    usage_record.outcome = (
+                        "self_update_interruption"
+                        if agent == "claude"
+                        else "executable_replacement_interruption"
+                    )
                     usage_record.log_path = str(result.log_path) if result.log_path else None
-                next_timeout_seconds = remaining
-                log(config, f"{agent_name}: {result.self_update_reason}; replaying once after executable stability")
+                next_timeout_seconds = replay_timeout
+                log(
+                    config,
+                    f"{agent_name}: {result.self_update_reason}; replaying once after executable stability",
+                )
                 continue
         should_retry = False
         provider_capacity = False
@@ -2875,6 +2946,17 @@ def _run_validated_agent(
                         f"{agent_name} quota exhausted. Reset in {duration_str} (at {at_str}). "
                         "Rerun when quota resets, or switch to a different API key / model."
                     )
+                    replacement_detail = _executable_replacement_failure_detail(
+                        provider=executable_replacement_provider,
+                        reason=executable_replacement_reason,
+                        stability_error=self_update_stability_error,
+                    )
+                    diagnostic_classification_text = classification_text
+                    if replacement_detail:
+                        message += f" {replacement_detail}"
+                        diagnostic_classification_text = (
+                            f"{classification_text}\n{replacement_detail}"
+                        ).strip()
                     diagnostics = _failed_run_diagnostics(
                         runner=runner,
                         config=config,
@@ -2883,7 +2965,7 @@ def _run_validated_agent(
                         operation_description=operation_description,
                         failure_category=last_failure_category,
                         failure_reason=message,
-                        classification_text=classification_text,
+                        classification_text=diagnostic_classification_text,
                         marker_description=marker_description,
                         result=last_result,
                     )
@@ -2928,9 +3010,21 @@ def _run_validated_agent(
                 continue
         break
 
-    if self_update_stability_error is not None:
-        last_error = f"{self_update_stability_error}; final failure: {last_error}"
-        last_failure_category = "self-update-interruption"
+    if executable_replacement_provider is not None:
+        replacement_detail = _executable_replacement_failure_detail(
+            provider=executable_replacement_provider,
+            reason=executable_replacement_reason,
+            stability_error=self_update_stability_error,
+        )
+        last_error = f"{replacement_detail}; final failure: {last_error}"
+        last_classification_text = (
+            f"{last_classification_text}\n{replacement_detail}"
+        ).strip()
+        last_failure_category = (
+            "self-update-interruption"
+            if executable_replacement_provider == "claude"
+            else "executable-replacement"
+        )
     diagnostics = _failed_run_diagnostics(
         runner=runner,
         config=config,

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -87,6 +87,54 @@ def executable_identity(command: str) -> ExecutableIdentity:
     return ExecutableIdentity(path, target, entry, resolved)
 
 
+def executable_identity_changed(
+    before: ExecutableIdentity,
+    after: ExecutableIdentity,
+    *,
+    command: str | None = None,
+    spawn_wall_time: float,
+    exit_wall_time: float,
+) -> bool:
+    """Return whether executable replacement is evidenced during an invocation.
+
+    Identity changes outside the invocation window are not enough: a command can
+    legitimately be updated between turns.  Missing post-exit identity is direct
+    disappearance evidence and remains eligible, while mtime-bearing changes are
+    bounded to the same small window used by the Claude recovery path.
+    """
+    if command is not None and os.path.isabs(command):
+        # An absolute override has no PATH entry to compare. Its exact target
+        # and entry metadata must change or disappear directly.
+        before_values = (before.target, before.entry_identity, before.target_identity)
+        after_values = (after.target, after.entry_identity, after.target_identity)
+    else:
+        # Bare commands include the resolved PATH entry itself, plus symlink and
+        # target identities, so PATH retargeting is observable.
+        before_values = (
+            before.path,
+            before.target,
+            before.entry_identity,
+            before.target_identity,
+        )
+        after_values = (
+            after.path,
+            after.target,
+            after.entry_identity,
+            after.target_identity,
+        )
+    changed = before_values != after_values
+    if not changed:
+        return False
+    mtimes = [
+        identity[2] / 1_000_000_000
+        for identity in (after.entry_identity, after.target_identity)
+        if identity
+    ]
+    return not mtimes or any(
+        spawn_wall_time - 5 <= mtime <= exit_wall_time + 2 for mtime in mtimes
+    )
+
+
 def ensure_log_dir_ignored(log_dir: Path) -> None:
     gitignore = log_dir / ".gitignore"
     if not gitignore.exists():
@@ -201,7 +249,7 @@ class Runner:
         self,
         cmd: list[str],
         spawn_attempt: Callable[[], _SpawnResult],
-    ) -> _SpawnResult:
+    ) -> tuple[_SpawnResult, float, float, ExecutableIdentity]:
         command = cmd[0]
         resolved = shutil.which(command)
         if resolved is not None:
@@ -210,8 +258,14 @@ class Runner:
 
         saw_preflight_disappearance = False
         for attempt in range(1, _SPAWN_ATTEMPTS + 1):
+            # Capture the identity for the attempt that actually succeeds.  In
+            # particular, do not resolve an absolute path or replace cmd[0]: a
+            # bare command must continue to resolve through PATH at exec time.
+            spawn_wall_time = time.time()
+            spawn_monotonic = time.monotonic()
+            before_identity = executable_identity(command)
             try:
-                return spawn_attempt()
+                return spawn_attempt(), spawn_wall_time, spawn_monotonic, before_identity
             except FileNotFoundError as exc:
                 if os.path.isabs(command):
                     raise self._missing_command_error(command) from exc
@@ -378,13 +432,10 @@ class Runner:
                         env={**os.environ, **env} if env is not None else None,
                     )
 
-                proc = self._spawn_with_retry(
+                proc, spawn_wall_time, spawn_monotonic, before_identity = self._spawn_with_retry(
                     cmd,
                     spawn,
                 )
-                spawn_wall_time = time.time()
-                spawn_monotonic = time.monotonic()
-                before_identity = executable_identity(cmd[0])
                 self._register_active_process(proc)
                 try:
                     while True:
@@ -430,10 +481,23 @@ class Runner:
                 full_output = ""
         output = full_output[len(header):] if full_output.startswith(header) else full_output
         exited = time.monotonic()
-        result = CommandResult(cmd, cwd, output, "", returncode, ExecutionObservation(
-            spawn_wall_time, spawn_monotonic,
-            exited, exited - spawn_monotonic, before_identity, executable_identity(cmd[0]), self._interrupted,
-        ), tuple(capture_diagnostics))
+        result = CommandResult(
+            cmd,
+            cwd,
+            output,
+            "",
+            returncode,
+            ExecutionObservation(
+                spawn_wall_time,
+                spawn_monotonic,
+                exited,
+                exited - spawn_monotonic,
+                before_identity,
+                executable_identity(cmd[0]),
+                self._interrupted,
+            ),
+            tuple(capture_diagnostics),
+        )
         if check and returncode != 0:
             raise AgentLoopError(
                 f"Command failed with exit {returncode}: {' '.join(cmd)}\n"
@@ -500,10 +564,10 @@ class Runner:
                     allocated_fds = None
                     raise
 
-            proc = self._spawn_with_retry(cmd, spawn_pty)
-            spawn_wall_time = time.time()
-            spawn_monotonic = time.monotonic()
-            before_identity = executable_identity(cmd[0])
+            proc, spawn_wall_time, spawn_monotonic, before_identity = self._spawn_with_retry(
+                cmd,
+                spawn_pty,
+            )
             assert allocated_fds is not None
             master_fd, slave_fd = allocated_fds
             os.close(slave_fd)
@@ -558,10 +622,22 @@ class Runner:
         raw = b"".join(chunks).decode("utf-8", errors="replace")
         output = strip_ansi(raw)
         exited = time.monotonic()
-        result = CommandResult(cmd, cwd, output, "", returncode, ExecutionObservation(
-            spawn_wall_time, spawn_monotonic, exited, exited - spawn_monotonic,
-            before_identity, executable_identity(cmd[0]), self._interrupted,
-        ))
+        result = CommandResult(
+            cmd,
+            cwd,
+            output,
+            "",
+            returncode,
+            ExecutionObservation(
+                spawn_wall_time,
+                spawn_monotonic,
+                exited,
+                exited - spawn_monotonic,
+                before_identity,
+                executable_identity(cmd[0]),
+                self._interrupted,
+            ),
+        )
         if check and returncode != 0:
             raise AgentLoopError(
                 f"Command failed with exit {returncode}: {' '.join(cmd)}\n"

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -94,6 +94,7 @@ class UsageCallRecord:
     outcome: Literal[
         "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
         "unavailable_model", "accepted_nonzero_exit", "accepted_timeout", "self_update_interruption",
+        "executable_replacement_interruption",
     ] | None = None
     log_path: str | None = None
     fallback_planned: bool | None = None
@@ -203,6 +204,7 @@ class RunUsageContext:
         outcome: Literal[
             "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
             "unavailable_model", "accepted_nonzero_exit", "accepted_timeout", "self_update_interruption",
+            "executable_replacement_interruption",
         ] | None = None,
         log_path: str | None = None,
         fallback_planned: bool | None = None,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3951,6 +3951,194 @@ def test_claude_self_update_stability_failure_sets_final_category(tmp_path):
     assert "wait for the Claude Code self-update to finish" in str(error.value)
 
 
+def _observed_codex_result(tmp_path, *, text="", raw_output="", returncode=1, changed=True):
+    before = ExecutableIdentity(
+        "/tmp/codex", "/tmp/codex-target", (1, 1, 100_000_000_000), (1, 2, 100_000_000_000)
+    )
+    after = (
+        ExecutableIdentity(
+            "/tmp/codex", "/tmp/codex-new-target", (1, 3, 101_000_000_000), (1, 4, 101_000_000_000)
+        )
+        if changed
+        else before
+    )
+    observation = ExecutionObservation(100, 100, 101, 1, before, after, False)
+    command_result = CommandResult(
+        ["codex", "exec", "--json"], tmp_path, raw_output, "", returncode, observation
+    )
+    return AgentResult(
+        text=text,
+        raw_output=raw_output,
+        returncode=returncode,
+        command_result=command_result,
+        self_update_reason=("Codex executable changed during invocation" if changed else None),
+    )
+
+
+def test_codex_executable_replacement_replay_uses_fresh_full_timeout(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Recovered.", reviewer="OpenAI Codex"
+    )
+    results = iter(
+        [
+            _observed_codex_result(tmp_path, raw_output="overloaded_error"),
+            AgentResult(text=valid, raw_output=valid, returncode=0),
+        ]
+    )
+    runner = FakeRunner()
+    stability_calls = []
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: (
+        stability_calls.append((command, deadline)) or True
+    )
+    config = make_config(tmp_path, reviewer="codex", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="codex",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="OpenAI Codex", unresolved_items=()
+            ),
+            timeout_seconds=60,
+        )
+
+    assert response.marker_value.state == "approved"
+    assert stability_calls == [(config.codex_cmd, None)]
+    assert run_mock.call_count == 2
+    assert run_mock.call_args_list[0].kwargs["timeout_seconds"] == 60
+    assert run_mock.call_args_list[1].kwargs["timeout_seconds"] == 60
+    assert "attempt_suffix" not in run_mock.call_args_list[0].kwargs
+    assert run_mock.call_args_list[1].kwargs["attempt_suffix"] == "executable-replacement-attempt2"
+
+
+def test_codex_replacement_replay_does_not_consume_ordinary_retry(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Recovered after retry.", reviewer="OpenAI Codex"
+    )
+    results = iter(
+        [
+            _observed_codex_result(tmp_path),
+            _observed_codex_result(
+                tmp_path, raw_output="overloaded_error", changed=False
+            ),
+            AgentResult(text=valid, raw_output=valid, returncode=0),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: True
+    config = make_config(tmp_path, reviewer="codex", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="codex",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="OpenAI Codex", unresolved_items=()
+            ),
+        )
+
+    assert response.marker_value.state == "approved"
+    assert run_mock.call_count == 3
+    assert run_mock.call_args_list[1].kwargs["attempt_suffix"] == "executable-replacement-attempt2"
+    assert "attempt_suffix" not in run_mock.call_args_list[2].kwargs
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["sleep"]]) == 1
+
+
+def test_codex_replacement_exhaustion_keeps_specific_terminal_category(tmp_path):
+    results = iter(
+        [
+            _observed_codex_result(tmp_path),
+            _observed_codex_result(tmp_path, raw_output="ordinary failure", changed=False),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: True
+    config = make_config(tmp_path, reviewer="codex", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results):
+        with pytest.raises(AgentInvocationError) as error:
+            _run_validated_agent(
+                runner,
+                agent="codex",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="test",
+                validate=lambda text: _validate_review_response(
+                    text, reviewer="OpenAI Codex", unresolved_items=()
+                ),
+            )
+
+    assert error.value.failure_category == "executable-replacement"
+    assert "Codex executable replacement" in str(error.value)
+    assert "wait for the Codex executable replacement" in str(error.value)
+
+
+def test_codex_unstable_replacement_retains_ordinary_retry(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Recovered by ordinary retry.", reviewer="OpenAI Codex"
+    )
+    results = iter(
+        [
+            _observed_codex_result(tmp_path, raw_output="overloaded_error"),
+            AgentResult(text=valid, raw_output=valid, returncode=0),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: False
+    config = make_config(tmp_path, reviewer="codex", agent_max_retries=1)
+
+    # The first failed replacement observation remains subject to normal
+    # retry accounting; this test uses a scripted valid ordinary retry.
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="codex",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="OpenAI Codex", unresolved_items=()
+            ),
+        )
+
+    assert response.marker_value.state == "approved"
+    assert run_mock.call_count == 2
+    assert "attempt_suffix" not in run_mock.call_args_list[1].kwargs
+
+
+def test_codex_replacement_context_does_not_change_long_quota_exit_priority(tmp_path):
+    result = _observed_codex_result(
+        tmp_path,
+        raw_output="HTTP 429: rate limit exceeded. Retry-After: 3600",
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: False
+    config = make_config(tmp_path, reviewer="codex", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", return_value=result):
+        with pytest.raises(QuotaResetExceededError) as error:
+            _run_validated_agent(
+                runner,
+                agent="codex",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="test",
+                validate=lambda text: _validate_review_response(
+                    text, reviewer="OpenAI Codex", unresolved_items=()
+                ),
+            )
+
+    assert QuotaResetExceededError.EXIT_CODE == 3
+    assert "quota exhausted" in str(error.value).lower()
+    assert "Codex executable replacement" in str(error.value)
+
+
 # ---------------------------------------------------------------------------
 # Antigravity (agy) backend + Gemini retirement guidance (#215)
 # ---------------------------------------------------------------------------
@@ -4264,9 +4452,10 @@ def test_runner_retries_preflighted_command_disappearance_and_recovers(
     assert result.returncode == 0
     assert "recovered after preflight" in result.stdout
     assert len(popen_calls) == 3
-    # Spawn retry keeps its existing three lookups; the completed invocation
-    # additionally records isolated pre/post executable observations.
-    assert which_calls == [command_name] * 5
+    # Each candidate spawn is resolved immediately before its attempt so the
+    # returned observation belongs to the successful attempt; the post-exit
+    # sample adds one final lookup.
+    assert which_calls == [command_name] * 7
     assert runner._resolved_commands[command_name] == str(command)
     assert sleep_calls[:2] == [2, 2]
     assert all(delay == 1 for delay in sleep_calls[2:])
@@ -4322,7 +4511,7 @@ def test_runner_preflighted_command_disappearance_retry_is_bounded(
         )
 
     assert len(popen_calls) == 3
-    assert which_calls == [command_name] * 4
+    assert which_calls == [command_name] * 7
     assert sleep_calls == [2, 2]
 
 
@@ -4478,7 +4667,7 @@ def test_runner_missing_command_without_dangling_evidence_does_not_retry(
         )
 
     assert len(popen_calls) == 1
-    assert which_calls == ["missing-agent", "missing-agent"]
+    assert which_calls == ["missing-agent"] * 3
     assert sleep_calls == []
 
 
@@ -4847,6 +5036,51 @@ def test_runner_records_attempt_local_executable_observation(tmp_path, use_pty):
     assert result.observation.before.path
     assert result.observation.after.path
     assert result.observation.elapsed_seconds >= 0
+
+
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_runner_observation_before_is_from_successful_spawn_attempt(
+    monkeypatch, tmp_path, use_pty
+):
+    """A failed spawn's identity is discarded before a later retry succeeds."""
+    import coding_review_agent_loop.runner as runner_module
+
+    command_name = "observed-agent"
+    command = tmp_path / command_name
+    command.symlink_to(sys.executable)
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
+    runner = Runner()
+    runner.remember_agent_command(command_name, str(command), "--codex-cmd")
+    first = ExecutableIdentity("/failed", "/failed", (1, 1, 1), (1, 1, 1))
+    successful = ExecutableIdentity("/successful", "/successful", (1, 2, 2), (1, 2, 2))
+    after = ExecutableIdentity("/after", "/after", (1, 3, 3), (1, 3, 3))
+    identities = iter([first, successful, after])
+    original_popen = runner_module.subprocess.Popen
+    popen_calls = []
+
+    def flaky_popen(*args, **kwargs):
+        popen_calls.append(args[0])
+        if len(popen_calls) == 1:
+            raise FileNotFoundError(command_name)
+        return original_popen(*args, **kwargs)
+
+    monkeypatch.setattr(runner_module, "executable_identity", lambda _command: next(identities))
+    monkeypatch.setattr(runner_module.subprocess, "Popen", flaky_popen)
+    monkeypatch.setattr(runner_module.time, "sleep", lambda _delay: None)
+
+    result = runner.run_with_log(
+        [command_name, "-c", "print('observed')"],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / f"successful-observation-{use_pty}.log",
+        label="Successful observation",
+        progress_interval_seconds=999,
+        use_pty=use_pty,
+    )
+
+    assert len(popen_calls) == 2
+    assert result.observation is not None
+    assert result.observation.before == successful
+    assert result.observation.after == after
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,6 +16,7 @@ from coding_review_agent_loop.agents.claude import (
 from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
 from coding_review_agent_loop.agents.codex import (
     BACKEND as CODEX_BACKEND,
+    classify_executable_replacement_interruption,
     _extract_codex_usage,
     _normalize_codex_usage,
 )
@@ -96,6 +97,173 @@ def test_claude_self_update_classification_requires_bounded_evidence():
     assert classify_self_update_interruption(
         diagnostic, command="claude", response_file_text=None, session_id=None
     ) == "Claude Code updater diagnostic"
+
+
+def _codex_result(
+    *,
+    stdout="",
+    returncode=1,
+    before=None,
+    after=None,
+    interrupted=False,
+    capture_diagnostics=(),
+    elapsed_seconds=1,
+):
+    before = before or ExecutableIdentity(
+        "/tmp/codex", "/tmp/codex-target", (1, 1, 100_000_000_000), (1, 2, 100_000_000_000)
+    )
+    after = after or ExecutableIdentity(
+        "/tmp/codex", "/tmp/codex-target", (1, 3, 101_000_000_000), (1, 4, 101_000_000_000)
+    )
+    observation = ExecutionObservation(
+        100,
+        100,
+        100 + elapsed_seconds,
+        elapsed_seconds,
+        before,
+        after,
+        interrupted,
+    )
+    return CommandResult(
+        ["codex", "exec", "--json"],
+        Path.cwd(),
+        stdout,
+        "",
+        returncode,
+        observation,
+        capture_diagnostics,
+    )
+
+
+@pytest.mark.parametrize("returncode", [0, 1])
+def test_codex_executable_replacement_classifies_outputless_exit(returncode):
+    result = _codex_result(returncode=returncode)
+
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=None,
+        last_message_artifact=None,
+    ) == "Codex executable changed during invocation"
+
+
+def test_codex_executable_replacement_has_no_elapsed_cap():
+    result = _codex_result(elapsed_seconds=31)
+
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=None,
+        last_message_artifact=None,
+    ) == "Codex executable changed during invocation"
+
+
+def test_codex_executable_replacement_accepts_one_setup_event_only():
+    result = _codex_result(
+        stdout=json.dumps({"type": "thread.started", "thread_id": "thread"})
+    )
+
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=None,
+        last_message_artifact=None,
+    ) == "Codex executable changed during invocation"
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        json.dumps({"type": "item.started"}),
+        json.dumps({"type": "turn.completed"}),
+        "\n".join([json.dumps({"type": "thread.started"}), json.dumps({"type": "item.started"})]),
+    ],
+)
+def test_codex_executable_replacement_rejects_work_progress_events(stdout):
+    result = _codex_result(stdout=stdout)
+
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=None,
+        last_message_artifact=None,
+    ) is None
+
+
+def test_codex_executable_replacement_bare_command_observes_path_entry_change():
+    before = ExecutableIdentity(
+        "/one/codex", "/one/target", (1, 1, 100_000_000_000), (1, 2, 100_000_000_000)
+    )
+    after = ExecutableIdentity(
+        "/two/codex", "/two/target", (1, 3, 101_000_000_000), (1, 4, 101_000_000_000)
+    )
+    result = _codex_result(before=before, after=after)
+
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=None,
+        last_message_artifact=None,
+    ) == "Codex executable changed during invocation"
+
+
+def test_codex_executable_replacement_absolute_override_requires_exact_identity_change():
+    command = "/configured/codex"
+    unchanged = ExecutableIdentity(
+        command, command, (1, 1, 100_000_000_000), (1, 2, 100_000_000_000)
+    )
+    result = _codex_result(before=unchanged, after=unchanged)
+    assert classify_executable_replacement_interruption(
+        result,
+        command=command,
+        response_file_text=None,
+        last_message_artifact=None,
+    ) is None
+
+    replaced = ExecutableIdentity(
+        command, "/configured/new-target", (1, 3, 101_000_000_000), (1, 4, 101_000_000_000)
+    )
+    result = _codex_result(before=unchanged, after=replaced)
+    assert classify_executable_replacement_interruption(
+        result,
+        command=command,
+        response_file_text=None,
+        last_message_artifact=None,
+    ) == "Codex executable changed during invocation"
+
+
+@pytest.mark.parametrize(
+    ("response_file_text", "last_message_artifact"),
+    [("valid public response", None), (None, "malformed but present")],
+)
+def test_codex_artifacts_suppress_replacement_classification(
+    response_file_text, last_message_artifact
+):
+    result = _codex_result()
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=response_file_text,
+        last_message_artifact=last_message_artifact,
+    ) is None
+
+
+@pytest.mark.parametrize(
+    ("interrupted", "capture_diagnostics"),
+    [(True, ()), (False, ("capture_read_failed:OSError: injected",))],
+)
+def test_codex_replacement_excludes_interruptions_and_capture_loss(
+    interrupted, capture_diagnostics
+):
+    result = _codex_result(
+        interrupted=interrupted, capture_diagnostics=capture_diagnostics
+    )
+    assert classify_executable_replacement_interruption(
+        result,
+        command="codex",
+        response_file_text=None,
+        last_message_artifact=None,
+    ) is None
 
 
 def test_parse_claude_output_falls_back_on_non_string_result():


### PR DESCRIPTION
## Summary

- Record shared executable identity and successful-spawn timing for pipe and PTY invocations.
- Add evidence-gated Codex replacement detection with one fresh full-timeout replay while preserving ordinary retries and quota priority.
- Preserve Claude recovery semantics, update troubleshooting docs, and add focused regression coverage.

## Verification

- `timeout 300s python3 -m pytest tests/test_backends.py tests/test_agent_loop.py -q`
- `timeout 1800s python3 -m pytest`

Fixes #678