### PR TITLE
Harden Claude self-update replay with workdir snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,22 @@ checkouts must point at the requested repository. Use explicit persistent
 directories for large repositories, long-lived agent worktrees, or setups that
 should survive `/tmp` cleanup or reboot.
 
+Claude's bounded self-update replay guard is read-only. It captures `git rev-parse
+HEAD` and `git status --porcelain` immediately before each Claude invocation; an
+empty porcelain result is the valid clean-worktree state, and non-empty output is
+compared exactly. A replay is accepted only when both available snapshots are
+identical. If either snapshot is unavailable, the guard fails closed for replay
+and records a diagnostic; that diagnostic does not change the provider-derived
+failure category or reviewer availability semantics. The separate PR handoff
+HEAD-advance guard remains strict about runner exceptions, while ordinary Git
+failure or blank HEAD output is treated as an unavailable observation.
+
+Codex is unchanged here because its JSONL stream supplies setup-versus-progress
+evidence and retains its separate fresh-timeout replacement replay. Local HEAD
+and porcelain status cannot observe byte-identical external effects such as a
+push, pull-request creation, or comment, so the snapshot guard reduces replay
+risk without eliminating it.
+
 Agent memory is enabled by default. Before invoking agents, the loop creates or
 refreshes advisory repo memory in a durable, repo-scoped user cache directory
 such as `~/.cache/coding-review-agent-loop/repos/OWNER-REPO/memory` on Linux:

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -2133,9 +2133,39 @@ commands compare PATH entry, symlink, and target identities; an absolute overrid
 requires direct evidence that its exact entry or target changed or disappeared.
 Claude's existing 30-second eligibility cap, updater diagnostics, deadline-
 bounded stability wait, remaining-time replay, and `self-update-attempt2` suffix
-remain unchanged. If a genuine long quota reset occurs after replacement
-context was recorded, quota remains primary and exit code 3 is preserved with
-the earlier replacement detail appended.
+remain unchanged, with one additional read-only workdir gate. Immediately before
+each Claude invocation the backend runs exactly `git rev-parse HEAD` and `git
+status --porcelain` in the assigned checkout. A zero exit with nonblank stripped
+HEAD is available; a zero exit with blank HEAD is unavailable. Status is available
+on zero exit even when stdout is empty, because empty porcelain output is the
+valid clean-worktree state. Non-empty porcelain output is preserved exactly, so
+unchanged dirty snapshots are replayable just like unchanged clean snapshots.
+
+The after snapshot is lazy and is taken only after the existing failure, elapsed,
+artifact, session, and parseable-JSON progress exclusions leave positive updater
+or managed-command identity evidence. Claude replay is accepted only when both
+snapshots are available and identical. Changed HEAD, changed status, and before
+or after probe unavailability fail closed for replay. Claude tolerates an
+`AgentLoopError` or `OSError` from these probes by recording structured
+unavailability; the separate PR HEAD-advance guard uses strict exception
+behavior, while ordinary nonzero or blank HEAD results still map to an
+unavailable observation.
+
+Replay refusal details are attempt-specific diagnostics only. They are recorded
+with the failed call's log path, do not set accepted executable-replacement
+evidence, do not trigger stability waiting or the dedicated replay, and do not
+change provider-derived retry eligibility, reviewer availability, or failure
+category. Terminal annotations are added once, with accepted replacement context
+before the latest refusal context and the underlying failure last. This remains
+a read-only guard: local HEAD and porcelain status cannot observe byte-identical
+external effects such as pushes, pull-request creation, or comments, so it
+reduces replay risk without eliminating it.
+
+Codex remains unchanged because its JSONL stream already supplies setup-versus-
+progress evidence and retains its separate fresh-timeout replacement replay. If
+a genuine long quota reset occurs after replacement context was recorded, quota
+remains primary and exit code 3 is preserved with the earlier replacement detail
+appended.
 
 Unsupported model/provider-auth compatibility errors are reported separately
 with failure category `unsupported_model`. These diagnostics name the agent and

--- a/src/coding_review_agent_loop/agents/base.py
+++ b/src/coding_review_agent_loop/agents/base.py
@@ -48,8 +48,12 @@ class AgentResult:
     command_result: CommandResult | None = None
     # Provider-neutral evidence that the configured executable was replaced or
     # disappeared during this invocation. Claude uses the historical field name;
-    # Codex sets it for the same bounded recovery signal.
+    # Codex sets it for the same bounded recovery signal. Replay refusal is
+    # separate: a candidate can be positively identified while the checkout
+    # snapshot makes replay unsafe.
     self_update_reason: str | None = None
+    self_update_replay_refusal_kind: str | None = None
+    self_update_replay_refusal_detail: str | None = None
 
 
 class AgentBackend(Protocol):

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -108,31 +108,13 @@ def _has_updater_diagnostic(output: str) -> bool:
     return bool(_UPDATER_DIAGNOSTIC_RE.search("\n".join(lines)[-2048:]))
 
 
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True)
 class SelfUpdateInterruptionEvidence:
     """Positive updater evidence and, independently, a replay refusal."""
 
     reason: str
     replay_refusal_kind: str | None = None
     replay_refusal_detail: str | None = None
-
-    def __eq__(self, other: object) -> bool:
-        # Keep the historical helper's string comparison useful to callers
-        # while exposing structured metadata to the backend and orchestrator.
-        if isinstance(other, str):
-            return self.reason == other
-        if isinstance(other, SelfUpdateInterruptionEvidence):
-            return (
-                self.reason,
-                self.replay_refusal_kind,
-                self.replay_refusal_detail,
-            ) == (
-                other.reason,
-                other.replay_refusal_kind,
-                other.replay_refusal_detail,
-            )
-        return NotImplemented
-
 
 def _workdir_probe_label(snapshot: WorkdirSnapshot) -> str:
     def describe(probe) -> str:

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,7 @@ from .base import (
 from ..logging import agent_log_path, log
 from ..runner import CommandResult, Runner, executable_identity_changed
 from ..usage import UsageMetadata, coerce_int, first_present
+from ..workdir_guard import WorkdirSnapshot, capture_workdir_snapshot
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -106,14 +108,96 @@ def _has_updater_diagnostic(output: str) -> bool:
     return bool(_UPDATER_DIAGNOSTIC_RE.search("\n".join(lines)[-2048:]))
 
 
+@dataclass(frozen=True, eq=False)
+class SelfUpdateInterruptionEvidence:
+    """Positive updater evidence and, independently, a replay refusal."""
+
+    reason: str
+    replay_refusal_kind: str | None = None
+    replay_refusal_detail: str | None = None
+
+    def __eq__(self, other: object) -> bool:
+        # Keep the historical helper's string comparison useful to callers
+        # while exposing structured metadata to the backend and orchestrator.
+        if isinstance(other, str):
+            return self.reason == other
+        if isinstance(other, SelfUpdateInterruptionEvidence):
+            return (
+                self.reason,
+                self.replay_refusal_kind,
+                self.replay_refusal_detail,
+            ) == (
+                other.reason,
+                other.replay_refusal_kind,
+                other.replay_refusal_detail,
+            )
+        return NotImplemented
+
+
+def _workdir_probe_label(snapshot: WorkdirSnapshot) -> str:
+    def describe(probe) -> str:
+        if probe.kind == "available":
+            return repr(probe.value)
+        if probe.kind == "exception":
+            return f"{probe.exception_type}: {probe.detail}"
+        if probe.kind == "command-failed":
+            return f"returncode={probe.returncode!r}"
+        return "blank"
+
+    return f"HEAD={describe(snapshot.head)}, status={describe(snapshot.status)}"
+
+
+def _gate_self_update_replay(
+    reason: str,
+    *,
+    before_snapshot: WorkdirSnapshot | None,
+    after_snapshot: WorkdirSnapshot | None,
+) -> SelfUpdateInterruptionEvidence:
+    """Accept a candidate only when both read-only snapshots are identical."""
+    # Calls without snapshots retain the historical evidence-only helper
+    # contract. ClaudeBackend always supplies both snapshots after candidate
+    # detection, so replay policy itself remains fail-closed there.
+    if before_snapshot is None and after_snapshot is None:
+        return SelfUpdateInterruptionEvidence(reason)
+    if before_snapshot is None or not before_snapshot.available:
+        detail = (
+            "Claude self-update replay refused: before workdir snapshot "
+            f"unavailable ({_workdir_probe_label(before_snapshot) if before_snapshot else 'missing'})."
+        )
+        return SelfUpdateInterruptionEvidence(reason, "before-unavailable", detail)
+    if after_snapshot is None or not after_snapshot.available:
+        detail = (
+            "Claude self-update replay refused: after workdir snapshot "
+            f"unavailable ({_workdir_probe_label(after_snapshot) if after_snapshot else 'missing'})."
+        )
+        return SelfUpdateInterruptionEvidence(reason, "after-unavailable", detail)
+    if before_snapshot.head.value != after_snapshot.head.value:
+        detail = (
+            "Claude self-update replay refused: assigned checkout HEAD changed "
+            f"during invocation (before={before_snapshot.head.value!r}, "
+            f"after={after_snapshot.head.value!r})."
+        )
+        return SelfUpdateInterruptionEvidence(reason, "changed-head", detail)
+    if before_snapshot.status.value != after_snapshot.status.value:
+        detail = (
+            "Claude self-update replay refused: dirty workdir status changed "
+            f"during invocation (before={before_snapshot.status.value!r}, "
+            f"after={after_snapshot.status.value!r})."
+        )
+        return SelfUpdateInterruptionEvidence(reason, "changed-status", detail)
+    return SelfUpdateInterruptionEvidence(reason)
+
+
 def classify_self_update_interruption(
     result: CommandResult,
     *,
     command: str,
     response_file_text: str | None,
     session_id: str | None,
-) -> str | None:
-    """Return bounded Claude-updater evidence, never a generic failure classification."""
+    before_snapshot: WorkdirSnapshot | None = None,
+    after_snapshot: WorkdirSnapshot | None = None,
+) -> SelfUpdateInterruptionEvidence | None:
+    """Return bounded Claude-updater evidence, then apply the workdir gate."""
     observation = result.observation
     if not isinstance(result.returncode, int) or result.returncode == 0 or observation is None:
         return None
@@ -127,7 +211,12 @@ def classify_self_update_interruption(
         except json.JSONDecodeError:
             pass
     if _has_updater_diagnostic(result.stdout):
-        return "Claude Code updater diagnostic"
+        reason = "Claude Code updater diagnostic"
+        return _gate_self_update_replay(
+            reason,
+            before_snapshot=before_snapshot,
+            after_snapshot=after_snapshot,
+        )
     # A user-supplied absolute override is only eligible with an explicit
     # updater diagnostic.  A managed bare command may additionally prove the
     # race through an identity change while it was running.
@@ -136,10 +225,16 @@ def classify_self_update_interruption(
     if executable_identity_changed(
         observation.before,
         observation.after,
+        command=command,
         spawn_wall_time=observation.spawn_wall_time,
         exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
     ):
-        return "Claude executable changed during invocation"
+        reason = "Claude executable changed during invocation"
+        return _gate_self_update_replay(
+            reason,
+            before_snapshot=before_snapshot,
+            after_snapshot=after_snapshot,
+        )
     return None
 
 
@@ -184,6 +279,14 @@ class ClaudeBackend:
             args.append(prompt_with_response_instruction)
         log_path = agent_log_path(config, "claude", run_id=run_id, label=label, attempt_suffix=attempt_suffix)
         log(config, f"Starting Claude in {config.claude_dir}; log: {log_path}; response: {response_path}")
+        # This is deliberately before every Claude invocation, including an
+        # ordinary retry and the dedicated replay. Snapshot failures are
+        # diagnostic evidence for the replay gate, not backend failures.
+        before_snapshot = capture_workdir_snapshot(
+            runner,
+            config.claude_dir,
+            tolerate_exceptions=True,
+        )
         result = runner.run_with_log(
             args,
             cwd=config.claude_dir,
@@ -198,6 +301,29 @@ class ClaudeBackend:
         log(config, f"Claude finished; log: {log_path}")
         message_text, new_session_id, usage, raw_usage, model_detected = _parse_claude_output(result.stdout)
         response_file_text = read_public_response_file(response_path)
+        candidate = classify_self_update_interruption(
+            result,
+            command=config.claude_cmd,
+            response_file_text=response_file_text,
+            session_id=new_session_id,
+        )
+        after_snapshot = None
+        if candidate is not None and candidate.replay_refusal_kind is None:
+            # The after probe is lazy: failures without positive replacement
+            # evidence never inspect status and cannot emit refusal metadata.
+            after_snapshot = capture_workdir_snapshot(
+                runner,
+                config.claude_dir,
+                tolerate_exceptions=True,
+            )
+            candidate = classify_self_update_interruption(
+                result,
+                command=config.claude_cmd,
+                response_file_text=response_file_text,
+                session_id=new_session_id,
+                before_snapshot=before_snapshot,
+                after_snapshot=after_snapshot,
+            )
         return AgentResult(
             text=response_file_text or message_text,
             raw_output=result.stdout,
@@ -214,8 +340,12 @@ class ClaudeBackend:
             # at signature time when detection is unavailable (e.g. non-JSON output).
             model_used=model_detected,
             command_result=result,
-            self_update_reason=classify_self_update_interruption(
-                result, command=config.claude_cmd, response_file_text=response_file_text, session_id=new_session_id,
+            self_update_reason=candidate.reason if candidate else None,
+            self_update_replay_refusal_kind=(
+                candidate.replay_refusal_kind if candidate else None
+            ),
+            self_update_replay_refusal_detail=(
+                candidate.replay_refusal_detail if candidate else None
             ),
         )
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -3075,10 +3075,11 @@ def _run_validated_agent(
         if latest_replay_refusal_detail:
             context_details.append(latest_replay_refusal_detail)
         last_error = f"{'; '.join(context_details)}; final failure: {last_error}"
-        last_classification_text = (
-            f"{replacement_detail}\n"
-            f"{latest_replay_refusal_detail + chr(10) if latest_replay_refusal_detail else ''}"
-            f"{last_classification_text}"
+        classification_parts = [last_classification_text, replacement_detail]
+        if latest_replay_refusal_detail:
+            classification_parts.append(latest_replay_refusal_detail)
+        last_classification_text = "\n".join(
+            part for part in classification_parts if part
         ).strip()
         last_failure_category = (
             "self-update-interruption"
@@ -3089,8 +3090,8 @@ def _run_validated_agent(
         # Refusal context is added only after all retry decisions. In
         # particular, the provider-derived category remains untouched.
         last_error = f"{latest_replay_refusal_detail}; final failure: {last_error}"
-        last_classification_text = (
-            f"{latest_replay_refusal_detail}\n{last_classification_text}"
+        last_classification_text = "\n".join(
+            part for part in (last_classification_text, latest_replay_refusal_detail) if part
         ).strip()
     diagnostics = _failed_run_diagnostics(
         runner=runner,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -251,6 +251,7 @@ from .transient import (
 from .usage import RunUsageContext, UsageMetadata, estimate_usage
 from .workdirs import active_workdir
 from .workdir_guard import (
+    read_workdir_head,
     validate_assigned_head_advanced,
     validate_checkout_inspected_evidence,
     validate_response_tests_within_workdir,
@@ -2269,6 +2270,9 @@ def _run_validated_agent(
     ordinary_retries_used = 0
     self_update_deadline: float | None = None
     self_update_stability_error: str | None = None
+    # Refusals are diagnostic-only context. Keep only the latest one, without
+    # treating it as accepted executable-replacement evidence.
+    latest_replay_refusal_detail: str | None = None
     next_timeout_seconds = timeout_seconds
     marker_safety_repair_attempted = False
 
@@ -2366,12 +2370,36 @@ def _run_validated_agent(
                 # envelope, even when the command itself failed.
                 text = artifact
 
-        # Claude or Codex can be replaced after spawning. This is exclusive with
+        if result.self_update_replay_refusal_kind is not None:
+            refusal_detail = result.self_update_replay_refusal_detail or (
+                f"{agent_name} replay refused ({result.self_update_replay_refusal_kind})"
+            )
+            latest_replay_refusal_detail = refusal_detail
+            refusal_outcome = (
+                "self_update_replay_refused_changed_workdir"
+                if result.self_update_replay_refusal_kind in {"changed-head", "changed-status"}
+                else "self_update_replay_refused_unavailable_workdir"
+            )
+            if usage_record is not None:
+                usage_record.outcome = refusal_outcome
+                usage_record.log_path = str(result.log_path) if result.log_path else None
+            log(
+                config,
+                f"{agent_name} attempt replay refusal: {refusal_detail}; "
+                "continuing with provider-derived retry classification",
+            )
+
+        # Claude or Codex can be replaced after spawning. Codex remains driven
+        # by its JSONL setup-versus-progress evidence; Claude's non-streaming
+        # JSON output additionally uses the workdir snapshot gate below.
+        # This is exclusive with
         # ordinary transient classification and gets one full replay only after
-        # the configured executable is stable.
+        # the configured executable is stable. A Claude workdir refusal above
+        # deliberately does not enter this branch.
         if (
             agent in {"claude", "codex"}
             and result.self_update_reason is not None
+            and result.self_update_replay_refusal_kind is None
             and not executable_replacement_considered
             and result.command_result is not None
         ):
@@ -2979,6 +3007,11 @@ def _run_validated_agent(
                         diagnostic_classification_text = (
                             f"{classification_text}\n{replacement_detail}"
                         ).strip()
+                    if latest_replay_refusal_detail:
+                        message += f" {latest_replay_refusal_detail}"
+                        diagnostic_classification_text = (
+                            f"{diagnostic_classification_text}\n{latest_replay_refusal_detail}"
+                        ).strip()
                     diagnostics = _failed_run_diagnostics(
                         runner=runner,
                         config=config,
@@ -3038,15 +3071,27 @@ def _run_validated_agent(
             reason=executable_replacement_reason,
             stability_error=self_update_stability_error,
         )
-        last_error = f"{replacement_detail}; final failure: {last_error}"
+        context_details = [replacement_detail]
+        if latest_replay_refusal_detail:
+            context_details.append(latest_replay_refusal_detail)
+        last_error = f"{'; '.join(context_details)}; final failure: {last_error}"
         last_classification_text = (
-            f"{last_classification_text}\n{replacement_detail}"
+            f"{replacement_detail}\n"
+            f"{latest_replay_refusal_detail + chr(10) if latest_replay_refusal_detail else ''}"
+            f"{last_classification_text}"
         ).strip()
         last_failure_category = (
             "self-update-interruption"
             if executable_replacement_provider == "claude"
             else "executable-replacement"
         )
+    elif latest_replay_refusal_detail:
+        # Refusal context is added only after all retry decisions. In
+        # particular, the provider-derived category remains untouched.
+        last_error = f"{latest_replay_refusal_detail}; final failure: {last_error}"
+        last_classification_text = (
+            f"{latest_replay_refusal_detail}\n{last_classification_text}"
+        ).strip()
     diagnostics = _failed_run_diagnostics(
         runner=runner,
         config=config,
@@ -3876,14 +3921,12 @@ def _handle_plan_first_split_scope(
 
 
 def _read_assigned_workdir_head(runner: Runner, config: AgentLoopConfig) -> str | None:
-    result = runner.run(
-        ("git", "rev-parse", "HEAD"),
-        cwd=active_workdir(config),
-        check=False,
-    )
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip() or None
+    # The PR handoff guard intentionally keeps strict exception behavior: a
+    # runner/tooling exception must not be silently converted into evidence
+    # that the coder advanced the assigned checkout. Ordinary Git failures
+    # and blank HEAD output remain an unavailable (None) observation.
+    probe = read_workdir_head(runner, active_workdir(config))
+    return probe.value if probe.available else None
 
 
 def _advisory_issue_pr_provenance(

--- a/src/coding_review_agent_loop/usage.py
+++ b/src/coding_review_agent_loop/usage.py
@@ -94,7 +94,8 @@ class UsageCallRecord:
     outcome: Literal[
         "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
         "unavailable_model", "accepted_nonzero_exit", "accepted_timeout", "self_update_interruption",
-        "executable_replacement_interruption",
+        "executable_replacement_interruption", "self_update_replay_refused_changed_workdir",
+        "self_update_replay_refused_unavailable_workdir",
     ] | None = None
     log_path: str | None = None
     fallback_planned: bool | None = None
@@ -204,7 +205,8 @@ class RunUsageContext:
         outcome: Literal[
             "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
             "unavailable_model", "accepted_nonzero_exit", "accepted_timeout", "self_update_interruption",
-            "executable_replacement_interruption",
+            "executable_replacement_interruption", "self_update_replay_refused_changed_workdir",
+            "self_update_replay_refused_unavailable_workdir",
         ] | None = None,
         log_path: str | None = None,
         fallback_planned: bool | None = None,

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -28,6 +28,123 @@ INTERPRETER_BASENAME_RE = re.compile(r"^(python|pypy)\d*(\.\d+)?$")
 # Origin of a reported test-command string.
 Origin = Literal["structured", "response"]
 
+# These probes are deliberately kept in the workdir guard module so the
+# Claude recovery path and the coder-reported-PR HEAD guard share the same
+# read-only Git command contract without sharing exception policy.
+GitProbeKind = Literal["available", "command-failed", "blank", "exception"]
+
+
+@dataclass(frozen=True)
+class GitProbeResult:
+    """The result of one bounded, read-only Git probe."""
+
+    command: tuple[str, ...]
+    kind: GitProbeKind
+    value: str | None = None
+    returncode: int | None = None
+    exception_type: str | None = None
+    detail: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.kind == "available"
+
+
+@dataclass(frozen=True)
+class WorkdirSnapshot:
+    """HEAD and porcelain status captured from one assigned checkout."""
+
+    head: GitProbeResult
+    status: GitProbeResult
+
+    @property
+    def available(self) -> bool:
+        return self.head.available and self.status.available
+
+
+def _git_probe(
+    runner: object,
+    *,
+    workdir: Path,
+    args: tuple[str, ...],
+    tolerate_exceptions: bool,
+) -> GitProbeResult:
+    command = ("git", *args)
+    try:
+        result = runner.run(command, cwd=workdir, check=False)  # type: ignore[attr-defined]
+    except (AgentLoopError, OSError) as exc:
+        if not tolerate_exceptions:
+            raise
+        return GitProbeResult(
+            command=command,
+            kind="exception",
+            exception_type=type(exc).__name__,
+            detail=str(exc),
+        )
+    if result.returncode != 0:
+        return GitProbeResult(
+            command=command,
+            kind="command-failed",
+            returncode=result.returncode,
+            detail=result.stderr or None,
+        )
+    if args == ("rev-parse", "HEAD"):
+        value = result.stdout.strip()
+        if not value:
+            return GitProbeResult(command=command, kind="blank", returncode=result.returncode)
+        return GitProbeResult(
+            command=command,
+            kind="available",
+            value=value,
+            returncode=result.returncode,
+        )
+    # `git status --porcelain` uses an empty stdout as the authoritative clean
+    # worktree state. Preserve all non-empty bytes so dirty-status comparisons
+    # remain exact and do not normalize away meaningful changes.
+    return GitProbeResult(
+        command=command,
+        kind="available",
+        value=result.stdout,
+        returncode=result.returncode,
+    )
+
+
+def read_workdir_head(
+    runner: object,
+    workdir: Path,
+    *,
+    tolerate_exceptions: bool = False,
+) -> GitProbeResult:
+    """Read only ``git rev-parse HEAD`` from ``workdir``."""
+    return _git_probe(
+        runner,
+        workdir=workdir,
+        args=("rev-parse", "HEAD"),
+        tolerate_exceptions=tolerate_exceptions,
+    )
+
+
+def capture_workdir_snapshot(
+    runner: object,
+    workdir: Path,
+    *,
+    tolerate_exceptions: bool = False,
+) -> WorkdirSnapshot:
+    """Capture HEAD and ``git status --porcelain`` without mutating the checkout."""
+    return WorkdirSnapshot(
+        head=read_workdir_head(
+            runner,
+            workdir,
+            tolerate_exceptions=tolerate_exceptions,
+        ),
+        status=_git_probe(
+            runner,
+            workdir=workdir,
+            args=("status", "--porcelain"),
+            tolerate_exceptions=tolerate_exceptions,
+        ),
+    )
+
 # ---------------------------------------------------------------------------
 # Toolchain / runner recognition (path pass, program-role tokens only).
 # ---------------------------------------------------------------------------

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -241,6 +241,8 @@ class FakeRunner(Runner):
         post_agent_git_diff_check=None,
         post_agent_git_diff_check_returncode=None,
         post_agent_git_diff_check_stderr=None,
+        git_probe_results=None,
+        git_probe_exceptions=None,
         issue_urls=None,
         public_response_outputs=None,
         advance_git_head_on_pr=True,
@@ -337,6 +339,9 @@ class FakeRunner(Runner):
         self.post_agent_git_diff_check = post_agent_git_diff_check
         self.post_agent_git_diff_check_returncode = post_agent_git_diff_check_returncode
         self.post_agent_git_diff_check_stderr = post_agent_git_diff_check_stderr
+        self.git_probe_results = list(git_probe_results or [])
+        self.git_probe_exceptions = list(git_probe_exceptions or [])
+        self.git_probe_calls = []
         self.issue_urls = list(issue_urls) if issue_urls is not None else None
         self.public_response_outputs = list(public_response_outputs or [])
         self.advance_git_head_on_pr = advance_git_head_on_pr
@@ -1031,6 +1036,23 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, "false\n", "", 1)
 
         if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            self.git_probe_calls.append(tuple(cmd))
+            if self.git_probe_exceptions:
+                raise self.git_probe_exceptions.pop(0)
+            if self.git_probe_results:
+                scripted = self.git_probe_results.pop(0)
+                if isinstance(scripted, CommandResult):
+                    return CommandResult(
+                        cmd, cwd_path, scripted.stdout, scripted.stderr, scripted.returncode
+                    )
+                if isinstance(scripted, dict):
+                    return CommandResult(
+                        cmd,
+                        cwd_path,
+                        scripted.get("stdout", ""),
+                        scripted.get("stderr", ""),
+                        scripted.get("returncode", 0),
+                    )
             return CommandResult(cmd, cwd_path, f"{self.git_head}\n", "", 0)
 
         if cmd[:3] == ["git", "checkout", "--detach"]:
@@ -1066,6 +1088,23 @@ class FakeRunner(Runner):
             return CommandResult(cmd, cwd_path, f"{self.git_remote}\n", "", 0)
 
         if cmd[:3] == ["git", "status", "--porcelain"]:
+            self.git_probe_calls.append(tuple(cmd))
+            if self.git_probe_exceptions:
+                raise self.git_probe_exceptions.pop(0)
+            if self.git_probe_results:
+                scripted = self.git_probe_results.pop(0)
+                if isinstance(scripted, CommandResult):
+                    return CommandResult(
+                        cmd, cwd_path, scripted.stdout, scripted.stderr, scripted.returncode
+                    )
+                if isinstance(scripted, dict):
+                    return CommandResult(
+                        cmd,
+                        cwd_path,
+                        scripted.get("stdout", ""),
+                        scripted.get("stderr", ""),
+                        scripted.get("returncode", 0),
+                    )
             return CommandResult(cmd, cwd_path, self._current_git_status(), "", 0)
 
         if cmd[:3] == ["git", "status", "--short"]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -39,6 +39,7 @@ from coding_review_agent_loop.github import CiWatchOutcome, IssueComment
 from coding_review_agent_loop.managed_ci import ManagedCiReadiness, ProtectionAssessment
 from coding_review_agent_loop.managed_pr import ManagedPrHandoff
 from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
+from coding_review_agent_loop.usage import RunUsageContext
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
     ValidatedAgentResponse,
@@ -3951,6 +3952,104 @@ def test_claude_self_update_stability_failure_sets_final_category(tmp_path):
     assert "wait for the Claude Code self-update to finish" in str(error.value)
 
 
+def _refused_claude_result(tmp_path, *, raw_output="fatal: auto-update in progress", kind="changed-status"):
+    identity = ExecutableIdentity("claude", "claude", (1, 1, 1), (1, 1, 1))
+    observation = ExecutionObservation(1, 1, 2, 1, identity, identity, False)
+    command_result = CommandResult(
+        ["claude", "--print"], tmp_path, raw_output, "", 1, observation
+    )
+    return AgentResult(
+        text="",
+        raw_output=raw_output,
+        returncode=1,
+        log_path=tmp_path / "claude-attempt1.log",
+        command_result=command_result,
+        self_update_reason="Claude Code updater diagnostic",
+        self_update_replay_refusal_kind=kind,
+        self_update_replay_refusal_detail=(
+            "Claude self-update replay refused: dirty workdir status changed during invocation"
+            if kind == "changed-status"
+            else "Claude self-update replay refused: after workdir snapshot unavailable"
+        ),
+    )
+
+
+def test_claude_replay_refusal_is_diagnostic_only_and_does_not_wait_or_override_category(tmp_path):
+    result = _refused_claude_result(tmp_path)
+    runner = FakeRunner()
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=0)
+    usage = RunUsageContext(run_id="run-refusal", summary_path=tmp_path / "usage.json")
+
+    with patch.object(orchestrator_module, "run_agent_result", return_value=result):
+        with pytest.raises(AgentInvocationError) as error:
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                validate=lambda text: _validate_review_response(
+                    text, reviewer="Anthropic Claude", unresolved_items=()
+                ),
+                usage_context=usage,
+            )
+
+    assert error.value.failure_category == "deterministic"
+    assert "dirty workdir" in str(error.value)
+    assert not any(command[:1] == ["sleep"] for command, _cwd in runner.commands)
+    assert usage.records[0].outcome == "self_update_replay_refused_changed_workdir"
+    assert usage.records[0].log_path == str(result.log_path)
+
+
+def test_transient_claude_replay_refusal_keeps_provider_retry_and_category(tmp_path):
+    refused = _refused_claude_result(tmp_path, raw_output="overloaded_error")
+    valid = AgentResult(
+        text=structured_pr_review(
+            state="approved", summary="Recovered after refusal.", reviewer="Anthropic Claude"
+        ),
+        returncode=0,
+    )
+    runner = FakeRunner()
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=[refused, valid]):
+        response = _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="<!-- AGENT_STATE: approved|blocking -->",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Anthropic Claude", unresolved_items=()
+            ),
+        )
+
+    assert response.marker_value.state == "approved"
+    assert any(command[:1] == ["sleep"] for command, _cwd in runner.commands)
+
+
+def test_transient_claude_replay_refusal_only_retains_transient_category(tmp_path):
+    refused = _refused_claude_result(tmp_path, raw_output="overloaded_error")
+    runner = FakeRunner()
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=0)
+
+    with patch.object(orchestrator_module, "run_agent_result", return_value=refused):
+        with pytest.raises(AgentInvocationError) as error:
+            _run_validated_agent(
+                runner,
+                agent="claude",
+                config=config,
+                prompt="Review the PR.",
+                marker_description="<!-- AGENT_STATE: approved|blocking -->",
+                validate=lambda text: _validate_review_response(
+                    text, reviewer="Anthropic Claude", unresolved_items=()
+                ),
+            )
+
+    assert error.value.failure_category == "transient"
+    assert "dirty workdir" in str(error.value)
+
+
 def _observed_codex_result(tmp_path, *, text="", raw_output="", returncode=1, changed=True):
     before = ExecutableIdentity(
         "/tmp/codex", "/tmp/codex-target", (1, 1, 100_000_000_000), (1, 2, 100_000_000_000)
@@ -4789,7 +4888,7 @@ def test_claude_backend_passes_model_when_declared(tmp_path):
     runner = FakeRunner(claude_outputs=[("STATE: approved\n\nok", 0)])
     config = make_config(tmp_path, claude_model="opus")
     ClaudeBackend().run(runner, config, "Review", run_id="r")
-    cmd = runner.commands[-1][0]
+    cmd = next(cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"])
     assert cmd[cmd.index("--model") + 1] == "opus"
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -86,7 +86,7 @@ def test_claude_self_update_classification_requires_bounded_evidence():
     failed = CommandResult(["claude"], Path.cwd(), "", "", 1, observation)
     assert classify_self_update_interruption(
         failed, command="claude", response_file_text=None, session_id=None
-    ) == "Claude executable changed during invocation"
+    ).reason == "Claude executable changed during invocation"
     ordinary = CommandResult(["claude"], Path.cwd(), "ordinary failure", "", 1,
                              ExecutionObservation(2, 10, 11, 1, identity, identity, False))
     assert classify_self_update_interruption(
@@ -96,7 +96,7 @@ def test_claude_self_update_classification_requires_bounded_evidence():
                                ExecutionObservation(2, 10, 11, 1, identity, identity, False))
     assert classify_self_update_interruption(
         diagnostic, command="claude", response_file_text=None, session_id=None
-    ) == "Claude Code updater diagnostic"
+    ).reason == "Claude Code updater diagnostic"
 
 
 def test_claude_self_update_workdir_gate_reports_changed_status_without_replacing_evidence():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -99,6 +99,96 @@ def test_claude_self_update_classification_requires_bounded_evidence():
     ) == "Claude Code updater diagnostic"
 
 
+def test_claude_self_update_workdir_gate_reports_changed_status_without_replacing_evidence():
+    from coding_review_agent_loop.workdir_guard import capture_workdir_snapshot
+
+    identity = ExecutableIdentity("/bin/claude", "/bin/claude", (1, 1, 1), (1, 1, 1))
+    observation = ExecutionObservation(2, 10, 11, 1, identity, identity, False)
+    result = CommandResult(
+        ["claude"], Path.cwd(), "Loading...\nInstalling Claude Code v2.1.226", "", 1, observation
+    )
+    before_runner = FakeRunner(
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": "", "returncode": 0},
+        ]
+    )
+    after_runner = FakeRunner(
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": " M changed.py\n", "returncode": 0},
+        ]
+    )
+    before = capture_workdir_snapshot(before_runner, Path.cwd())
+    after = capture_workdir_snapshot(after_runner, Path.cwd())
+
+    evidence = classify_self_update_interruption(
+        result,
+        command="claude",
+        response_file_text=None,
+        session_id=None,
+        before_snapshot=before,
+        after_snapshot=after,
+    )
+
+    assert evidence is not None
+    assert evidence.reason == "Claude Code updater diagnostic"
+    assert evidence.replay_refusal_kind == "changed-status"
+    assert "dirty workdir" in evidence.replay_refusal_detail
+
+
+def test_claude_backend_probes_before_every_call_but_after_only_for_candidates(tmp_path):
+    from coding_review_agent_loop.agents.claude import ClaudeBackend
+
+    identity = ExecutableIdentity("claude", "claude", (1, 1, 1), (1, 1, 1))
+    observation = ExecutionObservation(2, 10, 11, 1, identity, identity, False)
+
+    class ObservedRunner(FakeRunner):
+        def run_with_log(self, *args, **kwargs):
+            result = super().run_with_log(*args, **kwargs)
+            return CommandResult(
+                result.args,
+                result.cwd,
+                result.stdout,
+                result.stderr,
+                result.returncode,
+                observation,
+            )
+
+    candidate_runner = ObservedRunner(
+        claude_outputs=[("fatal: auto-update in progress", 1)],
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": "", "returncode": 0},
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": " M changed.py\n", "returncode": 0},
+        ],
+    )
+    candidate = ClaudeBackend().run(candidate_runner, make_config(tmp_path), "Review")
+    assert candidate.self_update_reason == "Claude Code updater diagnostic"
+    assert candidate.self_update_replay_refusal_kind == "changed-status"
+    assert candidate_runner.git_probe_calls == [
+        ("git", "rev-parse", "HEAD"),
+        ("git", "status", "--porcelain"),
+        ("git", "rev-parse", "HEAD"),
+        ("git", "status", "--porcelain"),
+    ]
+
+    ordinary_runner = ObservedRunner(
+        claude_outputs=[("ordinary failure", 1)],
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": "", "returncode": 0},
+        ],
+    )
+    ordinary = ClaudeBackend().run(ordinary_runner, make_config(tmp_path), "Review")
+    assert ordinary.self_update_reason is None
+    assert ordinary_runner.git_probe_calls == [
+        ("git", "rev-parse", "HEAD"),
+        ("git", "status", "--porcelain"),
+    ]
+
+
 def _codex_result(
     *,
     stdout="",

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -1,5 +1,137 @@
 from agent_loop_helpers import *  # noqa: F403
 
+from coding_review_agent_loop.workdir_guard import (
+    capture_workdir_snapshot,
+    read_workdir_head,
+)
+from coding_review_agent_loop.orchestrator import _read_assigned_workdir_head
+
+
+def test_workdir_snapshot_runs_exact_read_only_git_probes_and_accepts_clean_status(tmp_path):
+    runner = FakeRunner(
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": "", "returncode": 0},
+        ]
+    )
+
+    snapshot = capture_workdir_snapshot(runner, tmp_path)
+
+    assert snapshot.available
+    assert snapshot.head.value == "abc123"
+    assert snapshot.status.value == ""
+    assert runner.git_probe_calls == [
+        ("git", "rev-parse", "HEAD"),
+        ("git", "status", "--porcelain"),
+    ]
+
+
+def test_workdir_snapshot_preserves_identical_dirty_status_and_detects_changes(tmp_path):
+    before_runner = FakeRunner(
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": " M src/app.py\n", "returncode": 0},
+        ]
+    )
+    after_runner = FakeRunner(
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": " M src/app.py\n", "returncode": 0},
+        ]
+    )
+
+    before = capture_workdir_snapshot(before_runner, tmp_path)
+    after = capture_workdir_snapshot(after_runner, tmp_path)
+
+    assert before.status.value == after.status.value == " M src/app.py\n"
+    assert before == after
+
+    changed = capture_workdir_snapshot(
+        FakeRunner(
+            git_probe_results=[
+                {"stdout": "def456\n", "returncode": 0},
+                {"stdout": " M src/app.py\n", "returncode": 0},
+            ]
+        ),
+        tmp_path,
+    )
+    assert changed.head.value != before.head.value
+
+
+@pytest.mark.parametrize(
+    ("results", "expected_head_kind", "expected_status_kind"),
+    [
+        (
+            [{"stdout": "fatal: not a git repository\n", "returncode": 128},
+             {"stdout": "", "returncode": 128}],
+            "command-failed",
+            "command-failed",
+        ),
+        (
+            [{"stdout": "", "returncode": 0}, {"stdout": "", "returncode": 0}],
+            "blank",
+            "available",
+        ),
+        (
+            [{"stdout": "", "returncode": 128}, {"stdout": "", "returncode": 128}],
+            "command-failed",
+            "command-failed",
+        ),
+    ],
+)
+def test_workdir_snapshot_distinguishes_failed_blank_and_unborn_git_results(
+    tmp_path, results, expected_head_kind, expected_status_kind
+):
+    snapshot = capture_workdir_snapshot(
+        FakeRunner(git_probe_results=results),
+        tmp_path,
+        tolerate_exceptions=True,
+    )
+
+    assert snapshot.head.kind == expected_head_kind
+    assert snapshot.status.kind == expected_status_kind
+
+
+def test_workdir_snapshot_tolerates_agent_loop_error_and_oserror_per_probe(tmp_path):
+    runner = FakeRunner(
+        git_probe_exceptions=[AgentLoopError("runner interrupted"), OSError("git missing")]
+    )
+
+    snapshot = capture_workdir_snapshot(runner, tmp_path, tolerate_exceptions=True)
+
+    assert snapshot.head.kind == "exception"
+    assert snapshot.head.exception_type == "AgentLoopError"
+    assert snapshot.status.kind == "exception"
+    assert snapshot.status.exception_type == "OSError"
+
+
+def test_head_only_probe_does_not_invoke_status_and_strict_mode_reraises(tmp_path):
+    runner = FakeRunner(git_probe_exceptions=[OSError("git unavailable")])
+
+    with pytest.raises(OSError, match="git unavailable"):
+        read_workdir_head(runner, tmp_path)
+
+    assert runner.git_probe_calls == [("git", "rev-parse", "HEAD")]
+
+
+@pytest.mark.parametrize(
+    "scripted", [{"stdout": "", "returncode": 1}, {"stdout": "\n", "returncode": 0}]
+)
+def test_orchestrator_strict_head_probe_maps_only_nonzero_or_blank_to_none(tmp_path, scripted):
+    runner = FakeRunner(git_probe_results=[scripted])
+    config = make_config(tmp_path)
+
+    assert _read_assigned_workdir_head(runner, config) is None
+    assert runner.git_probe_calls == [("git", "rev-parse", "HEAD")]
+
+
+def test_orchestrator_strict_head_probe_reraises_exception(tmp_path):
+    runner = FakeRunner(git_probe_exceptions=[AgentLoopError("interrupted runner")])
+    config = make_config(tmp_path)
+
+    with pytest.raises(AgentLoopError, match="interrupted runner"):
+        _read_assigned_workdir_head(runner, config)
+
 
 def test_workdir_guard_rejects_outside_home_path(tmp_path):
     assigned = tmp_path / "claude" / "repo"


### PR DESCRIPTION
## Summary

- Add read-only HEAD and porcelain-status snapshots around Claude replay candidates.
- Refuse replay on changed or unavailable workdir evidence without changing provider failure classification or retry semantics.
- Record refusal outcomes, preserve strict PR HEAD validation, and document the guard and its limits.

## Tests

- `python3 -m pytest tests/test_workdir_guard.py tests/test_backends.py tests/test_agent_loop.py tests/test_orchestrator_pr.py tests/test_review_parallel.py -q`
- `python3 -m pytest -q`

Fixes #638