### PR TITLE
Harden durable protocol marker writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ guaranteed billing outcome.
 
 ## Develop This Tool
 
+### Durable protocol marker boundary
+
+Durable GitHub records are defined in the centralized
+`src/coding_review_agent_loop/protocol_markers.py` registry. Current
+agent-authored prose is untrusted and marker-free; only canonical producers
+can compose a `TrustedBody` segment for the GitHub surface that permits it.
+Historical ledger prose is a separate input class: reserved spans are replaced
+with stable descriptive labels before summaries are truncated or interpolated.
+Codec-contained salvage and round-state payloads remain opaque at their encoded
+occurrence and are checked when they are later projected into visible prose.
+Ordinary issue/PR writers and managed-PR/CI REST paths fail closed before any
+temp-file creation or remote mutation when provenance, grammar, surface, or
+canonical encoding checks fail.
+
 Use this if you are changing `coding-review-agent-loop` itself:
 
 ```bash

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -271,6 +271,37 @@ unresolvable fails safely with an actionable message rather than falling back
 to a fresh implementation; fix or select the correct PR and rerun
 `agent-loop pr <number>` directly.
 
+### Durable marker trust boundary
+
+All durable protocol records are registered in
+`src/coding_review_agent_loop/protocol_markers.py`. The registry owns each
+record's outer grammar, canonical codec, safe historical label, strictness, and
+allowed GitHub surfaces. Current untrusted responses are rejected if they
+contain a registered occurrence; trusted producers compose immutable
+`TrustedBody` segments, and writers verify a one-to-one match between every
+visible occurrence and its authorized canonical segment before posting.
+
+The loop distinguishes current prose from orchestrator-re-rendered history.
+When a prior ledger item is projected into a later public comment, only
+reserved spans are replaced with stable descriptive labels before the item is
+normalized or truncated. Item IDs, reviewer, round, source status,
+disposition, and disposition notes remain separate fields. The same
+transformation is used during initial rendering and resume reconstruction.
+
+Encoded or compressed payload values such as salvage patches and round-state
+copies are opaque at their outer occurrence: codec, size, integrity,
+decompression, secret/binary, and hydration checks still apply. If such a
+value is later projected into visible current prose it goes through current
+marker validation; if it becomes historical ledger prose it goes through the
+deterministic sanitizer.
+
+Surface policy is fail-closed. Issue comments carry issue-flow records, PR
+comments carry PR contracts and managed-CI audits, child issue bodies carry
+only the split-child record, and managed PR bodies carry only the managed
+origin record plus the invocation-correlated override trailer. Missing,
+duplicate, malformed, non-canonical, wrong-surface, stale, or uncorrelated
+records are never inferred from finished-body text or payload equality.
+
 Issues that predate this marker (or crashed before it could be posted) fall
 back to the legacy check: searching GitHub directly for an already-open PR
 that already references the target issue, independent of any handoff marker.

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -964,12 +964,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 title=args.title,
                 body=body,
             )
-            return run_pr_loop(
-                runner,
-                pr_number=handoff.pr_number,
-                config=handoff.config,
-                workdirs_ready=True,
-            )
+            run_kwargs = {
+                "pr_number": handoff.pr_number,
+                "config": handoff.config,
+                "workdirs_ready": True,
+            }
+            if handoff.source_branch is not None:
+                run_kwargs["managed_pr_origin"] = (
+                    handoff.source_branch,
+                    handoff.source_sha,
+                    handoff.managed_branch,
+                    handoff.config.managed_ci_expected_override_nonce,
+                )
+            return run_pr_loop(runner, **run_kwargs)
         if args.command == "task":
             task_text = _resolve_task_text(args)
             return run_task_loop(

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -37,6 +37,7 @@ from .protocol import (
     review_freeform_summary_text,
 )
 from .unresolved_items import HUMAN_REQUIREMENTS_ACK_ITEM_ID, MERGE_CONFLICT_ITEM_ID
+from .protocol_markers import sanitize_historical_text
 
 if TYPE_CHECKING:
     from .agents.base import AgentName
@@ -83,6 +84,10 @@ def _review_freeform_summary_text(text: str) -> str:
 
 
 def _normalize_item_summary(text: str, *, limit: int = ITEM_SUMMARY_LIMIT) -> str:
+    # Prior-item text is historical ledger data, not a fresh agent output.  It
+    # must be neutralized before truncation so a marker cannot survive in a
+    # later public rendering or be recreated at the truncation boundary.
+    text = sanitize_historical_text(text)
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped:

--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -13,6 +13,7 @@ from .config import AgentLoopConfig
 from .errors import AgentLoopError
 from .github import create_issue, post_issue_comment
 from .runner import Runner
+from .protocol_markers import TrustedBody
 
 MAX_DECOMPOSITION_PHASES = 8
 AUTOMATION_CLASSES = {"agent-pr", "human-action", "manual-close"}
@@ -587,12 +588,15 @@ def post_phase_implementation_handoff_comment(
         runner,
         config=config,
         issue_number=parent_issue,
-        body=format_phase_implementation_handoff_comment(
-            parent_issue=parent_issue,
-            mode=mode,
-            plan_hash=plan_hash,
-            phase_index=phase_index,
-            created=created,
+        body=TrustedBody.canonical(
+            format_phase_implementation_handoff_comment(
+                parent_issue=parent_issue,
+                mode=mode,
+                plan_hash=plan_hash,
+                phase_index=phase_index,
+                created=created,
+            ),
+            expected_tokens=("AGENT_PLAN_PHASE_IMPLEMENTATION",),
         ),
     )
 
@@ -610,11 +614,14 @@ def post_decomposition_parent_summary(
         runner,
         config=config,
         issue_number=parent_issue,
-        body=format_decomposition_parent_summary(
-            parent_issue=parent_issue,
-            mode=mode,
-            plan_hash=plan_hash,
-            created=created,
+        body=TrustedBody.canonical(
+            format_decomposition_parent_summary(
+                parent_issue=parent_issue,
+                mode=mode,
+                plan_hash=plan_hash,
+                created=created,
+            ),
+            expected_tokens=("AGENT_PLAN_DECOMPOSITION",),
         ),
     )
 
@@ -741,12 +748,15 @@ def post_one_shot_impl_handoff_comment(
         runner,
         config=config,
         issue_number=parent_issue,
-        body=format_one_shot_impl_handoff_comment(
-            parent_issue=parent_issue,
-            mode=mode,
-            plan_hash=plan_hash,
-            plan_subject=plan_subject,
-            pr_number=pr_number,
-            pr_head_sha=pr_head_sha,
+        body=TrustedBody.canonical(
+            format_one_shot_impl_handoff_comment(
+                parent_issue=parent_issue,
+                mode=mode,
+                plan_hash=plan_hash,
+                plan_subject=plan_subject,
+                pr_number=pr_number,
+                pr_head_sha=pr_head_sha,
+            ),
+            expected_tokens=("AGENT_PLAN_ONE_SHOT_IMPL",),
         ),
     )

--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -244,6 +244,14 @@ def _followup_update_notes(text: str) -> tuple[str, ...]:
     return tuple(f"Update from {part.strip()}" for part in parts[1:] if part.strip())
 
 
+def _safe_followup_main_text(text: str) -> str:
+    return sanitize_historical_text(_followup_main_text(text))
+
+
+def _safe_followup_update_notes(text: str) -> tuple[str, ...]:
+    return tuple(sanitize_historical_text(note) for note in _followup_update_notes(text))
+
+
 def _approved_followup_from_unresolved_item(item: UnresolvedReviewItem) -> ApprovedFollowup:
     text = item.text
     for note in item.notes:
@@ -347,10 +355,12 @@ def _format_approved_followup_summary(
         "",
     ]
     for followup in reconciliation.selected_groups:
-        reviewers = ", ".join(followup.reviewers)
-        lines.append(f"- {_followup_main_text(followup.text)} ({reviewers})")
+        reviewers = ", ".join(
+            sanitize_historical_text(reviewer) for reviewer in followup.reviewers
+        )
+        lines.append(f"- {_safe_followup_main_text(followup.text)} ({reviewers})")
         for item in followup.items:
-            for note in _followup_update_notes(item.text):
+            for note in _safe_followup_update_notes(item.text):
                 lines.append(f"  - {note}")
     lines.extend(
         [
@@ -466,7 +476,7 @@ def _has_plan_approved_followups_marker(
 
 
 def _followup_issue_title(followup: ApprovedFollowup) -> str:
-    text = " ".join(_followup_main_text(followup.text).split())
+    text = " ".join(_safe_followup_main_text(followup.text).split())
     title = f"Follow up future review note: {text}"
     return title[:120]
 
@@ -500,7 +510,7 @@ def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> s
         f"Future follow-up from approved review on PR #{pr_number}.",
         "",
     ]
-    reviewers = followup.reviewers
+    reviewers = tuple(sanitize_historical_text(reviewer) for reviewer in followup.reviewers)
     if len(reviewers) == 1:
         lines.append(f"Reviewer: {reviewers[0]}")
     else:
@@ -510,11 +520,14 @@ def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> s
         [
             "",
             "Follow-up:",
-            f"- {_followup_main_text(followup.text)}",
+            f"- {_safe_followup_main_text(followup.text)}",
         ]
     )
     lines.extend(["", "Original reviewer notes:"])
-    lines.extend(f"- {item.reviewer}: {item.text}" for item in followup.items)
+    lines.extend(
+        f"- {sanitize_historical_text(item.reviewer)}: {sanitize_historical_text(item.text)}"
+        for item in followup.items
+    )
     lines.extend(
         [
             "",
@@ -525,7 +538,7 @@ def _followup_issue_body(pr_number: int, followup: GroupedApprovedFollowup) -> s
 
 
 def _plan_followup_issue_title(followup: PlanGroupedApprovedFollowup) -> str:
-    text = " ".join(_followup_main_text(followup.text).split())
+    text = " ".join(_safe_followup_main_text(followup.text).split())
     title = f"Follow up future plan-review note: {text}"
     return title[:120]
 
@@ -533,10 +546,10 @@ def _plan_followup_issue_title(followup: PlanGroupedApprovedFollowup) -> str:
 def _plan_source_label(source: PlanApprovedFollowupSource) -> str:
     parts: list[str] = []
     if source.item_id:
-        parts.append(source.item_id)
+        parts.append(sanitize_historical_text(source.item_id))
     if source.source_round is not None:
         parts.append(f"round {source.source_round}")
-    parts.append(source.reviewer)
+    parts.append(sanitize_historical_text(source.reviewer))
     return ", ".join(parts)
 
 
@@ -547,15 +560,19 @@ def _plan_followup_issue_body(
     plan_subject: str,
     followup: PlanGroupedApprovedFollowup,
 ) -> str:
-    reviewers = followup.reviewers
+    reviewers = tuple(sanitize_historical_text(reviewer) for reviewer in followup.reviewers)
     rounds = sorted({source.source_round for source in followup.sources if source.source_round is not None})
-    item_ids = [source.item_id for source in followup.sources if source.item_id]
+    item_ids = [
+        sanitize_historical_text(source.item_id)
+        for source in followup.sources
+        if source.item_id
+    ]
     lines = [
         f"Future follow-up from approved planning for issue #{issue_number}.",
         "",
         "Source context:",
         f"- Parent issue: #{issue_number}",
-        f"- Approved plan subject: {plan_subject}",
+        f"- Approved plan subject: {sanitize_historical_text(plan_subject)}",
         f"- Approved plan hash: {plan_hash}",
     ]
     if rounds:
@@ -570,15 +587,17 @@ def _plan_followup_issue_body(
         [
             "",
             "Canonical follow-up:",
-            f"- {_followup_main_text(followup.text)}",
+            f"- {_safe_followup_main_text(followup.text)}",
             "",
             "Original reviewer notes:",
         ]
     )
     for source in followup.sources:
-        lines.append(f"- {_plan_source_label(source)}: {source.text}")
+        lines.append(
+            f"- {_plan_source_label(source)}: {sanitize_historical_text(source.text)}"
+        )
         for note in source.notes:
-            lines.append(f"  - Update from {note}")
+            lines.append(f"  - Update from {sanitize_historical_text(note)}")
     lines.extend(
         [
             "",
@@ -768,8 +787,10 @@ def _publish_approved_followups(
 def _format_same_pr_followups(followups: Sequence[ApprovedFollowup]) -> str:
     lines: list[str] = []
     for followup in followups:
-        lines.append(f"{followup.reviewer} same-PR follow-up:")
-        lines.append(f"- {followup.text}")
+        lines.append(
+            f"{sanitize_historical_text(followup.reviewer)} same-PR follow-up:"
+        )
+        lines.append(f"- {sanitize_historical_text(followup.text)}")
         lines.append("")
     return "\n".join(lines).strip()
 
@@ -789,7 +810,7 @@ def _format_plan_approval_summary_with_followups(
         "",
         "Approved plan:",
         "",
-        approved_plan,
+        sanitize_historical_text(approved_plan),
     ]
     if reconciliation is not None and reconciliation.selected_groups:
         if filing_enabled:
@@ -819,11 +840,15 @@ def _format_plan_approval_summary_with_followups(
                 ]
             )
             for followup in reconciliation.selected_groups:
-                reviewers = ", ".join(followup.reviewers)
-                lines.append(f"- {_followup_main_text(followup.text)} ({reviewers})")
+                reviewers = ", ".join(
+                    sanitize_historical_text(reviewer) for reviewer in followup.reviewers
+                )
+                lines.append(f"- {_safe_followup_main_text(followup.text)} ({reviewers})")
                 for source in followup.sources:
                     for note in source.notes:
-                        lines.append(f"  - Update from {note}")
+                        lines.append(
+                            f"  - Update from {sanitize_historical_text(note)}"
+                        )
             lines.extend(
                 [
                     "",

--- a/src/coding_review_agent_loop/followups.py
+++ b/src/coding_review_agent_loop/followups.py
@@ -12,6 +12,7 @@ from .github import create_issue, post_issue_comment, post_pr_comment
 from .logging import log
 from .protocol import ApprovedFollowup, UnresolvedReviewItem
 from .runner import Runner
+from .protocol_markers import TrustedBody, sanitize_historical_text
 
 MAX_APPROVED_FOLLOWUP_ISSUES = 3
 APPROVED_FOLLOWUP_MARKER_RE = re.compile(
@@ -719,7 +720,12 @@ def _publish_approved_followups(
             head_sha=head_sha,
             mode=mode,
         )
-        post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+        post_pr_comment(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            body=TrustedBody.canonical(body, expected_tokens=("AGENT_APPROVED_FOLLOWUPS",)),
+        )
         return True
 
     if config.approved_followups in ("issue", "fix-and-issue"):
@@ -749,7 +755,12 @@ def _publish_approved_followups(
                 head_sha=head_sha,
                 mode=mode,
             )
-            post_pr_comment(runner, config=config, pr_number=pr_number, body=body)
+            post_pr_comment(
+                runner,
+                config=config,
+                pr_number=pr_number,
+                body=TrustedBody.canonical(body, expected_tokens=("AGENT_APPROVED_FOLLOWUPS",)),
+            )
             return True
     return False
 
@@ -886,9 +897,12 @@ def _publish_plan_approved_followups(
                 reconciliation=reconciliation,
             )
 
+    # The approved plan is a re-rendered historical GitHub artifact.  Its
+    # encoded plan metadata may contain durable records, but those records are
+    # not newly authorized by this follow-up comment.
     body = _format_plan_approval_summary_with_followups(
         issue_number,
-        approved_plan,
+        sanitize_historical_text(approved_plan),
         reconciliation=reconciliation,
         issue_urls=issue_urls,
         filing_enabled=filing_enabled,
@@ -899,5 +913,10 @@ def _publish_plan_approved_followups(
         plan_hash=plan_hash,
         mode=mode,
     )
-    post_issue_comment(runner, config=config, issue_number=issue_number, body=body)
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body=TrustedBody.canonical(body, expected_tokens=("AGENT_PLAN_APPROVED_FOLLOWUPS",)),
+    )
     return True

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -37,7 +37,6 @@ from .protocol_markers import (
     ISSUE_COMMENT_SURFACE,
     PR_COMMENT_SURFACE,
     TrustedBody,
-    scan_reserved_markers,
 )
 from .runner import Runner
 from .workdirs import active_workdir
@@ -1349,6 +1348,7 @@ def post_pr_comment(
         log(config, f"Posting round transport with {len(bodies) - 1} sidecars to PR #{pr_number}")
     log(config, f"Posting agent output to PR #{pr_number}")
     for prepared in bodies:
+        prepared.validate_for_surface(PR_COMMENT_SURFACE)
         _post_comment_body(runner, config=config, command=["pr", "comment", str(pr_number)], body=prepared)
 
 
@@ -1365,6 +1365,7 @@ def post_issue_comment(
         log(config, f"Posting round transport with {len(bodies) - 1} sidecars to issue #{issue_number}")
     log(config, f"Posting agent output to issue #{issue_number}")
     for prepared in bodies:
+        prepared.validate_for_surface(ISSUE_COMMENT_SURFACE)
         _post_comment_body(runner, config=config, command=["issue", "comment", str(issue_number)], body=prepared)
 
 

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -32,6 +32,13 @@ from .pr_contract import (
 from .logging import log
 from .round_transport import MAX_GITHUB_BODY_CHARS, prepare_round_comment
 from .protocol import parse_signed_human_requirement_body
+from .protocol_markers import (
+    ISSUE_BODY_SURFACE,
+    ISSUE_COMMENT_SURFACE,
+    PR_COMMENT_SURFACE,
+    TrustedBody,
+    scan_reserved_markers,
+)
 from .runner import Runner
 from .workdirs import active_workdir
 
@@ -1334,10 +1341,10 @@ def post_pr_comment(
     *,
     config: AgentLoopConfig,
     pr_number: int,
-    body: str,
+    body: str | TrustedBody,
 ) -> None:
-    reject_forged_protocol_markers(body)
-    bodies = prepare_round_comment(body)
+    carrier = body if isinstance(body, TrustedBody) else TrustedBody.current_untrusted_visible(body)
+    bodies = prepare_round_comment(carrier)
     if len(bodies) > 1:
         log(config, f"Posting round transport with {len(bodies) - 1} sidecars to PR #{pr_number}")
     log(config, f"Posting agent output to PR #{pr_number}")
@@ -1350,10 +1357,10 @@ def post_issue_comment(
     *,
     config: AgentLoopConfig,
     issue_number: int,
-    body: str,
+    body: str | TrustedBody,
 ) -> None:
-    reject_forged_protocol_markers(body)
-    bodies = prepare_round_comment(body)
+    carrier = body if isinstance(body, TrustedBody) else TrustedBody.current_untrusted_visible(body)
+    bodies = prepare_round_comment(carrier)
     if len(bodies) > 1:
         log(config, f"Posting round transport with {len(bodies) - 1} sidecars to issue #{issue_number}")
     log(config, f"Posting agent output to issue #{issue_number}")
@@ -1362,13 +1369,8 @@ def post_issue_comment(
 
 
 def reject_forged_protocol_markers(body: str) -> None:
-    """Reject only well-formed reserved metadata markers in untrusted prose."""
-    if _AGENT_ISSUE_PR_HANDOFF_MARKER_RE.search(body) or PR_EXPECTED_CLOSING_MARKER_RE.search(body):
-        raise AgentLoopError(
-            "Ordinary agent-authored comments may not contain a well-formed reserved "
-            "handoff or expected-closing protocol marker. Remove the marker from the "
-            "prose; a bare marker name is allowed."
-        )
+    """Reject reserved records before any temp-file, runner, or remote mutation."""
+    TrustedBody.current_untrusted_visible(body)
 
 
 def _post_trusted_protocol_comment(
@@ -1413,23 +1415,16 @@ def post_trusted_pr_comment(
     *,
     config: AgentLoopConfig,
     pr_number: int,
-    body: str,
+    body: TrustedBody,
 ) -> None:
-    matches = tuple(PR_EXPECTED_CLOSING_MARKER_RE.finditer(body))
-    if not matches:
-        raise AgentLoopError(
-            f"Trusted PR protocol posting requires {PR_EXPECTED_CLOSING_MARKER}."
+    if not isinstance(body, TrustedBody):
+        raise AgentLoopError("Trusted PR comment posting requires a TrustedBody.")
+    bodies = prepare_round_comment(body)
+    for prepared in bodies:
+        prepared.validate_for_surface(PR_COMMENT_SURFACE)
+        _post_trusted_protocol_comment(
+            runner, config=config, command=["pr", "comment", str(pr_number)], body=prepared
         )
-    for match in matches:
-        encoded = match.group("payload")
-        contract = decode_pr_contract(encoded)
-        if encode_pr_contract(contract) != encoded:
-            raise AgentLoopError(
-                f"Trusted {PR_EXPECTED_CLOSING_MARKER} payload is not canonically encoded."
-            )
-    _post_trusted_protocol_comment(
-        runner, config=config, command=["pr", "comment", str(pr_number)], body=body
-    )
 
 
 def post_trusted_pr_contract_record(
@@ -1437,21 +1432,12 @@ def post_trusted_pr_contract_record(
     *,
     config: AgentLoopConfig,
     pr_number: int,
-    body: str,
+    body: TrustedBody,
 ) -> None:
     """Create a canonical PR contract record before issue-origin handoff."""
-    matches = tuple(PR_EXPECTED_CLOSING_MARKER_RE.finditer(body))
-    if not matches:
-        raise AgentLoopError(
-            f"Trusted PR protocol posting requires {PR_EXPECTED_CLOSING_MARKER}."
-        )
-    for match in matches:
-        encoded = match.group("payload")
-        contract = decode_pr_contract(encoded)
-        if encode_pr_contract(contract) != encoded:
-            raise AgentLoopError(
-                f"Trusted {PR_EXPECTED_CLOSING_MARKER} payload is not canonically encoded."
-            )
+    if not isinstance(body, TrustedBody):
+        raise AgentLoopError("Trusted PR contract posting requires a TrustedBody.")
+    body.validate_for_surface(PR_COMMENT_SURFACE)
     result = runner.run(
         [
             config.gh_cmd,
@@ -1463,7 +1449,7 @@ def post_trusted_pr_contract_record(
             "-",
         ],
         cwd=active_workdir(config),
-        input_text=json.dumps({"body": body}),
+        input_text=json.dumps({"body": str(body)}),
         check=False,
     )
     if result.returncode != 0:
@@ -1479,16 +1465,16 @@ def post_trusted_issue_comment(
     *,
     config: AgentLoopConfig,
     issue_number: int,
-    body: str,
+    body: TrustedBody,
 ) -> None:
-    _validate_canonical_json_marker_payload(
-        body,
-        marker_re=_AGENT_ISSUE_PR_HANDOFF_MARKER_RE,
-        marker_name="AGENT_ISSUE_PR_HANDOFF",
-    )
-    _post_trusted_protocol_comment(
-        runner, config=config, command=["issue", "comment", str(issue_number)], body=body
-    )
+    if not isinstance(body, TrustedBody):
+        raise AgentLoopError("Trusted issue comment posting requires a TrustedBody.")
+    bodies = prepare_round_comment(body)
+    for prepared in bodies:
+        prepared.validate_for_surface(ISSUE_COMMENT_SURFACE)
+        _post_trusted_protocol_comment(
+            runner, config=config, command=["issue", "comment", str(issue_number)], body=prepared
+        )
 
 
 def _post_comment_body(runner: Runner, *, config: AgentLoopConfig, command: list[str], body: str) -> None:
@@ -1514,9 +1500,14 @@ def create_issue(
     *,
     config: AgentLoopConfig,
     title: str,
-    body: str,
+    body: str | TrustedBody,
 ) -> str | None:
-    if len(body) > MAX_GITHUB_BODY_CHARS:
+    if isinstance(body, TrustedBody):
+        body.validate_for_surface(ISSUE_BODY_SURFACE)
+        rendered_body = str(body)
+    else:
+        rendered_body = str(TrustedBody.current_untrusted_visible(body))
+    if len(rendered_body) > MAX_GITHUB_BODY_CHARS:
         raise AgentLoopError(f"GitHub issue body exceeds {MAX_GITHUB_BODY_CHARS} characters; shorten the response.")
     log(config, f"Creating GitHub issue: {title}")
     if config.dry_run:
@@ -1530,7 +1521,7 @@ def create_issue(
                 "--title",
                 title,
                 "--body",
-                body,
+                rendered_body,
             ],
             cwd=active_workdir(config),
         )
@@ -1540,7 +1531,7 @@ def create_issue(
         return issue_url
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
-        handle.write(body)
+        handle.write(rendered_body)
         path = handle.name
     try:
         result = runner.run(

--- a/src/coding_review_agent_loop/issue_pr_handoff.py
+++ b/src/coding_review_agent_loop/issue_pr_handoff.py
@@ -34,6 +34,7 @@ from .github import (
 )
 from .pr_contract import PrExpectedClosingContract, find_latest_pr_contract
 from .runner import Runner
+from .protocol_markers import TrustedBody
 
 SCHEMA_VERSION = 1
 _VALID_FLOWS = {"issue-implementation", "approved-plan-implementation"}
@@ -494,14 +495,17 @@ def post_issue_pr_handoff_comment(
         runner,
         config=config,
         issue_number=issue_number,
-        body=format_issue_pr_handoff_comment(
-            issue_number=issue_number,
-            pr_number=pr_number,
-            pr_url=pr_url,
-            pr_head_sha=pr_head_sha,
-            flow=flow,
-            plan_hash=plan_hash,
-            expected_closing_issue_ids=expected_closing_issue_ids,
-            supersedes_hash=supersedes_hash,
+        body=TrustedBody.canonical(
+            format_issue_pr_handoff_comment(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                pr_head_sha=pr_head_sha,
+                flow=flow,
+                plan_hash=plan_hash,
+                expected_closing_issue_ids=expected_closing_issue_ids,
+                supersedes_hash=supersedes_hash,
+            ),
+            expected_tokens=("AGENT_ISSUE_PR_HANDOFF",),
         ),
     )

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -30,6 +30,7 @@ from .github import (
 from .logging import log
 from .runner import Runner
 from .workdirs import active_workdir
+from .protocol_markers import PR_COMMENT_SURFACE, TrustedBody
 
 
 MANAGED_LABEL = "agent-loop-managed"
@@ -1110,15 +1111,20 @@ def _activate_v2_managed_ci(
                     reason="the override trailer is not correlated to this invocation",
                 )
                 return None
+            audit_body = TrustedBody.canonical(
+                (
+                    f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
+                    f"base={base_ref} head={live_sha} protection={protection.state}\n\n"
+                    "Voluntary gate: GitHub cannot prevent manual merges, other automation, "
+                    "compromised credentials, or an agent-loop defect from bypassing it."
+                ),
+                expected_tokens=(UNPROTECTED_OVERRIDE_TRAILER,),
+            )
+            audit_body.validate_for_surface(PR_COMMENT_SURFACE)
             audit = runner.run(
                 [
                     config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/comments",
-                    "-f", "body=" + (
-                        f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
-                        f"base={base_ref} head={live_sha} protection={protection.state}\n\n"
-                        "Voluntary gate: GitHub cannot prevent manual merges, other automation, "
-                        "compromised credentials, or an agent-loop defect from bypassing it."
-                    ),
+                    "-f", "body=" + str(audit_body),
                 ], cwd=active_workdir(config), check=False,
             )
             if audit.returncode != 0:
@@ -1175,10 +1181,15 @@ def _activate_v2_managed_ci(
                 f"provenance_head={resume_provenance_head or 'unknown'} generation={secrets.token_urlsafe(12)}\n\n"
                 "Resume provenance only: the prior issue-created audit is not an authorization token."
             )
+            trusted_resume_body = TrustedBody.canonical(
+                resume_body,
+                expected_tokens=(UNPROTECTED_OVERRIDE_TRAILER,),
+            )
+            trusted_resume_body.validate_for_surface(PR_COMMENT_SURFACE)
             audit = runner.run(
                 [
                     config.gh_cmd, "api", "--method", "POST",
-                    f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={resume_body}",
+                    f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={trusted_resume_body}",
                 ], cwd=active_workdir(config), check=False,
             )
             if audit.returncode != 0:
@@ -1607,10 +1618,12 @@ def publish_manual_v2_qualification(
             " GitHub cannot force a human or other automation to use this SHA or the guarded command "
             "after agent-loop exits."
         )
+    trusted_body = TrustedBody.canonical(body, expected_tokens=(QUALIFICATION_MARKER,))
+    trusted_body.validate_for_surface(PR_COMMENT_SURFACE)
     posted = runner.run(
         [
             config.gh_cmd, "api", "--method", "POST",
-            f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={body}",
+            f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={trusted_body}",
         ], cwd=active_workdir(config), check=False,
     )
     if posted.returncode != 0:
@@ -1850,7 +1863,7 @@ def _dispatch_v2_qualification(
         log(config, f"PR #{pr_number}: dispatch accepted; waiting for run visibility")
 
 
-def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_sha: str, state: str) -> str:
+def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_sha: str, state: str) -> TrustedBody:
     payload = {
         "version": 2,
         "repository": contract.repository,
@@ -1871,7 +1884,10 @@ def _intent_body(contract: ManagedCiContract, *, pr_number: int, expected_head_s
             for run_id, run_attempt in contract.terminal_attempts
         ],
     }
-    return f"<!-- {INTENT_MARKER} {json.dumps(payload, separators=(',', ':'), sort_keys=True)} -->"
+    return TrustedBody.canonical(
+        f"<!-- {INTENT_MARKER} {json.dumps(payload, separators=(',', ':'), sort_keys=True)} -->",
+        expected_tokens=(INTENT_MARKER,),
+    )
 
 
 def _ensure_v2_intent(
@@ -1963,6 +1979,7 @@ def _ensure_v2_intent(
     contract.nonce = secrets.token_urlsafe(24)
     contract.created_at = int(time.time())
     body = _intent_body(contract, pr_number=pr_number, expected_head_sha=expected_head_sha, state="prepared")
+    body.validate_for_surface(PR_COMMENT_SURFACE)
     created = runner.run(
         [config.gh_cmd, "api", "--method", "POST", f"repos/{config.repo}/issues/{pr_number}/comments", "-f", f"body={body}"],
         cwd=active_workdir(config), check=False,
@@ -1988,6 +2005,7 @@ def _patch_intent(runner: Runner, *, config: AgentLoopConfig, contract: ManagedC
         expected_head_sha=contract.expected_head_sha or "",
         state=state,
     )
+    body.validate_for_surface(PR_COMMENT_SURFACE)
     # The immutable identifying fields are already in the original marker;
     # state updates add only live provenance and are still actor-owned.
     updated = runner.run(

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -12,7 +12,6 @@ from urllib.parse import quote
 from .config import AgentLoopConfig
 from .errors import AgentLoopError
 from .logging import log
-from .github import reject_forged_protocol_markers
 from .managed_ci import (
     MANAGED_LABEL,
     UNPROTECTED_OVERRIDE_TRAILER,
@@ -21,6 +20,7 @@ from .managed_ci import (
 )
 from .runner import CommandResult, Runner
 from .workdirs import active_workdir
+from .protocol_markers import PR_BODY_SURFACE, TrustedBody, scan_reserved_markers
 
 
 SOURCE_MARKER = "AGENT_MANAGED_PR_SOURCE_V1"
@@ -32,6 +32,7 @@ class ManagedPrHandoff:
     config: AgentLoopConfig
     source_sha: str
     managed_branch: str
+    source_branch: str | None = None
 
 
 def _api(
@@ -68,7 +69,7 @@ def _json_payload(result: CommandResult, *, operation: str) -> object:
         raise AgentLoopError(f"GitHub returned invalid JSON while {operation}.") from exc
 
 
-def _source_marker(*, source_branch: str, source_sha: str) -> str:
+def _source_marker(*, source_branch: str, source_sha: str) -> TrustedBody:
     encoded = base64.urlsafe_b64encode(
         json.dumps(
             {"source_branch": source_branch, "source_sha": source_sha},
@@ -76,7 +77,10 @@ def _source_marker(*, source_branch: str, source_sha: str) -> str:
             sort_keys=True,
         ).encode("utf-8")
     ).decode("ascii")
-    return f"<!-- {SOURCE_MARKER} {encoded} -->"
+    return TrustedBody.canonical(
+        f"<!-- {SOURCE_MARKER} {encoded} -->",
+        expected_tokens=(SOURCE_MARKER,),
+    )
 
 
 def _compose_body(
@@ -85,12 +89,80 @@ def _compose_body(
     source_branch: str,
     source_sha: str,
     override_nonce: str | None,
-) -> str:
-    sections = [body.rstrip()] if body.strip() else []
+) -> TrustedBody:
+    sections: list[TrustedBody | str] = []
+    if body.strip():
+        sections.append(TrustedBody.current_untrusted_visible(body.rstrip()))
+    if sections:
+        sections.append("\n\n")
     sections.append(_source_marker(source_branch=source_branch, source_sha=source_sha))
     if override_nonce:
-        sections.append(f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce}")
-    return "\n\n".join(sections) + "\n"
+        sections.extend(
+            [
+                "\n\n",
+                TrustedBody.marker(
+                    UNPROTECTED_OVERRIDE_TRAILER,
+                    f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce}",
+                ),
+            ]
+        )
+    return TrustedBody.join(*sections).append("\n")
+
+
+def validate_managed_pr_body(
+    body: str,
+    *,
+    source_branch: str,
+    source_sha: str,
+    managed_branch: str,
+    override_nonce: str | None,
+    fetched_head_sha: str | None,
+    fetched_head_branch: str | None,
+    fetched_base_branch: str | None,
+    expected_base_branch: str | None,
+) -> None:
+    """Validate the one managed-PR body that this invocation created."""
+    expected_tokens = {SOURCE_MARKER}
+    if override_nonce is not None:
+        expected_tokens.add(UNPROTECTED_OVERRIDE_TRAILER)
+    carrier = TrustedBody.canonical(
+        body,
+        surface=PR_BODY_SURFACE,
+        expected_tokens=expected_tokens,
+    )
+    carrier.validate_for_surface(PR_BODY_SURFACE)
+    occurrences = scan_reserved_markers(str(carrier))
+    source_occurrence = next(
+        item for item in occurrences if item.definition.token == SOURCE_MARKER
+    )
+    source_match = source_occurrence.definition.pattern.search(source_occurrence.text)
+    if source_match is None:
+        raise AgentLoopError("Managed PR source record is malformed.")
+    encoded = source_match.group("payload")
+    try:
+        decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        payload = json.loads(decoded.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AgentLoopError("Managed PR source record could not be decoded.") from exc
+    if not isinstance(payload, dict) or set(payload) != {"source_branch", "source_sha"}:
+        raise AgentLoopError("Managed PR source record has an invalid schema.")
+    if payload.get("source_branch") != source_branch or payload.get("source_sha") != source_sha:
+        raise AgentLoopError("Managed PR source record does not match this creation handoff.")
+    if fetched_head_sha != source_sha:
+        raise AgentLoopError("Managed PR head SHA does not match its creation handoff.")
+    if fetched_head_branch != managed_branch:
+        raise AgentLoopError("Managed PR head branch does not match its creation handoff.")
+    if expected_base_branch is not None and fetched_base_branch != expected_base_branch:
+        raise AgentLoopError("Managed PR base branch does not match its creation handoff.")
+    if override_nonce is not None:
+        override_occurrence = next(
+            item for item in occurrences if item.definition.token == UNPROTECTED_OVERRIDE_TRAILER
+        )
+        if override_occurrence.text.strip().split() != [
+            UNPROTECTED_OVERRIDE_TRAILER,
+            f"nonce={override_nonce}",
+        ]:
+            raise AgentLoopError("Managed PR override record does not match this creation handoff.")
 
 
 def _close_partial_handoff(
@@ -140,9 +212,12 @@ def create_managed_pr(
         raise AgentLoopError("--head must name a same-repository branch, without `refs/` or an owner prefix.")
     if not title:
         raise AgentLoopError("--title cannot be empty.")
-    reject_forged_protocol_markers(body)
-    if SOURCE_MARKER in body or UNPROTECTED_OVERRIDE_TRAILER in body:
-        raise AgentLoopError("The supplied PR body contains a reserved managed-PR protocol marker.")
+    try:
+        TrustedBody.current_untrusted_visible(body)
+    except AgentLoopError as exc:
+        raise AgentLoopError(
+            "The supplied PR body contains a reserved managed-PR protocol marker."
+        ) from exc
     if not config.base:
         raise AgentLoopError("Managed PR creation requires a resolved base branch.")
     if source_branch == config.base:
@@ -217,6 +292,7 @@ def create_managed_pr(
             source_sha=source_sha,
             override_nonce=intent.audit_nonce,
         )
+        rendered_body.validate_for_surface(PR_BODY_SURFACE)
         create_result = _api(
             runner,
             config=config,
@@ -312,4 +388,4 @@ def create_managed_pr(
         config,
         f"Created managed draft PR #{pr_number} from {source_branch}@{source_sha[:12]} via {managed_branch}",
     )
-    return ManagedPrHandoff(pr_number, correlated_config, source_sha, managed_branch)
+    return ManagedPrHandoff(pr_number, correlated_config, source_sha, managed_branch, source_branch)

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -196,8 +196,15 @@ def validate_managed_pr_body(
     fetched_head_branch: str | None,
     fetched_base_branch: str | None,
     expected_base_branch: str | None,
+    require_creation_head_sha: bool = True,
 ) -> None:
-    """Validate the one managed-PR body that this invocation created."""
+    """Validate a managed-PR body and its current branch/base identity.
+
+    A managed PR created in the current invocation must still point at the
+    source commit used to create its handoff.  A recovered managed PR may have
+    advanced through coder rounds, so its current head is only required to be
+    on the authenticated managed branch.
+    """
     expected_tokens = {SOURCE_MARKER}
     if override_nonce is not None:
         expected_tokens.add(UNPROTECTED_OVERRIDE_TRAILER)
@@ -211,7 +218,7 @@ def validate_managed_pr_body(
     source_branch_value, source_sha_value = _managed_pr_source_fields(carrier)
     if source_branch_value != source_branch or source_sha_value != source_sha:
         raise AgentLoopError("Managed PR source record does not match this creation handoff.")
-    if fetched_head_sha != source_sha:
+    if require_creation_head_sha and fetched_head_sha != source_sha:
         raise AgentLoopError("Managed PR head SHA does not match its creation handoff.")
     if fetched_head_branch != managed_branch:
         raise AgentLoopError("Managed PR head branch does not match its creation handoff.")

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -96,7 +96,7 @@ def _compose_body(
     if sections:
         sections.append("\n\n")
     sections.append(_source_marker(source_branch=source_branch, source_sha=source_sha))
-    if override_nonce:
+    if override_nonce is not None:
         sections.extend(
             [
                 "\n\n",
@@ -107,6 +107,82 @@ def _compose_body(
             ]
         )
     return TrustedBody.join(*sections).append("\n")
+
+
+def _managed_pr_source_fields(carrier: TrustedBody) -> tuple[str, str]:
+    source_occurrence = next(
+        item
+        for item in scan_reserved_markers(str(carrier))
+        if item.definition.token == SOURCE_MARKER
+    )
+    source_match = source_occurrence.definition.pattern.search(source_occurrence.text)
+    if source_match is None:
+        raise AgentLoopError("Managed PR source record is malformed.")
+    encoded = source_match.group("payload")
+    try:
+        decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        payload = json.loads(decoded.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AgentLoopError("Managed PR source record could not be decoded.") from exc
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"source_branch", "source_sha"}
+        or not isinstance(payload.get("source_branch"), str)
+        or not payload["source_branch"]
+        or not isinstance(payload.get("source_sha"), str)
+        or not payload["source_sha"]
+    ):
+        raise AgentLoopError("Managed PR source record has an invalid schema.")
+    return payload["source_branch"], payload["source_sha"]
+
+
+def _managed_pr_override_nonce(carrier: TrustedBody) -> str | None:
+    override_occurrences = [
+        item
+        for item in scan_reserved_markers(str(carrier))
+        if item.definition.token == UNPROTECTED_OVERRIDE_TRAILER
+    ]
+    if not override_occurrences:
+        return None
+    parts = override_occurrences[0].text.strip().split()
+    if len(parts) != 2 or not parts[1].startswith("nonce=") or not parts[1][len("nonce=") :]:
+        raise AgentLoopError("Managed PR override record has an invalid schema.")
+    return parts[1][len("nonce=") :]
+
+
+def recover_managed_pr_origin(
+    body: str,
+    *,
+    fetched_head_branch: str | None,
+) -> tuple[str, str, str, str | None] | None:
+    """Recover the managed-PR validation tuple for a plain PR resumption.
+
+    The body marker is only a candidate.  The caller must still pass the
+    resulting tuple through ``validate_managed_pr_body`` with the fetched PR
+    metadata before any review work begins.
+    """
+    occurrences = scan_reserved_markers(body)
+    if not any(item.definition.token == SOURCE_MARKER for item in occurrences):
+        return None
+    if not fetched_head_branch or not fetched_head_branch.startswith("agent-loop/managed-"):
+        return None
+    expected_tokens = {SOURCE_MARKER}
+    if any(
+        item.definition.token == UNPROTECTED_OVERRIDE_TRAILER for item in occurrences
+    ):
+        expected_tokens.add(UNPROTECTED_OVERRIDE_TRAILER)
+    carrier = TrustedBody.canonical(
+        body,
+        surface=PR_BODY_SURFACE,
+        expected_tokens=expected_tokens,
+    )
+    source_branch, source_sha = _managed_pr_source_fields(carrier)
+    return (
+        source_branch,
+        source_sha,
+        fetched_head_branch,
+        _managed_pr_override_nonce(carrier),
+    )
 
 
 def validate_managed_pr_body(
@@ -132,21 +208,8 @@ def validate_managed_pr_body(
     )
     carrier.validate_for_surface(PR_BODY_SURFACE)
     occurrences = scan_reserved_markers(str(carrier))
-    source_occurrence = next(
-        item for item in occurrences if item.definition.token == SOURCE_MARKER
-    )
-    source_match = source_occurrence.definition.pattern.search(source_occurrence.text)
-    if source_match is None:
-        raise AgentLoopError("Managed PR source record is malformed.")
-    encoded = source_match.group("payload")
-    try:
-        decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
-        payload = json.loads(decoded.decode("utf-8"))
-    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise AgentLoopError("Managed PR source record could not be decoded.") from exc
-    if not isinstance(payload, dict) or set(payload) != {"source_branch", "source_sha"}:
-        raise AgentLoopError("Managed PR source record has an invalid schema.")
-    if payload.get("source_branch") != source_branch or payload.get("source_sha") != source_sha:
+    source_branch_value, source_sha_value = _managed_pr_source_fields(carrier)
+    if source_branch_value != source_branch or source_sha_value != source_sha:
         raise AgentLoopError("Managed PR source record does not match this creation handoff.")
     if fetched_head_sha != source_sha:
         raise AgentLoopError("Managed PR head SHA does not match its creation handoff.")

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6257,6 +6257,7 @@ def run_pr_loop(
     ordinary_recovery: OrdinaryRecoveryCapability | None = None
     ordinary_recovery_selected = False
     managed_ci_qualified = False
+    managed_pr_recovered = False
     try:
         bootstrap_cwd = github_bootstrap_cwd(config)
         initial_pr_context = get_pr_review_context(
@@ -6266,12 +6267,15 @@ def run_pr_loop(
             cwd=bootstrap_cwd,
         )
         if managed_pr_origin is None:
-            managed_pr_origin = recover_managed_pr_origin(
+            recovered_origin = recover_managed_pr_origin(
                 initial_pr_context.metadata.body or "",
                 fetched_head_branch=initial_pr_context.metadata.head_branch,
             )
-            if managed_pr_origin is None:
+            if recovered_origin is None:
                 reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+            else:
+                managed_pr_origin = recovered_origin
+                managed_pr_recovered = True
         if managed_pr_origin is not None:
             source_branch, source_sha, managed_branch, override_nonce = managed_pr_origin
             validate_managed_pr_body(
@@ -6284,6 +6288,7 @@ def run_pr_loop(
                 fetched_head_branch=initial_pr_context.metadata.head_branch,
                 fetched_base_branch=initial_pr_context.metadata.base_branch,
                 expected_base_branch=config.base,
+                require_creation_head_sha=not managed_pr_recovered,
             )
         recorded_pr_contract = find_latest_pr_contract(
             initial_pr_context.comments,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -141,7 +141,7 @@ from .managed_ci import (
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
-from .managed_pr import validate_managed_pr_body
+from .managed_pr import recover_managed_pr_origin, validate_managed_pr_body
 from .migrations import validate_pr_migration_topology
 from .prompts import (
     CompactPlanTailContext,
@@ -6266,8 +6266,13 @@ def run_pr_loop(
             cwd=bootstrap_cwd,
         )
         if managed_pr_origin is None:
-            reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
-        else:
+            managed_pr_origin = recover_managed_pr_origin(
+                initial_pr_context.metadata.body or "",
+                fetched_head_branch=initial_pr_context.metadata.head_branch,
+            )
+            if managed_pr_origin is None:
+                reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+        if managed_pr_origin is not None:
             source_branch, source_sha, managed_branch, override_nonce = managed_pr_origin
             validate_managed_pr_body(
                 initial_pr_context.metadata.body or "",

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -141,6 +141,7 @@ from .managed_ci import (
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
+from .managed_pr import validate_managed_pr_body
 from .migrations import validate_pr_migration_topology
 from .prompts import (
     CompactPlanTailContext,
@@ -344,6 +345,7 @@ from .round_state import (
     _strip_round_metadata,
 )
 from .round_transport import is_round_transport_sidecar
+from .protocol_markers import TrustedBody, scan_reserved_markers
 from .unresolved_items import (
     ALL_RESOLVED_PROSE_RE,
     CODER_DISPUTE_NOTE_PREFIX,
@@ -371,12 +373,16 @@ from .unresolved_items import (
 )
 
 
-def _embed_pr_contract_marker(body: str, contract: PrExpectedClosingContract) -> str:
+def _embed_pr_contract_marker(body: str | TrustedBody, contract: PrExpectedClosingContract) -> TrustedBody:
     marker = render_pr_contract_marker(contract)
-    if "\n-- " in body:
-        prefix, signature = body.rsplit("\n-- ", 1)
-        return f"{prefix}\n{marker}\n-- {signature}"
-    return f"{body.rstrip()}\n{marker}"
+    body_text = str(body)
+    if "\n-- " in body_text:
+        prefix, signature = body_text.rsplit("\n-- ", 1)
+        rendered = f"{prefix}\n{marker}\n-- {signature}"
+    else:
+        rendered = f"{body_text.rstrip()}\n{marker}"
+    expected = tuple(item.definition.token for item in scan_reserved_markers(rendered))
+    return TrustedBody.canonical(rendered, expected_tokens=expected)
 
 
 # TRANSIENT_AGENT_OUTPUT_RE / NON_RETRYABLE_AGENT_OUTPUT_RE / is_transient_agent_output
@@ -2212,6 +2218,15 @@ def _run_validated_agent(
     operation_description: str | None = None,
     completion_recovery: CompletionRecoveryPolicy | None = None,
 ) -> ValidatedAgentResponse:
+    # Agent responses are current untrusted visible text.  Keep this guard in
+    # the validation seam so every artifact recovery and repair path receives
+    # the same provenance check before it can be accepted.
+    response_validator = validate
+
+    def validate(text: str) -> object:
+        TrustedBody.current_untrusted_visible(text)
+        return response_validator(text)
+
     agent_name = agent_display_name(agent)
     operation_description = operation_description or _operation_description_from_context(
         salvage_context=salvage_context,
@@ -2253,6 +2268,7 @@ def _run_validated_agent(
     self_update_deadline: float | None = None
     self_update_stability_error: str | None = None
     next_timeout_seconds = timeout_seconds
+    marker_safety_repair_attempted = False
 
     for attempt in range(1, max_attempts + 1):
         attempt_config = (
@@ -2504,6 +2520,7 @@ def _run_validated_agent(
                 )
             except AgentLoopError as exc:
                 last_error = str(exc)
+                marker_safety_failure = "Current untrusted GitHub text contains reserved protocol marker(s):" in str(exc)
                 classification_text = _agent_failure_classification_text(result, phase="validation")
                 last_classification_text = classification_text
                 public_text_is_transient = _is_transient_public_response(
@@ -2835,6 +2852,7 @@ def _run_validated_agent(
                     use_repair
                     and not public_text_is_transient
                     and not response_failure_is_unsupported
+                    and (not marker_safety_failure or not marker_safety_repair_attempted)
                     and not (
                         isinstance(exc, UnknownPriorItemDispositionError)
                         and ledger_incomplete
@@ -2874,6 +2892,8 @@ def _run_validated_agent(
                     elif repair_allowed_prior_item_ids is not None:
                         repair_kwargs["allowed_prior_item_ids"] = tuple(repair_allowed_prior_item_ids)
                     original_validation_error = str(exc)
+                    if marker_safety_failure:
+                        marker_safety_repair_attempted = True
                     repaired, repaired_marker, repair_attempts = _run_structured_repair(
                         normalized if normalized is not None else text,
                         runner=runner,
@@ -4071,7 +4091,10 @@ def _implement_approved_issue(
                 runner,
                 config=implementation_config,
                 pr_number=existing_pr_number,
-                body=format_pr_contract_comment(pr_contract),
+                body=TrustedBody.canonical(
+                    format_pr_contract_comment(pr_contract),
+                    expected_tokens=("AGENT_PR_EXPECTED_CLOSING_ISSUES",),
+                ),
             )
             post_issue_pr_handoff_comment(
                 runner,
@@ -4216,7 +4239,10 @@ def _implement_approved_issue(
         runner,
         config=implementation_config,
         pr_number=pr_number,
-        body=format_pr_contract_comment(pr_contract),
+        body=TrustedBody.canonical(
+            format_pr_contract_comment(pr_contract),
+            expected_tokens=("AGENT_PR_EXPECTED_CLOSING_ISSUES",),
+        ),
     )
     post_issue_pr_handoff_comment(
         runner,
@@ -5723,7 +5749,10 @@ def run_issue_loop(
                     runner,
                     config=config,
                     pr_number=resolved_pr.pr_number,
-                    body=format_pr_contract_comment(pr_contract),
+                    body=TrustedBody.canonical(
+                        format_pr_contract_comment(pr_contract),
+                        expected_tokens=("AGENT_PR_EXPECTED_CLOSING_ISSUES",),
+                    ),
                 )
                 post_issue_pr_handoff_comment(
                     runner,
@@ -5888,7 +5917,10 @@ def run_issue_loop(
             runner,
             config=config,
             pr_number=pr_number,
-            body=format_pr_contract_comment(pr_contract),
+            body=TrustedBody.canonical(
+                format_pr_contract_comment(pr_contract),
+                expected_tokens=("AGENT_PR_EXPECTED_CLOSING_ISSUES",),
+            ),
         )
         post_issue_pr_handoff_comment(
             runner,
@@ -6217,6 +6249,7 @@ def run_pr_loop(
     workdirs_ready: bool = False,
     usage_context: RunUsageContext | None = None,
     pre_review_test_pending: bool = False,
+    managed_pr_origin: tuple[str, str, str, str | None] | None = None,
 ) -> int:
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
@@ -6232,7 +6265,21 @@ def run_pr_loop(
             pr_number=pr_number,
             cwd=bootstrap_cwd,
         )
-        reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+        if managed_pr_origin is None:
+            reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+        else:
+            source_branch, source_sha, managed_branch, override_nonce = managed_pr_origin
+            validate_managed_pr_body(
+                initial_pr_context.metadata.body or "",
+                source_branch=source_branch,
+                source_sha=source_sha,
+                managed_branch=managed_branch,
+                override_nonce=override_nonce,
+                fetched_head_sha=initial_pr_context.metadata.head_sha,
+                fetched_head_branch=initial_pr_context.metadata.head_branch,
+                fetched_base_branch=initial_pr_context.metadata.base_branch,
+                expected_base_branch=config.base,
+            )
         recorded_pr_contract = find_latest_pr_contract(
             initial_pr_context.comments,
             repository=config.repo,
@@ -6426,7 +6473,10 @@ def run_pr_loop(
                     runner,
                     config=config,
                     pr_number=pr_number,
-                    body=format_pr_contract_comment(closing_contract),
+                    body=TrustedBody.canonical(
+                        format_pr_contract_comment(closing_contract),
+                        expected_tokens=("AGENT_PR_EXPECTED_CLOSING_ISSUES",),
+                    ),
                 )
             if (
                 contract_needs_persisting

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -81,6 +81,10 @@ def _scratch_file_guidance() -> str:
         "write them outside the repository checkout, for example under "
         "/tmp/coding-review-agent-loop/scratch/. Do not create temporary files in the "
         "repo worktree unless they are intended project changes.\n"
+        "Agent-authored GitHub responses must discuss durable orchestration protocols only "
+        "with safe descriptive labels such as handoff record, round metadata, or audit "
+        "record. Never emit a complete reserved marker grammar or reproduce either of the "
+        "strict bare-token managed records; the orchestrator adds authorized records.\n"
     )
 
 

--- a/src/coding_review_agent_loop/protocol_markers.py
+++ b/src/coding_review_agent_loop/protocol_markers.py
@@ -345,9 +345,34 @@ def _all_occurrences(text: str) -> tuple[MarkerOccurrence, ...]:
     # records, but a complete regular match always wins over its containing
     # line/token fallback.
     for occurrence in sorted(fallback, key=lambda item: (item.start, -(item.end - item.start), item.definition.token)):
-        if any(occurrence.start < old.end and old.start < occurrence.end for old in selected):
+        overlaps = [
+            old
+            for old in selected
+            if occurrence.start < old.end and old.start < occurrence.end
+        ]
+        if not overlaps:
+            selected.append(occurrence)
             continue
-        selected.append(occurrence)
+        if occurrence.definition.strictness != "name-bearing-line":
+            continue
+        # A name-bearing-line fallback normally replaces the whole line so a
+        # malformed record cannot survive. If a valid record already occupies
+        # part of that line, retain the strict fallback for each token mention
+        # outside the valid span instead of leaking the mention after the
+        # valid record is sanitized.
+        for match in re.finditer(re.escape(occurrence.definition.token), occurrence.text, re.I):
+            token_occurrence = MarkerOccurrence(
+                occurrence.definition,
+                occurrence.start + match.start(),
+                occurrence.start + match.end(),
+                match.group(0),
+            )
+            if any(
+                token_occurrence.start < old.end and old.start < token_occurrence.end
+                for old in selected
+            ):
+                continue
+            selected.append(token_occurrence)
     return tuple(sorted(selected, key=lambda item: item.start))
 
 

--- a/src/coding_review_agent_loop/protocol_markers.py
+++ b/src/coding_review_agent_loop/protocol_markers.py
@@ -1,0 +1,542 @@
+"""Central registry and provenance-aware carriers for durable agent markers.
+
+This module intentionally has no dependency on a marker owner.  Producers own
+their schemas, while this leaf owns the outer grammar, canonical wire form,
+surface policy, and the distinction between current untrusted prose and
+historical text that the orchestrator is deliberately re-rendering.
+"""
+
+from __future__ import annotations
+
+import ast
+import base64
+import json
+import re
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal
+
+from .errors import AgentLoopError
+
+MarkerStrictness = Literal["well-formed-only", "name-bearing-line", "bare-substring"]
+
+ISSUE_COMMENT_SURFACE = "issue_comment"
+PR_COMMENT_SURFACE = "pr_comment"
+ISSUE_BODY_SURFACE = "issue_body"
+PR_BODY_SURFACE = "pr_body"
+REST_CREATE_SURFACE = "rest_create"
+REST_PATCH_SURFACE = "rest_patch"
+ANY_COMMENT_SURFACE = "any_comment"
+
+
+def _b64_json(value: object) -> str:
+    raw = json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_b64_json(value: str) -> object:
+    return json.loads(base64.urlsafe_b64decode(value.encode("ascii")).decode("utf-8"))
+
+
+def _canonical_b64_json(match: re.Match[str], *, prefix: str) -> str:
+    value = _decode_b64_json(match.group("payload"))
+    encoded = _b64_json(value)
+    return f"<!-- {prefix}: {encoded} -->"
+
+
+def _canonical_source(match: re.Match[str], *, token: str) -> str:
+    value = _decode_b64_json(match.group("payload"))
+    return f"<!-- {token} {_b64_json(value)} -->"
+
+
+def _canonical_compressed_mapping(match: re.Match[str], *, token: str) -> str:
+    encoded = match.group("payload")
+    packed = base64.urlsafe_b64decode(encoded[3:].encode("ascii")) if encoded.startswith("v1_") else base64.urlsafe_b64decode(encoded.encode("ascii"))
+    value = json.loads(zlib.decompress(packed).decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("mapping required")
+    raw = json.dumps(value, separators=(",", ":"), sort_keys=True, ensure_ascii=False).encode("utf-8")
+    canonical = "v1_" + base64.urlsafe_b64encode(zlib.compress(raw, 9)).decode("ascii")
+    return f"<!-- {token}: {canonical} -->"
+
+
+def _canonical_raw_json(match: re.Match[str], *, token: str) -> str:
+    value = json.loads(match.group("payload"))
+    return f"<!-- {token} {json.dumps(value, separators=(',', ':'), sort_keys=True)} -->"
+
+
+def _canonical_hex(match: re.Match[str], *, token: str) -> str:
+    return f"<!-- {token}: {match.group('value').lower()} -->"
+
+
+def _canonical_split_child(match: re.Match[str]) -> str:
+    return f"<!-- AGENT_SPLIT_CHILD: parent={int(match.group('parent'))} key={match.group('key').lower()} -->"
+
+
+def _canonical_key_value_comment(match: re.Match[str], *, token: str, colon: bool = True) -> str:
+    raw = match.group("fields").strip()
+    fields: list[tuple[str, str]] = []
+    for item in raw.split():
+        if "=" not in item:
+            raise ValueError("key/value field required")
+        key, value = item.split("=", 1)
+        if not key or not value:
+            raise ValueError("key/value field required")
+        fields.append((key, value))
+    token_orders = {
+        "AGENT_APPROVED_FOLLOWUPS": ("pr", "head", "mode"),
+        "AGENT_PLAN_APPROVED_FOLLOWUPS": ("issue", "plan", "mode"),
+        "AGENT_SPLIT_UNFILED_WARNING": ("issue", "subject"),
+        "AGENT_LOOP_MANAGED_CI_QUALIFIED_V2": (
+            "repo", "pr", "base", "protocol", "qualified_head", "reviewers",
+            "protection", "nonce", "run_id", "attempt", "generation",
+        ),
+    }
+    ordered_keys = token_orders.get(token)
+    if ordered_keys is not None:
+        order = {key: index for index, key in enumerate(ordered_keys)}
+        fields.sort(key=lambda item: (order.get(item[0], 100), item[0]))
+        separator = ": " if colon else " "
+        return f"<!-- {token}{separator}" + " ".join(f"{key}={value}" for key, value in fields) + " -->"
+    preferred = {
+        "issue": 0,
+        "subject": 1,
+        "pr": 0,
+        "head": 1,
+        "mode": 2,
+        "repo": 1,
+        "base": 2,
+        "protocol": 3,
+        "qualified_head": 4,
+        "reviewers": 5,
+        "protection": 6,
+        "nonce": 7,
+        "run_id": 8,
+        "attempt": 9,
+        "generation": 10,
+    }
+    fields.sort(key=lambda item: (preferred.get(item[0], 100), item[0]))
+    separator = ": " if colon else " "
+    return f"<!-- {token}{separator}" + " ".join(f"{key}={value}" for key, value in fields) + " -->"
+
+
+def _canonical_line_key_value(match: re.Match[str], *, token: str) -> str:
+    raw = match.group("fields").strip()
+    fields: list[tuple[str, str]] = []
+    for item in raw.split():
+        if "=" not in item:
+            raise ValueError("key/value field required")
+        key, value = item.split("=", 1)
+        if not key or not value:
+            raise ValueError("key/value field required")
+        fields.append((key, value))
+    token_orders = {
+        "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1": (
+            "nonce", "repo", "base", "head", "protection",
+            "active_label_event_id", "resume_from", "provenance_head", "generation",
+        ),
+    }
+    order = {key: index for index, key in enumerate(token_orders.get(token, ())) }
+    preferred = {"nonce": 0, "repo": 1, "pr": 2, "base": 3, "head": 4, "label": 5, "protocol": 6, "generation": 7, "run_id": 8, "attempt": 9}
+    if order:
+        preferred = order
+    fields.sort(key=lambda item: (preferred.get(item[0], 100), item[0]))
+    return token + " " + " ".join(f"{key}={value}" for key, value in fields)
+
+
+def _b64_definition(token: str, *, surfaces: frozenset[str], codec: str = "b64-json") -> "MarkerDefinition":
+    pattern = re.compile(rf"<!--\s*{re.escape(token)}:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", re.I)
+    return MarkerDefinition(
+        token=token,
+        pattern=pattern,
+        strictness="well-formed-only",
+        codec=codec,
+        surfaces=surfaces,
+        safe_label=f"[{token.replace('AGENT_', 'protocol ')} record]",
+        canonicalizer=lambda match, token=token, codec=codec: (
+            _canonical_compressed_mapping(match, token=token)
+            if codec == "compressed-mapping"
+            else _canonical_b64_json(match, prefix=token)
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class MarkerDefinition:
+    token: str
+    pattern: re.Pattern[str]
+    strictness: MarkerStrictness
+    codec: str
+    surfaces: frozenset[str]
+    safe_label: str
+    canonicalizer: Callable[[re.Match[str]], str]
+
+
+_COMMENT = frozenset({ISSUE_COMMENT_SURFACE, PR_COMMENT_SURFACE, ANY_COMMENT_SURFACE})
+_ISSUE = frozenset({ISSUE_COMMENT_SURFACE, ISSUE_BODY_SURFACE, REST_CREATE_SURFACE, ANY_COMMENT_SURFACE})
+_PR = frozenset({PR_COMMENT_SURFACE, PR_BODY_SURFACE, REST_CREATE_SURFACE, REST_PATCH_SURFACE, ANY_COMMENT_SURFACE})
+_ISSUE_ONLY = frozenset({ISSUE_COMMENT_SURFACE, ANY_COMMENT_SURFACE})
+
+
+def _key_value_definition(token: str, *, surfaces: frozenset[str], strictness: MarkerStrictness = "name-bearing-line") -> MarkerDefinition:
+    pattern = re.compile(rf"<!--\s*{re.escape(token)}:\s*(?P<fields>[^\r\n]*?)\s*-->", re.I)
+    return MarkerDefinition(
+        token=token,
+        pattern=pattern,
+        strictness=strictness,
+        codec="key-value",
+        surfaces=surfaces,
+        safe_label=f"[{token.replace('AGENT_', 'protocol ')} record]",
+        canonicalizer=lambda match, token=token: _canonical_key_value_comment(match, token=token),
+    )
+
+
+def _line_definition(token: str, *, surfaces: frozenset[str], strictness: MarkerStrictness = "bare-substring") -> MarkerDefinition:
+    pattern = re.compile(rf"(?m)^[ \t]*{re.escape(token)}[ \t]+(?P<fields>[^\r\n]+?)[ \t]*$", re.I)
+    return MarkerDefinition(
+        token=token,
+        pattern=pattern,
+        strictness=strictness,
+        codec="key-value-line",
+        surfaces=surfaces,
+        safe_label=f"[{token.replace('AGENT_', 'protocol ')} audit]",
+        canonicalizer=lambda match, token=token: _canonical_line_key_value(match, token=token),
+    )
+
+
+def _make_registry() -> tuple[MarkerDefinition, ...]:
+    entries: list[MarkerDefinition] = [
+        _b64_definition("AGENT_ISSUE_PR_HANDOFF", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_PR_EXPECTED_CLOSING_ISSUES", surfaces=_COMMENT),
+        _b64_definition("AGENT_PLAN_EXPECTED_CLOSING_ISSUES", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_LOOP_META", surfaces=_COMMENT, codec="compressed-mapping"),
+        _b64_definition("AGENT_LOOP_SIDECAR", surfaces=_COMMENT),
+        _b64_definition("AGENT_TYPED_PLAN_STAGES", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_DEFERRED_STAGES", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_PLAN_DECOMPOSITION", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_PLAN_PHASE_IMPLEMENTATION", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_PLAN_ONE_SHOT_IMPL", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_DISCUSS_SPLIT", surfaces=_ISSUE_ONLY),
+        MarkerDefinition(
+            token="AGENT_DISCUSS_CONSENSUS",
+            pattern=re.compile(r"<!--\s*AGENT_DISCUSS_CONSENSUS:\s*(?P<value>[0-9a-f]+)\s*-->", re.I),
+            strictness="well-formed-only",
+            codec="bare-hex",
+            surfaces=_ISSUE_ONLY,
+            safe_label="[protocol consensus record]",
+            canonicalizer=lambda match: _canonical_hex(match, token="AGENT_DISCUSS_CONSENSUS"),
+        ),
+        _key_value_definition("AGENT_APPROVED_FOLLOWUPS", surfaces=_PR),
+        _key_value_definition("AGENT_PLAN_APPROVED_FOLLOWUPS", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_SALVAGE", surfaces=_ISSUE_ONLY),
+        MarkerDefinition(
+            token="AGENT_MANAGED_CI_INTENT_V2",
+            pattern=re.compile(r"<!--\s*AGENT_MANAGED_CI_INTENT_V2\s+(?P<payload>.*?)\s*-->", re.I),
+            strictness="well-formed-only",
+            codec="raw-sorted-json",
+            surfaces=_PR,
+            safe_label="[protocol managed-CI intent record]",
+            canonicalizer=lambda match: _canonical_raw_json(match, token="AGENT_MANAGED_CI_INTENT_V2"),
+        ),
+        MarkerDefinition(
+            token="AGENT_LOOP_MANAGED_CI_QUALIFIED_V2",
+            pattern=re.compile(r"<!--\s*AGENT_LOOP_MANAGED_CI_QUALIFIED_V2\s+(?P<fields>[^\r\n]*?)\s*-->", re.I),
+            strictness="name-bearing-line",
+            codec="key-value",
+            surfaces=_PR,
+            safe_label="[protocol managed-CI qualification audit]",
+            canonicalizer=lambda match: _canonical_key_value_comment(match, token="AGENT_LOOP_MANAGED_CI_QUALIFIED_V2", colon=False),
+        ),
+        _line_definition("AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1", surfaces=_PR),
+        MarkerDefinition(
+            token="AGENT_MANAGED_PR_SOURCE_V1",
+            pattern=re.compile(r"<!--\s*AGENT_MANAGED_PR_SOURCE_V1\s+(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->", re.I),
+            strictness="bare-substring",
+            codec="source-b64-json",
+            surfaces=_PR,
+            safe_label="[protocol managed-PR origin record]",
+            canonicalizer=lambda match: _canonical_source(match, token="AGENT_MANAGED_PR_SOURCE_V1"),
+        ),
+        MarkerDefinition(
+            token="AGENT_SPLIT_CHILD",
+            pattern=re.compile(r"<!--\s*AGENT_SPLIT_CHILD:\s*parent=(?P<parent>\d+)\s+key=(?P<key>[0-9a-f]{64})\s*-->", re.I),
+            strictness="well-formed-only",
+            codec="hex/key-value",
+            surfaces=frozenset({ISSUE_BODY_SURFACE, REST_CREATE_SURFACE}),
+            safe_label="[protocol split-child record]",
+            canonicalizer=_canonical_split_child,
+        ),
+        _b64_definition("AGENT_SPLIT_STAGE_HANDOFF", surfaces=_ISSUE_ONLY),
+        MarkerDefinition(
+            token="AGENT_SPLIT_UNFILED_WARNING",
+            pattern=re.compile(r"<!--\s*AGENT_SPLIT_UNFILED_WARNING:\s*issue=(?P<issue>\d+)\s+subject=(?P<subject>\S+)\s*-->", re.I),
+            strictness="name-bearing-line",
+            codec="key-value",
+            surfaces=_ISSUE_ONLY,
+            safe_label="[protocol split-warning record]",
+            canonicalizer=lambda match: f"<!-- AGENT_SPLIT_UNFILED_WARNING: issue={int(match.group('issue'))} subject={match.group('subject')} -->",
+        ),
+    ]
+    return tuple(entries)
+
+
+RESERVED_MARKER_REGISTRY: tuple[MarkerDefinition, ...] = _make_registry()
+MARKER_BY_TOKEN = {entry.token: entry for entry in RESERVED_MARKER_REGISTRY}
+
+# These strings are deliberately not durable protocol records.  They are
+# public response grammar, configuration/environment names, workflow feature
+# probes, or ordinary state markers and therefore remain outside this writer
+# boundary.
+EXCLUDED_PROTOCOL_LITERALS = frozenset(
+    {
+        "AGENT_LOOP_MANAGED_CI_V2_PR_ADOPTION",
+        "AGENT_LOOP_MANAGED_CI_V2",
+        "AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1",
+        "AGENT_LOOP_PUBLIC_RESPONSE_BELOW",
+        "AGENT_LOOP_MANAGED_ACTOR",
+        "AGENT_LOOP_WORKDIR",
+        "AGENT_STATE",
+        "AGENT_PLAN_STATE",
+        "AGENT_PR",
+        "AGENT_CLARIFY",
+        "AGENT_UNAVAILABLE",
+        "AGENT_MARKER_RE",
+        "AGENT_OUTPUT_RE",
+        "AGENT_UNAVAILABLE_CATEGORIES",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MarkerOccurrence:
+    definition: MarkerDefinition
+    start: int
+    end: int
+    text: str
+
+
+def _all_occurrences(text: str) -> tuple[MarkerOccurrence, ...]:
+    found: list[MarkerOccurrence] = []
+    fallback: list[MarkerOccurrence] = []
+    for definition in RESERVED_MARKER_REGISTRY:
+        for match in definition.pattern.finditer(text):
+            found.append(MarkerOccurrence(definition, match.start(), match.end(), match.group(0)))
+        if definition.strictness == "bare-substring":
+            for match in re.finditer(re.escape(definition.token), text, re.I):
+                fallback.append(
+                    MarkerOccurrence(definition, match.start(), match.end(), match.group(0))
+                )
+        elif definition.strictness == "name-bearing-line":
+            line_pattern = re.compile(rf"(?m)^.*{re.escape(definition.token)}.*$", re.I)
+            for match in line_pattern.finditer(text):
+                fallback.append(
+                    MarkerOccurrence(definition, match.start(), match.end(), match.group(0))
+                )
+    # Prefer the complete outer record where a bare-substring token overlaps
+    # it.  This is important for deterministic historical replacement.
+    found.sort(key=lambda item: (item.start, -(item.end - item.start), item.definition.token))
+    selected: list[MarkerOccurrence] = []
+    for occurrence in found:
+        if any(occurrence.start < old.end and old.start < occurrence.end for old in selected):
+            continue
+        selected.append(occurrence)
+    # Fallback spans provide strictness-specific rejection for malformed
+    # records, but a complete regular match always wins over its containing
+    # line/token fallback.
+    for occurrence in sorted(fallback, key=lambda item: (item.start, -(item.end - item.start), item.definition.token)):
+        if any(occurrence.start < old.end and old.start < occurrence.end for old in selected):
+            continue
+        selected.append(occurrence)
+    return tuple(sorted(selected, key=lambda item: item.start))
+
+
+def scan_reserved_markers(text: str) -> tuple[MarkerOccurrence, ...]:
+    """Return non-overlapping reserved occurrences in source order."""
+    return _all_occurrences(text)
+
+
+def sanitize_historical_text(text: str) -> str:
+    """Replace reserved spans with stable labels, preserving surrounding prose."""
+    occurrences = _all_occurrences(text)
+    if not occurrences:
+        return text
+    pieces: list[str] = []
+    cursor = 0
+    for occurrence in occurrences:
+        pieces.append(text[cursor : occurrence.start])
+        pieces.append(occurrence.definition.safe_label)
+        cursor = occurrence.end
+    pieces.append(text[cursor:])
+    safe = "".join(pieces)
+    if _all_occurrences(safe):
+        raise AgentLoopError("Historical marker neutralization produced a reserved marker.")
+    return safe
+
+
+@dataclass(frozen=True)
+class _BodySegment:
+    text: str
+    token: str | None = None
+
+
+class TrustedBody(str):
+    """Immutable body text with explicit authorization for every marker span."""
+
+    _segments: tuple[_BodySegment, ...]
+
+    def __new__(cls, text: str, segments: tuple[_BodySegment, ...] = ()) -> "TrustedBody":
+        instance = str.__new__(cls, text)
+        instance._segments = segments or (_BodySegment(text),)
+        return instance
+
+    @property
+    def segments(self) -> tuple[tuple[str, str | None], ...]:
+        return tuple((segment.text, segment.token) for segment in self._segments)
+
+    @classmethod
+    def current_untrusted_visible(cls, text: str) -> "TrustedBody":
+        if not isinstance(text, str):
+            raise TypeError("TrustedBody text must be a string")
+        occurrences = scan_reserved_markers(text)
+        if occurrences:
+            names = ", ".join(sorted({item.definition.token for item in occurrences}))
+            raise AgentLoopError(
+                "Current untrusted GitHub text contains reserved protocol marker(s): "
+                + names
+            )
+        return cls(text, (_BodySegment(text),))
+
+    @classmethod
+    def historical_visible(cls, text: str) -> "TrustedBody":
+        return cls.current_untrusted_visible(sanitize_historical_text(text))
+
+    @classmethod
+    def canonical(
+        cls,
+        text: str,
+        *,
+        surface: str | None = None,
+        expected_tokens: tuple[str, ...] | list[str] | set[str] | None = None,
+    ) -> "TrustedBody":
+        occurrences = scan_reserved_markers(text)
+        expected = set(expected_tokens or ())
+        if expected and {item.definition.token for item in occurrences} != expected:
+            raise AgentLoopError(
+                "Trusted body marker set mismatch: expected "
+                f"{sorted(expected)}, found {sorted({item.definition.token for item in occurrences})}."
+            )
+        if len({item.definition.token for item in occurrences}) != len(occurrences):
+            raise AgentLoopError("Trusted body contains duplicate reserved protocol markers.")
+        segments: list[_BodySegment] = []
+        cursor = 0
+        for occurrence in occurrences:
+            definition = occurrence.definition
+            if surface is not None and surface not in definition.surfaces:
+                raise AgentLoopError(
+                    f"{definition.token} is not allowed on the {surface} surface."
+                )
+            try:
+                match = definition.pattern.search(occurrence.text)
+                if match is None:
+                    raise ValueError("reserved marker does not match its declared grammar")
+                canonical = definition.canonicalizer(
+                    match
+                )
+            except (ValueError, TypeError, UnicodeError, json.JSONDecodeError, zlib.error) as exc:
+                raise AgentLoopError(f"Invalid {definition.token} protocol record.") from exc
+            if canonical != occurrence.text:
+                raise AgentLoopError(f"{definition.token} protocol record is not canonical.")
+            if occurrence.start > cursor:
+                segments.append(_BodySegment(text[cursor : occurrence.start]))
+            segments.append(_BodySegment(text=occurrence.text, token=definition.token))
+            cursor = occurrence.end
+        if cursor < len(text) or not segments:
+            segments.append(_BodySegment(text=text[cursor:]))
+        return cls(text, tuple(segment for segment in segments if segment.text or len(segments) == 1))
+
+    @classmethod
+    def marker(cls, token: str, text: str) -> "TrustedBody":
+        if token not in MARKER_BY_TOKEN:
+            raise AgentLoopError(f"Unknown reserved protocol marker {token}.")
+        body = cls.canonical(text, expected_tokens=(token,))
+        return body
+
+    @classmethod
+    def join(cls, *parts: "TrustedBody | str") -> "TrustedBody":
+        converted: list[TrustedBody] = []
+        for part in parts:
+            converted.append(part if isinstance(part, TrustedBody) else cls.current_untrusted_visible(part))
+        return cls("".join(str(part) for part in converted), tuple(segment for part in converted for segment in part._segments))
+
+    def append(self, *parts: "TrustedBody | str") -> "TrustedBody":
+        return self.join(self, *parts)
+
+    def prepend(self, *parts: "TrustedBody | str") -> "TrustedBody":
+        return self.join(*parts, self)
+
+    def replace_text(self, old: str, replacement: "TrustedBody | str") -> "TrustedBody":
+        index = str(self).find(old)
+        if index < 0:
+            raise AgentLoopError("Trusted body replacement target was not found.")
+        left = str(self)[:index]
+        right = str(self)[index + len(old) :]
+        return self.join(self.current_untrusted_visible(left), replacement, self.current_untrusted_visible(right))
+
+    def validate_for_surface(self, surface: str) -> None:
+        if not isinstance(self, TrustedBody):
+            raise AgentLoopError("Trusted GitHub writers require a TrustedBody carrier.")
+        rebuilt = "".join(segment.text for segment in self._segments)
+        if rebuilt != str(self):
+            raise AgentLoopError("Trusted body segment provenance does not match its text.")
+        seen: set[str] = set()
+        for segment in self._segments:
+            occurrences = scan_reserved_markers(segment.text)
+            if segment.token is None:
+                if occurrences:
+                    raise AgentLoopError("Reserved marker appears in an unauthorized body segment.")
+                continue
+            if len(occurrences) != 1 or occurrences[0].start != 0 or occurrences[0].end != len(segment.text):
+                raise AgentLoopError("Trusted marker segment is not a single exact marker span.")
+            occurrence = occurrences[0]
+            if occurrence.definition.token != segment.token:
+                raise AgentLoopError("Trusted marker segment provenance is inconsistent.")
+            if segment.token in seen:
+                raise AgentLoopError("Trusted body contains duplicate authorized marker segments.")
+            seen.add(segment.token)
+            if surface not in occurrence.definition.surfaces:
+                raise AgentLoopError(f"{segment.token} is not allowed on the {surface} surface.")
+
+
+def trusted_body(
+    text: str,
+    *,
+    surface: str | None = None,
+    expected_tokens: tuple[str, ...] | list[str] | set[str] | None = None,
+) -> TrustedBody:
+    """Authorize a canonical producer result at the composition seam."""
+    return TrustedBody.canonical(text, surface=surface, expected_tokens=expected_tokens)
+
+
+def source_protocol_literals(root: Path) -> set[str]:
+    """Collect string-literal protocol names for the source-inventory guard."""
+    found: set[str] = set()
+    for path in sorted((root / "src").rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            found.update(re.findall(r"\bAGENT_[A-Z0-9_]+\b", node.value))
+    return found
+
+
+def assert_source_inventory(root: Path) -> None:
+    found = source_protocol_literals(root)
+    unknown = found - set(MARKER_BY_TOKEN) - EXCLUDED_PROTOCOL_LITERALS
+    if unknown:
+        raise AgentLoopError(
+            "Unregistered AGENT_* protocol-looking literal(s): " + ", ".join(sorted(unknown))
+        )

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -1000,6 +1000,12 @@ sourced fact. Do not repair answer mode into `discuss_review`, and do not add
 
 ## FORMAT:
 1. Start DIRECTLY with { — no prose, no markdown fences.
+Before emitting the repaired response, remove any complete reserved durable
+protocol grammar from prose or JSON values. Discuss such protocols only with
+safe descriptive labels, and do not reproduce the two strict bare-token
+managed records. Preserve the response kind, schema fields, prior-item IDs,
+human-requirement data, footer, signature, and substantive meaning; change
+only the quoted reserved syntax required for safety.
 2. After }: For approved `pr_review` or `plan_review` that now includes `<!-- HUMAN_REQUIREMENTS_RESOLVED -->`,
    place that marker immediately after the JSON and before the AGENT_STATE/AGENT_PLAN_STATE footer.
    For `plan_state` or `plan_revision`, place the optional signed human requirements acknowledgement before the footer only when it was present in the malformed original.

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -13,6 +13,7 @@ from .agents.base import AgentName
 from .agents.registry import agent_display_name
 from .errors import AgentLoopError
 from .round_transport import ROUND_RESUME_MARKER_RE, decode_mapping, encode_mapping, hydrate_mapping
+from .protocol_markers import TrustedBody, scan_reserved_markers
 from .workdir_guard import validate_checkout_inspected_evidence
 from .protocol import (
     HTML_COMMENT_RE,
@@ -294,10 +295,15 @@ def _attach_round_metadata(body: str, metadata: PostedRoundMetadata) -> str:
     prefix = "\n".join(lines[:metadata_start]).rstrip("\n")
     suffix = "\n".join(lines[metadata_start:]).lstrip("\n")
     if not prefix:
-        return "\n".join(part for part in (marker, suffix) if part)
-    if not suffix:
-        return "\n".join((prefix, marker))
-    return "\n".join((prefix, marker, suffix))
+        rendered = "\n".join(part for part in (marker, suffix) if part)
+    elif not suffix:
+        rendered = "\n".join((prefix, marker))
+    else:
+        rendered = "\n".join((prefix, marker, suffix))
+    expected = tuple(item.definition.token for item in scan_reserved_markers(rendered))
+    if "AGENT_LOOP_META" not in expected:
+        expected = (*expected, "AGENT_LOOP_META")
+    return TrustedBody.canonical(rendered, expected_tokens=expected)
 
 
 def _strip_round_metadata(body: str) -> str:

--- a/src/coding_review_agent_loop/round_transport.py
+++ b/src/coding_review_agent_loop/round_transport.py
@@ -10,6 +10,7 @@ import zlib
 from collections.abc import Mapping, Sequence
 
 from .errors import AgentLoopError
+from .protocol_markers import TrustedBody, scan_reserved_markers
 
 MAX_GITHUB_BODY_CHARS = 60_000
 ROUND_RESUME_MARKER_RE = re.compile(
@@ -84,31 +85,47 @@ def is_round_transport_sidecar(body: str) -> bool:
     return bool(ROUND_TRANSPORT_SIDECAR_RE.search(body))
 
 
-def _sidecar(payload: Mapping[str, object]) -> str:
+def _sidecar(payload: Mapping[str, object]) -> TrustedBody:
     encoded = _b64(
         json.dumps(dict(payload), separators=(",", ":"), sort_keys=True).encode()
     )
-    return f"<!-- AGENT_LOOP_SIDECAR: {encoded} -->"
+    return TrustedBody.canonical(
+        f"<!-- AGENT_LOOP_SIDECAR: {encoded} -->",
+        expected_tokens=("AGENT_LOOP_SIDECAR",),
+    )
 
 
-def prepare_round_comment(body: str) -> tuple[str, ...]:
+def prepare_round_comment(body: str | TrustedBody) -> tuple[TrustedBody, ...]:
     """Return sidecars followed by an anchor; non-round bodies are strictly bounded."""
-    matches = list(ROUND_RESUME_MARKER_RE.finditer(body))
-    if len(body) > MAX_GITHUB_BODY_CHARS and not matches:
+    if isinstance(body, TrustedBody):
+        carrier = body
+    else:
+        occurrences = scan_reserved_markers(body)
+        carrier = (
+            TrustedBody.current_untrusted_visible(body)
+            if not occurrences
+            else TrustedBody.canonical(
+                body,
+                expected_tokens=tuple(item.definition.token for item in occurrences),
+            )
+        )
+    body_text = str(carrier)
+    matches = list(ROUND_RESUME_MARKER_RE.finditer(body_text))
+    if len(body_text) > MAX_GITHUB_BODY_CHARS and not matches:
         raise AgentLoopError(
             f"GitHub comment body exceeds {MAX_GITHUB_BODY_CHARS} characters; shorten the response."
         )
     if not matches:
-        return (body,)
+        return (carrier,)
 
     # Resume reads the last marker when a legacy comment contains more than one.
     match = matches[-1]
     payload = decode_mapping(match.group("payload"))
     sidecars: list[str] = []
-    anchor_id = hashlib.sha256(body.encode()).hexdigest()[:24]
+    anchor_id = hashlib.sha256(body_text.encode()).hexdigest()[:24]
 
     def render_anchor(mapping: Mapping[str, object]) -> str:
-        return body[: match.start("payload")] + encode_mapping(mapping) + body[match.end("payload") :]
+        return body_text[: match.start("payload")] + encode_mapping(mapping) + body_text[match.end("payload") :]
 
     for field in _SPILL_FIELDS:
         current_anchor = render_anchor(payload)
@@ -163,7 +180,8 @@ def prepare_round_comment(body: str) -> tuple[str, ...]:
         )
     if any(len(item) > MAX_GITHUB_BODY_CHARS for item in sidecars):
         raise AgentLoopError("Round metadata sidecar exceeds GitHub body budget.")
-    return (*sidecars, anchor)
+    expected = tuple(item.definition.token for item in scan_reserved_markers(anchor))
+    return (*sidecars, TrustedBody.canonical(anchor, expected_tokens=expected))
 
 
 def hydrate_mapping(

--- a/src/coding_review_agent_loop/salvage.py
+++ b/src/coding_review_agent_loop/salvage.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 from .agents.base import AgentName, AgentResult
 from .errors import AgentLoopError
 from .github import IssueComment, post_issue_comment
+from .protocol_markers import TrustedBody
 from .logging import log
 from .runner import ensure_log_dir_ignored
 from .round_transport import MAX_GITHUB_BODY_CHARS
@@ -628,7 +629,12 @@ def post_salvage_comment(
             patch_max_bytes=config.salvage_comment_patch_max_bytes,
         )
         body = _render_clamped_salvage_comment(payload)
-        post_issue_comment(runner, config=config, issue_number=context.issue_number, body=body)
+        post_issue_comment(
+            runner,
+            config=config,
+            issue_number=context.issue_number,
+            body=TrustedBody.canonical(body, expected_tokens=("AGENT_SALVAGE",)),
+        )
     except (AgentLoopError, OSError, UnicodeDecodeError) as exc:
         log(config, f"salvage comment posting failed ({exc}); preserving original agent failure")
         return False

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -20,6 +20,7 @@ from .github import FoundIssue, create_issue, post_issue_comment, search_issues
 from .logging import log
 from .protocol import ChildStage, DeferredStage, ISSUE_REFERENCE_RE, TRACKER_ACTION_TITLE_RE
 from .runner import Runner
+from .protocol_markers import TrustedBody
 
 MAX_SPLIT_CHILDREN = 8
 DISCUSS_SPLIT_MARKER_RE = re.compile(
@@ -437,11 +438,14 @@ def materialize_split_proposals(
             runner,
             config=config,
             title=_child_issue_title(parent_issue, proposal),
-            body=_format_child_issue_body(
-                parent_issue=parent_issue,
-                proposal=proposal,
-                rationale=rationale,
-                siblings_so_far=resolved_so_far,
+            body=TrustedBody.canonical(
+                _format_child_issue_body(
+                    parent_issue=parent_issue,
+                    proposal=proposal,
+                    rationale=rationale,
+                    siblings_so_far=resolved_so_far,
+                ),
+                expected_tokens=("AGENT_SPLIT_CHILD",),
             ),
         )
         child = MaterializedSplitChild(
@@ -482,7 +486,10 @@ def materialize_split_proposals(
         runner,
         config=config,
         issue_number=parent_issue,
-        body=format_split_materialization_summary(parent_issue=parent_issue, metadata=metadata),
+        body=TrustedBody.canonical(
+            format_split_materialization_summary(parent_issue=parent_issue, metadata=metadata),
+            expected_tokens=("AGENT_DISCUSS_SPLIT",),
+        ),
     )
     return metadata
 
@@ -613,8 +620,11 @@ def post_split_stage_handoff_comment(
         runner,
         config=config,
         issue_number=parent_issue,
-        body=format_split_stage_handoff_comment(
-            parent_issue=parent_issue, plan_hash=plan_hash, child=child
+        body=TrustedBody.canonical(
+            format_split_stage_handoff_comment(
+                parent_issue=parent_issue, plan_hash=plan_hash, child=child
+            ),
+            expected_tokens=("AGENT_SPLIT_STAGE_HANDOFF",),
         ),
     )
 
@@ -675,4 +685,9 @@ def post_unfiled_split_warning(
             "-- coding-review-agent-loop",
         ]
     )
-    post_issue_comment(runner, config=config, issue_number=issue_number, body=body)
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body=TrustedBody.canonical(body, expected_tokens=("AGENT_SPLIT_UNFILED_WARNING",)),
+    )

--- a/tests/test_managed_pr.py
+++ b/tests/test_managed_pr.py
@@ -7,7 +7,11 @@ import pytest
 
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.managed_ci import ManagedCiCreationIntent, UNPROTECTED_OVERRIDE_TRAILER
-from coding_review_agent_loop.managed_pr import SOURCE_MARKER, create_managed_pr
+from coding_review_agent_loop.managed_pr import (
+    SOURCE_MARKER,
+    _compose_body,
+    create_managed_pr,
+)
 from coding_review_agent_loop.runner import CommandResult, Runner
 
 from agent_loop_helpers import make_config
@@ -120,6 +124,16 @@ def test_create_managed_pr_opens_labeled_draft_and_correlates_override(tmp_path)
     )
     assert label_payload == {"labels": ["agent-loop-managed"]}
     assert runner.branch_reads == 2
+
+
+def test_empty_override_nonce_is_rejected_at_body_composition(tmp_path):
+    with pytest.raises(AgentLoopError, match="Invalid AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1"):
+        _compose_body(
+            "",
+            source_branch="fix/empty-nonce",
+            source_sha="a" * 40,
+            override_nonce="",
+        )
 
 
 def test_create_managed_pr_creates_documented_label_before_applying_it(tmp_path):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import json
 import re
@@ -14,7 +15,16 @@ from coding_review_agent_loop.comment_rendering import (
     _render_public_pr_review_comment,
 )
 from coding_review_agent_loop.errors import QuotaResetExceededError
-from coding_review_agent_loop.followups import MAX_APPROVED_FOLLOWUP_ISSUES, reconcile_approved_followups
+from coding_review_agent_loop.followups import (
+    MAX_APPROVED_FOLLOWUP_ISSUES,
+    PlanApprovedFollowupSource,
+    _followup_issue_body,
+    _format_approved_followup_summary,
+    _format_plan_approval_summary_with_followups,
+    _plan_followup_issue_body,
+    reconcile_approved_followups,
+    reconcile_plan_approved_followups,
+)
 from coding_review_agent_loop.github import (
     CiWaitOutcome,
     CiWatchOutcome,
@@ -114,6 +124,65 @@ def test_direct_pr_resolves_single_linked_issue_context_for_reviewer(tmp_path):
     assert "Keep compatibility." in prompt
     assert "Later clarification." in prompt
     assert "Human requirements" in prompt
+
+
+def test_plain_pr_recovery_accepts_loop_created_managed_pr_body(tmp_path):
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(
+            {"source_branch": "feature/review-context", "source_sha": "abc123"},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    ).decode()
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={
+            "body": f"<!-- AGENT_MANAGED_PR_SOURCE_V1 {encoded} -->",
+            "headRefName": "agent-loop/managed-direct-token",
+        },
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=make_config(tmp_path)) == 0
+    assert runner.comments == ["**Review verdict:** Approved\n\nLGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"]
+
+
+def test_approved_followup_public_renderings_sanitize_historical_marker_mentions():
+    followup = ApprovedFollowup(
+        reviewer="Claude",
+        text="Document AGENT_APPROVED_FOLLOWUPS handling.",
+    )
+    reconciliation = reconcile_approved_followups([followup])
+
+    summary = _format_approved_followup_summary(77, reconciliation)
+    issue_body = _followup_issue_body(77, reconciliation.selected_groups[0])
+
+    assert "AGENT_APPROVED_FOLLOWUPS" not in summary
+    assert "AGENT_APPROVED_FOLLOWUPS" not in issue_body
+
+    source = PlanApprovedFollowupSource(
+        item_id="item-1",
+        reviewer="Claude",
+        source_round=1,
+        text="Document AGENT_PLAN_APPROVED_FOLLOWUPS handling.",
+        notes=("AGENT_SPLIT_UNFILED_WARNING was also discussed.",),
+    )
+    plan_reconciliation = reconcile_plan_approved_followups([source])
+    plan_body = _plan_followup_issue_body(
+        issue_number=56,
+        plan_hash="abc123",
+        plan_subject="Plan AGENT_MANAGED_PR_SOURCE_V1 handling.",
+        followup=plan_reconciliation.selected_groups[0],
+    )
+    plan_summary = _format_plan_approval_summary_with_followups(
+        56,
+        "Plan AGENT_MANAGED_PR_SOURCE_V1 handling.",
+        reconciliation=plan_reconciliation,
+    )
+
+    for rendered in (plan_body, plan_summary):
+        assert "AGENT_PLAN_APPROVED_FOLLOWUPS" not in rendered
+        assert "AGENT_SPLIT_UNFILED_WARNING" not in rendered
+        assert "AGENT_MANAGED_PR_SOURCE_V1" not in rendered
 
 
 def test_direct_pr_keeps_linked_issue_context_for_coder_followup(tmp_path):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -146,6 +146,57 @@ def test_plain_pr_recovery_accepts_loop_created_managed_pr_body(tmp_path):
     assert runner.comments == ["**Review verdict:** Approved\n\nLGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"]
 
 
+def test_plain_pr_recovery_accepts_managed_pr_head_after_creation_sha_advanced(tmp_path):
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(
+            {"source_branch": "feature/review-context", "source_sha": "abc123"},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    ).decode()
+    runner = FakeRunner(
+        codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"],
+        pr_payload={
+            "body": f"<!-- AGENT_MANAGED_PR_SOURCE_V1 {encoded} -->",
+            "headRefName": "agent-loop/managed-direct-token",
+            "headRefOid": "abc123-coder-1",
+        },
+    )
+
+    assert run_pr_loop(runner, pr_number=77, config=make_config(tmp_path)) == 0
+    assert runner.comments == ["**Review verdict:** Approved\n\nLGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"]
+
+
+def test_in_process_managed_pr_handoff_still_requires_creation_sha(tmp_path):
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(
+            {"source_branch": "feature/review-context", "source_sha": "abc123"},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    ).decode()
+    runner = FakeRunner(
+        pr_payload={
+            "body": f"<!-- AGENT_MANAGED_PR_SOURCE_V1 {encoded} -->",
+            "headRefName": "agent-loop/managed-direct-token",
+            "headRefOid": "abc123-coder-1",
+        },
+    )
+
+    with pytest.raises(AgentLoopError, match="Managed PR head SHA does not match"):
+        run_pr_loop(
+            runner,
+            pr_number=77,
+            config=make_config(tmp_path),
+            managed_pr_origin=(
+                "feature/review-context",
+                "abc123",
+                "agent-loop/managed-direct-token",
+                None,
+            ),
+        )
+
+
 def test_approved_followup_public_renderings_sanitize_historical_marker_mentions():
     followup = ApprovedFollowup(
         reviewer="Claude",

--- a/tests/test_protocol_markers.py
+++ b/tests/test_protocol_markers.py
@@ -2,10 +2,12 @@ import base64
 import json
 import zlib
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.github import post_issue_comment, post_pr_comment
 from coding_review_agent_loop.protocol_markers import (
     ISSUE_BODY_SURFACE,
     ISSUE_COMMENT_SURFACE,
@@ -89,6 +91,49 @@ def test_historical_sanitization_preserves_surrounding_ledger_fields():
     assert safe.startswith("item-13 / reviewer / round 4:")
     assert safe.endswith("— future")
     assert "AGENT_ISSUE_PR_HANDOFF" not in safe
+
+
+def test_historical_sanitization_neutralizes_fallback_mention_next_to_record():
+    sidecar = next(marker for token, marker, _surface in MARKERS if token == "AGENT_LOOP_SIDECAR")
+    text = (
+        f"Reviewer flagged that {sidecar} and AGENT_APPROVED_FOLLOWUPS "
+        "share a writer."
+    )
+
+    safe = sanitize_historical_text(text)
+
+    assert "Reviewer flagged that" in safe
+    assert "share a writer." in safe
+    assert "AGENT_APPROVED_FOLLOWUPS" not in safe
+    assert not scan_reserved_markers(safe)
+
+
+def test_ordinary_pr_comment_writer_enforces_pr_comment_surface():
+    marker = next(
+        marker for token, marker, _surface in MARKERS if token == "AGENT_ISSUE_PR_HANDOFF"
+    )
+
+    with pytest.raises(AgentLoopError, match="not allowed on the pr_comment surface"):
+        post_pr_comment(
+            None,
+            config=SimpleNamespace(quiet=True),
+            pr_number=1,
+            body=TrustedBody.canonical(marker, expected_tokens=("AGENT_ISSUE_PR_HANDOFF",)),
+        )
+
+
+def test_ordinary_issue_comment_writer_enforces_issue_comment_surface():
+    marker = next(
+        marker for token, marker, _surface in MARKERS if token == "AGENT_APPROVED_FOLLOWUPS"
+    )
+
+    with pytest.raises(AgentLoopError, match="not allowed on the issue_comment surface"):
+        post_issue_comment(
+            None,
+            config=SimpleNamespace(quiet=True),
+            issue_number=1,
+            body=TrustedBody.canonical(marker, expected_tokens=("AGENT_APPROVED_FOLLOWUPS",)),
+        )
 
 
 def test_source_inventory_has_no_unregistered_protocol_literals():

--- a/tests/test_protocol_markers.py
+++ b/tests/test_protocol_markers.py
@@ -1,0 +1,96 @@
+import base64
+import json
+import zlib
+from pathlib import Path
+
+import pytest
+
+from coding_review_agent_loop.errors import AgentLoopError
+from coding_review_agent_loop.protocol_markers import (
+    ISSUE_BODY_SURFACE,
+    ISSUE_COMMENT_SURFACE,
+    PR_BODY_SURFACE,
+    PR_COMMENT_SURFACE,
+    RESERVED_MARKER_REGISTRY,
+    TrustedBody,
+    assert_source_inventory,
+    sanitize_historical_text,
+    scan_reserved_markers,
+)
+
+
+def _b64(value: object) -> str:
+    raw = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode()
+
+
+def _compressed(value: object) -> str:
+    raw = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return "v1_" + base64.urlsafe_b64encode(zlib.compress(raw, 9)).decode()
+
+
+MARKERS = (
+    ("AGENT_ISSUE_PR_HANDOFF", f"<!-- AGENT_ISSUE_PR_HANDOFF: {_b64({'issue_number': 1})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_PR_EXPECTED_CLOSING_ISSUES", f"<!-- AGENT_PR_EXPECTED_CLOSING_ISSUES: {_b64({'issue_ids': [1]})} -->", PR_COMMENT_SURFACE),
+    ("AGENT_PLAN_EXPECTED_CLOSING_ISSUES", f"<!-- AGENT_PLAN_EXPECTED_CLOSING_ISSUES: {_b64({'issue_ids': [1]})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_LOOP_META", f"<!-- AGENT_LOOP_META: {_compressed({'flow': 'pr'})} -->", PR_COMMENT_SURFACE),
+    ("AGENT_LOOP_SIDECAR", f"<!-- AGENT_LOOP_SIDECAR: {_b64({'v': 1})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_TYPED_PLAN_STAGES", f"<!-- AGENT_TYPED_PLAN_STAGES: {_b64({'child_stages': []})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_DEFERRED_STAGES", f"<!-- AGENT_DEFERRED_STAGES: {_b64({'stages': []})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_PLAN_DECOMPOSITION", f"<!-- AGENT_PLAN_DECOMPOSITION: {_b64({'phases': []})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_PLAN_PHASE_IMPLEMENTATION", f"<!-- AGENT_PLAN_PHASE_IMPLEMENTATION: {_b64({'phase': 1})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_PLAN_ONE_SHOT_IMPL", f"<!-- AGENT_PLAN_ONE_SHOT_IMPL: {_b64({'pr_number': 1})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_DISCUSS_SPLIT", f"<!-- AGENT_DISCUSS_SPLIT: {_b64({'parent_issue': 1})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_DISCUSS_CONSENSUS", "<!-- AGENT_DISCUSS_CONSENSUS: " + "a" * 64 + " -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_APPROVED_FOLLOWUPS", "<!-- AGENT_APPROVED_FOLLOWUPS: pr=1 head=abc mode=summarize -->", PR_COMMENT_SURFACE),
+    ("AGENT_PLAN_APPROVED_FOLLOWUPS", "<!-- AGENT_PLAN_APPROVED_FOLLOWUPS: issue=1 plan=abc mode=summarize -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_SALVAGE", f"<!-- AGENT_SALVAGE: {_b64({'scope': 'issue-implementation'})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_MANAGED_CI_INTENT_V2", "<!-- AGENT_MANAGED_CI_INTENT_V2 {\"pr\":1,\"repository\":\"OWNER/REPO\"} -->", PR_COMMENT_SURFACE),
+    ("AGENT_LOOP_MANAGED_CI_QUALIFIED_V2", "<!-- AGENT_LOOP_MANAGED_CI_QUALIFIED_V2 repo=OWNER/REPO pr=1 base=main protocol=2 qualified_head=abc reviewers=Codex protection=strict nonce=n run_id=1 attempt=1 generation=g -->", PR_COMMENT_SURFACE),
+    ("AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1", "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1 nonce=n", PR_COMMENT_SURFACE),
+    ("AGENT_MANAGED_PR_SOURCE_V1", f"<!-- AGENT_MANAGED_PR_SOURCE_V1 {_b64({'source_branch': 'fix', 'source_sha': 'a'})} -->", PR_BODY_SURFACE),
+    ("AGENT_SPLIT_CHILD", "<!-- AGENT_SPLIT_CHILD: parent=1 key=" + "a" * 64 + " -->", ISSUE_BODY_SURFACE),
+    ("AGENT_SPLIT_STAGE_HANDOFF", f"<!-- AGENT_SPLIT_STAGE_HANDOFF: {_b64({'parent_issue': 1})} -->", ISSUE_COMMENT_SURFACE),
+    ("AGENT_SPLIT_UNFILED_WARNING", "<!-- AGENT_SPLIT_UNFILED_WARNING: issue=1 subject=abc -->", ISSUE_COMMENT_SURFACE),
+)
+
+
+@pytest.mark.parametrize("token,marker,surface", MARKERS)
+def test_every_registered_marker_has_one_canonical_authorized_segment(token, marker, surface):
+    body = TrustedBody.canonical(marker, surface=surface, expected_tokens=(token,))
+    body.validate_for_surface(surface)
+    assert body.segments == ((marker, token),)
+
+
+@pytest.mark.parametrize("token,marker,_surface", MARKERS)
+def test_current_visible_text_rejects_forged_marker_before_writing(token, marker, _surface):
+    with pytest.raises(AgentLoopError):
+        TrustedBody.current_untrusted_visible(f"quoted prose\n{marker}")
+
+
+def test_strict_bare_records_are_rejected_even_without_complete_grammar():
+    for token in ("AGENT_MANAGED_PR_SOURCE_V1", "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1"):
+        with pytest.raises(AgentLoopError):
+            TrustedBody.current_untrusted_visible(f"ordinary prose mentions {token}")
+
+
+def test_historical_sanitization_is_stable_and_cannot_create_adjacent_marker():
+    text = "prefix AGENT_MANAGED_PR_SOURCE_V1AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1 suffix"
+    safe = sanitize_historical_text(text)
+    assert "AGENT_MANAGED_PR_SOURCE_V1" not in safe
+    assert "AGENT_MANAGED_CI_UNPROTECTED_OVERRIDE_V1" not in safe
+    assert not scan_reserved_markers(safe)
+    assert sanitize_historical_text(text) == safe
+
+
+def test_historical_sanitization_preserves_surrounding_ledger_fields():
+    marker = MARKERS[0][1]
+    safe = TrustedBody.historical_visible(f"item-13 / reviewer / round 4: {marker} — future").__str__()
+    assert safe.startswith("item-13 / reviewer / round 4:")
+    assert safe.endswith("— future")
+    assert "AGENT_ISSUE_PR_HANDOFF" not in safe
+
+
+def test_source_inventory_has_no_unregistered_protocol_literals():
+    assert_source_inventory(Path(__file__).parents[1])
+    assert len(RESERVED_MARKER_REGISTRY) == 22


### PR DESCRIPTION
## Summary

- Add a centralized durable protocol-marker registry and immutable TrustedBody provenance boundary.
- Fail closed for ordinary GitHub writers, sanitize historical ledger text, and preserve opaque encoded payloads.
- Migrate marker producers, managed-PR provenance, agent-response repair, docs, and regression coverage.

Fixes #685

## Tests

- `timeout 900s python3 -m pytest` — 2255 passed.
