### PR TITLE
Harden legacy issue PR recovery provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,10 @@ or `Resolves`) for the issue; bare references, `Refs`, contextual URLs, and
 discussion prose are not implementation evidence. Multiple candidates stop
 with cleanup guidance. Use `agent-loop pr <number>` when the PR is known, and
 see [Issue-to-PR association and recovery](docs/local_agent_loop.md#issue-to-pr-association-and-recovery)
-for plan-hash checks and operator recovery.
+for plan-hash checks and operator recovery. Metadata-free closing-reference
+recovery now requires an exact unauthenticated commit-trailer scope, so
+pre-trailer PRs and `agent-loop managed-pr --head` PRs without that trailer
+must be resumed directly with `agent-loop pr <number>` rather than adopted.
 
 ### Expected closing issues
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1052,7 +1052,12 @@ Bare `#123`, `Refs #123`, contextual URLs, discussion prose, titles, branch
 names, and cross-repository references are not candidates. Pagination covers
 the full open-PR list. Multiple strong candidates stop with their PR numbers
 and matched closing evidence, plus cleanup and `agent-loop pr <number>`
-guidance.
+guidance. A sole candidate must also carry one or more identical, complete
+`Agent-Issue-Provenance` Git commit trailers for the exact repository, issue,
+flow, and (for plan-first recovery) approved-plan hash. Missing, malformed,
+conflicting, stale, or unstable commit history fails closed. This trailer is
+an unauthenticated convention that reduces accidental adoption, not an
+authentication boundary, because contributors can copy it.
 
 New direct and approved-plan PRs must contain a closing phrase for their issue
 before a handoff marker is posted. A staged child closes the child, includes
@@ -1066,7 +1071,12 @@ planning; a definite mismatch stops with the PR and both hashes and directs the
 operator to `agent-loop pr <number>` or handoff cleanup. If no plan round can be
 reconstructed, a valid canonical record resumes with a warning and its recorded
 hash. A metadata-free legacy candidate is stopped rather than assigned invented
-plan provenance, while direct mode can backfill a strong legacy candidate.
+plan provenance, while direct mode can backfill only a matching trailer-backed
+candidate. Metadata-free recovery is retired: pre-trailer PRs and
+`agent-loop managed-pr --head` PRs without a trailer require direct resume with
+`agent-loop pr <number>`. Squash or rebase removal of the trailer matters only
+before a canonical handoff exists; newly created PRs receive an advisory
+warning and still complete their authoritative handoff.
 
 Logs identify canonical marker versus legacy closing-reference evidence. To
 recover from a false handoff, edit or delete the latest canonical marker and,

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -3847,7 +3847,10 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
     if dry_run:
         from coding_review_agent_loop.github import IssueContext
 
-        preview_issue_number = first_phase.issue_number or 0
+        # A dry-run fake GitHub response may not assign a child number. Keep
+        # the prompt scope valid by previewing against the parent issue rather
+        # than manufacturing the invalid issue zero.
+        preview_issue_number = first_phase.issue_number or issue
         preview_context = IssueContext(
             number=preview_issue_number,
             repo=repo,

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -30,6 +30,11 @@ from .pr_contract import (
     encode_pr_contract,
 )
 from .logging import log
+from .issue_pr_provenance import (
+    IssuePrProvenanceScope,
+    compare_issue_pr_provenance,
+    parse_issue_pr_provenance_messages,
+)
 from .round_transport import MAX_GITHUB_BODY_CHARS, prepare_round_comment
 from .protocol import parse_signed_human_requirement_body
 from .protocol_markers import (
@@ -231,6 +236,205 @@ class OpenPrClosingMatch(int):
     @property
     def pr_number(self) -> int:
         return int(self)
+
+
+@dataclass(frozen=True)
+class PullRequestCommitMetadata:
+    """One commit in the provider-reported PR base-to-head connection."""
+
+    oid: str
+    message: str
+
+
+def _graphql_repository_parts(repository: str) -> tuple[str, str]:
+    parts = repository.split("/", 1)
+    if len(parts) != 2 or not all(parts):
+        raise AgentLoopError(f"Repository {repository!r} is not an owner/repository identity.")
+    return parts[0], parts[1]
+
+
+_PR_COMMIT_CONNECTION_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      headRefOid
+      commits(first: 100, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          commit { oid message }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def _query_pr_commit_connection(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    after: str | None,
+) -> object:
+    owner, name = _graphql_repository_parts(config.repo)
+    args = [
+        config.gh_cmd,
+        "api",
+        "graphql",
+        "-f",
+        f"query={_PR_COMMIT_CONNECTION_QUERY}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+        "-F",
+        f"number={pr_number}",
+    ]
+    if after is not None:
+        args.extend(("-F", f"after={after}"))
+    result = runner.run(args, cwd=active_workdir(config), check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise AgentLoopError(
+            f"GitHub PR commit provenance query failed for PR #{pr_number}"
+            + (f": {detail}" if detail else ".")
+        )
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AgentLoopError(
+            f"GitHub returned malformed PR commit provenance JSON for PR #{pr_number}."
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("errors"):
+        raise AgentLoopError(f"GitHub returned an error for PR #{pr_number} commit provenance.")
+    return payload
+
+
+def _parse_pr_commit_connection_page(
+    payload: object,
+    *,
+    pr_number: int,
+) -> tuple[str, int, tuple[PullRequestCommitMetadata, ...], bool, str | None]:
+    if not isinstance(payload, dict):
+        raise AgentLoopError(f"GitHub returned a malformed commit page for PR #{pr_number}.")
+    data = payload.get("data")
+    repository = data.get("repository") if isinstance(data, dict) else None
+    pull_request = repository.get("pullRequest") if isinstance(repository, dict) else None
+    connection = pull_request.get("commits") if isinstance(pull_request, dict) else None
+    head_oid = pull_request.get("headRefOid") if isinstance(pull_request, dict) else None
+    if not isinstance(head_oid, str) or not head_oid:
+        raise AgentLoopError(f"GitHub returned no current head OID for PR #{pr_number}.")
+    if not isinstance(connection, dict):
+        raise AgentLoopError(f"GitHub returned no complete commit connection for PR #{pr_number}.")
+    total = connection.get("totalCount")
+    page_info = connection.get("pageInfo")
+    nodes = connection.get("nodes")
+    if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+        raise AgentLoopError(f"GitHub returned an invalid commit total for PR #{pr_number}.")
+    if not isinstance(page_info, dict):
+        raise AgentLoopError(f"GitHub returned malformed commit pagination for PR #{pr_number}.")
+    has_next = page_info.get("hasNextPage")
+    end_cursor = page_info.get("endCursor")
+    if not isinstance(has_next, bool) or (has_next and (not isinstance(end_cursor, str) or not end_cursor)):
+        raise AgentLoopError(f"GitHub returned malformed commit pagination for PR #{pr_number}.")
+    if end_cursor is not None and not isinstance(end_cursor, str):
+        raise AgentLoopError(f"GitHub returned malformed commit pagination for PR #{pr_number}.")
+    if not isinstance(nodes, list):
+        raise AgentLoopError(f"GitHub returned malformed commit nodes for PR #{pr_number}.")
+    commits: list[PullRequestCommitMetadata] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            raise AgentLoopError(f"GitHub returned an incomplete commit node for PR #{pr_number}.")
+        commit_node = node.get("commit") if isinstance(node.get("commit"), dict) else node
+        oid = commit_node.get("oid") if isinstance(commit_node, dict) else None
+        message = commit_node.get("message") if isinstance(commit_node, dict) else None
+        if not isinstance(oid, str) or not oid or not isinstance(message, str):
+            raise AgentLoopError(f"GitHub returned an incomplete commit node for PR #{pr_number}.")
+        commits.append(PullRequestCommitMetadata(oid=oid, message=message))
+    return head_oid, total, tuple(commits), has_next, end_cursor
+
+
+def read_pull_request_commit_metadata(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+) -> tuple[PullRequestCommitMetadata, ...]:
+    """Read the complete stable commit history for one PR.
+
+    The connection is paginated independently of the provider's default page
+    cap.  Both the head OID and provider-reported total are sampled again
+    after traversal so a concurrent push or truncated response is unavailable
+    for recovery rather than being mistaken for a clean provenance miss.
+    """
+    if config.dry_run:
+        return ()
+    first_payload = _query_pr_commit_connection(
+        runner, config=config, pr_number=pr_number, after=None
+    )
+    before_head, expected_total, first_commits, has_next, cursor = _parse_pr_commit_connection_page(
+        first_payload, pr_number=pr_number
+    )
+    commits = list(first_commits)
+    seen_oids = {commit.oid for commit in commits}
+    seen_cursors: set[str] = set()
+    while has_next:
+        assert cursor is not None
+        if cursor in seen_cursors:
+            raise AgentLoopError(f"GitHub commit pagination for PR #{pr_number} did not advance.")
+        seen_cursors.add(cursor)
+        payload = _query_pr_commit_connection(
+            runner, config=config, pr_number=pr_number, after=cursor
+        )
+        head, total, page_commits, has_next, next_cursor = _parse_pr_commit_connection_page(
+            payload, pr_number=pr_number
+        )
+        if head != before_head or total != expected_total:
+            raise AgentLoopError(f"PR #{pr_number} commit history changed during provenance scan.")
+        if not page_commits and has_next:
+            raise AgentLoopError(f"GitHub commit pagination for PR #{pr_number} returned an empty advancing page.")
+        for commit in page_commits:
+            if commit.oid in seen_oids:
+                raise AgentLoopError(f"GitHub commit pagination for PR #{pr_number} repeated a commit.")
+            seen_oids.add(commit.oid)
+            commits.append(commit)
+        if has_next and next_cursor == cursor:
+            raise AgentLoopError(f"GitHub commit pagination for PR #{pr_number} did not advance.")
+        cursor = next_cursor
+    if len(commits) != expected_total:
+        raise AgentLoopError(
+            f"GitHub PR #{pr_number} commit provenance was truncated: provider reported "
+            f"{expected_total} commits but returned {len(commits)}."
+        )
+    final_payload = _query_pr_commit_connection(
+        runner, config=config, pr_number=pr_number, after=None
+    )
+    final_head, final_total, _ignored, _ignored_next, _ignored_cursor = _parse_pr_commit_connection_page(
+        final_payload, pr_number=pr_number
+    )
+    if final_head != before_head or final_total != expected_total:
+        raise AgentLoopError(f"PR #{pr_number} commit history changed during provenance scan.")
+    return tuple(commits)
+
+
+get_pull_request_commit_metadata = read_pull_request_commit_metadata
+
+
+def validate_pull_request_provenance(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    expected_scope: IssuePrProvenanceScope,
+) -> IssuePrProvenanceScope:
+    commits = read_pull_request_commit_metadata(runner, config=config, pr_number=pr_number)
+    try:
+        claims = parse_issue_pr_provenance_messages(commit.message for commit in commits)
+        return compare_issue_pr_provenance(claims, expected=expected_scope)
+    except AgentLoopError as exc:
+        raise AgentLoopError(f"PR #{pr_number} commit provenance is unavailable: {exc}") from exc
 
 
 def _issue_reference_evidence_from_match(
@@ -613,8 +817,15 @@ def validate_pr_body_does_not_close_issue(
     )
 
 
+_UNSET_PROVENANCE_SCOPE = object()
+
+
 def find_open_pr_closing_issue(
-    runner: Runner, *, config: AgentLoopConfig, issue_number: int
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    expected_scope: IssuePrProvenanceScope | None | object = _UNSET_PROVENANCE_SCOPE,
 ) -> OpenPrClosingMatch | None:
     """Find the unique open PR with strong closing evidence for an issue.
 
@@ -624,6 +835,13 @@ def find_open_pr_closing_issue(
     """
     if config.dry_run:
         return None
+    if expected_scope is _UNSET_PROVENANCE_SCOPE:
+        # Preserve the direct helper's historical default while resolver call
+        # sites pass an explicit scope (including ``None`` when a plan cannot
+        # be reconstructed).
+        expected_scope = IssuePrProvenanceScope(
+            repository=config.repo, issue_number=issue_number, flow="direct"
+        )
     result = runner.run(
         [
             config.gh_cmd,
@@ -684,7 +902,31 @@ def find_open_pr_closing_issue(
             "reference or close the unrelated PR(s), then rerun `agent-loop pr <number>` directly "
             "to continue review on the correct one."
         )
-    return matches[0]
+    match = matches[0]
+    if expected_scope is None:
+        raise _candidate_provenance_error(
+            match.pr_number,
+            "the issue-mode plan has no reconstructable approved-plan scope",
+        )
+    try:
+        validate_pull_request_provenance(
+            runner,
+            config=config,
+            pr_number=match.pr_number,
+            expected_scope=expected_scope,
+        )
+    except AgentLoopError as exc:
+        raise _candidate_provenance_error(match.pr_number, str(exc)) from exc
+    return match
+
+
+def _candidate_provenance_error(pr_number: int, reason: str) -> AgentLoopError:
+    return AgentLoopError(
+        f"Open PR #{pr_number} is the sole closing-reference candidate, but it cannot be "
+        f"safely adopted: {reason} Remove the closing reference from this unrelated PR or "
+        f"close the unrelated PR; if PR #{pr_number} is the intended implementation, resume "
+        f"it directly with `agent-loop pr {pr_number}`."
+    )
 
 
 def _parse_pr_metadata(

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -285,15 +285,15 @@ def _query_pr_commit_connection(
         "graphql",
         "-f",
         f"query={_PR_COMMIT_CONNECTION_QUERY}",
-        "-F",
+        "-f",
         f"owner={owner}",
-        "-F",
+        "-f",
         f"name={name}",
         "-F",
         f"number={pr_number}",
     ]
     if after is not None:
-        args.extend(("-F", f"after={after}"))
+        args.extend(("-f", f"after={after}"))
     result = runner.run(args, cwd=active_workdir(config), check=False)
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
@@ -429,12 +429,24 @@ def validate_pull_request_provenance(
     pr_number: int,
     expected_scope: IssuePrProvenanceScope,
 ) -> IssuePrProvenanceScope:
-    commits = read_pull_request_commit_metadata(runner, config=config, pr_number=pr_number)
     try:
-        claims = parse_issue_pr_provenance_messages(commit.message for commit in commits)
-        return compare_issue_pr_provenance(claims, expected=expected_scope)
+        commits = read_pull_request_commit_metadata(runner, config=config, pr_number=pr_number)
     except AgentLoopError as exc:
         raise AgentLoopError(f"PR #{pr_number} commit provenance is unavailable: {exc}") from exc
+    try:
+        claims = parse_issue_pr_provenance_messages(commit.message for commit in commits)
+    except AgentLoopError as exc:
+        raise AgentLoopError(f"PR #{pr_number} commit provenance is malformed: {exc}") from exc
+    try:
+        return compare_issue_pr_provenance(claims, expected=expected_scope)
+    except AgentLoopError as exc:
+        if not claims:
+            reason = "is missing"
+        elif len(set(claims)) != 1:
+            reason = "contains conflicting claims"
+        else:
+            reason = "does not match the expected scope"
+        raise AgentLoopError(f"PR #{pr_number} commit provenance {reason}: {exc}") from exc
 
 
 def _issue_reference_evidence_from_match(
@@ -906,7 +918,7 @@ def find_open_pr_closing_issue(
     if expected_scope is None:
         raise _candidate_provenance_error(
             match.pr_number,
-            "the issue-mode plan has no reconstructable approved-plan scope",
+            "the issue-mode plan has no reconstructable approved-plan scope.",
         )
     try:
         validate_pull_request_provenance(

--- a/src/coding_review_agent_loop/issue_pr_handoff.py
+++ b/src/coding_review_agent_loop/issue_pr_handoff.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from .config import AgentLoopConfig
 from .errors import AgentLoopError
 from .expected_closure import contract_hash, normalize_issue_ids
+from .issue_pr_provenance import IssuePrProvenanceScope
 from .github import (
     IssueContext,
     OpenPrClosingMatch,
@@ -43,6 +44,9 @@ AGENT_ISSUE_PR_HANDOFF_RE = re.compile(
     r"<!--\s*AGENT_ISSUE_PR_HANDOFF:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
     re.I,
 )
+
+
+_UNSET_FALLBACK_SCOPE = object()
 
 
 @dataclass(frozen=True)
@@ -311,6 +315,7 @@ def resolve_canonical_pr_for_issue(
     config: AgentLoopConfig,
     issue_number: int,
     issue_context: IssueContext,
+    expected_fallback_scope: IssuePrProvenanceScope | None | object = _UNSET_FALLBACK_SCOPE,
 ) -> ResolvedIssuePr | None:
     """Resolve the PR a rerun of `agent-loop issue <issue_number>` should resume.
 
@@ -387,8 +392,15 @@ def resolve_canonical_pr_for_issue(
         return ResolvedIssuePr(
             pr_number=canonical.pr_number, source="canonical", evidence=canonical
         )
+    if expected_fallback_scope is _UNSET_FALLBACK_SCOPE:
+        expected_fallback_scope = IssuePrProvenanceScope(
+            repository=config.repo, issue_number=issue_number, flow="direct"
+        )
     legacy_match = find_open_pr_closing_issue(
-        runner, config=config, issue_number=issue_number
+        runner,
+        config=config,
+        issue_number=issue_number,
+        expected_scope=expected_fallback_scope,
     )
     if legacy_match is None:
         return None

--- a/src/coding_review_agent_loop/issue_pr_provenance.py
+++ b/src/coding_review_agent_loop/issue_pr_provenance.py
@@ -1,0 +1,234 @@
+"""Unauthenticated commit provenance for issue-origin PR recovery.
+
+This is deliberately a conventional Git trailer, not a durable protocol
+marker.  It helps avoid adopting an unrelated open PR after an interrupted
+issue implementation, but contributors can copy it, so it is not an
+authentication boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from .errors import AgentLoopError
+
+
+ISSUE_PR_PROVENANCE_TRAILER_KEY = "Agent-Issue-Provenance"
+ISSUE_PR_PROVENANCE_VERSION = 1
+# Public aliases keep the convention easy to discover without introducing a
+# reserved protocol-marker definition.
+ISSUE_PR_PROVENANCE_TRAILER = ISSUE_PR_PROVENANCE_TRAILER_KEY
+PROVENANCE_TRAILER_KEY = ISSUE_PR_PROVENANCE_TRAILER_KEY
+IssuePrProvenanceFlow = Literal["direct", "approved"]
+
+_REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
+_PLAN_HASH_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_TRAILER_LINE_RE = re.compile(
+    rf"^{re.escape(ISSUE_PR_PROVENANCE_TRAILER_KEY)}:\s+(?P<value>\S(?:.*\S)?)$"
+)
+
+
+def normalize_repository(repository: str) -> str:
+    """Normalize a GitHub ``owner/repository`` identity for comparison."""
+    if not isinstance(repository, str):
+        raise AgentLoopError("Issue provenance repository must be a string.")
+    normalized = repository.strip().casefold()
+    if not _REPOSITORY_RE.fullmatch(normalized):
+        raise AgentLoopError(
+            "Issue provenance repository must be a non-empty owner/repository identity."
+        )
+    return normalized
+
+
+def _normalize_plan_hash(plan_hash: str | None) -> str | None:
+    if plan_hash is None:
+        return None
+    if not isinstance(plan_hash, str) or not plan_hash.strip():
+        raise AgentLoopError("Approved issue provenance requires a non-empty plan hash.")
+    normalized = plan_hash.strip()
+    if not _PLAN_HASH_RE.fullmatch(normalized):
+        raise AgentLoopError("Issue provenance plan hash contains invalid characters.")
+    return normalized
+
+
+@dataclass(frozen=True)
+class IssuePrProvenanceScope:
+    """The exact issue-origin scope a recovered PR must claim."""
+
+    repository: str
+    issue_number: int
+    flow: IssuePrProvenanceFlow
+    approved_plan_hash: str | None = None
+
+    @property
+    def repository_identity(self) -> str:
+        return self.repository
+
+    @property
+    def plan_hash(self) -> str | None:
+        return self.approved_plan_hash
+
+    def __post_init__(self) -> None:
+        repository = normalize_repository(self.repository)
+        issue_number = self.issue_number
+        if isinstance(issue_number, str) and re.fullmatch(r"[1-9]\d*", issue_number.strip()):
+            issue_number = int(issue_number.strip())
+        if (
+            isinstance(issue_number, bool)
+            or not isinstance(issue_number, int)
+            or issue_number <= 0
+        ):
+            raise AgentLoopError("Issue provenance issue number must be a positive integer.")
+        if self.flow not in {"direct", "approved"}:
+            raise AgentLoopError(
+                "Issue provenance flow must be exactly 'direct' or 'approved'."
+            )
+        plan_hash = _normalize_plan_hash(self.approved_plan_hash)
+        if self.flow == "direct" and plan_hash is not None:
+            raise AgentLoopError("Direct issue provenance cannot carry a plan hash.")
+        if self.flow == "approved" and plan_hash is None:
+            raise AgentLoopError("Approved issue provenance requires a plan hash.")
+        object.__setattr__(self, "repository", repository)
+        object.__setattr__(self, "issue_number", issue_number)
+        object.__setattr__(self, "approved_plan_hash", plan_hash)
+
+
+# Short aliases make the model convenient for callers that use the term
+# "scope" rather than the full record name.
+IssueProvenanceScope = IssuePrProvenanceScope
+
+
+def format_issue_pr_provenance(scope: IssuePrProvenanceScope) -> str:
+    """Render the canonical complete trailer line for ``scope``."""
+    if not isinstance(scope, IssuePrProvenanceScope):
+        raise AgentLoopError("Cannot format an invalid issue provenance scope.")
+    fields = [
+        f"v{ISSUE_PR_PROVENANCE_VERSION}",
+        f"repo={scope.repository}",
+        f"issue={scope.issue_number}",
+        f"flow={scope.flow}",
+    ]
+    if scope.approved_plan_hash is not None:
+        fields.append(f"plan={scope.approved_plan_hash}")
+    return f"{ISSUE_PR_PROVENANCE_TRAILER_KEY}: " + " ".join(fields)
+
+
+format_issue_provenance_trailer = format_issue_pr_provenance
+
+
+def _parse_fields(value: str) -> dict[str, str]:
+    parts = value.split()
+    if not parts or not parts[0].startswith("v"):
+        raise AgentLoopError("Issue provenance trailer has no supported version.")
+    try:
+        version = int(parts[0][1:])
+    except ValueError as exc:
+        raise AgentLoopError("Issue provenance trailer has an invalid version.") from exc
+    if version != ISSUE_PR_PROVENANCE_VERSION:
+        raise AgentLoopError(f"Issue provenance trailer has unsupported version {version}.")
+    fields: dict[str, str] = {}
+    for part in parts[1:]:
+        key, separator, raw_value = part.partition("=")
+        if not separator or not key or not raw_value or key in fields:
+            raise AgentLoopError("Issue provenance trailer has malformed fields.")
+        fields[key] = raw_value
+    if set(fields) not in ({"repo", "issue", "flow"}, {"repo", "issue", "flow", "plan"}):
+        raise AgentLoopError("Issue provenance trailer has an incomplete or unknown scope.")
+    try:
+        issue_number = int(fields["issue"])
+    except ValueError as exc:
+        raise AgentLoopError("Issue provenance trailer issue is not an integer.") from exc
+    flow = fields["flow"]
+    plan_hash = fields.get("plan")
+    return {
+        "repo": fields["repo"],
+        "issue": str(issue_number),
+        "flow": flow,
+        "plan": plan_hash or "",
+    }
+
+
+def parse_issue_pr_provenance_line(line: str) -> IssuePrProvenanceScope | None:
+    """Parse one complete trailer line; unrelated lines return ``None``."""
+    if not isinstance(line, str):
+        raise AgentLoopError("Issue provenance commit message line must be text.")
+    stripped = line.strip()
+    if not stripped:
+        return None
+    if not (
+        stripped == ISSUE_PR_PROVENANCE_TRAILER_KEY
+        or stripped.startswith(f"{ISSUE_PR_PROVENANCE_TRAILER_KEY}:")
+        or stripped.startswith(f"{ISSUE_PR_PROVENANCE_TRAILER_KEY} ")
+    ):
+        return None
+    match = _TRAILER_LINE_RE.fullmatch(stripped)
+    if match is None:
+        raise AgentLoopError("Issue provenance trailer is malformed.")
+    fields = _parse_fields(match.group("value"))
+    try:
+        return IssuePrProvenanceScope(
+            repository=fields["repo"],
+            issue_number=int(fields["issue"]),
+            flow=fields["flow"],  # type: ignore[arg-type]
+            approved_plan_hash=fields["plan"] or None,
+        )
+    except AgentLoopError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise AgentLoopError("Issue provenance trailer has an invalid scope.") from exc
+
+
+parse_issue_provenance_trailer = parse_issue_pr_provenance_line
+
+
+def parse_issue_pr_provenance_messages(
+    messages: Iterable[str],
+) -> tuple[IssuePrProvenanceScope, ...]:
+    """Parse complete provenance trailer lines from commit messages only.
+
+    A line that starts with the trailer key is an occurrence even when it is
+    malformed.  That distinction lets callers fail closed for valid-plus-
+    malformed mixtures instead of silently ignoring the malformed claim.
+    """
+    claims: list[IssuePrProvenanceScope] = []
+    for message in messages:
+        if not isinstance(message, str):
+            raise AgentLoopError("GitHub returned a non-text commit message.")
+        for line in message.splitlines():
+            stripped = line.strip()
+            if (
+                stripped == ISSUE_PR_PROVENANCE_TRAILER_KEY
+                or stripped.startswith(f"{ISSUE_PR_PROVENANCE_TRAILER_KEY}:")
+                or stripped.startswith(f"{ISSUE_PR_PROVENANCE_TRAILER_KEY} ")
+            ):
+                claim = parse_issue_pr_provenance_line(line)
+                if claim is None:  # pragma: no cover - guarded by the prefix check
+                    raise AgentLoopError("Issue provenance trailer is malformed.")
+                claims.append(claim)
+    return tuple(claims)
+
+
+def compare_issue_pr_provenance(
+    claims: Iterable[IssuePrProvenanceScope],
+    *,
+    expected: IssuePrProvenanceScope,
+) -> IssuePrProvenanceScope:
+    """Validate a non-empty set of identical claims against an exact scope."""
+    claims = tuple(claims)
+    if not claims:
+        raise AgentLoopError("No issue provenance trailer was found in the PR commits.")
+    unique = set(claims)
+    if len(unique) != 1:
+        raise AgentLoopError("PR commit provenance contains conflicting issue scopes.")
+    found = unique.pop()
+    if found != expected:
+        raise AgentLoopError(
+            "PR commit provenance does not match the expected repository, issue, flow, or plan scope."
+        )
+    return found
+
+
+validate_issue_pr_provenance = compare_issue_pr_provenance

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -79,6 +79,7 @@ from .github import (
     validate_pr_body_does_not_close_issue,
     validate_pr_expected_closing_issues,
     validate_pr_references_issue,
+    validate_pull_request_provenance,
     wait_for_ci,
     watch_pr_checks,
 )
@@ -88,6 +89,7 @@ from .issue_pr_handoff import (
     require_pr_metadata_for_handoff,
     resolve_canonical_pr_for_issue,
 )
+from .issue_pr_provenance import IssuePrProvenanceScope
 from .pr_contract import (
     PR_EXPECTED_CLOSING_MARKER_RE,
     PrExpectedClosingContract,
@@ -3884,6 +3886,33 @@ def _read_assigned_workdir_head(runner: Runner, config: AgentLoopConfig) -> str 
     return result.stdout.strip() or None
 
 
+def _advisory_issue_pr_provenance(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    expected_scope: IssuePrProvenanceScope,
+) -> None:
+    """Warn on missing provenance without blocking a newly created PR handoff."""
+    try:
+        validate_pull_request_provenance(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            expected_scope=expected_scope,
+        )
+    except AgentLoopError as exc:
+        log(
+            config,
+            f"WARNING: PR #{pr_number} did not prove expected issue commit provenance "
+            f"(repository={expected_scope.repository}, issue=#{expected_scope.issue_number}, "
+            f"flow={expected_scope.flow}, plan={expected_scope.approved_plan_hash or 'none'}): {exc}. "
+            "Do not rewrite or force-push solely to satisfy this warning. If execution is "
+            "interrupted before handoff, resume the PR directly with "
+            f"`agent-loop pr {pr_number}`.",
+        )
+
+
 def _validate_response_tests_with_post_pr_context(
     text: str,
     *,
@@ -4018,7 +4047,16 @@ def _implement_approved_issue(
     # legacy exactly-one-open-PR GitHub search when no record exists yet
     # (#495, #589).
     resolved_pr = resolve_canonical_pr_for_issue(
-        runner, config=config, issue_number=issue_number, issue_context=issue_context
+        runner,
+        config=config,
+        issue_number=issue_number,
+        issue_context=issue_context,
+        expected_fallback_scope=IssuePrProvenanceScope(
+            repository=config.repo,
+            issue_number=issue_number,
+            flow="approved",
+            approved_plan_hash=plan_hash,
+        ),
     )
     recovered_contract_ids = (
         resolved_pr.metadata.expected_closing_issue_ids
@@ -4225,6 +4263,17 @@ def _implement_approved_issue(
         pr_number=pr_number,
         expected_issue_ids=closing_contract.issue_ids,
         body=initial_pr_context.metadata.body,
+    )
+    _advisory_issue_pr_provenance(
+        runner,
+        config=implementation_config,
+        pr_number=pr_number,
+        expected_scope=IssuePrProvenanceScope(
+            repository=implementation_config.repo,
+            issue_number=issue_number,
+            flow="approved",
+            approved_plan_hash=plan_hash,
+        ),
     )
     initial_pr_url, initial_pr_head_sha = require_pr_metadata_for_handoff(initial_pr_context.metadata)
     pr_contract = make_pr_contract(
@@ -5359,7 +5408,16 @@ def _run_plan_first_loop(
                 # it (#589). It is scoped to the selected target issue, since
                 # a split-stage plan implements a child, not the parent.
                 resolved_pr = resolve_canonical_pr_for_issue(
-                    runner, config=config, issue_number=target_issue_number, issue_context=target_issue_context
+                    runner,
+                    config=config,
+                    issue_number=target_issue_number,
+                    issue_context=target_issue_context,
+                    expected_fallback_scope=IssuePrProvenanceScope(
+                        repository=config.repo,
+                        issue_number=target_issue_number,
+                        flow="approved",
+                        approved_plan_hash=plan_hash,
+                    ),
                 )
                 if resolved_pr is not None:
                     if (
@@ -5658,7 +5716,20 @@ def run_issue_loop(
         # interrupted PR review resumes that PR instead of creating a
         # duplicate (#589).
         resolved_pr = resolve_canonical_pr_for_issue(
-            runner, config=config, issue_number=issue_number, issue_context=issue_context
+            runner,
+            config=config,
+            issue_number=issue_number,
+            issue_context=issue_context,
+            expected_fallback_scope=(
+                None
+                if plan_first and recovered_plan_hash is None
+                else IssuePrProvenanceScope(
+                    repository=config.repo,
+                    issue_number=issue_number,
+                    flow="approved" if plan_first else "direct",
+                    approved_plan_hash=recovered_plan_hash if plan_first else None,
+                )
+            ),
         )
         if resolved_pr is not None:
             closing_contract = resolve_issue_contract(
@@ -5904,6 +5975,16 @@ def run_issue_loop(
             pr_number=pr_number,
             expected_issue_ids=closing_contract.issue_ids,
             body=initial_pr_metadata.body,
+        )
+        _advisory_issue_pr_provenance(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            expected_scope=IssuePrProvenanceScope(
+                repository=config.repo,
+                issue_number=issue_number,
+                flow="direct",
+            ),
         )
         initial_pr_url, initial_pr_head_sha = require_pr_metadata_for_handoff(initial_pr_metadata)
         pr_contract = make_pr_contract(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3894,6 +3894,8 @@ def _advisory_issue_pr_provenance(
     expected_scope: IssuePrProvenanceScope,
 ) -> None:
     """Warn on missing provenance without blocking a newly created PR handoff."""
+    if config.dry_run:
+        return
     try:
         validate_pull_request_provenance(
             runner,

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -12,8 +12,9 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
-from .decomposition import MAX_DECOMPOSITION_PHASES
+from .decomposition import MAX_DECOMPOSITION_PHASES, approved_plan_hash
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
+from .issue_pr_provenance import IssuePrProvenanceScope, format_issue_pr_provenance
 from .memory import AgentMemoryContext, format_agent_memory_context
 from .managed_ci import ManagedCiCreationIntent, UNPROTECTED_OVERRIDE_TRAILER
 from .salvage import AGENT_SALVAGE_MARKER_RE
@@ -187,6 +188,21 @@ def _coder_documentation_guidance() -> str:
     return (
         "If your implementation adds or changes a user-facing subcommand, flag, "
         "or mode, update README.md and any relevant docs/ files as part of this PR.\n"
+    )
+
+
+def _issue_pr_provenance_guidance(scope: IssuePrProvenanceScope) -> str:
+    trailer = format_issue_pr_provenance(scope)
+    return (
+        "Commit provenance is an unauthenticated convention used only to reduce accidental "
+        "adoption of an unrelated open PR; it is not an authentication boundary. Before creating "
+        "the PR, ensure at least one implementation commit carries this complete Git trailer line "
+        f"exactly: `{trailer}`. Keep this trailer out of the PR body and all comments. Use an "
+        "explicit PR body when creating the PR; if `gh pr create --fill` copied the trailer into "
+        "the body, remove that copy before opening or update the body explicitly while preserving "
+        "all required closing references. Do not rewrite or force-push solely to add the trailer "
+        "after a canonical handoff exists."
+        "\n"
     )
 
 
@@ -1235,6 +1251,9 @@ def build_issue_prompt(
             expected_closing_issue_ids=config.expected_closing_issue_ids,
         )
     )
+    provenance_guidance = _issue_pr_provenance_guidance(
+        IssuePrProvenanceScope(repository=config.repo, issue_number=issue_number, flow="direct")
+    )
     managed_creation_guidance = _managed_ci_creation_guidance(managed_ci_creation_intent)
     return f"""Fix GitHub issue #{issue_number} in {config.repo}.
 
@@ -1244,6 +1263,7 @@ run relevant tests, commit, push, and open a pull request against {config.base}.
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
+{provenance_guidance}
 {managed_creation_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,
@@ -1825,6 +1845,14 @@ def build_issue_implementation_prompt(
             expected_closing_issue_ids=config.expected_closing_issue_ids,
         )
     )
+    provenance_guidance = _issue_pr_provenance_guidance(
+        IssuePrProvenanceScope(
+            repository=config.repo,
+            issue_number=issue_number,
+            flow="approved",
+            approved_plan_hash=approved_plan_hash(approved_plan),
+        )
+    )
     managed_creation_guidance = _managed_ci_creation_guidance(managed_ci_creation_intent)
     return f"""Implement the approved plan for GitHub issue #{issue_number} in {config.repo}.
 
@@ -1835,6 +1863,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {_scratch_file_guidance()}
 {_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
+{provenance_guidance}
 {managed_creation_guidance}
 {human_requirements_context.block}{_coder_human_requirements_guidance(
     human_requirements_context,

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -248,6 +248,9 @@ class FakeRunner(Runner):
         search_issues_payload=None,
         open_prs_payload=None,
         mergeability_payloads=None,
+        pr_commit_pages=None,
+        pr_commit_metadata_payloads=None,
+        pr_commit_query_failures=None,
     ):
         super().__init__(dry_run=False)
         self.claude_outputs = list(claude_outputs or [])
@@ -361,6 +364,12 @@ class FakeRunner(Runner):
             list(mergeability_payloads) if mergeability_payloads is not None else None
         )
         self.mergeability_calls = 0
+        self.pr_commit_pages = list(
+            pr_commit_pages if pr_commit_pages is not None else pr_commit_metadata_payloads or []
+        )
+        self.pr_commit_query_failures = list(pr_commit_query_failures or [])
+        self.pr_commit_calls = 0
+        self._provenance_issue_number = self.issue_payload.get("number", 56)
         self._agent_pr_counter = 0
         self._agent_command_seen = False
         # Parallel discuss debaters (#475) call run_with_log from worker
@@ -823,6 +832,18 @@ class FakeRunner(Runner):
 
         if cmd[:3] == ["gh", "pr", "list"]:
             self.open_prs_calls += 1
+            for item in self.open_prs_payload:
+                if not isinstance(item, dict):
+                    continue
+                body = str(item.get("body") or "")
+                issue_match = re.search(
+                    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9]\d*)",
+                    body,
+                    re.I,
+                )
+                if issue_match:
+                    self._provenance_issue_number = int(issue_match.group(1))
+                    break
             return CommandResult(cmd, cwd_path, json_dumps(self.open_prs_payload), "", 0)
 
         if (
@@ -875,6 +896,59 @@ class FakeRunner(Runner):
 
         if cmd[:2] == ["gh", "api"] and "/issues/" in cmd[2]:
             return CommandResult(cmd, cwd_path, json_dumps(self.issue_payload), "", 0)
+
+        if cmd[:3] == ["gh", "api", "graphql"]:
+            self.pr_commit_calls += 1
+            if self.pr_commit_query_failures:
+                failure = self.pr_commit_query_failures.pop(0)
+                return CommandResult(cmd, cwd_path, "", str(failure), 1)
+            if self.pr_commit_pages:
+                payload = self.pr_commit_pages.pop(0)
+            else:
+                head_sha = self.pr_payload.get("headRefOid") or "abc123"
+                issue_number = self._provenance_issue_number
+                payload = {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "headRefOid": head_sha,
+                                "commits": {
+                                    "totalCount": 1,
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": [
+                                        {
+                                            "commit": {
+                                                "oid": "commit-1",
+                                                "message": (
+                                                    "Implement issue.\n\n"
+                                                    "Agent-Issue-Provenance: v1 "
+                                                    f"repo=owner/repo issue={issue_number} flow=direct"
+                                                ),
+                                            }
+                                        }
+                                    ],
+                                },
+                            }
+                        }
+                    }
+                }
+            if isinstance(payload, list):
+                head_sha = self.pr_payload.get("headRefOid") or "abc123"
+                payload = {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "headRefOid": head_sha,
+                                "commits": {
+                                    "totalCount": len(payload),
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": payload,
+                                },
+                            }
+                        }
+                    }
+                }
+            return CommandResult(cmd, cwd_path, json_dumps(payload), "", 0)
 
         if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs"):
             if "--jq" in cmd:

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -92,6 +92,16 @@ def test_local_agent_loop_doc_has_ci_infrastructure_stall_section():
     assert "runner_unavailable" in text
 
 
+def test_issue_recovery_docs_describe_commit_provenance_retirement():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    readme_text = README.read_text(encoding="utf-8")
+    assert "Agent-Issue-Provenance" in text
+    assert "Metadata-free recovery is retired" in text
+    assert "unauthenticated convention" in text
+    assert "Squash or rebase removal" in text
+    assert "managed-pr --head" in readme_text
+
+
 def test_readme_links_to_ci_infrastructure_stall_section():
     doc_text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert f"### {CI_STALL_HEADING_TEXT}" in doc_text, "heading moved; update CI_STALL_HEADING_TEXT"

--- a/tests/test_issue_pr_handoff.py
+++ b/tests/test_issue_pr_handoff.py
@@ -3,7 +3,18 @@ import base64
 import pytest
 
 from coding_review_agent_loop.errors import AgentLoopError
-from coding_review_agent_loop.github import IssueComment, PullRequestMetadata
+from coding_review_agent_loop.github import (
+    IssueComment,
+    PullRequestMetadata,
+    find_open_pr_closing_issue,
+    read_pull_request_commit_metadata,
+)
+from coding_review_agent_loop.issue_pr_provenance import (
+    IssuePrProvenanceScope,
+    compare_issue_pr_provenance,
+    format_issue_pr_provenance,
+    parse_issue_pr_provenance_messages,
+)
 from coding_review_agent_loop.issue_pr_handoff import (
     _decode_issue_pr_handoff_metadata,
     _encode_issue_pr_handoff_metadata,
@@ -13,6 +24,7 @@ from coding_review_agent_loop.issue_pr_handoff import (
     format_issue_pr_handoff_comment,
     require_pr_metadata_for_handoff,
 )
+from agent_loop_helpers import FakeRunner, make_config
 
 
 def _comment(body: str) -> IssueComment:
@@ -31,6 +43,33 @@ def _metadata(**overrides) -> IssuePrHandoffMetadata:
     )
     defaults.update(overrides)
     return IssuePrHandoffMetadata(**defaults)
+
+
+def _commit_page(messages, *, head="abc123", total=None, has_next=False, cursor=None):
+    nodes = [
+        {"commit": {"oid": f"commit-{index}", "message": message}}
+        for index, message in enumerate(messages, start=1)
+    ]
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "headRefOid": head,
+                    "commits": {
+                        "totalCount": len(nodes) if total is None else total,
+                        "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                        "nodes": nodes,
+                    },
+                }
+            }
+        }
+    }
+
+
+def _provenance_pages(message, *, issue=56, flow="direct", plan=None):
+    scope = IssuePrProvenanceScope("OWNER/REPO", issue, flow, plan)
+    page = _commit_page([f"Change\n\n{format_issue_pr_provenance(scope)}"])
+    return [page, page]
 
 
 def test_round_trips_metadata_through_marker():
@@ -299,3 +338,77 @@ def test_require_pr_metadata_for_handoff_returns_tuple_when_present():
         "https://github.com/OWNER/REPO/pull/77",
         "abc123",
     )
+
+
+def test_provenance_parser_collapses_identical_claims_across_commits():
+    scope = IssuePrProvenanceScope("OWNER/REPO", 56, "direct")
+    messages = [
+        f"first\n\n{format_issue_pr_provenance(scope)}",
+        f"second\n\n{format_issue_pr_provenance(scope)}",
+    ]
+
+    claims = parse_issue_pr_provenance_messages(messages)
+
+    assert compare_issue_pr_provenance(claims, expected=scope) == scope
+
+
+def test_legacy_recovery_requires_complete_matching_commit_provenance(tmp_path):
+    runner = FakeRunner(
+        open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+        pr_commit_pages=_provenance_pages("ignored"),
+    )
+    config = make_config(tmp_path)
+
+    found = find_open_pr_closing_issue(runner, config=config, issue_number=56)
+
+    assert found is not None
+    assert found.pr_number == 77
+
+
+@pytest.mark.parametrize(
+    "pages",
+    [
+        [_commit_page([]), _commit_page([])],
+        [
+            _commit_page(
+                ["Change\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=direct\n"
+                 "Agent-Issue-Provenance: malformed"]
+            ),
+            _commit_page(["ignored"]),
+        ],
+        [
+            _commit_page(
+                [
+                    "Change\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=direct",
+                    "Other\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=57 flow=direct",
+                ],
+                total=2,
+            ),
+            _commit_page(["ignored"], total=2),
+        ],
+    ],
+)
+def test_invalid_single_candidate_recovery_includes_both_safe_remedies(tmp_path, pages):
+    runner = FakeRunner(
+        open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+        pr_commit_pages=pages,
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError) as exc_info:
+        find_open_pr_closing_issue(runner, config=config, issue_number=56)
+
+    message = str(exc_info.value)
+    assert "Remove the closing reference" in message
+    assert "close the unrelated PR" in message
+    assert "agent-loop pr 77" in message
+
+
+def test_commit_connection_rejects_count_truncation(tmp_path):
+    scope = IssuePrProvenanceScope("OWNER/REPO", 56, "direct")
+    page = _commit_page([format_issue_pr_provenance(scope)], total=2)
+    runner = FakeRunner(pr_commit_pages=[page, page])
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="truncated"):
+        read_pull_request_commit_metadata(runner, config=config, pr_number=77)

--- a/tests/test_issue_pr_handoff.py
+++ b/tests/test_issue_pr_handoff.py
@@ -45,10 +45,18 @@ def _metadata(**overrides) -> IssuePrHandoffMetadata:
     return IssuePrHandoffMetadata(**defaults)
 
 
-def _commit_page(messages, *, head="abc123", total=None, has_next=False, cursor=None):
+def _commit_page(
+    messages,
+    *,
+    head="abc123",
+    total=None,
+    has_next=False,
+    cursor=None,
+    oid_start=1,
+):
     nodes = [
         {"commit": {"oid": f"commit-{index}", "message": message}}
-        for index, message in enumerate(messages, start=1)
+        for index, message in enumerate(messages, start=oid_start)
     ]
     return {
         "data": {
@@ -66,7 +74,7 @@ def _commit_page(messages, *, head="abc123", total=None, has_next=False, cursor=
     }
 
 
-def _provenance_pages(message, *, issue=56, flow="direct", plan=None):
+def _provenance_pages(*, issue=56, flow="direct", plan=None):
     scope = IssuePrProvenanceScope("OWNER/REPO", issue, flow, plan)
     page = _commit_page([f"Change\n\n{format_issue_pr_provenance(scope)}"])
     return [page, page]
@@ -355,7 +363,7 @@ def test_provenance_parser_collapses_identical_claims_across_commits():
 def test_legacy_recovery_requires_complete_matching_commit_provenance(tmp_path):
     runner = FakeRunner(
         open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
-        pr_commit_pages=_provenance_pages("ignored"),
+        pr_commit_pages=_provenance_pages(),
     )
     config = make_config(tmp_path)
 
@@ -366,29 +374,37 @@ def test_legacy_recovery_requires_complete_matching_commit_provenance(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "pages",
+    ("pages", "provenance_reason"),
     [
-        [_commit_page([]), _commit_page([])],
-        [
-            _commit_page(
-                ["Change\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=direct\n"
-                 "Agent-Issue-Provenance: malformed"]
-            ),
-            _commit_page(["ignored"]),
-        ],
-        [
-            _commit_page(
-                [
-                    "Change\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=direct",
-                    "Other\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=57 flow=direct",
-                ],
-                total=2,
-            ),
-            _commit_page(["ignored"], total=2),
-        ],
+        ([_commit_page([]), _commit_page([])], "is missing"),
+        (
+            [
+                _commit_page(
+                    ["Change\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=direct\n"
+                     "Agent-Issue-Provenance: malformed"]
+                ),
+                _commit_page(["ignored"]),
+            ],
+            "is malformed",
+        ),
+        (
+            [
+                _commit_page(
+                    [
+                        "Change\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=direct",
+                        "Other\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=57 flow=direct",
+                    ],
+                    total=2,
+                ),
+                _commit_page(["ignored"], total=2),
+            ],
+            "contains conflicting claims",
+        ),
     ],
 )
-def test_invalid_single_candidate_recovery_includes_both_safe_remedies(tmp_path, pages):
+def test_invalid_single_candidate_recovery_includes_both_safe_remedies(
+    tmp_path, pages, provenance_reason
+):
     runner = FakeRunner(
         open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
         pr_commit_pages=pages,
@@ -399,9 +415,178 @@ def test_invalid_single_candidate_recovery_includes_both_safe_remedies(tmp_path,
         find_open_pr_closing_issue(runner, config=config, issue_number=56)
 
     message = str(exc_info.value)
+    assert provenance_reason in message
+    assert "unavailable" not in message
     assert "Remove the closing reference" in message
     assert "close the unrelated PR" in message
     assert "agent-loop pr 77" in message
+
+
+@pytest.mark.parametrize(
+    ("claimed_scope", "expected_scope"),
+    [
+        (
+            IssuePrProvenanceScope("OTHER/REPO", 56, "direct"),
+            IssuePrProvenanceScope("OWNER/REPO", 56, "direct"),
+        ),
+        (
+            IssuePrProvenanceScope("OWNER/REPO", 57, "direct"),
+            IssuePrProvenanceScope("OWNER/REPO", 56, "direct"),
+        ),
+        (
+            IssuePrProvenanceScope("OWNER/REPO", 56, "direct"),
+            IssuePrProvenanceScope("OWNER/REPO", 56, "approved", "current-plan"),
+        ),
+        (
+            IssuePrProvenanceScope("OWNER/REPO", 56, "approved", "current-plan"),
+            IssuePrProvenanceScope("OWNER/REPO", 56, "direct"),
+        ),
+        (
+            IssuePrProvenanceScope("OWNER/REPO", 56, "approved", "old-plan"),
+            IssuePrProvenanceScope("OWNER/REPO", 56, "approved", "current-plan"),
+        ),
+    ],
+    ids=["repository", "issue", "direct-to-approved", "approved-to-direct", "plan-hash"],
+)
+def test_single_candidate_recovery_rejects_one_well_formed_wrong_scope(
+    tmp_path, claimed_scope, expected_scope
+):
+    page = _commit_page([format_issue_pr_provenance(claimed_scope)])
+    runner = FakeRunner(
+        open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+        pr_commit_pages=[page, page],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="does not match the expected scope") as exc_info:
+        find_open_pr_closing_issue(
+            runner,
+            config=config,
+            issue_number=56,
+            expected_scope=expected_scope,
+        )
+
+    message = str(exc_info.value)
+    assert "unavailable" not in message
+    assert "Remove the closing reference" in message
+    assert "close the unrelated PR" in message
+    assert "agent-loop pr 77" in message
+
+
+def test_single_candidate_recovery_without_reconstructable_scope_gives_safe_remedies(tmp_path):
+    runner = FakeRunner(open_prs_payload=[{"number": 77, "body": "Fixes #56"}])
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="reconstructable approved-plan scope\\. Remove") as exc_info:
+        find_open_pr_closing_issue(
+            runner,
+            config=config,
+            issue_number=56,
+            expected_scope=None,
+        )
+
+    message = str(exc_info.value)
+    assert "close the unrelated PR" in message
+    assert "agent-loop pr 77" in message
+    assert runner.pr_commit_calls == 0
+
+
+def test_single_candidate_recovery_distinguishes_commit_query_unavailability(tmp_path):
+    runner = FakeRunner(
+        open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+        pr_commit_query_failures=["connection reset"],
+    )
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="commit provenance is unavailable.*query failed") as exc_info:
+        find_open_pr_closing_issue(runner, config=config, issue_number=56)
+
+    message = str(exc_info.value)
+    assert "Remove the closing reference" in message
+    assert "close the unrelated PR" in message
+    assert "agent-loop pr 77" in message
+
+
+@pytest.mark.parametrize(
+    "changed_page",
+    [
+        _commit_page(["second"], head="def456", total=2, oid_start=2),
+        _commit_page(["second"], total=3, oid_start=2),
+    ],
+    ids=["head", "total"],
+)
+def test_commit_connection_rejects_history_change_during_pagination(tmp_path, changed_page):
+    first_page = _commit_page(["first"], total=2, has_next=True, cursor="cursor-1")
+    runner = FakeRunner(pr_commit_pages=[first_page, changed_page])
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="history changed during provenance scan"):
+        read_pull_request_commit_metadata(runner, config=config, pr_number=77)
+
+
+@pytest.mark.parametrize(
+    "final_page",
+    [
+        _commit_page(["first"], head="def456"),
+        _commit_page(["first"], total=2),
+    ],
+    ids=["head", "total"],
+)
+def test_commit_connection_rejects_history_change_after_pagination(tmp_path, final_page):
+    first_page = _commit_page(["first"])
+    runner = FakeRunner(pr_commit_pages=[first_page, final_page])
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="history changed during provenance scan"):
+        read_pull_request_commit_metadata(runner, config=config, pr_number=77)
+
+
+@pytest.mark.parametrize(
+    "pages",
+    [
+        [
+            _commit_page(["first"], total=2, has_next=True, cursor="cursor-1"),
+            _commit_page(["second"], total=2, has_next=True, cursor="cursor-1", oid_start=2),
+        ],
+        [
+            _commit_page(["first"], total=4, has_next=True, cursor="cursor-1"),
+            _commit_page(["second"], total=4, has_next=True, cursor="cursor-2", oid_start=2),
+            _commit_page(["third"], total=4, has_next=True, cursor="cursor-1", oid_start=3),
+        ],
+    ],
+    ids=["non-advancing", "repeated"],
+)
+def test_commit_connection_rejects_non_advancing_or_repeated_cursors(tmp_path, pages):
+    runner = FakeRunner(pr_commit_pages=pages)
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="pagination.*did not advance"):
+        read_pull_request_commit_metadata(runner, config=config, pr_number=77)
+
+
+def test_commit_connection_sends_string_graphql_variables_with_raw_fields(tmp_path):
+    first_page = _commit_page(["first"], total=2, has_next=True, cursor="cursor-1")
+    second_page = _commit_page(["second"], total=2, oid_start=2)
+    final_page = _commit_page([], total=2)
+    runner = FakeRunner(pr_commit_pages=[first_page, second_page, final_page])
+    config = make_config(tmp_path, repo="2048/null")
+
+    read_pull_request_commit_metadata(runner, config=config, pr_number=77)
+
+    graphql_commands = [cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "api", "graphql"]]
+    first_command = graphql_commands[0]
+    owner_index = first_command.index("owner=2048")
+    number_index = first_command.index("number=77")
+    assert first_command[owner_index - 1 : number_index + 1] == [
+        "-f",
+        "owner=2048",
+        "-f",
+        "name=null",
+        "-F",
+        "number=77",
+    ]
+    after_index = graphql_commands[1].index("after=cursor-1")
+    assert graphql_commands[1][after_index - 1 : after_index + 1] == ["-f", "after=cursor-1"]
 
 
 def test_commit_connection_rejects_count_truncation(tmp_path):

--- a/tests/test_managed_pr.py
+++ b/tests/test_managed_pr.py
@@ -283,3 +283,29 @@ def test_create_managed_pr_rejects_reserved_body_markers(tmp_path, marker):
         )
 
     assert runner.calls == []
+
+
+def test_create_managed_pr_accepts_non_reserved_issue_provenance_body_text(tmp_path):
+    runner = ManagedPrRunner()
+
+    # The trailer is commit metadata, not a durable body record. If a provider
+    # copies it into a body, managed-pr must still apply its normal body checks.
+    body = (
+        "Fixes #680\n\n"
+        "Agent-Issue-Provenance: v1 repo=owner/repo issue=680 flow=direct"
+    )
+    with patch("coding_review_agent_loop.managed_pr.preflight_managed_ci_creation", _intent):
+        create_managed_pr(
+            runner,
+            config=_config(tmp_path),
+            source_branch="fix/body-provenance",
+            title="Non-reserved provenance",
+            body=body,
+        )
+
+    assert any(
+        "--method" in cmd
+        and cmd[cmd.index("--method") + 1] == "POST"
+        and cmd[cmd.index("--method") + 2].endswith("/pulls")
+        for cmd, _body in runner.calls
+    )

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -51,6 +51,24 @@ from agent_loop_helpers import (
 )
 
 
+def _provenance_pages(message: str):
+    page = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "headRefOid": "abc123",
+                    "commits": {
+                        "totalCount": 1,
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [{"commit": {"oid": "commit-1", "message": message}}],
+                    },
+                }
+            }
+        }
+    }
+    return [page, page]
+
+
 class FakeRunner(_FakeRunner):
     """Issue-loop fixtures model the PR created for issue #56 explicitly."""
 
@@ -2437,6 +2455,10 @@ def test_issue_loop_plan_first_one_shot_resumes_existing_pr_after_crash_before_h
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         open_prs_payload=[{"number": 77, "body": "Fixes #56"}],
+        pr_commit_pages=_provenance_pages(
+            "Implement issue.\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=approved "
+            f"plan={approved_plan_hash(plan)}"
+        ),
     )
     config = make_config(tmp_path)
 
@@ -2489,6 +2511,10 @@ def test_issue_loop_plan_first_one_shot_resume_existing_pr_logs_clear_message(tm
             "LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex",
         ],
         open_prs_payload=[{"number": 492, "body": "Fixes #56"}],
+        pr_commit_pages=_provenance_pages(
+            "Implement issue.\n\nAgent-Issue-Provenance: v1 repo=owner/repo issue=56 flow=approved "
+            f"plan={approved_plan_hash(plan)}"
+        ),
     )
     config = make_config(tmp_path, quiet=False)
 

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -13,8 +13,10 @@ from coding_review_agent_loop.issue_pr_handoff import (
     format_issue_pr_handoff_comment,
     resolve_canonical_pr_for_issue,
 )
+from coding_review_agent_loop.issue_pr_provenance import IssuePrProvenanceScope
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
+    _advisory_issue_pr_provenance,
     _attach_round_metadata,
     _decode_round_metadata,
     _infer_staged_parent_issue,
@@ -67,6 +69,20 @@ def _provenance_pages(message: str):
         }
     }
     return [page, page]
+
+
+def test_advisory_issue_provenance_skips_commit_scan_in_dry_run(tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path, dry_run=True)
+
+    _advisory_issue_pr_provenance(
+        runner,
+        config=config,
+        pr_number=77,
+        expected_scope=IssuePrProvenanceScope("OWNER/REPO", 56, "direct"),
+    )
+
+    assert runner.pr_commit_calls == 0
 
 
 class FakeRunner(_FakeRunner):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -285,6 +285,20 @@ def test_issue_prompts_include_salvage_guardrail_block(tmp_path):
         assert "partial.patch" in prompt
 
 
+def test_issue_implementation_prompts_inject_exact_scoped_trailer_guidance(tmp_path):
+    config = make_config(tmp_path)
+    direct_prompt = build_issue_prompt(680, config)
+    approved_prompt = build_issue_implementation_prompt(680, "Approved plan text.", config)
+
+    assert "Agent-Issue-Provenance: v1 repo=owner/repo issue=680 flow=direct" in direct_prompt
+    assert "Agent-Issue-Provenance: v1 repo=owner/repo issue=680 flow=approved plan=" in approved_prompt
+    for prompt in (direct_prompt, approved_prompt):
+        assert "at least one implementation commit carries" in prompt
+        assert "Keep this trailer out of the PR body and all comments" in prompt
+        assert "gh pr create --fill" in prompt
+        assert "preserving all required closing references" in prompt
+
+
 def test_issue_prompts_render_remote_salvage_summary_shape(tmp_path):
     from coding_review_agent_loop.salvage import RemoteSalvageRecord, render_remote_salvage_summary
 

--- a/tests/test_protocol_markers.py
+++ b/tests/test_protocol_markers.py
@@ -139,3 +139,13 @@ def test_ordinary_issue_comment_writer_enforces_issue_comment_surface():
 def test_source_inventory_has_no_unregistered_protocol_literals():
     assert_source_inventory(Path(__file__).parents[1])
     assert len(RESERVED_MARKER_REGISTRY) == 22
+
+
+def test_issue_provenance_trailer_is_not_a_reserved_marker_or_forged_body_record():
+    body = (
+        "Fixes #680\n\n"
+        "Agent-Issue-Provenance: v1 repo=owner/repo issue=680 flow=direct"
+    )
+
+    assert not scan_reserved_markers(body)
+    TrustedBody.current_untrusted_visible(body)


### PR DESCRIPTION
## Summary

- Add exact-scope, non-reserved commit-trailer provenance for legacy issue PR recovery.
- Validate complete paginated PR commit history and fail closed on malformed, conflicting, mismatched, truncated, or unstable metadata.
- Add scoped prompt guidance, advisory post-creation validation, tests, and recovery documentation.

## Tests

- `timeout 1800s python3 -m pytest tests/test_issue_pr_handoff.py tests/test_prompts.py -q`
- `timeout 1800s python3 -m pytest tests/test_orchestrator_issue.py tests/test_split_orchestration.py -q`
- `timeout 1800s python3 -m pytest tests/test_protocol_markers.py tests/test_managed_pr.py tests/test_docs_guidance.py tests/test_prompts.py -q`
- `timeout 1800s python3 -m pytest -q` (`2273 passed`)

Fixes #680
