### PR TITLE
Fix managed-CI issue handoff and CI merge gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,19 +822,24 @@ resume writes a fresh audit and intent generation; prior dispatched runs,
 including rejected or failed runs, remain previous-invocation outcomes and are
 never attached to the new generation.
 
-When safe managed resume is unavailable, agent-loop waits for a new unlabeled
-recovery run on the exact current head and then requires the ordinary required
-checks. Only the draft released by that invocation may be made ready, and only
-with `--auto-merge`; unrelated drafts remain drafts. The head is revalidated
-before and after `gh pr ready`, and merge uses `--match-head-commit`. If that
-later merge fails, the PR remains ready and unmerged for a safe retry.
+When safe managed resume is unavailable, agent-loop selects ordinary recovery
+only when the base workflow proves it has an unlabeled pull-request route. It
+baselines existing current-head runs, retains the draft, and waits at most
+`--ci-startup-timeout-seconds` (default 120) for a new current-head run to
+materialize. A missing, queued-only, or jobless run is not success: the draft
+stays unmerged and the terminal prints a shell-quoted `agent-loop pr` resume
+command. A qualifying recovery also needs a successful run and a non-empty
+passing current-head board. The live head is re-read immediately before merge
+and GitHub receives the same SHA through `--match-head-commit`.
 
 For repositories without that contract, `--auto-merge` foreground-polls the
 complete check board after approval with
 `--ci-timeout-seconds` and
 `--ci-poll-interval-seconds`, without invoking agents while checks are pending.
-Failure resumes the coder with the failed-check details; a successful/no-check
-board is merged. The watcher is synchronous and interruptible: Ctrl-C leaves
+Failure resumes the coder with the failed-check details; only a non-empty
+successful board is mergeable. An empty rollup is a bounded startup state, not
+CI success: after `--ci-startup-timeout-seconds` it stops with a resumable PR
+command and does not ready or merge the PR. The watcher is synchronous and interruptible: Ctrl-C leaves
 no worker behind, and a rerun starts from fresh PR state. On timeout the local
 terminal prints a shell-quoted rerun command; PR comments intentionally contain
 no captured command arguments. Use `--no-watch-pending-ci` with `--auto-merge`

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1471,17 +1471,21 @@ A successful resume records a fresh audit, nonce, and invocation intent
 generation. Earlier ledger entries and attached workflow runs remain history:
 even a queued, successful, failed, or rejected prior run is logged as the
 previous invocation's outcome and is never adopted by the new dispatch. If
-safe managed resume is unavailable, agent-loop removes the exact active
-managed label and waits for a new post-`unlabeled` workflow run on the exact
-head, then requires the ordinary current-head check board to pass. It does not
-accept pre-release green checks, `no_checks`, or a different SHA. Only the
-invocation-owned fallback draft can be made ready, and only an auto-merge
-invocation can take this deliberate ordinary-recovery path; explicit managed
-manual mode fails closed instead. Unrelated or intentional drafts remain
-drafts. Agent-loop checks
-the exact head before and after `gh pr ready` and merges with
-`--match-head-commit`. If that merge fails after readiness, it logs that the PR
-remains ready and leaves it unmerged rather than restoring draft state.
+safe managed resume is unavailable, agent-loop selects ordinary recovery only
+when the base workflow proves an unlabeled pull-request route. It baselines
+current-head run IDs before label release, retains the draft, and observes
+startup for at most `--ci-startup-timeout-seconds` (default 120). A missing,
+queued-only, or jobless run is never success: the draft remains unmerged and
+the local terminal prints a deterministic shell-quoted PR resume command. A
+new post-`unlabeled` run must complete successfully and the exact head must
+have a non-empty complete passing board. It does not accept pre-release green
+checks, an empty rollup, or a different SHA. Only the invocation-owned fallback draft
+can be made ready, and only an auto-merge invocation can take this
+deliberate ordinary-recovery path; explicit managed manual mode fails closed
+instead. Unrelated or intentional drafts remain drafts. Agent-loop checks the
+exact head before and after `gh pr ready`, then performs one final live-head
+read before merging with `--match-head-commit`; if that guarded merge fails,
+the PR remains ready and unmerged for a safe retry.
 
 Suppression-capable v2 workflows must additionally advertise
 `AGENT_LOOP_MANAGED_CI_UNLABELED_RECOVERY_V1` and subscribe their
@@ -1539,11 +1543,16 @@ and ordinary PRs retain regular CI unless they are explicitly adopted as
 described below.
 
 For an unprotected override, the coder carries the preflight-minted nonce in
-the creation trailer. During that same invocation agent-loop compares the
-trailer to its in-memory nonce and writes an actor-owned PR audit comment
-before accepting activation or dispatching qualification. A forged, stale, or
-mismatched trailer, or a failed audit write, releases the suppression label;
-a later invocation cannot reuse a body nonce as its authorization.
+one canonical body record containing only that nonce; it must not add another
+reserved body record. During the same issue-created handoff, agent-loop checks
+the draft's repository/base/head/branch/label/author tuple and one issue
+closing reference, re-reads it to catch races, then compares the body record
+to its in-memory nonce before any handoff publication. The richer actor-owned
+audit comment has separate provenance fields and its own schema. A forged,
+stale, duplicate, malformed, unrelated, or mismatched record fails before any
+handoff write. A direct PR resume treats historical records as provenance only
+and mints fresh authorization; it never accepts an old nonce for dispatch,
+readiness, or merge authority.
 
 #### Creating a managed PR from an existing branch
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -352,6 +352,15 @@ def build_parser() -> argparse.ArgumentParser:
             help="Polling interval for the CI check before auto-merge (default: 30).",
         )
         subparser.add_argument(
+            "--ci-startup-timeout-seconds",
+            type=int,
+            default=120,
+            help=(
+                "Maximum time to observe a newly materialized current-head CI run/check before "
+                "stopping with a resumable command (default: 120)."
+            ),
+        )
+        subparser.add_argument(
             "--watch-pending-ci",
             action=argparse.BooleanOptionalAction,
             dest="watch_pending_ci",

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -213,6 +213,9 @@ class AgentLoopConfig:
     # Origin for a contract created by the public direct/managed PR entry point.
     # Issue-origin handoffs select their own flow when a linked issue exists.
     pr_origin_flow: str = "direct-pr"
+    # Separate bounded startup observation for CI that has not materialized a
+    # run/check yet.  Empty boards are never evidence that CI succeeded.
+    ci_startup_timeout_seconds: int = 120
 
     @property
     def effective_managed_ci(self) -> bool:
@@ -933,6 +936,8 @@ def config_from_args(
         raise AgentLoopError("--ci-timeout-seconds must be greater than zero.")
     if args.ci_poll_interval_seconds <= 0:
         raise AgentLoopError("--ci-poll-interval-seconds must be greater than zero.")
+    if getattr(args, "ci_startup_timeout_seconds", 120) <= 0:
+        raise AgentLoopError("--ci-startup-timeout-seconds must be greater than zero.")
     if getattr(args, "ci_queued_grace_seconds", 1200) <= 0:
         raise AgentLoopError("--ci-queued-grace-seconds must be greater than zero.")
     if getattr(args, "mergeability_poll_attempts", 3) <= 0:
@@ -1020,6 +1025,7 @@ def config_from_args(
         ci_check_name=args.ci_check_name,
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
+        ci_startup_timeout_seconds=getattr(args, "ci_startup_timeout_seconds", 120),
         watch_pending_ci=(
             bool(getattr(args, "auto_merge", False))
             if getattr(args, "watch_pending_ci", None) is None

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -1952,7 +1952,7 @@ class CiWatchOutcome:
 
     status: Literal[
         "passed",
-        "no_checks",
+        "not_started",
         "failed",
         "timeout",
         "infrastructure_stall",
@@ -1990,6 +1990,12 @@ def watch_pr_checks(
         1, config.ci_timeout_seconds // config.ci_poll_interval_seconds
     )
     latest: PullRequestChecks | None = None
+    empty_attempts = 0
+    startup_attempt_limit = max(
+        1,
+        (config.ci_startup_timeout_seconds + config.ci_poll_interval_seconds - 1)
+        // config.ci_poll_interval_seconds,
+    )
     for attempt in range(limit):
         # A flaky head probe is diagnostic only.  The full-board and
         # mergeability probes already degrade transient API failures safely.
@@ -2033,10 +2039,17 @@ def watch_pr_checks(
                 attempts_used=attempt + 1,
             )
         if snapshot.state == "no_checks" and reliable and not snapshot.missing_required:
-            return CiWatchOutcome(
-                status="no_checks", pr_checks=snapshot, head_sha=current_head,
-                attempts_used=attempt + 1,
-            )
+            empty_attempts += 1
+            # GitHub can expose an empty rollup while a pull_request workflow
+            # is queued but no job/check has materialized.  It is a startup
+            # state, not a passing board and never a merge permit.
+            if empty_attempts >= startup_attempt_limit:
+                return CiWatchOutcome(
+                    status="not_started", pr_checks=snapshot, head_sha=current_head,
+                    attempts_used=attempt + 1,
+                )
+        else:
+            empty_attempts = 0
         if time.monotonic() >= deadline or attempt == limit - 1:
             return CiWatchOutcome(
                 status="timeout", pr_checks=latest, head_sha=current_head,

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -139,6 +139,10 @@ class ManagedCiContract:
     terminal_attempts: tuple[tuple[int, int | None], ...] = ()
     activation_path: Literal["managed", "ordinary_fallback"] = "managed"
     ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
+    # Derived from the exact base workflow at activation. Retain it for a
+    # delayed dispatch-time fallback so a suppressed draft is released only
+    # when that same workflow advertises an unlabeled CI route.
+    ordinary_recovery_capable: bool = False
 
 
 @dataclass(frozen=True)
@@ -1607,6 +1611,7 @@ def _activate_v2_managed_ci(
         active_label_event_id=active_event[0] if active_event is not None else None,
         issue_created_pr=True,
         invocation_applied_label=label_applied,
+        ordinary_recovery_capable=ordinary_recovery_capable,
     )
 
 
@@ -2191,6 +2196,7 @@ def _dispatch_v2_qualification(
             runner, config=config, pr_number=pr_number, base_ref=contract.base_ref,
             expected_head_sha=expected_head_sha, active_event=event,
             reason=f"fresh intent ledger could not be reconciled ({exc})",
+            recovery_capable=contract.ordinary_recovery_capable,
         )
         contract.activation_path = "ordinary_fallback"
         contract.ordinary_recovery = recovery

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import secrets
 import shlex
 import time
@@ -26,11 +27,17 @@ from .github import (
     get_pr_checks,
     get_pr_head_sha,
     get_pr_mergeability,
+    parse_strong_issue_reference_evidence,
 )
 from .logging import log
 from .runner import Runner
 from .workdirs import active_workdir
-from .protocol_markers import PR_COMMENT_SURFACE, TrustedBody
+from .protocol_markers import (
+    PR_BODY_SURFACE,
+    PR_COMMENT_SURFACE,
+    TrustedBody,
+    scan_reserved_markers,
+)
 
 
 MANAGED_LABEL = "agent-loop-managed"
@@ -132,6 +139,7 @@ class ManagedCiContract:
     terminal_attempts: tuple[tuple[int, int | None], ...] = ()
     activation_path: Literal["managed", "ordinary_fallback"] = "managed"
     ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
+    recovery_capable: bool = False
 
 
 @dataclass(frozen=True)
@@ -142,6 +150,120 @@ class ManagedCiCreationIntent:
     trusted_actor: str
     protection_mode: str = "strict"
     audit_nonce: str | None = None
+    recovery_capable: bool = False
+
+
+@dataclass(frozen=True)
+class ManagedCiOverrideRecord:
+    """Canonical override record parsed from one trusted PR surface.
+
+    The same marker has deliberately different schemas on a PR body and on
+    an actor-authored audit comment.  Keeping that distinction here prevents
+    one consumer from accepting a permissive form that another rejects.
+    """
+
+    nonce: str
+    fields: tuple[tuple[str, str], ...]
+
+    def field_map(self) -> dict[str, str]:
+        return dict(self.fields)
+
+
+@dataclass(frozen=True)
+class AuthenticatedIssueCreatedHandoff:
+    """Read-only proof for the issue-created draft -> PR-loop transition."""
+
+    pr_number: int
+    issue_number: int
+    repository: str
+    base_ref: str
+    head_sha: str
+    branch: str
+    trusted_actor_login: str
+    trusted_actor_id: int
+    protection_mode: str
+    override_nonce: str | None
+    recovery_capable: bool
+    active_label_event_id: int | None = None
+
+
+def parse_managed_ci_override_record(
+    body: str,
+    *,
+    surface: str,
+    schema: Literal["body", "audit"],
+    required: bool = False,
+    expected_nonce: str | None = None,
+    additional_allowed_tokens: frozenset[str] = frozenset(),
+) -> ManagedCiOverrideRecord | None:
+    """Parse one canonical managed-CI override record and reject every variant.
+
+    ``TrustedBody`` supplies the registry/surface/canonical-wire checks.  This
+    helper owns the inner field schema so body records cannot quietly acquire
+    audit provenance fields and audit comments cannot omit their provenance.
+    """
+    occurrences = scan_reserved_markers(body)
+    override = [
+        occurrence for occurrence in occurrences
+        if occurrence.definition.token == UNPROTECTED_OVERRIDE_TRAILER
+    ]
+    allowed = set(additional_allowed_tokens)
+    allowed.add(UNPROTECTED_OVERRIDE_TRAILER)
+    unexpected = [
+        occurrence.definition.token for occurrence in occurrences
+        if occurrence.definition.token not in allowed
+    ]
+    if unexpected:
+        raise AgentLoopError(
+            "Managed-CI override carrier contains unrelated reserved protocol record(s): "
+            + ", ".join(sorted(set(unexpected)))
+        )
+    if not override:
+        if required:
+            raise AgentLoopError("Managed-CI override record is required for this handoff.")
+        # Still canonicalize allowed companion records, including malformed
+        # bare-token fallbacks, before returning absence.
+        if occurrences:
+            TrustedBody.canonical(
+                body,
+                surface=surface,
+                expected_tokens={item.definition.token for item in occurrences},
+            )
+        return None
+    if len(override) != 1:
+        raise AgentLoopError("Managed-CI override carrier contains duplicate override records.")
+    TrustedBody.canonical(
+        body,
+        surface=surface,
+        expected_tokens={item.definition.token for item in occurrences},
+    )
+    parts = override[0].text.strip().split()
+    if not parts or parts[0] != UNPROTECTED_OVERRIDE_TRAILER:
+        raise AgentLoopError("Managed-CI override record has an invalid schema.")
+    fields: list[tuple[str, str]] = []
+    for token in parts[1:]:
+        key, separator, value = token.partition("=")
+        if not separator or not key or not value or any(key == old for old, _ in fields):
+            raise AgentLoopError("Managed-CI override record has an invalid schema.")
+        fields.append((key, value))
+    values = dict(fields)
+    body_keys = {"nonce"}
+    audit_keys = {
+        "nonce", "repo", "base", "head", "protection", "active_label_event_id",
+        "resume_from", "provenance_head", "generation",
+    }
+    if schema == "body":
+        if set(values) != body_keys:
+            raise AgentLoopError("Managed-CI PR-body override record must contain only its nonce.")
+    else:
+        if not {"nonce", "repo", "base", "head", "protection"}.issubset(values) or set(values) - audit_keys:
+            raise AgentLoopError("Managed-CI override audit record has an invalid provenance schema.")
+    nonce = values.get("nonce")
+    if not nonce:
+        raise AgentLoopError("Managed-CI override record has no nonce.")
+    if expected_nonce is not None and nonce != expected_nonce:
+        raise AgentLoopError("Managed-CI override record does not match this creation handoff.")
+    return ManagedCiOverrideRecord(nonce=nonce, fields=tuple(fields))
 
 
 @dataclass(frozen=True)
@@ -155,6 +277,7 @@ class OrdinaryRecoveryCapability:
     released_label_event_id: int | None
     released_at: int
     prior_run_ids: frozenset[int] = frozenset()
+    recovery_capable: bool = True
 
 
 @dataclass(frozen=True)
@@ -167,6 +290,7 @@ class ManagedCiOutcome:
         "merge_conflict",
         "infrastructure_stall",
         "terminal_without_status",
+        "not_started",
     ]
     checks: PullRequestChecks | None = None
     mergeability: PullRequestMergeability | None = None
@@ -690,7 +814,245 @@ def preflight_managed_ci_creation(
         trusted_actor=readiness.actor or config.managed_ci_trusted_actor,
         protection_mode=readiness.protection.state,
         audit_nonce=secrets.token_urlsafe(18) if config.allow_unprotected_managed_ci else None,
+        recovery_capable=readiness.recovery_capable,
     )
+
+
+def _issue_created_tuple(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    issue_number: int,
+    metadata: PullRequestMetadata,
+    expected_branch: str,
+    expected_nonce: str | None,
+    protection_mode: str,
+    recovery_capable: bool,
+) -> AuthenticatedIssueCreatedHandoff:
+    """Read and verify the immutable tuple before any handoff publication.
+
+    The GraphQL view is useful to the review loop but cannot attest author,
+    same-repository head, labels, and draft state together.  Require it to
+    agree with the REST tuple and re-read the REST tuple before returning so a
+    transient body/head race cannot escape into a writer.
+    """
+    if not config.base or metadata.number != pr_number or metadata.repo.casefold() != config.repo.casefold():
+        raise AgentLoopError("Managed-CI issue handoff does not match the configured repository/base.")
+    body = metadata.body or ""
+    record = parse_managed_ci_override_record(
+        body,
+        surface=PR_BODY_SURFACE,
+        schema="body",
+        required=expected_nonce is not None,
+        expected_nonce=expected_nonce,
+    )
+    if expected_nonce is None and record is not None:
+        raise AgentLoopError("Strict managed-CI issue handoff must not contain an override record.")
+    linked = parse_strong_issue_reference_evidence(body, repo=config.repo, issue_number=issue_number)
+    if len(linked) != 1:
+        raise AgentLoopError("Managed-CI issue handoff requires one canonical closing reference to its issue.")
+    who = _api_json(runner, config, "user", quiet=True)
+    actor_login = who.get("login") if isinstance(who.get("login"), str) else None
+    actor_id = who.get("id") if isinstance(who.get("id"), int) else None
+    variable = _api_json(
+        runner, config,
+        f"repos/{config.repo}/actions/variables/AGENT_LOOP_MANAGED_ACTOR",
+        quiet=True,
+    )
+    advertised = variable.get("value") if isinstance(variable.get("value"), str) else None
+    configured = (config.managed_ci_trusted_actor or "").strip()
+    if (
+        not configured or not actor_login or actor_id is None or not advertised
+        or actor_login.casefold() != configured.casefold()
+        or actor_login.casefold() != advertised.casefold()
+    ):
+        raise AgentLoopError("Managed-CI issue handoff actor authentication does not match repository settings.")
+
+    def check_rest(pr: dict[str, object]) -> tuple[str, str]:
+        head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+        base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
+        author = pr.get("user") if isinstance(pr.get("user"), dict) else {}
+        head_repo = head.get("repo") if isinstance(head.get("repo"), dict) else {}
+        labels = {
+            item.get("name") for item in (pr.get("labels") or [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        sha = head.get("sha") if isinstance(head.get("sha"), str) else None
+        branch = head.get("ref") if isinstance(head.get("ref"), str) else None
+        rest_body = pr.get("body") if isinstance(pr.get("body"), str) else ""
+        if (
+            pr.get("state") not in {"open", "OPEN"}
+            or pr.get("draft") is not True
+            or head_repo.get("full_name", "").casefold() != config.repo.casefold()
+            or branch != expected_branch
+            or base.get("ref") != config.base
+            or MANAGED_LABEL not in labels
+            or author.get("login", "").casefold() != actor_login.casefold()
+            or author.get("id") != actor_id
+            or sha != metadata.head_sha
+            or branch != metadata.head_branch
+            or base.get("ref") != metadata.base_branch
+            or rest_body != body
+        ):
+            raise AgentLoopError("Managed-CI issue-created opening tuple is missing or changed.")
+        return sha, branch
+
+    first = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    sha, branch = check_rest(first)
+    second = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    live_sha, live_branch = check_rest(second)
+    if (live_sha, live_branch) != (sha, branch):
+        raise AgentLoopError("Managed-CI issue-created opening tuple changed during validation.")
+    return AuthenticatedIssueCreatedHandoff(
+        pr_number=pr_number,
+        issue_number=issue_number,
+        repository=config.repo,
+        base_ref=config.base,
+        head_sha=sha,
+        branch=branch,
+        trusted_actor_login=actor_login,
+        trusted_actor_id=actor_id,
+        protection_mode=protection_mode,
+        override_nonce=record.nonce if record is not None else None,
+        recovery_capable=recovery_capable,
+    )
+
+
+def authenticate_issue_created_handoff(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    intent: ManagedCiCreationIntent,
+    issue_number: int,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+) -> AuthenticatedIssueCreatedHandoff:
+    """Authenticate a just-created issue draft before *any* remote write."""
+    return _issue_created_tuple(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        issue_number=issue_number,
+        metadata=metadata,
+        expected_branch=intent.branch,
+        expected_nonce=intent.audit_nonce,
+        protection_mode=intent.protection_mode,
+        recovery_capable=intent.recovery_capable,
+    )
+
+
+def revalidate_issue_created_handoff(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    handoff: AuthenticatedIssueCreatedHandoff,
+    metadata: PullRequestMetadata,
+) -> AuthenticatedIssueCreatedHandoff:
+    """Re-read an authenticated handoff at PR-loop entry before any writer."""
+    if handoff.repository.casefold() != config.repo.casefold() or handoff.base_ref != config.base:
+        raise AgentLoopError("Managed-CI handoff does not belong to this invocation.")
+    validated = _issue_created_tuple(
+        runner,
+        config=config,
+        pr_number=handoff.pr_number,
+        issue_number=handoff.issue_number,
+        metadata=metadata,
+        expected_branch=handoff.branch,
+        expected_nonce=handoff.override_nonce,
+        protection_mode=handoff.protection_mode,
+        recovery_capable=handoff.recovery_capable,
+    )
+    if handoff.active_label_event_id is not None:
+        event = _active_managed_label_event(runner, config=config, pr_number=handoff.pr_number)
+        if (
+            event is None
+            or event[0] != handoff.active_label_event_id
+            or event[1].casefold() != handoff.trusted_actor_login.casefold()
+            or event[2] != handoff.trusted_actor_id
+        ):
+            raise AgentLoopError("Managed-CI direct-resume label provenance changed before activation.")
+        validated = replace(validated, active_label_event_id=handoff.active_label_event_id)
+    return validated
+
+
+def recover_issue_created_handoff(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    metadata: PullRequestMetadata,
+) -> AuthenticatedIssueCreatedHandoff | None:
+    """Reconstruct provenance for a direct PR resume without reusing authority.
+
+    This only recognizes the nonce-bearing unprotected body form.  Strict
+    issue-created drafts retain their existing label/timeline activation path;
+    source-managed PRs are handled by ``managed_pr`` before this function.
+    """
+    if not config.managed_ci_pr_mode:
+        return None
+    body = metadata.body or ""
+    if UNPROTECTED_OVERRIDE_TRAILER not in body:
+        return None
+    record = parse_managed_ci_override_record(
+        body, surface=PR_BODY_SURFACE, schema="body", required=True,
+    )
+    branch = metadata.head_branch or ""
+    match = re.fullmatch(r"agent-loop/managed-([1-9]\d*)", branch)
+    if match is None:
+        raise AgentLoopError("Managed-CI direct resume requires the exact issue-created managed branch.")
+    issue_number = int(match.group(1))
+    # A resumed nonce is provenance only.  Its value is checked against the
+    # live body, then activation mints a fresh audit/generation.
+    handoff = _issue_created_tuple(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        issue_number=issue_number,
+        metadata=metadata,
+        expected_branch=branch,
+        expected_nonce=record.nonce,
+        protection_mode="voluntary",
+        recovery_capable=True,
+    )
+    event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+    if (
+        event is None
+        or event[1].casefold() != handoff.trusted_actor_login.casefold()
+        or event[2] != handoff.trusted_actor_id
+    ):
+        raise AgentLoopError("Managed-CI direct resume requires an actor-owned active managed-label event.")
+    comments = _api_list(runner, config, f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100")
+    if comments is None:
+        raise AgentLoopError("Managed-CI direct resume could not inspect override audit provenance.")
+    if any(
+        UNPROTECTED_OVERRIDE_TRAILER in (comment.get("body") if isinstance(comment.get("body"), str) else "")
+        for comment in comments
+    ) and _find_resume_audit(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        actor_login=handoff.trusted_actor_login,
+        actor_id=handoff.trusted_actor_id,
+        base_ref=handoff.base_ref,
+    ) is None:
+        raise AgentLoopError("Managed-CI direct resume found malformed or uncorrelated override audit provenance.")
+    return replace(handoff, active_label_event_id=event[0])
+
+
+def render_managed_ci_resume_command(
+    config: AgentLoopConfig, *, pr_number: int
+) -> str:
+    """Render the deterministic, shell-quoted public recovery contract."""
+    command = ["agent-loop", "pr", str(pr_number), "--repo", config.repo]
+    if config.base:
+        command.extend(("--base", config.base))
+    command.append("--managed-ci")
+    if config.managed_ci_trusted_actor:
+        command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
+    if config.allow_unprotected_managed_ci:
+        command.append("--allow-unprotected-managed-ci")
+    return " ".join(shlex.quote(part) for part in command)
 
 
 def _restore_ordinary_ci_after_v2_fallback(
@@ -727,6 +1089,7 @@ def _release_for_ordinary_recovery(
     expected_head_sha: str,
     active_event: tuple[int, str, int] | None,
     reason: str,
+    recovery_capable: bool = True,
 ) -> OrdinaryRecoveryCapability | None:
     """Release the exact active label and return a narrowly scoped capability.
 
@@ -741,6 +1104,13 @@ def _release_for_ordinary_recovery(
     later exact-head ordinary-CI gate remains mandatory before readiness or
     merge.
     """
+    if not recovery_capable:
+        log(
+            config,
+            f"PR #{pr_number}: ordinary recovery was not selected because the base workflow "
+            "does not prove an unlabeled pull_request trigger",
+        )
+        return None
     prior_run_ids: set[int] = set()
     try:
         prior_run_ids = _workflow_run_ids(runner, config=config, head_sha=expected_head_sha)
@@ -780,6 +1150,7 @@ def _release_for_ordinary_recovery(
         released_label_event_id=active_event[0] if active_event is not None else None,
         released_at=int(time.time()),
         prior_run_ids=frozenset(prior_run_ids),
+        recovery_capable=True,
     )
 
 
@@ -824,24 +1195,17 @@ def refresh_ordinary_recovery_capability(
 
 
 def _parse_override_audit(body: str) -> dict[str, str] | None:
-    """Parse only the structured provenance fields of an old audit comment."""
-    first = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
-    if not first:
+    """Parse the documented richer audit form through the shared validator."""
+    try:
+        record = parse_managed_ci_override_record(
+            body,
+            surface=PR_COMMENT_SURFACE,
+            schema="audit",
+            required=False,
+        )
+    except AgentLoopError:
         return None
-    fields: dict[str, str] = {}
-    for token in first.split()[1:]:
-        key, separator, value = token.partition("=")
-        if not separator or key not in {
-            "nonce", "repo", "base", "head", "protection", "active_label_event_id",
-            "resume_from", "provenance_head", "generation",
-        } or not value:
-            return None
-        if key in fields:
-            return None
-        fields[key] = value
-    if not {"repo", "base", "head", "protection"}.issubset(fields):
-        return None
-    return fields
+    return None if record is None else record.field_map()
 
 
 def _find_resume_audit(
@@ -928,6 +1292,9 @@ def _activate_v2_managed_ci(
     workflow_text = base_workflow.stdout or ""
     if any(marker not in workflow_text for marker in V2_FEATURE_MARKERS):
         raise AgentLoopError("The base branch does not contain the complete managed-CI v2 workflow.")
+    ordinary_recovery_capable = (
+        RECOVERY_MARKER in workflow_text and "pull_request" in workflow_text and "unlabeled" in workflow_text
+    )
 
     pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}")
     head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
@@ -1035,6 +1402,7 @@ def _activate_v2_managed_ci(
                 runner, config=config, pr_number=pr_number, base_ref=base_ref,
                 expected_head_sha=live_sha, active_event=active_event,
                 reason="the active managed-label event is temporarily unreadable",
+                recovery_capable=ordinary_recovery_capable,
             )
             return ManagedCiContract(
                 activation_path="ordinary_fallback",
@@ -1045,6 +1413,7 @@ def _activate_v2_managed_ci(
                 runner, config=config, pr_number=pr_number, base_ref=base_ref,
                 expected_head_sha=live_sha, active_event=active_event,
                 reason="the active managed-label event is not actor-owned",
+                recovery_capable=ordinary_recovery_capable,
             )
             return ManagedCiContract(
                 activation_path="ordinary_fallback",
@@ -1071,6 +1440,7 @@ def _activate_v2_managed_ci(
                     runner, config=config, pr_number=pr_number, base_ref=base_ref,
                     expected_head_sha=live_sha, active_event=active_event,
                     reason="strict protection is unavailable and the explicit waiver is absent",
+                    recovery_capable=ordinary_recovery_capable,
                 )
                 return ManagedCiContract(
                     activation_path="ordinary_fallback", ordinary_recovery=recovery,
@@ -1084,33 +1454,35 @@ def _activate_v2_managed_ci(
                     runner, config=config, pr_number=pr_number, base_ref=base_ref,
                     expected_head_sha=live_sha, active_event=active_event,
                     reason="no unambiguous actor-owned issue-created override audit exists",
+                    recovery_capable=ordinary_recovery_capable,
                 )
                 return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
             resume_audit_id, prior_fields = prior_audit
             resume_provenance_head = prior_fields.get("head")
         elif protection.state != "strict":
             body = pr.get("body") if isinstance(pr.get("body"), str) else ""
-            marker_line = next((line.strip() for line in body.splitlines() if line.strip().startswith(UNPROTECTED_OVERRIDE_TRAILER)), "")
-            if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"} or not marker_line:
+            if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"}:
                 _restore_ordinary_ci_after_v2_fallback(
                     runner, config=config, pr_number=pr_number,
                     reason="strict protection or the explicit override is unavailable",
                 )
                 return None
-            parts = marker_line.split("nonce=", 1)
-            if len(parts) != 2 or not parts[1].strip():
+            try:
+                override = parse_managed_ci_override_record(
+                    body,
+                    surface=PR_BODY_SURFACE,
+                    schema="body",
+                    required=True,
+                    expected_nonce=config.managed_ci_expected_override_nonce,
+                )
+            except AgentLoopError as error:
                 _restore_ordinary_ci_after_v2_fallback(
                     runner, config=config, pr_number=pr_number,
-                    reason="the override trailer has no nonce",
+                    reason=str(error),
                 )
                 return None
-            override_nonce = parts[1].strip().split()[0]
-            if override_nonce != config.managed_ci_expected_override_nonce:
-                _restore_ordinary_ci_after_v2_fallback(
-                    runner, config=config, pr_number=pr_number,
-                    reason="the override trailer is not correlated to this invocation",
-                )
-                return None
+            assert override is not None
+            override_nonce = override.nonce
             audit_body = TrustedBody.canonical(
                 (
                     f"{UNPROTECTED_OVERRIDE_TRAILER} nonce={override_nonce} repo={config.repo} "
@@ -1170,6 +1542,7 @@ def _activate_v2_managed_ci(
                 runner, config=config, pr_number=pr_number, base_ref=base_ref,
                 expected_head_sha=live_sha, active_event=live_event,
                 reason="the immutable resume tuple changed before activation",
+                recovery_capable=ordinary_recovery_capable,
             )
             return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
         if protection.state != "strict":
@@ -1197,6 +1570,7 @@ def _activate_v2_managed_ci(
                     runner, config=config, pr_number=pr_number, base_ref=base_ref,
                     expected_head_sha=live_sha, active_event=active_event,
                     reason="the fresh resume audit could not be recorded",
+                    recovery_capable=ordinary_recovery_capable,
                 )
                 return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
             try:
@@ -1208,6 +1582,7 @@ def _activate_v2_managed_ci(
                     runner, config=config, pr_number=pr_number, base_ref=base_ref,
                     expected_head_sha=live_sha, active_event=active_event,
                     reason="the fresh resume audit response was malformed",
+                    recovery_capable=ordinary_recovery_capable,
                 )
                 return ManagedCiContract(activation_path="ordinary_fallback", ordinary_recovery=recovery)
         else:
@@ -1234,6 +1609,7 @@ def _activate_v2_managed_ci(
         active_label_event_id=active_event[0] if active_event is not None else None,
         issue_created_pr=True,
         invocation_applied_label=label_applied,
+        recovery_capable=ordinary_recovery_capable,
     )
 
 
@@ -2204,7 +2580,15 @@ def wait_for_final_qualification(
             final = _find_context(latest, FINAL_CONTEXT)
         status = final.status.lower() if final is not None else "pending"
         log(config, f"Managed CI context '{FINAL_CONTEXT}' status: {status}")
-        if status == "success":
+        complete_board = (
+            latest.check_query_status == "ok"
+            and latest.branch_protection_status in {"configured", "not_found", "forbidden"}
+            and latest.state == "passing"
+            and bool(latest.passing)
+            and not latest.pending
+            and not latest.missing_required
+        )
+        if status == "success" and complete_board:
             if contract is not None and contract.protocol_version == 2:
                 _patch_intent(runner, config=config, contract=contract, state="completed")
             return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
@@ -2226,7 +2610,7 @@ def wait_for_final_qualification(
                 )
                 if final is not None and final.status.lower() in _TERMINAL_CI_STATUSES:
                     status = final.status.lower()
-                    if status == "success":
+                    if status == "success" and complete_board:
                         _patch_intent(runner, config=config, contract=contract, state="completed")
                         return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
                 else:
@@ -2516,6 +2900,11 @@ def wait_for_ordinary_recovery(
     """Wait for a post-unlabel current-head run and a complete ordinary board."""
     expected_head = capability.expected_head_sha
     attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
+    startup_attempt_limit = max(
+        1,
+        (config.ci_startup_timeout_seconds + config.ci_poll_interval_seconds - 1)
+        // config.ci_poll_interval_seconds,
+    )
     latest: PullRequestChecks | None = None
     for attempt in range(attempts):
         live_head = get_pr_head_sha(runner, config, capability.pr_number)
@@ -2545,21 +2934,24 @@ def wait_for_ordinary_recovery(
                 stall=CiInfrastructureStall(checks=latest.infrastructure_stalls),
             )
         completed = [run for run in recovery_runs if run.get("status") == "completed"]
-        if completed and any(run.get("conclusion") not in {"success", "neutral", "skipped"} for run in completed):
+        if completed and any(run.get("conclusion") != "success" for run in completed):
             return ManagedCiOutcome(status="failed", checks=latest, head_sha=live_head)
         reliable = latest.check_query_status == "ok" and latest.branch_protection_status in {
             "configured", "not_found", "forbidden",
         }
         if (
             recovery_runs
-            and any(run.get("status") == "completed" and run.get("conclusion") in {"success", "neutral", "skipped"} for run in completed)
+            and any(run.get("status") == "completed" and run.get("conclusion") == "success" for run in completed)
             and latest.state == "passing"
+            and bool(latest.passing)
             and reliable
             and not latest.pending
             and not latest.missing_required
         ):
             log(config, f"PR #{capability.pr_number}: ordinary unlabeled recovery passed at {expected_head}")
             return ManagedCiOutcome(status="passed", checks=latest, head_sha=live_head)
+        if not recovery_runs and attempt + 1 >= startup_attempt_limit:
+            return ManagedCiOutcome(status="not_started", checks=latest, head_sha=live_head)
         if attempt < attempts - 1:
             runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
     return ManagedCiOutcome(status="timeout", checks=latest, head_sha=expected_head)

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -139,7 +139,6 @@ class ManagedCiContract:
     terminal_attempts: tuple[tuple[int, int | None], ...] = ()
     activation_path: Literal["managed", "ordinary_fallback"] = "managed"
     ordinary_recovery: "OrdinaryRecoveryCapability | None" = None
-    recovery_capable: bool = False
 
 
 @dataclass(frozen=True)
@@ -150,7 +149,6 @@ class ManagedCiCreationIntent:
     trusted_actor: str
     protection_mode: str = "strict"
     audit_nonce: str | None = None
-    recovery_capable: bool = False
 
 
 @dataclass(frozen=True)
@@ -183,7 +181,6 @@ class AuthenticatedIssueCreatedHandoff:
     trusted_actor_id: int
     protection_mode: str
     override_nonce: str | None
-    recovery_capable: bool
     active_label_event_id: int | None = None
 
 
@@ -277,7 +274,6 @@ class OrdinaryRecoveryCapability:
     released_label_event_id: int | None
     released_at: int
     prior_run_ids: frozenset[int] = frozenset()
-    recovery_capable: bool = True
 
 
 @dataclass(frozen=True)
@@ -814,7 +810,6 @@ def preflight_managed_ci_creation(
         trusted_actor=readiness.actor or config.managed_ci_trusted_actor,
         protection_mode=readiness.protection.state,
         audit_nonce=secrets.token_urlsafe(18) if config.allow_unprotected_managed_ci else None,
-        recovery_capable=readiness.recovery_capable,
     )
 
 
@@ -828,7 +823,6 @@ def _issue_created_tuple(
     expected_branch: str,
     expected_nonce: str | None,
     protection_mode: str,
-    recovery_capable: bool,
 ) -> AuthenticatedIssueCreatedHandoff:
     """Read and verify the immutable tuple before any handoff publication.
 
@@ -915,7 +909,6 @@ def _issue_created_tuple(
         trusted_actor_id=actor_id,
         protection_mode=protection_mode,
         override_nonce=record.nonce if record is not None else None,
-        recovery_capable=recovery_capable,
     )
 
 
@@ -938,7 +931,6 @@ def authenticate_issue_created_handoff(
         expected_branch=intent.branch,
         expected_nonce=intent.audit_nonce,
         protection_mode=intent.protection_mode,
-        recovery_capable=intent.recovery_capable,
     )
 
 
@@ -961,7 +953,6 @@ def revalidate_issue_created_handoff(
         expected_branch=handoff.branch,
         expected_nonce=handoff.override_nonce,
         protection_mode=handoff.protection_mode,
-        recovery_capable=handoff.recovery_capable,
     )
     if handoff.active_label_event_id is not None:
         event = _active_managed_label_event(runner, config=config, pr_number=handoff.pr_number)
@@ -1013,7 +1004,6 @@ def recover_issue_created_handoff(
         expected_branch=branch,
         expected_nonce=record.nonce,
         protection_mode="voluntary",
-        recovery_capable=True,
     )
     event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
     if (
@@ -1041,17 +1031,26 @@ def recover_issue_created_handoff(
 
 
 def render_managed_ci_resume_command(
-    config: AgentLoopConfig, *, pr_number: int
+    config: AgentLoopConfig, *, pr_number: int, managed_ci: bool
 ) -> str:
     """Render the deterministic, shell-quoted public recovery contract."""
     command = ["agent-loop", "pr", str(pr_number), "--repo", config.repo]
     if config.base:
         command.extend(("--base", config.base))
-    command.append("--managed-ci")
-    if config.managed_ci_trusted_actor:
-        command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
-    if config.allow_unprotected_managed_ci:
-        command.append("--allow-unprotected-managed-ci")
+    if config.auto_merge:
+        command.append("--auto-merge")
+    if config.watch_pending_ci:
+        command.append("--watch-pending-ci")
+    elif config.auto_merge:
+        # CLI invocations enable this by default with --auto-merge, so an
+        # explicit opt-out is required to faithfully reproduce this stop.
+        command.append("--no-watch-pending-ci")
+    if managed_ci:
+        command.append("--managed-ci")
+        if config.managed_ci_trusted_actor:
+            command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
+        if config.allow_unprotected_managed_ci:
+            command.append("--allow-unprotected-managed-ci")
     return " ".join(shlex.quote(part) for part in command)
 
 
@@ -1089,7 +1088,7 @@ def _release_for_ordinary_recovery(
     expected_head_sha: str,
     active_event: tuple[int, str, int] | None,
     reason: str,
-    recovery_capable: bool = True,
+    recovery_capable: bool,
 ) -> OrdinaryRecoveryCapability | None:
     """Release the exact active label and return a narrowly scoped capability.
 
@@ -1150,7 +1149,6 @@ def _release_for_ordinary_recovery(
         released_label_event_id=active_event[0] if active_event is not None else None,
         released_at=int(time.time()),
         prior_run_ids=frozenset(prior_run_ids),
-        recovery_capable=True,
     )
 
 
@@ -1609,7 +1607,6 @@ def _activate_v2_managed_ci(
         active_label_event_id=active_event[0] if active_event is not None else None,
         issue_created_pr=True,
         invocation_applied_label=label_applied,
-        recovery_capable=ordinary_recovery_capable,
     )
 
 

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -211,7 +211,6 @@ def validate_managed_pr_body(
         expected_tokens=expected_tokens,
     )
     carrier.validate_for_surface(PR_BODY_SURFACE)
-    occurrences = scan_reserved_markers(str(carrier))
     source_branch_value, source_sha_value = _managed_pr_source_fields(carrier)
     if source_branch_value != source_branch or source_sha_value != source_sha:
         raise AgentLoopError("Managed PR source record does not match this creation handoff.")

--- a/src/coding_review_agent_loop/managed_pr.py
+++ b/src/coding_review_agent_loop/managed_pr.py
@@ -16,6 +16,7 @@ from .managed_ci import (
     MANAGED_LABEL,
     UNPROTECTED_OVERRIDE_TRAILER,
     ensure_managed_label,
+    parse_managed_ci_override_record,
     preflight_managed_ci_creation,
 )
 from .runner import CommandResult, Runner
@@ -137,17 +138,13 @@ def _managed_pr_source_fields(carrier: TrustedBody) -> tuple[str, str]:
 
 
 def _managed_pr_override_nonce(carrier: TrustedBody) -> str | None:
-    override_occurrences = [
-        item
-        for item in scan_reserved_markers(str(carrier))
-        if item.definition.token == UNPROTECTED_OVERRIDE_TRAILER
-    ]
-    if not override_occurrences:
-        return None
-    parts = override_occurrences[0].text.strip().split()
-    if len(parts) != 2 or not parts[1].startswith("nonce=") or not parts[1][len("nonce=") :]:
-        raise AgentLoopError("Managed PR override record has an invalid schema.")
-    return parts[1][len("nonce=") :]
+    record = parse_managed_ci_override_record(
+        str(carrier),
+        surface=PR_BODY_SURFACE,
+        schema="body",
+        additional_allowed_tokens=frozenset({SOURCE_MARKER}),
+    )
+    return None if record is None else record.nonce
 
 
 def recover_managed_pr_origin(
@@ -225,14 +222,14 @@ def validate_managed_pr_body(
     if expected_base_branch is not None and fetched_base_branch != expected_base_branch:
         raise AgentLoopError("Managed PR base branch does not match its creation handoff.")
     if override_nonce is not None:
-        override_occurrence = next(
-            item for item in occurrences if item.definition.token == UNPROTECTED_OVERRIDE_TRAILER
+        parse_managed_ci_override_record(
+            str(carrier),
+            surface=PR_BODY_SURFACE,
+            schema="body",
+            required=True,
+            expected_nonce=override_nonce,
+            additional_allowed_tokens=frozenset({SOURCE_MARKER}),
         )
-        if override_occurrence.text.strip().split() != [
-            UNPROTECTED_OVERRIDE_TRAILER,
-            f"nonce={override_nonce}",
-        ]:
-            raise AgentLoopError("Managed PR override record does not match this creation handoff.")
 
 
 def _close_partial_handoff(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6768,7 +6768,7 @@ def run_pr_loop(
             )
             if ordinary_recovery is None:
                 command = render_managed_ci_resume_command(
-                    config, pr_number=pr_number, managed_ci=False,
+                    config, pr_number=pr_number, managed_ci=True,
                 )
                 print(
                     f"PR #{pr_number} remains draft and unmerged because managed recovery provenance or "

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6362,7 +6362,9 @@ def _finalize_ordinary_recovery_merge(
     )
     if outcome.status != "passed":
         if outcome.status == "not_started":
-            command = render_managed_ci_resume_command(config, pr_number=pr_number)
+            command = render_managed_ci_resume_command(
+                config, pr_number=pr_number, managed_ci=False,
+            )
             log(
                 config,
                 f"PR #{pr_number}: ordinary recovery CI did not start within the bounded startup window; "
@@ -6765,7 +6767,9 @@ def run_pr_loop(
                 "the previous managed activation is not being resumed",
             )
             if ordinary_recovery is None:
-                command = render_managed_ci_resume_command(config, pr_number=pr_number)
+                command = render_managed_ci_resume_command(
+                    config, pr_number=pr_number, managed_ci=False,
+                )
                 print(
                     f"PR #{pr_number} remains draft and unmerged because managed recovery provenance or "
                     f"an unlabeled CI route is unavailable. Resume with `{command}`."
@@ -7992,7 +7996,9 @@ def run_pr_loop(
                             print(f"PR #{pr_number} is merge-ready after CI watch completed.")
                         return 0
                     if watch_outcome.status == "not_started":
-                        command = render_managed_ci_resume_command(config, pr_number=pr_number)
+                        command = render_managed_ci_resume_command(
+                            config, pr_number=pr_number, managed_ci=False,
+                        )
                         log(
                             config,
                             f"Round {round_number}: PR #{pr_number} has no materialized CI board within "
@@ -8016,7 +8022,9 @@ def run_pr_loop(
                                 f"PR #{pr_number} has no ordinary CI checks while `{MANAGED_LABEL}` "
                                 "is present or unreadable; remove the label and wait for real CI before merging."
                             )
-                        command = render_managed_ci_resume_command(config, pr_number=pr_number)
+                        command = render_managed_ci_resume_command(
+                            config, pr_number=pr_number, managed_ci=False,
+                        )
                         print(
                             f"PR #{pr_number} has an empty CI board. No merge was attempted; "
                             f"resume with `{command}`."
@@ -8413,13 +8421,15 @@ def run_pr_loop(
                                     f"PR #{pr_number} ordinary recovery provenance is unavailable; "
                                     "no merge attempted."
                                 )
-                            _finalize_ordinary_recovery_merge(
+                            merged = _finalize_ordinary_recovery_merge(
                                 runner,
                                 config=config,
                                 pr_number=pr_number,
                                 capability=ordinary_recovery,
                             )
-                            wait_outcome = None
+                            if merged:
+                                print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
+                            return 0
                         else:
                             wait_outcome = wait_for_ci(
                                 runner, config, pr_number, metadata=pr_metadata

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -62,6 +62,7 @@ from .github import (
     PullRequestChecks,
     PullRequestMergeability,
     PullRequestReviewContext,
+    get_pr_head_sha,
     get_issue_context,
     get_pr_mergeability,
     parse_linked_issue_numbers,
@@ -124,11 +125,13 @@ from .evidence_reconciliation import (
 )
 from .memory import AgentMemoryContext, prepare_agent_memory
 from .managed_ci import (
+    AuthenticatedIssueCreatedHandoff,
     FINAL_CONTEXT,
     MANAGED_LABEL,
     ManagedCiOutcome,
     OrdinaryRecoveryCapability,
     activate_managed_ci,
+    authenticate_issue_created_handoff,
     dispatch_final_qualification,
     intermediate_managed_checks,
     managed_label_present,
@@ -139,6 +142,9 @@ from .managed_ci import (
     refresh_ordinary_recovery_capability,
     release_adopted_managed_ci,
     revalidate_adopted_managed_ci,
+    revalidate_issue_created_handoff,
+    recover_issue_created_handoff,
+    render_managed_ci_resume_command,
     validate_ordinary_recovery_capability,
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
@@ -498,6 +504,39 @@ _ABSOLUTE_RESET_TIME_RE = re.compile(
     r"\((?P<timezone>[A-Za-z0-9_./+-]+)\)",
     re.I,
 )
+
+
+@dataclass(frozen=True)
+class ExactHeadCiProof:
+    """Non-empty current-head CI evidence required by automated merge paths."""
+
+    head_sha: str
+    source: str
+
+
+def _merge_with_exact_head_proof(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    proof: ExactHeadCiProof,
+) -> None:
+    """Make the live-head read the final remote operation before merging."""
+    # Fetch a fresh, minimal head as the final normal remote read. If GitHub
+    # serves an inconsistent GraphQL projection while it is converging, fetch
+    # the full live PR tuple and require that authoritative view to agree with
+    # the proof too; neither cached review metadata nor an old check board is
+    # accepted.
+    live_head = get_pr_head_sha(runner, config, pr_number)
+    if live_head != proof.head_sha:
+        live_head = get_pr_review_context(
+            runner, config=config, pr_number=pr_number
+        ).metadata.head_sha
+    if live_head != proof.head_sha:
+        raise AgentLoopError(
+            f"PR #{pr_number} head changed after {proof.source} CI proof; no merge attempted."
+        )
+    merge_pr(runner, config, pr_number, expected_head_sha=proof.head_sha)
 
 
 @dataclass(frozen=True)
@@ -4294,7 +4333,25 @@ def _implement_approved_issue(
     log(config, f"{coder_name} reported PR #{pr_number}; validating it is open")
     validate_open_pr(runner, config=implementation_config, pr_number=pr_number)
     initial_pr_context = get_pr_review_context(runner, config=implementation_config, pr_number=pr_number)
-    reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+    managed_ci_handoff: AuthenticatedIssueCreatedHandoff | None = None
+    if managed_ci_creation_intent is not None:
+        managed_ci_handoff = authenticate_issue_created_handoff(
+            runner,
+            config=implementation_config,
+            intent=managed_ci_creation_intent,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            metadata=initial_pr_context.metadata,
+        )
+        if managed_ci_handoff.override_nonce is not None:
+            # Install the expected nonce before any PR/issue publication.  It
+            # remains runtime-only and is revalidated at run_pr_loop entry.
+            implementation_config = dataclasses_replace(
+                implementation_config,
+                managed_ci_expected_override_nonce=managed_ci_handoff.override_nonce,
+            )
+    else:
+        reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
     validate_pr_references_issue(
         runner,
         config=implementation_config,
@@ -4387,11 +4444,6 @@ def _implement_approved_issue(
         pr_number=pr_number,
         body=_embed_pr_contract_marker(initial_coder_body, pr_contract),
     )
-    if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
-        implementation_config = dataclasses_replace(
-            implementation_config,
-            managed_ci_expected_override_nonce=managed_ci_creation_intent.audit_nonce,
-        )
     return run_pr_loop(
         runner,
         pr_number=pr_number,
@@ -4401,6 +4453,7 @@ def _implement_approved_issue(
         workdirs_ready=True,
         usage_context=usage_context,
         pre_review_test_pending=True,
+        managed_ci_handoff=managed_ci_handoff,
     )
 
 
@@ -6005,7 +6058,23 @@ def run_issue_loop(
         log(config, f"{agent_display_name(config.coder)} reported PR #{pr_number}; validating it is open")
         validate_open_pr(runner, config=config, pr_number=pr_number)
         initial_pr_context = get_pr_review_context(runner, config=config, pr_number=pr_number)
-        reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+        managed_ci_handoff: AuthenticatedIssueCreatedHandoff | None = None
+        if managed_ci_creation_intent is not None:
+            managed_ci_handoff = authenticate_issue_created_handoff(
+                runner,
+                config=config,
+                intent=managed_ci_creation_intent,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                metadata=initial_pr_context.metadata,
+            )
+            if managed_ci_handoff.override_nonce is not None:
+                config = dataclasses_replace(
+                    config,
+                    managed_ci_expected_override_nonce=managed_ci_handoff.override_nonce,
+                )
+        else:
+            reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
         initial_pr_metadata = initial_pr_context.metadata
         validate_pr_references_issue(
             runner,
@@ -6085,11 +6154,6 @@ def run_issue_loop(
             pr_number=pr_number,
             body=_embed_pr_contract_marker(initial_coder_body, pr_contract),
         )
-        if managed_ci_creation_intent is not None and managed_ci_creation_intent.audit_nonce:
-            config = dataclasses_replace(
-                config,
-                managed_ci_expected_override_nonce=managed_ci_creation_intent.audit_nonce,
-            )
         return run_pr_loop(
             runner,
             pr_number=pr_number,
@@ -6099,6 +6163,7 @@ def run_issue_loop(
             workdirs_ready=True,
             usage_context=usage_context,
             pre_review_test_pending=True,
+            managed_ci_handoff=managed_ci_handoff,
         )
     finally:
         if owned_usage_context:
@@ -6281,7 +6346,7 @@ def _finalize_ordinary_recovery_merge(
     config: AgentLoopConfig,
     pr_number: int,
     capability: OrdinaryRecoveryCapability,
-) -> None:
+) -> bool:
     """Qualify, ready, and merge only the draft released by this invocation."""
     refreshed = refresh_ordinary_recovery_capability(
         runner, config=config, capability=capability,
@@ -6296,6 +6361,18 @@ def _finalize_ordinary_recovery_merge(
         metadata=get_pr_review_context(runner, config=config, pr_number=pr_number).metadata,
     )
     if outcome.status != "passed":
+        if outcome.status == "not_started":
+            command = render_managed_ci_resume_command(config, pr_number=pr_number)
+            log(
+                config,
+                f"PR #{pr_number}: ordinary recovery CI did not start within the bounded startup window; "
+                "leaving the PR draft and unmerged",
+            )
+            print(
+                f"PR #{pr_number} remains draft and unmerged because ordinary recovery CI did not "
+                f"materialize for the current head. Resume with `{command}`."
+            )
+            return False
         raise AgentLoopError(
             f"PR #{pr_number} ordinary recovery did not qualify the exact head "
             f"({outcome.status}); the draft was left unmerged."
@@ -6318,12 +6395,21 @@ def _finalize_ordinary_recovery_merge(
             "the PR remains ready and was not merged."
         )
     try:
-        merge_pr(runner, config, pr_number, expected_head_sha=capability.expected_head_sha)
+        _merge_with_exact_head_proof(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            proof=ExactHeadCiProof(
+                head_sha=capability.expected_head_sha,
+                source="ordinary recovery",
+            ),
+        )
     except Exception:
         # Do not convert a successfully readied PR back into a draft. A safe
         # rerun can now inspect the ready exact head and retry the merge gate.
         log(config, f"PR #{pr_number}: merge failed after ordinary recovery readiness; PR remains ready")
         raise
+    return True
 
 
 def _stop_on_terminal_without_status(
@@ -6377,6 +6463,7 @@ def run_pr_loop(
     usage_context: RunUsageContext | None = None,
     pre_review_test_pending: bool = False,
     managed_pr_origin: tuple[str, str, str, str | None] | None = None,
+    managed_ci_handoff: AuthenticatedIssueCreatedHandoff | None = None,
 ) -> int:
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
@@ -6393,16 +6480,37 @@ def run_pr_loop(
             pr_number=pr_number,
             cwd=bootstrap_cwd,
         )
+        if managed_ci_handoff is not None:
+            managed_ci_handoff = revalidate_issue_created_handoff(
+                runner,
+                config=config,
+                handoff=managed_ci_handoff,
+                metadata=initial_pr_context.metadata,
+            )
         if managed_pr_origin is None:
             recovered_origin = recover_managed_pr_origin(
                 initial_pr_context.metadata.body or "",
                 fetched_head_branch=initial_pr_context.metadata.head_branch,
             )
-            if recovered_origin is None:
-                reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
-            else:
+            if recovered_origin is not None:
                 managed_pr_origin = recovered_origin
                 managed_pr_recovered = True
+            elif managed_ci_handoff is None:
+                managed_ci_handoff = recover_issue_created_handoff(
+                    runner,
+                    config=config,
+                    pr_number=pr_number,
+                    metadata=initial_pr_context.metadata,
+                )
+                if managed_ci_handoff is None:
+                    reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
+                else:
+                    managed_ci_handoff = revalidate_issue_created_handoff(
+                        runner,
+                        config=config,
+                        handoff=managed_ci_handoff,
+                        metadata=initial_pr_context.metadata,
+                    )
         if managed_pr_origin is not None:
             source_branch, source_sha, managed_branch, override_nonce = managed_pr_origin
             validate_managed_pr_body(
@@ -6656,6 +6764,13 @@ def run_pr_loop(
                 f"PR #{pr_number}: ordinary recovery selected; "
                 "the previous managed activation is not being resumed",
             )
+            if ordinary_recovery is None:
+                command = render_managed_ci_resume_command(config, pr_number=pr_number)
+                print(
+                    f"PR #{pr_number} remains draft and unmerged because managed recovery provenance or "
+                    f"an unlabeled CI route is unavailable. Resume with `{command}`."
+                )
+                return 0
         else:
             managed_ci = activation
 
@@ -7808,13 +7923,14 @@ def run_pr_loop(
                             f"PR #{pr_number} was released to ordinary CI, but recovery provenance "
                             "could not be correlated; no merge attempted."
                         )
-                    _finalize_ordinary_recovery_merge(
+                    merged = _finalize_ordinary_recovery_merge(
                         runner,
                         config=config,
                         pr_number=pr_number,
                         capability=ordinary_recovery,
                     )
-                    print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
+                    if merged:
+                        print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
                     return 0
                 if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
                     if watch_deadline is None:
@@ -7851,19 +7967,7 @@ def run_pr_loop(
                     if watch_outcome.status == "dry_run":
                         print(f"PR #{pr_number} approval found; dry-run preview did not perform live CI watching.")
                         return 0
-                    if watch_outcome.status in {"passed", "no_checks"}:
-                        # A later invocation may omit the explicit override
-                        # while the opening label still suppresses pull_request
-                        # CI.  `no_checks` must never become a merge permit in
-                        # that state.
-                        label_live = managed_label_present(
-                            runner, config=config, pr_number=pr_number
-                        )
-                        if watch_outcome.status == "no_checks" and label_live is not False:
-                            raise AgentLoopError(
-                                f"PR #{pr_number} has no ordinary CI checks while `{MANAGED_LABEL}` "
-                                "is present or unreadable; remove the label and wait for real CI before merging."
-                            )
+                    if watch_outcome.status == "passed":
                         _publish_approved_followups(
                             runner,
                             config=config,
@@ -7874,13 +7978,49 @@ def run_pr_loop(
                         )
                         run_optional_tests(runner, config)
                         if config.auto_merge:
-                            merge_pr(
-                                runner, config, pr_number,
-                                expected_head_sha=pr_metadata.head_sha,
+                            _merge_with_exact_head_proof(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                proof=ExactHeadCiProof(
+                                    head_sha=pr_metadata.head_sha or "",
+                                    source="full-board",
+                                ),
                             )
                             print(f"PR #{pr_number} merged after CI watch completed.")
                         else:
                             print(f"PR #{pr_number} is merge-ready after CI watch completed.")
+                        return 0
+                    if watch_outcome.status == "not_started":
+                        command = render_managed_ci_resume_command(config, pr_number=pr_number)
+                        log(
+                            config,
+                            f"Round {round_number}: PR #{pr_number} has no materialized CI board within "
+                            "the startup window; no merge attempted",
+                        )
+                        print(
+                            f"PR #{pr_number} has no materialized current-head CI board. No merge was "
+                            f"attempted; resume with `{command}`."
+                        )
+                        return 0
+                    # Compatibility fail-safe for an older watcher/provider
+                    # that still emits the retired outcome. It is never a
+                    # merge permit; unreadable managed suppression remains a
+                    # hard error rather than silently becoming ordinary CI.
+                    if watch_outcome.status == "no_checks":
+                        label_live = managed_label_present(
+                            runner, config=config, pr_number=pr_number
+                        )
+                        if label_live is not False:
+                            raise AgentLoopError(
+                                f"PR #{pr_number} has no ordinary CI checks while `{MANAGED_LABEL}` "
+                                "is present or unreadable; remove the label and wait for real CI before merging."
+                            )
+                        command = render_managed_ci_resume_command(config, pr_number=pr_number)
+                        print(
+                            f"PR #{pr_number} has an empty CI board. No merge was attempted; "
+                            f"resume with `{command}`."
+                        )
                         return 0
                     if watch_outcome.status == "infrastructure_stall":
                         _publish_approved_followups(
@@ -8100,13 +8240,14 @@ def run_pr_loop(
                                         f"PR #{pr_number} managed resume could not be correlated to ordinary "
                                         "recovery CI; no merge attempted."
                                     )
-                                _finalize_ordinary_recovery_merge(
+                                merged = _finalize_ordinary_recovery_merge(
                                     runner,
                                     config=config,
                                     pr_number=pr_number,
                                     capability=ordinary_recovery,
                                 )
-                                print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
+                                if merged:
+                                    print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
                                 return 0
                             managed_outcome = wait_for_final_qualification(
                                 runner,
@@ -8125,11 +8266,14 @@ def run_pr_loop(
                                         expected_head_sha=pr_metadata.head_sha,
                                         contract=managed_ci,
                                     )
-                                    merge_pr(
+                                    _merge_with_exact_head_proof(
                                         runner,
-                                        config,
-                                        pr_number,
-                                        expected_head_sha=pr_metadata.head_sha,
+                                        config=config,
+                                        pr_number=pr_number,
+                                        proof=ExactHeadCiProof(
+                                            head_sha=pr_metadata.head_sha or "",
+                                            source="managed exact-head",
+                                        ),
                                     )
                                     print(
                                         f"PR #{pr_number} approved by "
@@ -8329,9 +8473,14 @@ def run_pr_loop(
                                 "during the CI wait; no merge attempted",
                             )
                         else:
-                            merge_pr(
-                                runner, config, pr_number,
-                                expected_head_sha=pr_metadata.head_sha,
+                            _merge_with_exact_head_proof(
+                                runner,
+                                config=config,
+                                pr_number=pr_number,
+                                proof=ExactHeadCiProof(
+                                    head_sha=pr_metadata.head_sha or "",
+                                    source="configured CI",
+                                ),
                             )
                     if not must_fix_items:
                         print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -1212,13 +1212,15 @@ def _managed_ci_creation_guidance(
         override = (
             " This invocation uses the explicit unprotected override. Include this exact "
             f"PR-body trailer on its own line: `{UNPROTECTED_OVERRIDE_TRAILER} nonce={intent.audit_nonce}`. "
+            "Include it exactly once and do not include any other reserved protocol record in the PR body. "
             "This is a voluntary gate: GitHub cannot force a later human merge, other automation, "
             "a compromised credential, or an agent-loop defect to use the qualified SHA."
         )
     return (
         "\nThis invocation has authenticated managed-CI v2 enabled. Create the PR atomically: "
-        f"use the reserved branch `{intent.branch}`, create or verify the `agent-loop-managed` "
-        "label, then run `gh pr create --draft --label agent-loop-managed`. Do not mark it ready; "
+        f"use exactly the reserved branch `{intent.branch}`, create or verify the `agent-loop-managed` "
+        "label, then run `gh pr create --draft --label agent-loop-managed` so it is born open, draft, "
+        "and labeled. Do not create a second PR or apply a readiness transition. Do not mark it ready; "
         f"agent-loop will dispatch exact-head qualification after review.{override}\n"
     )
 

--- a/tests/test_ci_watch.py
+++ b/tests/test_ci_watch.py
@@ -63,6 +63,27 @@ def test_watch_success_and_head_change_are_terminal(tmp_path):
         assert watch_pr_checks(runner, make_config(tmp_path, watch_pending_ci=True), 7, metadata=_metadata()).status == "head_changed"
 
 
+def test_watch_empty_rollup_stops_as_not_started_never_as_success(tmp_path):
+    runner = _Runner()
+    with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \
+         patch("coding_review_agent_loop.github.get_pr_mergeability", return_value=_mergeability()), \
+         patch("coding_review_agent_loop.github.get_pr_checks", return_value=_checks("no_checks")):
+        outcome = watch_pr_checks(
+            runner,
+            make_config(
+                tmp_path,
+                watch_pending_ci=True,
+                ci_timeout_seconds=60,
+                ci_poll_interval_seconds=30,
+                ci_startup_timeout_seconds=30,
+            ),
+            7,
+            metadata=_metadata(),
+        )
+    assert outcome.status == "not_started"
+    assert runner.commands == []
+
+
 def test_watch_timeout_retries_transient_snapshots_and_dry_run_does_not_poll(tmp_path):
     runner = _Runner()
     with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -38,6 +38,7 @@ from coding_review_agent_loop.managed_ci import (
     intermediate_managed_checks,
     preflight_managed_ci_creation,
     parse_managed_ci_override_record,
+    render_managed_ci_resume_command,
     recover_issue_created_handoff,
     revalidate_issue_created_handoff,
     prepare_v2_merge,
@@ -512,6 +513,35 @@ def test_override_record_parser_enforces_surface_schema_agreement(body, surface,
             parse_managed_ci_override_record(body, surface=surface, schema=schema, required=True)
 
 
+def test_ordinary_resume_command_preserves_merge_and_watch_mode_without_managed_ci(tmp_path):
+    command = render_managed_ci_resume_command(
+        make_config(
+            tmp_path,
+            auto_merge=True,
+            watch_pending_ci=True,
+            managed_ci=True,
+            managed_ci_trusted_actor="agent-loop",
+            allow_unprotected_managed_ci=True,
+        ),
+        pr_number=42,
+        managed_ci=False,
+    )
+
+    assert command == (
+        "agent-loop pr 42 --repo OWNER/REPO --base main --auto-merge --watch-pending-ci"
+    )
+
+
+def test_resume_command_preserves_explicit_ordinary_watch_opt_out(tmp_path):
+    command = render_managed_ci_resume_command(
+        make_config(tmp_path, auto_merge=True, watch_pending_ci=False),
+        pr_number=42,
+        managed_ci=False,
+    )
+
+    assert command.endswith("--auto-merge --no-watch-pending-ci")
+
+
 def test_issue_created_handoff_authenticates_override_before_any_remote_write(tmp_path):
     body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"
     runner = V2ManagedRunner(
@@ -532,7 +562,6 @@ def test_issue_created_handoff_authenticates_override_before_any_remote_write(tm
         trusted_actor="agent-loop",
         protection_mode="voluntary",
         audit_nonce="fresh",
-        recovery_capable=True,
     )
 
     handoff = authenticate_issue_created_handoff(
@@ -2058,10 +2087,11 @@ def test_explicit_activation_release_is_terminal_and_unqualified(tmp_path):
             config=config,
             pr_number=7,
             base_ref="main",
-            expected_head_sha="abc123",
-            active_event=None,
-            reason="timeline unavailable",
-        )
+                expected_head_sha="abc123",
+                active_event=None,
+                reason="timeline unavailable",
+                recovery_capable=True,
+            )
     assert any(
         command[:5] == [
             "gh", "api", "--method", "DELETE",

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -32,10 +32,14 @@ from coding_review_agent_loop.managed_ci import (
     _v2_correlated_status,
     _api_list,
     activate_managed_ci,
+    authenticate_issue_created_handoff,
     dispatch_final_qualification,
     evaluate_managed_ci_readiness,
     intermediate_managed_checks,
     preflight_managed_ci_creation,
+    parse_managed_ci_override_record,
+    recover_issue_created_handoff,
+    revalidate_issue_created_handoff,
     prepare_v2_merge,
     publish_manual_v2_qualification,
     publish_round_readiness,
@@ -47,6 +51,7 @@ from coding_review_agent_loop.managed_ci import (
     wait_for_ordinary_recovery,
     wait_for_final_qualification,
 )
+from coding_review_agent_loop.protocol_markers import PR_BODY_SURFACE, PR_COMMENT_SURFACE
 from coding_review_agent_loop.orchestrator import (
     _finalize_ordinary_recovery_merge,
     _stop_on_terminal_without_status,
@@ -481,6 +486,109 @@ def test_override_activation_requires_the_preflight_nonce_and_releases_label_on_
         command[:5] == ["gh", "api", "--method", "DELETE", f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}"]
         for command, _ in mismatch.commands
     )
+
+
+@pytest.mark.parametrize(
+    ("body", "surface", "schema", "accepted"),
+    [
+        (f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh", PR_BODY_SURFACE, "body", True),
+        (
+            f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh repo=OWNER/REPO base=main head=abc protection=voluntary",
+            PR_COMMENT_SURFACE,
+            "audit",
+            True,
+        ),
+        (f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh repo=OWNER/REPO", PR_BODY_SURFACE, "body", False),
+        (f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=other", PR_BODY_SURFACE, "body", False),
+        (f"{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh repo=OWNER/REPO", PR_COMMENT_SURFACE, "audit", False),
+    ],
+)
+def test_override_record_parser_enforces_surface_schema_agreement(body, surface, schema, accepted):
+    if accepted:
+        parsed = parse_managed_ci_override_record(body, surface=surface, schema=schema, required=True)
+        assert parsed is not None and parsed.nonce == "fresh"
+    else:
+        with pytest.raises(AgentLoopError):
+            parse_managed_ci_override_record(body, surface=surface, schema=schema, required=True)
+
+
+def test_issue_created_handoff_authenticates_override_before_any_remote_write(tmp_path):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"
+    runner = V2ManagedRunner(
+        rest_pr={"state": "open", "body": body},
+    )
+    metadata = PullRequestMetadata(
+        number=7,
+        repo="OWNER/REPO",
+        title="Managed CI",
+        head_branch="agent-loop/managed-643",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/7",
+        body=body,
+    )
+    intent = managed_ci.ManagedCiCreationIntent(
+        branch="agent-loop/managed-643",
+        trusted_actor="agent-loop",
+        protection_mode="voluntary",
+        audit_nonce="fresh",
+        recovery_capable=True,
+    )
+
+    handoff = authenticate_issue_created_handoff(
+        runner,
+        config=make_config(
+            tmp_path,
+            managed_ci=True,
+            base="main",
+            managed_ci_trusted_actor="agent-loop",
+            allow_unprotected_managed_ci=True,
+        ),
+        intent=intent,
+        issue_number=643,
+        pr_number=7,
+        metadata=metadata,
+    )
+
+    assert handoff.head_sha == "abc123"
+    assert handoff.override_nonce == "fresh"
+    assert not any("--method" in command for command, _ in runner.commands)
+
+
+def test_direct_resume_reconstructs_issue_override_as_provenance_before_writes(tmp_path):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=old"
+    runner = V2ManagedRunner(
+        rest_pr={"state": "open", "body": body},
+        issue_events=[label_event()],
+    )
+    metadata = PullRequestMetadata(
+        number=7,
+        repo="OWNER/REPO",
+        title="Managed CI",
+        head_branch="agent-loop/managed-643",
+        base_branch="main",
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/7",
+        body=body,
+    )
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_pr_mode=True,
+        base="main",
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+
+    handoff = recover_issue_created_handoff(
+        runner, config=config, pr_number=7, metadata=metadata,
+    )
+    assert handoff is not None
+    assert handoff.active_label_event_id == 101
+    assert revalidate_issue_created_handoff(
+        runner, config=config, handoff=handoff, metadata=metadata,
+    ).override_nonce == "old"
+    assert not any("--method" in command for command, _ in runner.commands)
 
 
 def _resume_audit(*, head="old-head", repo="OWNER/REPO", base="main"):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -532,6 +532,26 @@ def test_ordinary_resume_command_preserves_merge_and_watch_mode_without_managed_
     )
 
 
+def test_managed_resume_command_retains_managed_ci_configuration(tmp_path):
+    command = render_managed_ci_resume_command(
+        make_config(
+            tmp_path,
+            auto_merge=True,
+            watch_pending_ci=True,
+            managed_ci=True,
+            managed_ci_trusted_actor="agent-loop",
+            allow_unprotected_managed_ci=True,
+        ),
+        pr_number=42,
+        managed_ci=True,
+    )
+
+    assert command == (
+        "agent-loop pr 42 --repo OWNER/REPO --base main --auto-merge --watch-pending-ci "
+        "--managed-ci --managed-ci-trusted-actor agent-loop --allow-unprotected-managed-ci"
+    )
+
+
 def test_resume_command_preserves_explicit_ordinary_watch_opt_out(tmp_path):
     command = render_managed_ci_resume_command(
         make_config(tmp_path, auto_merge=True, watch_pending_ci=False),
@@ -653,6 +673,7 @@ def test_pr_mode_resumes_only_from_immutable_issue_draft_facts_and_mints_fresh_a
     assert contract.audit_nonce and contract.audit_nonce != "old-nonce"
     assert contract.audit_comment_id == 17
     assert contract.intent_generation
+    assert contract.ordinary_recovery_capable is True
     assert any("active_label_event_id=101" in " ".join(cmd) for cmd, _ in runner.commands)
 
 
@@ -2087,11 +2108,11 @@ def test_explicit_activation_release_is_terminal_and_unqualified(tmp_path):
             config=config,
             pr_number=7,
             base_ref="main",
-                expected_head_sha="abc123",
-                active_event=None,
-                reason="timeline unavailable",
-                recovery_capable=True,
-            )
+            expected_head_sha="abc123",
+            active_event=None,
+            reason="timeline unavailable",
+            recovery_capable=True,
+        )
     assert any(
         command[:5] == [
             "gh", "api", "--method", "DELETE",
@@ -2133,6 +2154,36 @@ def test_v2_dispatch_discovers_existing_run_before_dispatching(tmp_path):
 
     assert contract.attached_run_id == 100
     assert not any("/dispatches" in " ".join(cmd) for cmd, _cwd in runner.commands)
+
+
+def test_v2_dispatch_ledger_failure_uses_authenticated_ordinary_recovery_capability(tmp_path, monkeypatch):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+    )
+    runner = V2ManagedRunner(issue_events=[label_event()])
+    contract = v2_contract(ordinary_recovery_capable=True)
+
+    def fail_intent(*args, **kwargs):
+        raise AgentLoopError("intent ledger unavailable")
+
+    monkeypatch.setattr(managed_ci, "_ensure_v2_intent", fail_intent)
+
+    _dispatch_v2_qualification(
+        runner, config=config, pr_number=7, expected_head_sha="abc123", contract=contract
+    )
+
+    assert contract.activation_path == "ordinary_fallback"
+    assert contract.ordinary_recovery is not None
+    assert any(
+        command[:5] == [
+            "gh", "api", "--method", "DELETE",
+            f"repos/OWNER/REPO/issues/7/labels/{MANAGED_LABEL}",
+        ]
+        for command, _cwd in runner.commands
+    )
 
 
 def test_v2_dispatch_discovers_run_with_display_title_and_qualified_path(tmp_path):

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -9,6 +9,14 @@ from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
 from coding_review_agent_loop.decomposition import approved_plan_hash, format_one_shot_impl_handoff_comment
 from coding_review_agent_loop.errors import QuotaResetExceededError
 from coding_review_agent_loop.github import IssueComment, IssueContext, get_issue_context
+from coding_review_agent_loop.managed_ci import (
+    AuthenticatedIssueCreatedHandoff,
+    ManagedCiContract,
+    ManagedCiCreationIntent,
+    ManagedCiOutcome,
+    UNPROTECTED_OVERRIDE_TRAILER,
+    parse_managed_ci_override_record,
+)
 from coding_review_agent_loop.issue_pr_handoff import (
     format_issue_pr_handoff_comment,
     resolve_canonical_pr_for_issue,
@@ -27,6 +35,7 @@ from coding_review_agent_loop.prompts import (
     COMPACT_PLANNING_VOLATILE_TAIL_MARKER,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
 )
+from coding_review_agent_loop.protocol_markers import PR_BODY_SURFACE
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
     ParsedPlanReview,
@@ -71,6 +80,21 @@ def _provenance_pages(message: str):
     return [page, page]
 
 
+def _managed_issue_handoff(*, nonce: str) -> AuthenticatedIssueCreatedHandoff:
+    return AuthenticatedIssueCreatedHandoff(
+        pr_number=77,
+        issue_number=56,
+        repository="OWNER/REPO",
+        base_ref="main",
+        head_sha="abc123",
+        branch="agent-loop/managed-56",
+        trusted_actor_login="agent-loop",
+        trusted_actor_id=1,
+        protection_mode="voluntary",
+        override_nonce=nonce,
+    )
+
+
 def test_advisory_issue_provenance_skips_commit_scan_in_dry_run(tmp_path):
     runner = FakeRunner()
     config = make_config(tmp_path, dry_run=True)
@@ -83,6 +107,176 @@ def test_advisory_issue_provenance_skips_commit_scan_in_dry_run(tmp_path):
     )
 
     assert runner.pr_commit_calls == 0
+
+
+def test_direct_issue_managed_draft_nonce_reaches_review_and_exact_head_merge(tmp_path, monkeypatch):
+    nonce = "direct-managed-nonce"
+    body = f"Fixes #56\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce={nonce}"
+    intent = ManagedCiCreationIntent(
+        branch="agent-loop/managed-56",
+        trusted_actor="agent-loop",
+        protection_mode="voluntary",
+        audit_nonce=nonce,
+    )
+    handoff = _managed_issue_handoff(nonce=nonce)
+    runner = FakeRunner(
+        claude_outputs=[
+            "Implemented the issue.\n<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved managed draft.")],
+        pr_payload={
+            "body": body,
+            "headRefName": "agent-loop/managed-56",
+            "headRefOid": "abc123",
+        },
+    )
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+        pre_review_tests=True,
+        test_command=("verify-managed-head",),
+    )
+    authentication_calls = []
+    readiness_heads = []
+    dispatches = []
+    prepared_heads = []
+    merged_heads = []
+
+    def authenticate(*_args, **kwargs):
+        record = parse_managed_ci_override_record(
+            kwargs["metadata"].body or "",
+            surface=PR_BODY_SURFACE,
+            schema="body",
+            required=True,
+            expected_nonce=nonce,
+        )
+        assert record is not None
+        assert kwargs["intent"] == intent
+        # Handoff authentication must precede every durable PR/issue write.
+        assert runner.comments == []
+        authentication_calls.append(kwargs)
+        return handoff
+
+    def revalidate(*_args, **kwargs):
+        assert kwargs["config"].managed_ci_expected_override_nonce == nonce
+        assert kwargs["handoff"] == handoff
+        return handoff
+
+    monkeypatch.setattr(orchestrator_module, "preflight_managed_ci_creation", lambda *_args, **_kwargs: intent)
+    monkeypatch.setattr(orchestrator_module, "authenticate_issue_created_handoff", authenticate)
+    monkeypatch.setattr(orchestrator_module, "revalidate_issue_created_handoff", revalidate)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "activate_managed_ci",
+        lambda *_args, **_kwargs: ManagedCiContract(protocol_version=2, issue_created_pr=True),
+    )
+    monkeypatch.setattr(orchestrator_module, "revalidate_adopted_managed_ci", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(orchestrator_module, "managed_label_present", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "publish_round_readiness",
+        lambda *_args, **kwargs: readiness_heads.append(kwargs["head_sha"]),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "dispatch_final_qualification",
+        lambda *_args, **kwargs: dispatches.append(kwargs),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "wait_for_final_qualification",
+        lambda *_args, **_kwargs: ManagedCiOutcome(status="passed", head_sha="abc123"),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "prepare_v2_merge",
+        lambda *_args, **kwargs: prepared_heads.append(kwargs["expected_head_sha"]),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "merge_pr",
+        lambda *_args, **kwargs: merged_heads.append(kwargs["expected_head_sha"]),
+    )
+
+    assert run_issue_loop(runner, issue_number=56, config=config) == 0
+
+    assert len(authentication_calls) == 1
+    assert ["verify-managed-head"] in [command for command, _cwd in runner.commands]
+    assert readiness_heads == ["abc123"]
+    assert [dispatch["expected_head_sha"] for dispatch in dispatches] == ["abc123"]
+    assert prepared_heads == ["abc123"]
+    assert merged_heads == ["abc123"]
+
+
+def test_plan_first_issue_managed_draft_nonce_is_authenticated_before_pr_review(tmp_path, monkeypatch):
+    nonce = "plan-managed-nonce"
+    body = f"Fixes #56\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce={nonce}"
+    intent = ManagedCiCreationIntent(
+        branch="agent-loop/managed-56",
+        trusted_actor="agent-loop",
+        protection_mode="voluntary",
+        audit_nonce=nonce,
+    )
+    handoff = _managed_issue_handoff(nonce=nonce)
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(summary="Implement the managed draft."),
+            "Implemented approved plan.\n<!-- AGENT_PR: 77 -->\n"
+            "<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+        ],
+        codex_outputs=[structured_plan_review(state="approved", summary="Plan approved.")],
+        pr_payload={
+            "body": body,
+            "headRefName": "agent-loop/managed-56",
+            "headRefOid": "abc123",
+        },
+    )
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    reviewed = []
+
+    def authenticate(*_args, **kwargs):
+        record = parse_managed_ci_override_record(
+            kwargs["metadata"].body or "",
+            surface=PR_BODY_SURFACE,
+            schema="body",
+            required=True,
+            expected_nonce=nonce,
+        )
+        assert record is not None
+        assert kwargs["intent"] == intent
+        return handoff
+
+    def review_entry(*_args, **kwargs):
+        assert kwargs["config"].managed_ci_expected_override_nonce == nonce
+        assert kwargs["managed_ci_handoff"] == handoff
+        reviewed.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(orchestrator_module, "preflight_managed_ci_creation", lambda *_args, **_kwargs: intent)
+    monkeypatch.setattr(orchestrator_module, "authenticate_issue_created_handoff", authenticate)
+    monkeypatch.setattr(orchestrator_module, "run_pr_loop", review_entry)
+
+    assert (
+        run_issue_loop(
+            runner,
+            issue_number=56,
+            config=config,
+            plan_first=True,
+            implement_after_approval=True,
+        )
+        == 0
+    )
+
+    assert len(reviewed) == 1
 
 
 class FakeRunner(_FakeRunner):


### PR DESCRIPTION
## Summary

- authenticate issue-created managed draft handoffs before any orchestration writes
- unify override parsing, bound empty-board CI startup, and require a final live-head merge proof
- document deterministic managed recovery and add focused regressions

## Tests

- `python3 -m pytest tests/test_managed_ci.py tests/test_ci_watch.py tests/test_managed_pr.py tests/test_prompts.py tests/test_orchestrator_pr.py tests/test_orchestrator_issue.py tests/test_docs_guidance.py tests/test_protocol_markers.py tests/test_agent_loop.py`

Fixes #698