### PR TITLE
Add Gemini and Antigravity executable-replacement recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,36 @@ no-capacity errors retry the active model before advancing through this chain.
 defaults and control fallback eligibility. Invalid settings, unsupported models,
 timeouts, and schema-invalid responses remain deterministic and do not fall back.
 
+### Executable replacement recovery
+
+Gemini and Antigravity use a conservative startup gate for launcher replacement:
+the command must have a direct before/after identity change, an integer exit,
+healthy PTY capture, and no response-file artifact, public-response marker,
+structured payload, or ordinary narration/tool progress. Gemini accepts only an
+empty transcript or recognized startup/Node-loader/updater diagnostics; Antigravity
+also accepts its version/model startup chrome. A valid response-file artifact has
+priority over replacement handling, including after a nonzero exit or timeout.
+
+For Gemini, the checkout HEAD and exact porcelain status are captured immediately
+before spawn and the after probe is taken only for a surviving candidate. For
+Antigravity, reviewer and coder probes run while the settings lock and the
+exclusive `GEMINI.md` lock are held: before injection, then after invocation and
+prefix cleanup. This prevents peer prompt injection or cleanup from creating a
+false worktree delta. Isolated formatting-repair runs bypass both probes and all
+replacement metadata. These read-only snapshots are evidence gates only; they do
+not prevent an agent from making external changes, so replacement replay is
+conservative rather than a general side-effect safety guarantee.
+
+Each eligible Gemini or Antigravity invocation gets one bounded executable
+stability wait and at most one fresh full-timeout replay, logged with the
+`executable-replacement-attempt2` suffix. Gemini's budget is
+`agent_max_retries + 2`; Antigravity's is
+`len(models) + agent_max_retries + 1`. The dedicated replay does not consume an
+ordinary retry; Antigravity also keeps the same model and leaves its retry,
+model-index, and attempt counters unchanged until a later ordinary failure.
+Failed stability checks retain the normal Gemini retry or Antigravity model
+fallback chain.
+
 Each `agy --print` invocation is run with `--print-timeout` set from
 `--antigravity-print-timeout-seconds` (default 600, i.e. ten minutes), which
 overrides `agy`'s own five-minute print-mode default so long coder/reviewer

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -167,6 +167,44 @@ Currently supported local agent CLIs:
 - Claude Code via `claude`
 - OpenAI Codex CLI via `codex`
 - Gemini CLI via `gemini` (best-effort support for users whose organization or API-key setup still has access)
+- Antigravity CLI via `agy` (first-class backend; also the Gemini CLI migration path)
+
+### Startup replacement evidence and replay
+
+The Gemini and Antigravity backends classify executable replacement only from
+attempt-local evidence. The launcher identity must change between the pre-spawn
+and post-exit observations, the exit must be an integer, capture must not report
+an interruption, timeout, or PTY read failure, and no non-empty public response
+file, public-response marker, structured payload, or ordinary narration may be
+present. Gemini's residual output is limited to empty output and recognized
+startup, Node-loader, or updater diagnostics. Antigravity additionally permits
+recognized `agy` version/model startup chrome; unknown lines are treated as
+progress and suppress replay. A valid response-file artifact is accepted before
+this gate, even for a failed or timed-out command; a malformed artifact follows
+normal validation/repair.
+
+Gemini takes a read-only `HEAD` and exact `git status --porcelain` snapshot
+immediately before `run_with_log`, then lazily takes the after snapshot only for
+an otherwise eligible candidate. Antigravity takes the before snapshot after
+acquiring both the settings lock and the exclusive `GEMINI.md` lock, before
+tool-owned injection. It invokes the backend, removes the injected prefix in a
+`finally` path, parses the candidate, and takes the after snapshot before
+releasing either lock. Reviewer and coder paths therefore cannot observe a peer's
+injected prompt as worktree activity. Isolated `role=repair` / `run_repair`
+invocations skip Git probes, replacement metadata, and replay eligibility. The
+snapshots are read-only evidence gates and cannot guarantee that a backend had no
+other external side effects.
+
+When the gate succeeds, Gemini and Antigravity wait for one bounded executable
+stability window and may make one fresh full-timeout replay using the
+`executable-replacement-attempt2` log suffix. Gemini allows
+`agent_max_retries + 2` total slots; Antigravity allows
+`len(antigravity_models) + agent_max_retries + 1`. The dedicated replay is outside
+ordinary retry accounting. Antigravity replays the same singleton model without
+advancing `retries_remaining`, `model_index`, or `attempts`; only a later ordinary
+failure may retry or fall back. A failed stability wait keeps ordinary retry and
+fallback eligibility, while changed or unavailable snapshots retain diagnostic
+refusal metadata without triggering stability waiting.
 
 ## Prerequisites
 

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -24,7 +24,6 @@ emits no token usage (usage falls back to the estimated path).
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-import json
 from pathlib import Path
 import re
 import tempfile
@@ -44,12 +43,7 @@ from ..errors import AgentLoopError
 from ..logging import agent_log_path, log
 from ..protocol import PUBLIC_RESPONSE_MARKER
 from ..runner import CommandResult, Runner, strip_ansi
-from ..workdir_guard import (
-    WorkdirReplayEvidence,
-    WorkdirSnapshot,
-    capture_workdir_snapshot,
-    gate_workdir_replay,
-)
+from ..workdir_guard import WorkdirReplayEvidence, WorkdirSnapshot, capture_workdir_snapshot
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -190,6 +184,8 @@ _ANTIGRAVITY_LOADER_LINE_RE = re.compile(
     r"(?:updat(?:e|er)|launcher|replacement).*(?:failed|error|unavailable|in\s+progress)"
     r")"
 )
+
+
 def classify_antigravity_executable_replacement_interruption(
     result: CommandResult,
     *,

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -39,10 +39,11 @@ from .base import (
     read_public_response_file,
     with_public_response_file_instruction,
 )
+from .replacement import classify_provider_executable_replacement_interruption
 from ..errors import AgentLoopError
 from ..logging import agent_log_path, log
 from ..protocol import PUBLIC_RESPONSE_MARKER
-from ..runner import CommandResult, Runner, executable_identity_changed, strip_ansi
+from ..runner import CommandResult, Runner, strip_ansi
 from ..workdir_guard import (
     WorkdirReplayEvidence,
     WorkdirSnapshot,
@@ -173,7 +174,7 @@ _ANTIGRAVITY_STARTUP_LINE_RE = re.compile(
     r"model\s*[:=].+|"
     r"version\s*[:=]\s*[\w.-]+|"
     r"loaded\s+(?:configuration|credentials|settings)\b.*|"
-    r"(?:checking|applying)\s+(?:for\s+)?(?:agy|antigravity|gemini\s+)?updates?\b.*"
+    r"(?:checking|applying)\s+(?:for\s+)?(?:(?:agy|antigravity|gemini)\s+)?updates?\b.*"
     r")$"
 )
 _ANTIGRAVITY_LOADER_LINE_RE = re.compile(
@@ -189,38 +190,6 @@ _ANTIGRAVITY_LOADER_LINE_RE = re.compile(
     r"(?:updat(?:e|er)|launcher|replacement).*(?:failed|error|unavailable|in\s+progress)"
     r")"
 )
-_ANTIGRAVITY_DIAGNOSTIC_MAX_LINES = 40
-_ANTIGRAVITY_DIAGNOSTIC_MAX_CHARS = 8192
-
-
-def _agy_structured_payload(raw: str) -> bool:
-    for candidate in (raw, *raw.splitlines()):
-        if not candidate.strip():
-            continue
-        try:
-            json.loads(candidate)
-        except (json.JSONDecodeError, ValueError):
-            continue
-        return True
-    return False
-
-
-def _agy_startup_or_loader_diagnostics(raw: str) -> bool:
-    normalized = strip_ansi(raw).strip()
-    if not normalized:
-        return True
-    if len(normalized) > _ANTIGRAVITY_DIAGNOSTIC_MAX_CHARS:
-        return False
-    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
-    if len(lines) > _ANTIGRAVITY_DIAGNOSTIC_MAX_LINES:
-        return False
-    return all(
-        _ANTIGRAVITY_STARTUP_LINE_RE.fullmatch(line) is not None
-        or _ANTIGRAVITY_LOADER_LINE_RE.search(line) is not None
-        for line in lines
-    )
-
-
 def classify_antigravity_executable_replacement_interruption(
     result: CommandResult,
     *,
@@ -229,33 +198,14 @@ def classify_antigravity_executable_replacement_interruption(
     before_snapshot: WorkdirSnapshot | None = None,
     after_snapshot: WorkdirSnapshot | None = None,
 ) -> WorkdirReplayEvidence | None:
-    """Classify a quiet `agy` launcher replacement with fail-closed gates."""
-    observation = result.observation
-    if (
-        type(result.returncode) is not int
-        or observation is None
-        or observation.interrupted
-        or result.capture_diagnostics
-        or response_file_text
-        or PUBLIC_RESPONSE_MARKER in result.stdout
-        or _agy_structured_payload(result.stdout)
-        or not _agy_startup_or_loader_diagnostics(result.stdout)
-    ):
-        return None
-    if not executable_identity_changed(
-        observation.before,
-        observation.after,
+    return classify_provider_executable_replacement_interruption(
+        result,
         command=command,
-        spawn_wall_time=observation.spawn_wall_time,
-        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
-    ):
-        return None
-    reason = "Antigravity executable changed during invocation"
-    if before_snapshot is None and after_snapshot is None:
-        return WorkdirReplayEvidence(reason)
-    return gate_workdir_replay(
-        "Antigravity executable replacement",
-        reason,
+        response_file_text=response_file_text,
+        startup_line_re=_ANTIGRAVITY_STARTUP_LINE_RE,
+        loader_line_re=_ANTIGRAVITY_LOADER_LINE_RE,
+        provider_label="Antigravity executable replacement",
+        reason="Antigravity executable changed during invocation",
         before_snapshot=before_snapshot,
         after_snapshot=after_snapshot,
     )

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -24,7 +24,9 @@ emits no token usage (usage falls back to the estimated path).
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+import json
 from pathlib import Path
+import re
 import tempfile
 from typing import TYPE_CHECKING
 
@@ -40,7 +42,13 @@ from .base import (
 from ..errors import AgentLoopError
 from ..logging import agent_log_path, log
 from ..protocol import PUBLIC_RESPONSE_MARKER
-from ..runner import Runner, strip_ansi
+from ..runner import CommandResult, Runner, executable_identity_changed, strip_ansi
+from ..workdir_guard import (
+    WorkdirReplayEvidence,
+    WorkdirSnapshot,
+    capture_workdir_snapshot,
+    gate_workdir_replay,
+)
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -152,6 +160,110 @@ background tasks, or invoke subagents. Use only the malformed response and proto
 examples in the prompt. Return the repaired response immediately.
 
 """
+
+# `agy --print` normally emits a small amount of startup chrome before it can
+# reach the Node launcher. Replacement replay is safe only when every residual
+# line is one of these known startup/loader diagnostics; narration and tool
+# output are treated as progress.
+_ANTIGRAVITY_STARTUP_LINE_RE = re.compile(
+    r"(?ix)^(?:"
+    r"(?:agy|antigravity)(?:\s+cli)?(?:\s+(?:v|version)\s*[\w.-]+)?|"
+    r"(?:starting|initiali[sz]ing|loading)\s+(?:agy|antigravity|gemini)(?:\s+cli)?|"
+    r"(?:using|selected|requested)\s+model\s*[:=].+|"
+    r"model\s*[:=].+|"
+    r"version\s*[:=]\s*[\w.-]+|"
+    r"loaded\s+(?:configuration|credentials|settings)\b.*|"
+    r"(?:checking|applying)\s+(?:for\s+)?(?:agy|antigravity|gemini\s+)?updates?\b.*"
+    r")$"
+)
+_ANTIGRAVITY_LOADER_LINE_RE = re.compile(
+    r"(?ix)(?:"
+    r"MODULE_NOT_FOUND|cannot\s+find\s+module|"
+    r"^node:(?:internal/)?modules/.*|^at\s+.+node:(?:internal/)?modules/.*|"
+    r"^throw\s+err;?$|^require\s+stack:.*|"
+    r"^code\s*[:=]\s*['\"]?(?:MODULE_NOT_FOUND|ENOENT)['\"]?\s*$|"
+    r"(?:ENOENT|ENOEXEC)|exec(?:ution)?\s+format\s+error|"
+    r"no\s+such\s+file\s+or\s+directory|"
+    r"(?:agy|antigravity|gemini|node|npm|launcher|executable|binary).*(?:not\s+found|missing|failed|error)|"
+    r"(?:failed|error).*(?:launch|launcher|startup|updat(?:e|er)|replacement)|"
+    r"(?:updat(?:e|er)|launcher|replacement).*(?:failed|error|unavailable|in\s+progress)"
+    r")"
+)
+_ANTIGRAVITY_DIAGNOSTIC_MAX_LINES = 40
+_ANTIGRAVITY_DIAGNOSTIC_MAX_CHARS = 8192
+
+
+def _agy_structured_payload(raw: str) -> bool:
+    for candidate in (raw, *raw.splitlines()):
+        if not candidate.strip():
+            continue
+        try:
+            json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        return True
+    return False
+
+
+def _agy_startup_or_loader_diagnostics(raw: str) -> bool:
+    normalized = strip_ansi(raw).strip()
+    if not normalized:
+        return True
+    if len(normalized) > _ANTIGRAVITY_DIAGNOSTIC_MAX_CHARS:
+        return False
+    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
+    if len(lines) > _ANTIGRAVITY_DIAGNOSTIC_MAX_LINES:
+        return False
+    return all(
+        _ANTIGRAVITY_STARTUP_LINE_RE.fullmatch(line) is not None
+        or _ANTIGRAVITY_LOADER_LINE_RE.search(line) is not None
+        for line in lines
+    )
+
+
+def classify_antigravity_executable_replacement_interruption(
+    result: CommandResult,
+    *,
+    command: str,
+    response_file_text: str | None,
+    before_snapshot: WorkdirSnapshot | None = None,
+    after_snapshot: WorkdirSnapshot | None = None,
+) -> WorkdirReplayEvidence | None:
+    """Classify a quiet `agy` launcher replacement with fail-closed gates."""
+    observation = result.observation
+    if (
+        type(result.returncode) is not int
+        or observation is None
+        or observation.interrupted
+        or result.capture_diagnostics
+        or response_file_text
+        or PUBLIC_RESPONSE_MARKER in result.stdout
+        or _agy_structured_payload(result.stdout)
+        or not _agy_startup_or_loader_diagnostics(result.stdout)
+    ):
+        return None
+    if not executable_identity_changed(
+        observation.before,
+        observation.after,
+        command=command,
+        spawn_wall_time=observation.spawn_wall_time,
+        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
+    ):
+        return None
+    reason = "Antigravity executable changed during invocation"
+    if before_snapshot is None and after_snapshot is None:
+        return WorkdirReplayEvidence(reason)
+    return gate_workdir_replay(
+        "Antigravity executable replacement",
+        reason,
+        before_snapshot=before_snapshot,
+        after_snapshot=after_snapshot,
+    )
+
+
+classify_executable_replacement_interruption = (
+    classify_antigravity_executable_replacement_interruption
+)
 
 
 def _antigravity_settings_path() -> Path:
@@ -320,80 +432,65 @@ class AntigravityBackend:
         settings_lock_path = settings_path.with_suffix(".json.lock")
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_lock = settings_lock_path.open("a+")
+        before_snapshot: WorkdirSnapshot | None = None
+        after_snapshot: WorkdirSnapshot | None = None
+        candidate: WorkdirReplayEvidence | None = None
+        response_file_text: str | None = None
+        result: CommandResult | None = None
+
+        def strip_injected_prefix() -> None:
+            if not gemini_md_path.exists():
+                return
+            current = gemini_md_path.read_text(encoding="utf-8")
+            if current.startswith(injected_gemini_prefix):
+                remainder = current[len(injected_gemini_prefix):]
+                if remainder:
+                    gemini_md_path.write_text(remainder, encoding="utf-8")
+                else:
+                    gemini_md_path.unlink()
+
+        settings_was_injected = role in {"reviewer", "repair"}
+        original_settings_text: str | None = None
+        settings_restore_required = False
         try:
             fcntl.flock(settings_lock, fcntl.LOCK_EX)
-            if role in {"reviewer", "repair"}:
+            existing_settings: dict[str, object] = {}
+            if settings_was_injected:
                 try:
                     original_settings_text = settings_path.read_text(encoding="utf-8")
                     try:
-                        existing_settings = json.loads(original_settings_text)
+                        parsed_settings = json.loads(original_settings_text)
                     except json.JSONDecodeError as exc:
                         raise AgentLoopError(f"settings.json malformed: {exc}") from exc
-                    if not isinstance(existing_settings, dict):
+                    if not isinstance(parsed_settings, dict):
                         raise AgentLoopError("settings.json root is not a JSON object")
+                    existing_settings = parsed_settings
                 except FileNotFoundError:
                     original_settings_text = None
-                    existing_settings = {}
-                try:
-                    injection = (
-                        _REPAIR_SETTINGS_INJECTION
-                        if role == "repair"
-                        else _REVIEWER_SETTINGS_INJECTION
+                injection = (
+                    _REPAIR_SETTINGS_INJECTION
+                    if role == "repair"
+                    else _REVIEWER_SETTINGS_INJECTION
+                )
+                injected = {**existing_settings, **injection}
+                # Mark this before writing: a partial write that raises still
+                # needs the original settings restored in the outer finally.
+                settings_restore_required = True
+                settings_path.write_text(json.dumps(injected, indent=2), encoding="utf-8")
+
+            # Hold both locks across the complete normal-run lifecycle. Repair
+            # uses an isolated temporary directory and intentionally performs no
+            # checkout probes or replacement classification.
+            gemini_lock_file = gemini_lock_path.open("a+")
+            try:
+                fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
+                if role != "repair":
+                    before_snapshot = capture_workdir_snapshot(
+                        runner,
+                        config.antigravity_dir,
+                        tolerate_exceptions=True,
                     )
-                    injected = {**existing_settings, **injection}
-                    settings_path.write_text(json.dumps(injected, indent=2), encoding="utf-8")
-                    # Inner: GEMINI.md lock
-                    gemini_lock_file = gemini_lock_path.open("a+")
-                    try:
-                        fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
-                        try:
-                            existing_gemini = gemini_md_path.read_text(encoding="utf-8")
-                        except FileNotFoundError:
-                            existing_gemini = None
-                        gemini_md_path.write_text(
-                            injected_gemini_prefix + (existing_gemini or ""),
-                            encoding="utf-8",
-                        )
-                        try:
-                            result = runner.run_with_log(
-                                args,
-                                cwd=config.antigravity_dir,
-                                log_path=log_path,
-                                label=f"Antigravity ({model})",
-                                progress_interval_seconds=config.progress_interval_seconds,
-                                check=False,
-                                env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
-                                use_pty=True,
-                                timeout_seconds=(
-                                    config.repair_timeout_seconds
-                                    if role == "repair"
-                                    else timeout_seconds
-                                ),
-                            )
-                        finally:
-                            if gemini_md_path.exists():
-                                current = gemini_md_path.read_text(encoding="utf-8")
-                                if current.startswith(injected_gemini_prefix):
-                                    remainder = current[len(injected_gemini_prefix):]
-                                    if remainder:
-                                        gemini_md_path.write_text(remainder, encoding="utf-8")
-                                    else:
-                                        gemini_md_path.unlink()
-                    finally:
-                        fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
-                        gemini_lock_file.close()
-                        if role == "repair":
-                            gemini_lock_path.unlink(missing_ok=True)
-                finally:
-                    if original_settings_text is None:
-                        settings_path.unlink(missing_ok=True)
-                    else:
-                        settings_path.write_text(original_settings_text, encoding="utf-8")
-            else:
-                # Coder path: hold settings lock without modifying settings.json
-                gemini_lock_file = gemini_lock_path.open("a+")
                 try:
-                    fcntl.flock(gemini_lock_file, fcntl.LOCK_EX)
                     try:
                         existing_gemini = gemini_md_path.read_text(encoding="utf-8")
                     except FileNotFoundError:
@@ -412,28 +509,56 @@ class AntigravityBackend:
                             check=False,
                             env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
                             use_pty=True,
-                            timeout_seconds=timeout_seconds,
+                            timeout_seconds=(
+                                config.repair_timeout_seconds
+                                if role == "repair"
+                                else timeout_seconds
+                            ),
                         )
                     finally:
-                        if gemini_md_path.exists():
-                            current = gemini_md_path.read_text(encoding="utf-8")
-                            if current.startswith(injected_gemini_prefix):
-                                remainder = current[len(injected_gemini_prefix):]
-                                if remainder:
-                                    gemini_md_path.write_text(remainder, encoding="utf-8")
-                                else:
-                                    gemini_md_path.unlink()
+                        strip_injected_prefix()
                 finally:
-                    fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
-                    gemini_lock_file.close()
+                    # Parse only after cleanup, while both locks are still held.
+                    if role != "repair" and result is not None:
+                        response_file_text = read_public_response_file(response_path)
+                        candidate = classify_antigravity_executable_replacement_interruption(
+                            result,
+                            command=config.antigravity_cmd,
+                            response_file_text=response_file_text,
+                        )
+                        if candidate is not None:
+                            after_snapshot = capture_workdir_snapshot(
+                                runner,
+                                config.antigravity_dir,
+                                tolerate_exceptions=True,
+                            )
+                            candidate = classify_antigravity_executable_replacement_interruption(
+                                result,
+                                command=config.antigravity_cmd,
+                                response_file_text=response_file_text,
+                                before_snapshot=before_snapshot,
+                                after_snapshot=after_snapshot,
+                            )
+            finally:
+                fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
+                gemini_lock_file.close()
+                if role == "repair":
+                    gemini_lock_path.unlink(missing_ok=True)
         finally:
+            if settings_restore_required:
+                if original_settings_text is None:
+                    settings_path.unlink(missing_ok=True)
+                else:
+                    settings_path.write_text(original_settings_text, encoding="utf-8")
             fcntl.flock(settings_lock, fcntl.LOCK_UN)
             settings_lock.close()
         log(config, f"Antigravity ({model}) finished; log: {log_path}")
 
         # Prefer the public response file the prompt asks the agent to write; else
         # keep only what follows the public-response marker in stdout; else stdout.
-        response_file_text = read_public_response_file(response_path)
+        if role == "repair":
+            response_file_text = read_public_response_file(response_path)
+        assert result is not None
         if response_file_text is not None:
             message_text, text_source = response_file_text, "response_file"
         else:
@@ -454,6 +579,13 @@ class AntigravityBackend:
             # caller's attempt state advances to a fallback model if needed.
             model_used=model,
             command_result=result,
+            self_update_reason=candidate.reason if candidate else None,
+            self_update_replay_refusal_kind=(
+                candidate.replay_refusal_kind if candidate else None
+            ),
+            self_update_replay_refusal_detail=(
+                candidate.replay_refusal_detail if candidate else None
+            ),
         )
 
     def run_repair(

--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -499,46 +499,46 @@ class AntigravityBackend:
                         injected_gemini_prefix + (existing_gemini or ""),
                         encoding="utf-8",
                     )
-                    try:
-                        result = runner.run_with_log(
-                            args,
-                            cwd=config.antigravity_dir,
-                            log_path=log_path,
-                            label=f"Antigravity ({model})",
-                            progress_interval_seconds=config.progress_interval_seconds,
-                            check=False,
-                            env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
-                            use_pty=True,
-                            timeout_seconds=(
-                                config.repair_timeout_seconds
-                                if role == "repair"
-                                else timeout_seconds
-                            ),
-                        )
-                    finally:
-                        strip_injected_prefix()
+                    result = runner.run_with_log(
+                        args,
+                        cwd=config.antigravity_dir,
+                        log_path=log_path,
+                        label=f"Antigravity ({model})",
+                        progress_interval_seconds=config.progress_interval_seconds,
+                        check=False,
+                        env={"AGENT_LOOP_WORKDIR": str(config.antigravity_dir.resolve())},
+                        use_pty=True,
+                        timeout_seconds=(
+                            config.repair_timeout_seconds
+                            if role == "repair"
+                            else timeout_seconds
+                        ),
+                    )
                 finally:
-                    # Parse only after cleanup, while both locks are still held.
-                    if role != "repair" and result is not None:
-                        response_file_text = read_public_response_file(response_path)
+                    # This also handles a partial GEMINI.md write that raises
+                    # before the subprocess is spawned.
+                    strip_injected_prefix()
+                # Parse only after cleanup, while both locks are still held.
+                if role != "repair" and result is not None:
+                    response_file_text = read_public_response_file(response_path)
+                    candidate = classify_antigravity_executable_replacement_interruption(
+                        result,
+                        command=config.antigravity_cmd,
+                        response_file_text=response_file_text,
+                    )
+                    if candidate is not None:
+                        after_snapshot = capture_workdir_snapshot(
+                            runner,
+                            config.antigravity_dir,
+                            tolerate_exceptions=True,
+                        )
                         candidate = classify_antigravity_executable_replacement_interruption(
                             result,
                             command=config.antigravity_cmd,
                             response_file_text=response_file_text,
+                            before_snapshot=before_snapshot,
+                            after_snapshot=after_snapshot,
                         )
-                        if candidate is not None:
-                            after_snapshot = capture_workdir_snapshot(
-                                runner,
-                                config.antigravity_dir,
-                                tolerate_exceptions=True,
-                            )
-                            candidate = classify_antigravity_executable_replacement_interruption(
-                                result,
-                                command=config.antigravity_cmd,
-                                response_file_text=response_file_text,
-                                before_snapshot=before_snapshot,
-                                after_snapshot=after_snapshot,
-                            )
             finally:
                 fcntl.flock(gemini_lock_file, fcntl.LOCK_UN)
                 gemini_lock_file.close()

--- a/src/coding_review_agent_loop/agents/claude.py
+++ b/src/coding_review_agent_loop/agents/claude.py
@@ -20,7 +20,12 @@ from .base import (
 from ..logging import agent_log_path, log
 from ..runner import CommandResult, Runner, executable_identity_changed
 from ..usage import UsageMetadata, coerce_int, first_present
-from ..workdir_guard import WorkdirSnapshot, capture_workdir_snapshot
+from ..workdir_guard import (
+    WorkdirReplayEvidence,
+    WorkdirSnapshot,
+    capture_workdir_snapshot,
+    gate_workdir_replay,
+)
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -108,68 +113,6 @@ def _has_updater_diagnostic(output: str) -> bool:
     return bool(_UPDATER_DIAGNOSTIC_RE.search("\n".join(lines)[-2048:]))
 
 
-@dataclass(frozen=True)
-class SelfUpdateInterruptionEvidence:
-    """Positive updater evidence and, independently, a replay refusal."""
-
-    reason: str
-    replay_refusal_kind: str | None = None
-    replay_refusal_detail: str | None = None
-
-def _workdir_probe_label(snapshot: WorkdirSnapshot) -> str:
-    def describe(probe) -> str:
-        if probe.kind == "available":
-            return repr(probe.value)
-        if probe.kind == "exception":
-            return f"{probe.exception_type}: {probe.detail}"
-        if probe.kind == "command-failed":
-            return f"returncode={probe.returncode!r}"
-        return "blank"
-
-    return f"HEAD={describe(snapshot.head)}, status={describe(snapshot.status)}"
-
-
-def _gate_self_update_replay(
-    reason: str,
-    *,
-    before_snapshot: WorkdirSnapshot | None,
-    after_snapshot: WorkdirSnapshot | None,
-) -> SelfUpdateInterruptionEvidence:
-    """Accept a candidate only when both read-only snapshots are identical."""
-    # Calls without snapshots retain the historical evidence-only helper
-    # contract. ClaudeBackend always supplies both snapshots after candidate
-    # detection, so replay policy itself remains fail-closed there.
-    if before_snapshot is None and after_snapshot is None:
-        return SelfUpdateInterruptionEvidence(reason)
-    if before_snapshot is None or not before_snapshot.available:
-        detail = (
-            "Claude self-update replay refused: before workdir snapshot "
-            f"unavailable ({_workdir_probe_label(before_snapshot) if before_snapshot else 'missing'})."
-        )
-        return SelfUpdateInterruptionEvidence(reason, "before-unavailable", detail)
-    if after_snapshot is None or not after_snapshot.available:
-        detail = (
-            "Claude self-update replay refused: after workdir snapshot "
-            f"unavailable ({_workdir_probe_label(after_snapshot) if after_snapshot else 'missing'})."
-        )
-        return SelfUpdateInterruptionEvidence(reason, "after-unavailable", detail)
-    if before_snapshot.head.value != after_snapshot.head.value:
-        detail = (
-            "Claude self-update replay refused: assigned checkout HEAD changed "
-            f"during invocation (before={before_snapshot.head.value!r}, "
-            f"after={after_snapshot.head.value!r})."
-        )
-        return SelfUpdateInterruptionEvidence(reason, "changed-head", detail)
-    if before_snapshot.status.value != after_snapshot.status.value:
-        detail = (
-            "Claude self-update replay refused: dirty workdir status changed "
-            f"during invocation (before={before_snapshot.status.value!r}, "
-            f"after={after_snapshot.status.value!r})."
-        )
-        return SelfUpdateInterruptionEvidence(reason, "changed-status", detail)
-    return SelfUpdateInterruptionEvidence(reason)
-
-
 def classify_self_update_interruption(
     result: CommandResult,
     *,
@@ -178,7 +121,7 @@ def classify_self_update_interruption(
     session_id: str | None,
     before_snapshot: WorkdirSnapshot | None = None,
     after_snapshot: WorkdirSnapshot | None = None,
-) -> SelfUpdateInterruptionEvidence | None:
+) -> WorkdirReplayEvidence | None:
     """Return bounded Claude-updater evidence, then apply the workdir gate."""
     observation = result.observation
     if not isinstance(result.returncode, int) or result.returncode == 0 or observation is None:
@@ -194,7 +137,8 @@ def classify_self_update_interruption(
             pass
     if _has_updater_diagnostic(result.stdout):
         reason = "Claude Code updater diagnostic"
-        return _gate_self_update_replay(
+        return gate_workdir_replay(
+            "Claude self-update",
             reason,
             before_snapshot=before_snapshot,
             after_snapshot=after_snapshot,
@@ -212,7 +156,8 @@ def classify_self_update_interruption(
         exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
     ):
         reason = "Claude executable changed during invocation"
-        return _gate_self_update_replay(
+        return gate_workdir_replay(
+            "Claude self-update",
             reason,
             before_snapshot=before_snapshot,
             after_snapshot=after_snapshot,

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -22,12 +22,7 @@ from ..logging import agent_log_path, log
 from ..protocol import CLARIFY_RE, PLAN_STATE_RE, PUBLIC_RESPONSE_MARKER, STATE_RE
 from ..runner import CommandResult, Runner
 from ..usage import UsageMetadata, coerce_int, first_present
-from ..workdir_guard import (
-    WorkdirReplayEvidence,
-    WorkdirSnapshot,
-    capture_workdir_snapshot,
-    gate_workdir_replay,
-)
+from ..workdir_guard import WorkdirReplayEvidence, WorkdirSnapshot, capture_workdir_snapshot
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -17,9 +17,10 @@ from .base import (
     read_public_response_file,
     with_public_response_file_instruction,
 )
+from .replacement import classify_provider_executable_replacement_interruption
 from ..logging import agent_log_path, log
 from ..protocol import CLARIFY_RE, PLAN_STATE_RE, PUBLIC_RESPONSE_MARKER, STATE_RE
-from ..runner import CommandResult, Runner, executable_identity_changed, strip_ansi
+from ..runner import CommandResult, Runner
 from ..usage import UsageMetadata, coerce_int, first_present
 from ..workdir_guard import (
     WorkdirReplayEvidence,
@@ -87,38 +88,6 @@ _GEMINI_LOADER_LINE_RE = re.compile(
     r"(?:updat(?:e|er)|launcher|replacement).*(?:failed|error|unavailable|in\s+progress)"
     r")"
 )
-_GEMINI_DIAGNOSTIC_MAX_LINES = 40
-_GEMINI_DIAGNOSTIC_MAX_CHARS = 8192
-
-
-def _json_structured_payload(raw: str) -> bool:
-    """Return true for a complete or line-delimited structured payload."""
-    candidates = [raw, *raw.splitlines()]
-    for candidate in candidates:
-        if not candidate.strip():
-            continue
-        try:
-            json.loads(candidate)
-        except (json.JSONDecodeError, ValueError):
-            continue
-        return True
-    return False
-
-
-def _gemini_startup_or_loader_diagnostics(raw: str) -> bool:
-    normalized = strip_ansi(raw).strip()
-    if not normalized:
-        return True
-    if len(normalized) > _GEMINI_DIAGNOSTIC_MAX_CHARS:
-        return False
-    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
-    if len(lines) > _GEMINI_DIAGNOSTIC_MAX_LINES:
-        return False
-    return all(
-        _GEMINI_STARTUP_LINE_RE.fullmatch(line) is not None
-        or _GEMINI_LOADER_LINE_RE.search(line) is not None
-        for line in lines
-    )
 
 
 def classify_gemini_executable_replacement_interruption(
@@ -129,33 +98,14 @@ def classify_gemini_executable_replacement_interruption(
     before_snapshot: WorkdirSnapshot | None = None,
     after_snapshot: WorkdirSnapshot | None = None,
 ) -> WorkdirReplayEvidence | None:
-    """Classify a quiet Gemini launcher replacement with fail-closed gates."""
-    observation = result.observation
-    if (
-        type(result.returncode) is not int
-        or observation is None
-        or observation.interrupted
-        or result.capture_diagnostics
-        or response_file_text
-        or PUBLIC_RESPONSE_MARKER in result.stdout
-        or _json_structured_payload(result.stdout)
-        or not _gemini_startup_or_loader_diagnostics(result.stdout)
-    ):
-        return None
-    if not executable_identity_changed(
-        observation.before,
-        observation.after,
+    return classify_provider_executable_replacement_interruption(
+        result,
         command=command,
-        spawn_wall_time=observation.spawn_wall_time,
-        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
-    ):
-        return None
-    reason = "Gemini executable changed during invocation"
-    if before_snapshot is None and after_snapshot is None:
-        return WorkdirReplayEvidence(reason)
-    return gate_workdir_replay(
-        "Gemini executable replacement",
-        reason,
+        response_file_text=response_file_text,
+        startup_line_re=_GEMINI_STARTUP_LINE_RE,
+        loader_line_re=_GEMINI_LOADER_LINE_RE,
+        provider_label="Gemini executable replacement",
+        reason="Gemini executable changed during invocation",
         before_snapshot=before_snapshot,
         after_snapshot=after_snapshot,
     )

--- a/src/coding_review_agent_loop/agents/gemini.py
+++ b/src/coding_review_agent_loop/agents/gemini.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,8 +19,14 @@ from .base import (
 )
 from ..logging import agent_log_path, log
 from ..protocol import CLARIFY_RE, PLAN_STATE_RE, PUBLIC_RESPONSE_MARKER, STATE_RE
-from ..runner import Runner
+from ..runner import CommandResult, Runner, executable_identity_changed, strip_ansi
 from ..usage import UsageMetadata, coerce_int, first_present
+from ..workdir_guard import (
+    WorkdirReplayEvidence,
+    WorkdirSnapshot,
+    capture_workdir_snapshot,
+    gate_workdir_replay,
+)
 
 if TYPE_CHECKING:
     from ..config import AgentLoopConfig
@@ -52,6 +59,111 @@ _GEMINI_RETIREMENT_SIGNATURES = (
     "no longer",
     "retir",
 )
+
+# A replacement can leave Gemini's Node launcher with no public response. Keep
+# this classifier deliberately narrow: ordinary prose, tool narration, and
+# unknown diagnostics are progress and must suppress replay.
+_GEMINI_STARTUP_LINE_RE = re.compile(
+    r"(?ix)^(?:"
+    r"gemini(?:\s+cli)?(?:\s+(?:v|version)\s*[\w.-]+)?|"
+    r"(?:starting|initiali[sz]ing|loading)\s+gemini(?:\s+cli)?|"
+    r"(?:using|selected|requested)\s+model\s*[:=].+|"
+    r"model\s*[:=].+|"
+    r"version\s*[:=]\s*[\w.-]+|"
+    r"loaded\s+(?:configuration|credentials|settings)\b.*|"
+    r"(?:checking|applying)\s+(?:for\s+)?(?:gemini\s+)?updates?\b.*"
+    r")$"
+)
+_GEMINI_LOADER_LINE_RE = re.compile(
+    r"(?ix)(?:"
+    r"MODULE_NOT_FOUND|cannot\s+find\s+module|"
+    r"^node:(?:internal/)?modules/.*|^at\s+.+node:(?:internal/)?modules/.*|"
+    r"^throw\s+err;?$|^require\s+stack:.*|"
+    r"^code\s*[:=]\s*['\"]?(?:MODULE_NOT_FOUND|ENOENT)['\"]?\s*$|"
+    r"(?:ENOENT|ENOEXEC)|exec(?:ution)?\s+format\s+error|"
+    r"no\s+such\s+file\s+or\s+directory|"
+    r"(?:gemini|node|npm|launcher|executable|binary).*(?:not\s+found|missing|failed|error)|"
+    r"(?:failed|error).*(?:launch|launcher|startup|updat(?:e|er)|replacement)|"
+    r"(?:updat(?:e|er)|launcher|replacement).*(?:failed|error|unavailable|in\s+progress)"
+    r")"
+)
+_GEMINI_DIAGNOSTIC_MAX_LINES = 40
+_GEMINI_DIAGNOSTIC_MAX_CHARS = 8192
+
+
+def _json_structured_payload(raw: str) -> bool:
+    """Return true for a complete or line-delimited structured payload."""
+    candidates = [raw, *raw.splitlines()]
+    for candidate in candidates:
+        if not candidate.strip():
+            continue
+        try:
+            json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        return True
+    return False
+
+
+def _gemini_startup_or_loader_diagnostics(raw: str) -> bool:
+    normalized = strip_ansi(raw).strip()
+    if not normalized:
+        return True
+    if len(normalized) > _GEMINI_DIAGNOSTIC_MAX_CHARS:
+        return False
+    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
+    if len(lines) > _GEMINI_DIAGNOSTIC_MAX_LINES:
+        return False
+    return all(
+        _GEMINI_STARTUP_LINE_RE.fullmatch(line) is not None
+        or _GEMINI_LOADER_LINE_RE.search(line) is not None
+        for line in lines
+    )
+
+
+def classify_gemini_executable_replacement_interruption(
+    result: CommandResult,
+    *,
+    command: str,
+    response_file_text: str | None,
+    before_snapshot: WorkdirSnapshot | None = None,
+    after_snapshot: WorkdirSnapshot | None = None,
+) -> WorkdirReplayEvidence | None:
+    """Classify a quiet Gemini launcher replacement with fail-closed gates."""
+    observation = result.observation
+    if (
+        type(result.returncode) is not int
+        or observation is None
+        or observation.interrupted
+        or result.capture_diagnostics
+        or response_file_text
+        or PUBLIC_RESPONSE_MARKER in result.stdout
+        or _json_structured_payload(result.stdout)
+        or not _gemini_startup_or_loader_diagnostics(result.stdout)
+    ):
+        return None
+    if not executable_identity_changed(
+        observation.before,
+        observation.after,
+        command=command,
+        spawn_wall_time=observation.spawn_wall_time,
+        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
+    ):
+        return None
+    reason = "Gemini executable changed during invocation"
+    if before_snapshot is None and after_snapshot is None:
+        return WorkdirReplayEvidence(reason)
+    return gate_workdir_replay(
+        "Gemini executable replacement",
+        reason,
+        before_snapshot=before_snapshot,
+        after_snapshot=after_snapshot,
+    )
+
+
+# Keep the provider-local spelling parallel with Codex's existing classifier;
+# callers that operate on a backend do not need to know the provider's helper name.
+classify_executable_replacement_interruption = classify_gemini_executable_replacement_interruption
 
 # Gemini's documented headless mode is selected by --prompt.  For large tasks,
 # stdin carries the complete prompt and this short trailing prompt tells Gemini
@@ -237,6 +349,14 @@ class GeminiBackend:
             args += ["--model", config.gemini_model]
         if session_id:
             args += ["--resume", session_id]
+        # Capture the assigned checkout immediately before spawn. The after
+        # probe is deliberately lazy and only runs for positive replacement
+        # evidence, keeping ordinary Gemini failures cheap and side-effect free.
+        before_snapshot = capture_workdir_snapshot(
+            runner,
+            config.gemini_dir,
+            tolerate_exceptions=True,
+        )
         result = runner.run_with_log(
             args,
             cwd=config.gemini_dir,
@@ -258,6 +378,25 @@ class GeminiBackend:
             )
         message_text, new_session_id, usage, raw_usage, message_source = _parse_gemini_payload(result.stdout)
         response_file_text = read_public_response_file(response_path)
+        candidate = classify_gemini_executable_replacement_interruption(
+            result,
+            command=config.gemini_cmd,
+            response_file_text=response_file_text,
+        )
+        after_snapshot = None
+        if candidate is not None:
+            after_snapshot = capture_workdir_snapshot(
+                runner,
+                config.gemini_dir,
+                tolerate_exceptions=True,
+            )
+            candidate = classify_gemini_executable_replacement_interruption(
+                result,
+                command=config.gemini_cmd,
+                response_file_text=response_file_text,
+                before_snapshot=before_snapshot,
+                after_snapshot=after_snapshot,
+            )
         raw_output = result.stdout
         if retired_failure:
             # Append the guidance to the *returned* output, not just stderr: callers
@@ -280,6 +419,13 @@ class GeminiBackend:
             raw_usage=raw_usage,
             model_used=config.gemini_model or None,
             command_result=result,
+            self_update_reason=candidate.reason if candidate else None,
+            self_update_replay_refusal_kind=(
+                candidate.replay_refusal_kind if candidate else None
+            ),
+            self_update_replay_refusal_detail=(
+                candidate.replay_refusal_detail if candidate else None
+            ),
         )
 
 

--- a/src/coding_review_agent_loop/agents/replacement.py
+++ b/src/coding_review_agent_loop/agents/replacement.py
@@ -1,0 +1,93 @@
+"""Shared executable-replacement evidence gates for text-based backends."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from ..protocol import PUBLIC_RESPONSE_MARKER
+from ..runner import CommandResult, executable_identity_changed, strip_ansi
+from ..workdir_guard import WorkdirReplayEvidence, WorkdirSnapshot, gate_workdir_replay
+
+
+DIAGNOSTIC_MAX_LINES = 40
+DIAGNOSTIC_MAX_CHARS = 8192
+
+
+def _structured_payload(raw: str) -> bool:
+    """Return true for a complete or line-delimited structured payload."""
+    for candidate in (raw, *raw.splitlines()):
+        if not candidate.strip():
+            continue
+        try:
+            json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        return True
+    return False
+
+
+def _startup_or_loader_diagnostics(
+    raw: str,
+    *,
+    startup_line_re: re.Pattern[str],
+    loader_line_re: re.Pattern[str],
+) -> bool:
+    normalized = strip_ansi(raw).strip()
+    if not normalized:
+        return True
+    if len(normalized) > DIAGNOSTIC_MAX_CHARS:
+        return False
+    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
+    if len(lines) > DIAGNOSTIC_MAX_LINES:
+        return False
+    return all(
+        startup_line_re.fullmatch(line) is not None
+        or loader_line_re.search(line) is not None
+        for line in lines
+    )
+
+
+def classify_provider_executable_replacement_interruption(
+    result: CommandResult,
+    *,
+    command: str,
+    response_file_text: str | None,
+    startup_line_re: re.Pattern[str],
+    loader_line_re: re.Pattern[str],
+    provider_label: str,
+    reason: str,
+    before_snapshot: WorkdirSnapshot | None = None,
+    after_snapshot: WorkdirSnapshot | None = None,
+) -> WorkdirReplayEvidence | None:
+    """Classify a quiet provider launcher replacement with fail-closed gates."""
+    observation = result.observation
+    if (
+        type(result.returncode) is not int
+        or observation is None
+        or observation.interrupted
+        or result.capture_diagnostics
+        or response_file_text
+        or PUBLIC_RESPONSE_MARKER in result.stdout
+        or _structured_payload(result.stdout)
+        or not _startup_or_loader_diagnostics(
+            result.stdout,
+            startup_line_re=startup_line_re,
+            loader_line_re=loader_line_re,
+        )
+    ):
+        return None
+    if not executable_identity_changed(
+        observation.before,
+        observation.after,
+        command=command,
+        spawn_wall_time=observation.spawn_wall_time,
+        exit_wall_time=observation.spawn_wall_time + observation.elapsed_seconds,
+    ):
+        return None
+    return gate_workdir_replay(
+        provider_label,
+        reason,
+        before_snapshot=before_snapshot,
+        after_snapshot=after_snapshot,
+    )

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -2347,6 +2347,7 @@ def _run_validated_agent(
     }
 
     for attempt in range(1, max_attempts + 1):
+        replacement_stability_failed = False
         attempt_config = (
             antigravity_attempts.singleton_config(config)
             if antigravity_attempts is not None
@@ -2502,6 +2503,7 @@ def _run_validated_agent(
                 replay_timeout = timeout_seconds
                 deadline_exhausted = False
             if not stable or deadline_exhausted:
+                replacement_stability_failed = True
                 deadline_label = (
                     "within the invocation deadline"
                     if uses_remaining_deadline
@@ -2553,7 +2555,11 @@ def _run_validated_agent(
             if result.command_result is not None and result.command_result.capture_diagnostics:
                 classification_text += "\nsubprocess capture unavailable; retryable tooling failure"
             last_classification_text = classification_text
-            should_retry = bool(result.command_result and result.command_result.capture_diagnostics) or _is_transient_agent_output(classification_text)
+            should_retry = (
+                replacement_stability_failed
+                or bool(result.command_result and result.command_result.capture_diagnostics)
+                or _is_transient_agent_output(classification_text)
+            )
             last_failure_category = _failure_category(classification_text)
             capacity = classify_antigravity_capacity(
                 classification_text,
@@ -2569,7 +2575,9 @@ def _run_validated_agent(
             last_error = "agent response was empty"
             classification_text = _agent_failure_classification_text(result, phase="empty")
             last_classification_text = classification_text
-            should_retry = _is_transient_agent_output(classification_text)
+            should_retry = replacement_stability_failed or _is_transient_agent_output(
+                classification_text
+            )
             last_failure_category = _failure_category(classification_text)
             capacity = classify_antigravity_capacity(
                 classification_text,
@@ -2665,7 +2673,7 @@ def _run_validated_agent(
                 response_failure_is_unsupported = last_failure_category == "unsupported_model"
                 # Marker near-misses are a separate first-attempt nudge for common footer typos;
                 # structured JSON protocol drift still remains repairable when retries are exhausted.
-                should_retry = public_text_is_transient or (
+                should_retry = replacement_stability_failed or public_text_is_transient or (
                     not response_failure_is_unsupported
                     and attempt == 1
                     and _is_retryable_marker_near_miss(classification_text)

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -1375,6 +1375,10 @@ def _executable_replacement_failure_detail(
         label = "Claude self-update"
     elif provider == "codex":
         label = "Codex executable replacement"
+    elif provider == "gemini":
+        label = "Gemini executable replacement"
+    elif provider == "antigravity":
+        label = "Antigravity executable replacement"
     else:
         label = "agent executable replacement"
     detail = f"likely {label} interruption"
@@ -1403,9 +1407,9 @@ def _failure_suggestion(
     if category == "self-update-interruption":
         if agent_name.lower() == "claude":
             return "Suggestion: wait for the Claude Code self-update to finish, then re-run."
-        return "Suggestion: wait for the agent executable replacement to finish, then re-run."
+        return f"Suggestion: wait for the {agent_name} executable replacement to finish, then re-run."
     if category == "executable-replacement":
-        return "Suggestion: wait for the Codex executable replacement to finish, then re-run."
+        return f"Suggestion: wait for the {agent_name} executable replacement to finish, then re-run."
     if category == "transient":
         if _QUOTA_RATE_LIMIT_RE.search(combined):
             return (
@@ -1497,9 +1501,9 @@ def _format_invalid_agent_response_error(
         if agent_name.lower() == "claude":
             category_hint = " Failure category: self-update-interruption (Claude Code updated during startup)."
         else:
-            category_hint = " Failure category: self-update-interruption (the agent executable changed during invocation)."
+            category_hint = f" Failure category: self-update-interruption ({agent_name} executable changed during invocation)."
     elif category == "executable-replacement":
-        category_hint = " Failure category: executable-replacement (Codex changed during invocation)."
+        category_hint = f" Failure category: executable-replacement ({agent_name} changed during invocation)."
     elif category == "agent-unavailable":
         category_hint = " Failure category: agent-unavailable (the agent explicitly could not continue)."
     if not classification_text:
@@ -2283,11 +2287,12 @@ def _run_validated_agent(
         if agent == "antigravity"
         else None
     )
-    # Each fallback retains an initial attempt; retry allowance is shared.
+    # Each fallback retains an initial attempt; retry allowance is shared. The
+    # provider-specific replacement replay gets one explicit extra slot.
     max_attempts = (
-        len(config.antigravity_models) + config.agent_max_retries
+        len(config.antigravity_models) + config.agent_max_retries + 1
         if antigravity_attempts is not None
-        else config.agent_max_retries + 2 if agent in {"claude", "codex"} else config.agent_max_retries + 1
+        else config.agent_max_retries + 2
     )
     last_error = f"{agent_name} produced no output."
     last_result: AgentResult | None = None
@@ -2314,6 +2319,32 @@ def _run_validated_agent(
     latest_replay_refusal_detail: str | None = None
     next_timeout_seconds = timeout_seconds
     marker_safety_repair_attempted = False
+    executable_replacement_policies: dict[AgentName, tuple[str, str, str, bool]] = {
+        "claude": (
+            config.claude_cmd,
+            "Claude self-update",
+            "self-update-attempt2",
+            True,
+        ),
+        "codex": (
+            config.codex_cmd,
+            "Codex executable replacement",
+            "executable-replacement-attempt2",
+            False,
+        ),
+        "gemini": (
+            config.gemini_cmd,
+            "Gemini executable replacement",
+            "executable-replacement-attempt2",
+            False,
+        ),
+        "antigravity": (
+            config.antigravity_cmd,
+            "Antigravity executable replacement",
+            "executable-replacement-attempt2",
+            False,
+        ),
+    }
 
     for attempt in range(1, max_attempts + 1):
         attempt_config = (
@@ -2329,8 +2360,8 @@ def _run_validated_agent(
                 if is_executable_replacement_replay
                 else f"attempt{ordinary_retries_used + 1}"
             )
-        elif agent == "codex" and is_executable_replacement_replay:
-            invocation_kwargs["attempt_suffix"] = "executable-replacement-attempt2"
+        elif is_executable_replacement_replay:
+            invocation_kwargs["attempt_suffix"] = executable_replacement_policies[agent][2]
         result = run_agent_result(
             runner,
             agent=agent,
@@ -2428,15 +2459,12 @@ def _run_validated_agent(
                 "continuing with provider-derived retry classification",
             )
 
-        # Claude or Codex can be replaced after spawning. Codex remains driven
-        # by its JSONL setup-versus-progress evidence; Claude's non-streaming
-        # JSON output additionally uses the workdir snapshot gate below.
-        # This is exclusive with
-        # ordinary transient classification and gets one full replay only after
-        # the configured executable is stable. A Claude workdir refusal above
-        # deliberately does not enter this branch.
+        # A configured provider executable can be replaced after spawning. Each
+        # backend supplies its own evidence gate, while this branch owns the
+        # bounded stability wait, one replay, and retry accounting. A workdir
+        # refusal deliberately remains diagnostic-only and cannot enter it.
         if (
-            agent in {"claude", "codex"}
+            agent in executable_replacement_policies
             and result.self_update_reason is not None
             and result.self_update_replay_refusal_kind is None
             and not executable_replacement_considered
@@ -2446,7 +2474,10 @@ def _run_validated_agent(
             executable_replacement_provider = agent
             executable_replacement_reason = result.self_update_reason
             observation = result.command_result.observation
-            if agent == "claude":
+            command, provider_label, _suffix, uses_remaining_deadline = (
+                executable_replacement_policies[agent]
+            )
+            if uses_remaining_deadline:
                 self_update_deadline = (
                     observation.spawn_monotonic + timeout_seconds
                     if timeout_seconds is not None and observation is not None
@@ -2462,23 +2493,18 @@ def _run_validated_agent(
                 replay_timeout = remaining
                 deadline_exhausted = remaining is not None and remaining <= 0
             else:
-                # Codex replacement recovery has its own bounded six-second
-                # stability observation. The replay is a fresh invocation and
-                # receives the full configured timeout, if any.
+                # Codex, Gemini, and Antigravity use a bounded six-second
+                # stability observation. Their replay is fresh and receives the
+                # complete configured timeout, if any.
                 stable = runner.wait_for_executable_stability(
-                    config.codex_cmd, deadline=None
+                    command, deadline=None
                 )
                 replay_timeout = timeout_seconds
                 deadline_exhausted = False
             if not stable or deadline_exhausted:
-                provider_label = (
-                    "Claude self-update"
-                    if agent == "claude"
-                    else "Codex executable replacement"
-                )
                 deadline_label = (
                     "within the invocation deadline"
-                    if agent == "claude"
+                    if uses_remaining_deadline
                     else "within the bounded stability window"
                 )
                 self_update_stability_error = (
@@ -2488,7 +2514,7 @@ def _run_validated_agent(
                 if usage_record is not None:
                     usage_record.outcome = (
                         "self_update_interruption"
-                        if agent == "claude"
+                        if uses_remaining_deadline
                         else "executable_replacement_interruption"
                     )
                     usage_record.log_path = str(result.log_path) if result.log_path else None
@@ -2499,7 +2525,7 @@ def _run_validated_agent(
                 if usage_record is not None:
                     usage_record.outcome = (
                         "self_update_interruption"
-                        if agent == "claude"
+                        if uses_remaining_deadline
                         else "executable_replacement_interruption"
                     )
                     usage_record.log_path = str(result.log_path) if result.log_path else None

--- a/src/coding_review_agent_loop/runner.py
+++ b/src/coding_review_agent_loop/runner.py
@@ -538,6 +538,7 @@ class Runner:
         next_progress = started + progress_interval_seconds
         header = f"$ {' '.join(cmd)}\n\n"
         chunks: list[bytes] = []
+        capture_diagnostics: list[str] = []
         with log_path.open("wb") as log_file:
             log_file.write(header.encode("utf-8"))
             log_file.flush()
@@ -585,12 +586,32 @@ class Runner:
                         wait_seconds = min(1.0, max(0.0, deadline - now))
                     else:
                         wait_seconds = 1.0
-                    ready, _, _ = select.select([master_fd], [], [], wait_seconds)
+                    try:
+                        ready, _, _ = select.select([master_fd], [], [], wait_seconds)
+                    except OSError as exc:
+                        capture_diagnostics.append(
+                            f"capture_select_failed:{type(exc).__name__}:{exc}"
+                        )
+                        if proc.poll() is None:
+                            self._terminate_process_group(proc)
+                        break
                     if master_fd in ready:
                         try:
                             data = os.read(master_fd, 65536)
-                        except OSError:
-                            data = b""  # EIO once the slave side has fully closed
+                        except OSError as exc:
+                            # Linux reports EIO when the PTY slave closes. That is
+                            # the normal equivalent of EOF; every other read
+                            # failure is observable capture loss and must remain
+                            # fail-closed for callers that classify quiet output.
+                            if exc.errno == errno.EIO:
+                                data = b""
+                            else:
+                                capture_diagnostics.append(
+                                    f"capture_read_failed:{type(exc).__name__}:{exc}"
+                                )
+                                if proc.poll() is None:
+                                    self._terminate_process_group(proc)
+                                break
                         if data:
                             log_file.write(data)
                             log_file.flush()
@@ -637,6 +658,7 @@ class Runner:
                 executable_identity(cmd[0]),
                 self._interrupted,
             ),
+            tuple(capture_diagnostics),
         )
         if check and returncode != 0:
             raise AgentLoopError(

--- a/src/coding_review_agent_loop/workdir_guard.py
+++ b/src/coding_review_agent_loop/workdir_guard.py
@@ -62,6 +62,72 @@ class WorkdirSnapshot:
         return self.head.available and self.status.available
 
 
+@dataclass(frozen=True)
+class WorkdirReplayEvidence:
+    """Replacement evidence plus an optional fail-closed replay refusal."""
+
+    reason: str
+    replay_refusal_kind: str | None = None
+    replay_refusal_detail: str | None = None
+
+
+def _workdir_probe_label(snapshot: WorkdirSnapshot) -> str:
+    def describe(probe: GitProbeResult) -> str:
+        if probe.kind == "available":
+            return repr(probe.value)
+        if probe.kind == "exception":
+            return f"{probe.exception_type}: {probe.detail}"
+        if probe.kind == "command-failed":
+            return f"returncode={probe.returncode!r}"
+        return "blank"
+
+    return f"HEAD={describe(snapshot.head)}, status={describe(snapshot.status)}"
+
+
+def gate_workdir_replay(
+    provider_label: str,
+    reason: str,
+    *,
+    before_snapshot: WorkdirSnapshot | None,
+    after_snapshot: WorkdirSnapshot | None,
+) -> WorkdirReplayEvidence:
+    """Allow replay only when both checkout snapshots are available and equal.
+
+    The provider label is deliberately supplied by each backend so refusal
+    diagnostics identify the actual backend while the metadata contract stays
+    provider-neutral.
+    """
+    if before_snapshot is None and after_snapshot is None:
+        return WorkdirReplayEvidence(reason)
+    if before_snapshot is None or not before_snapshot.available:
+        detail = (
+            f"{provider_label} replay refused: before workdir snapshot unavailable "
+            f"({ _workdir_probe_label(before_snapshot) if before_snapshot else 'missing'})."
+        )
+        return WorkdirReplayEvidence(reason, "before-unavailable", detail)
+    if after_snapshot is None or not after_snapshot.available:
+        detail = (
+            f"{provider_label} replay refused: after workdir snapshot unavailable "
+            f"({ _workdir_probe_label(after_snapshot) if after_snapshot else 'missing'})."
+        )
+        return WorkdirReplayEvidence(reason, "after-unavailable", detail)
+    if before_snapshot.head.value != after_snapshot.head.value:
+        detail = (
+            f"{provider_label} replay refused: assigned checkout HEAD changed during "
+            f"invocation (before={before_snapshot.head.value!r}, "
+            f"after={after_snapshot.head.value!r})."
+        )
+        return WorkdirReplayEvidence(reason, "changed-head", detail)
+    if before_snapshot.status.value != after_snapshot.status.value:
+        detail = (
+            f"{provider_label} replay refused: dirty workdir status changed during "
+            f"invocation (before={before_snapshot.status.value!r}, "
+            f"after={after_snapshot.status.value!r})."
+        )
+        return WorkdirReplayEvidence(reason, "changed-status", detail)
+    return WorkdirReplayEvidence(reason)
+
+
 def _git_probe(
     runner: object,
     *,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4238,6 +4238,156 @@ def test_codex_replacement_context_does_not_change_long_quota_exit_priority(tmp_
     assert "Codex executable replacement" in str(error.value)
 
 
+def _observed_replacement_result(
+    tmp_path, *, command, reason, raw_output="", returncode=1, model_used=None
+):
+    identity = ExecutableIdentity(
+        command, f"{command}-target", (1, 1, 90_000_000_000), (1, 2, 90_000_000_000)
+    )
+    changed = ExecutableIdentity(
+        command, f"{command}-new-target", (1, 3, 100_000_000_000), (1, 4, 100_000_000_000)
+    )
+    observation = ExecutionObservation(100, 100, 101, 1, identity, changed, False)
+    return AgentResult(
+        text="",
+        raw_output=raw_output,
+        returncode=returncode,
+        model_used=model_used,
+        command_result=CommandResult(
+            [command], tmp_path, raw_output, "", returncode, observation
+        ),
+        self_update_reason=reason,
+    )
+
+
+def test_gemini_replacement_replay_uses_fresh_timeout_and_provider_suffix(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Gemini recovered.", reviewer="Google Gemini"
+    )
+    results = iter(
+        [
+            _observed_replacement_result(
+                tmp_path,
+                command="gemini",
+                reason="Gemini executable changed during invocation",
+            ),
+            AgentResult(text=valid, raw_output=valid, returncode=0, model_used="gemini-model"),
+        ]
+    )
+    runner = FakeRunner()
+    stability_calls = []
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: (
+        stability_calls.append((command, deadline)) or True
+    )
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=0)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Google Gemini", unresolved_items=()
+            ),
+            timeout_seconds=60,
+        )
+
+    assert response.marker_value.state == "approved"
+    assert stability_calls == [(config.gemini_cmd, None)]
+    assert run_mock.call_args_list[0].kwargs["timeout_seconds"] == 60
+    assert run_mock.call_args_list[1].kwargs["timeout_seconds"] == 60
+    assert run_mock.call_args_list[1].kwargs["attempt_suffix"] == "executable-replacement-attempt2"
+
+
+def test_gemini_unstable_replacement_preserves_ordinary_retry(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Ordinary retry recovered.", reviewer="Google Gemini"
+    )
+    results = iter(
+        [
+            _observed_replacement_result(
+                tmp_path,
+                command="gemini",
+                reason="Gemini executable changed during invocation",
+                raw_output="overloaded_error",
+            ),
+            AgentResult(text=valid, raw_output=valid, returncode=0),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: False
+    config = make_config(tmp_path, reviewer="gemini", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="gemini",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Google Gemini", unresolved_items=()
+            ),
+        )
+
+    assert response.marker_value.state == "approved"
+    assert run_mock.call_count == 2
+    assert "attempt_suffix" not in run_mock.call_args_list[1].kwargs
+
+
+def test_antigravity_replacement_replay_does_not_advance_model_state(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Antigravity recovered.", reviewer="Google Antigravity"
+    )
+    results = iter(
+        [
+            _observed_replacement_result(
+                tmp_path,
+                command="agy",
+                reason="Antigravity executable changed during invocation",
+                model_used="ModelA",
+            ),
+            AgentResult(text="", raw_output="overloaded_error", returncode=1, model_used="ModelA"),
+            AgentResult(text="", raw_output="quota exceeded", returncode=1, model_used="ModelA"),
+            AgentResult(text=valid, raw_output=valid, returncode=0, model_used="ModelB"),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: True
+    config = make_config(
+        tmp_path,
+        reviewer="antigravity",
+        antigravity_models=("ModelA", "ModelB"),
+        agent_max_retries=1,
+    )
+    models: list[tuple[str, ...]] = []
+
+    def mock_run(_runner, *, config, **_kwargs):
+        models.append(config.antigravity_models)
+        return next(results)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=mock_run) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="antigravity",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Google Antigravity", unresolved_items=()
+            ),
+            timeout_seconds=60,
+        )
+
+    assert response.marker_value.state == "approved"
+    assert models == [("ModelA",), ("ModelA",), ("ModelA",), ("ModelB",)]
+    assert run_mock.call_args_list[1].kwargs["attempt_suffix"] == "executable-replacement-attempt2"
+    assert "attempt_suffix" not in run_mock.call_args_list[2].kwargs
+    assert "attempt_suffix" not in run_mock.call_args_list[3].kwargs
+
+
 # ---------------------------------------------------------------------------
 # Antigravity (agy) backend + Gemini retirement guidance (#215)
 # ---------------------------------------------------------------------------
@@ -4269,6 +4419,58 @@ def test_runner_pty_reports_tty_and_strips_ansi(tmp_path):
     assert "GREEN" in result.stdout
     assert "\x1b[" not in result.stdout  # ANSI stripped from captured output
     assert result.returncode == 0
+
+
+def test_runner_pty_preserves_bytes_and_reports_unexpected_master_read_failure(
+    tmp_path, monkeypatch
+):
+    import errno
+    import pty
+    import coding_review_agent_loop.runner as runner_module
+
+    program = (
+        "import sys, time\n"
+        "sys.stdout.write('captured-before-read-failure\\n'); sys.stdout.flush()\n"
+        "time.sleep(1)\n"
+    )
+    calls = [0]
+    master_fd: list[int] = []
+    real_openpty = pty.openpty
+    real_read = runner_module.os.read
+
+    def capture_master_fd():
+        pair = real_openpty()
+        master_fd.append(pair[0])
+        return pair
+
+    monkeypatch.setattr(pty, "openpty", capture_master_fd)
+
+    def fail_after_first_read(fd, size):
+        if not master_fd or fd != master_fd[0]:
+            return real_read(fd, size)
+        calls[0] += 1
+        if calls[0] == 1:
+            # Seed the real PTY capture buffer deterministically; process
+            # scheduling may otherwise let the child close before the first
+            # select/read cycle is reached.
+            return b"captured-before-read-failure\n"
+        raise OSError(errno.EBADF, "injected PTY read failure")
+
+    monkeypatch.setattr(runner_module.os, "read", fail_after_first_read)
+    result = Runner().run_with_log(
+        [sys.executable, "-c", program],
+        cwd=tmp_path,
+        log_path=tmp_path / "logs" / "pty-read-failure.log",
+        label="PtyReadFailureProbe",
+        progress_interval_seconds=999,
+        check=False,
+        use_pty=True,
+    )
+
+    assert "captured-before-read-failure" in result.stdout
+    assert result.capture_diagnostics == (
+        "capture_read_failed:OSError:[Errno 9] injected PTY read failure",
+    )
 
 
 def test_runner_keeps_output_when_capture_path_is_unlinked(tmp_path):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4184,7 +4184,7 @@ def test_codex_unstable_replacement_retains_ordinary_retry(tmp_path):
     )
     results = iter(
         [
-            _observed_codex_result(tmp_path, raw_output="overloaded_error"),
+            _observed_codex_result(tmp_path),
             AgentResult(text=valid, raw_output=valid, returncode=0),
         ]
     )
@@ -4311,7 +4311,7 @@ def test_gemini_unstable_replacement_preserves_ordinary_retry(tmp_path):
                 tmp_path,
                 command="gemini",
                 reason="Gemini executable changed during invocation",
-                raw_output="overloaded_error",
+                returncode=0,
             ),
             AgentResult(text=valid, raw_output=valid, returncode=0),
         ]
@@ -4335,6 +4335,90 @@ def test_gemini_unstable_replacement_preserves_ordinary_retry(tmp_path):
     assert response.marker_value.state == "approved"
     assert run_mock.call_count == 2
     assert "attempt_suffix" not in run_mock.call_args_list[1].kwargs
+
+
+def test_claude_quiet_unstable_replacement_keeps_ordinary_retry(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Ordinary retry recovered.", reviewer="Anthropic Claude"
+    )
+    results = iter(
+        [
+            _observed_replacement_result(
+                tmp_path,
+                command="claude",
+                reason="Claude Code updater diagnostic",
+            ),
+            AgentResult(text=valid, raw_output=valid, returncode=0),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: False
+    config = make_config(tmp_path, reviewer="claude", agent_max_retries=1)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=results) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="claude",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Anthropic Claude", unresolved_items=()
+            ),
+        )
+
+    assert response.marker_value.state == "approved"
+    assert run_mock.call_count == 2
+    assert run_mock.call_args_list[1].kwargs["attempt_suffix"] == "attempt2"
+
+
+def test_antigravity_quiet_unstable_replacement_reaches_model_fallback(tmp_path):
+    valid = structured_pr_review(
+        state="approved", summary="Fallback recovered.", reviewer="Google Antigravity"
+    )
+    results = iter(
+        [
+            _observed_replacement_result(
+                tmp_path,
+                command="agy",
+                reason="Antigravity executable changed during invocation",
+                returncode=0,
+                model_used="ModelA",
+            ),
+            AgentResult(text="", raw_output="quota exceeded", returncode=1, model_used="ModelA"),
+            AgentResult(text=valid, raw_output=valid, returncode=0, model_used="ModelB"),
+        ]
+    )
+    runner = FakeRunner()
+    runner.wait_for_executable_stability = lambda command, *, deadline=None: False
+    config = make_config(
+        tmp_path,
+        reviewer="antigravity",
+        antigravity_models=("ModelA", "ModelB"),
+        agent_max_retries=1,
+    )
+    models: list[tuple[str, ...]] = []
+
+    def mock_run(_runner, *, config, **_kwargs):
+        models.append(config.antigravity_models)
+        return next(results)
+
+    with patch.object(orchestrator_module, "run_agent_result", side_effect=mock_run) as run_mock:
+        response = _run_validated_agent(
+            runner,
+            agent="antigravity",
+            config=config,
+            prompt="Review the PR.",
+            marker_description="test",
+            validate=lambda text: _validate_review_response(
+                text, reviewer="Google Antigravity", unresolved_items=()
+            ),
+        )
+
+    assert response.marker_value.state == "approved"
+    assert models == [("ModelA",), ("ModelA",), ("ModelB",)]
+    assert "attempt_suffix" not in run_mock.call_args_list[1].kwargs
+    assert "attempt_suffix" not in run_mock.call_args_list[2].kwargs
 
 
 def test_antigravity_replacement_replay_does_not_advance_model_state(tmp_path):

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -775,9 +775,9 @@ def test_antigravity_after_snapshot_runs_after_gemini_cleanup_under_lock(
     agy_dir = tmp_path / "agy"
     agy_dir.mkdir(parents=True)
     settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
     if role == "reviewer":
         settings_file.write_text('{"existing": true}', encoding="utf-8")
-        monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
 
     identity = ExecutableIdentity(
         "agy", "agy-target", (1, 1, 90_000_000_000), (1, 2, 90_000_000_000)

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -763,6 +763,83 @@ def test_antigravity_backend_strips_dangerously_skip_permissions_for_reviewer(
     )
     assert "--dangerously-skip-permissions" in captured_args[-1]
 
+
+@pytest.mark.parametrize("role", [None, "reviewer"])
+def test_antigravity_after_snapshot_runs_after_gemini_cleanup_under_lock(
+    tmp_path, monkeypatch, role
+):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+    from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
+
+    agy_dir = tmp_path / "agy"
+    agy_dir.mkdir(parents=True)
+    settings_file = tmp_path / "settings.json"
+    if role == "reviewer":
+        settings_file.write_text('{"existing": true}', encoding="utf-8")
+        monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+
+    identity = ExecutableIdentity(
+        "agy", "agy-target", (1, 1, 90_000_000_000), (1, 2, 90_000_000_000)
+    )
+    changed = ExecutableIdentity(
+        "agy", "agy-new-target", (1, 3, 100_000_000_000), (1, 4, 100_000_000_000)
+    )
+    observation = ExecutionObservation(100, 100, 101, 1, identity, changed, False)
+    snapshots_seen: list[tuple[bool, str]] = []
+
+    class ObservedRunner(FakeRunner):
+        def run_with_log(self, args, *, cwd, **kwargs):
+            raw = super().run_with_log(args, cwd=cwd, **kwargs)
+            return CommandResult(
+                raw.args, raw.cwd, raw.stdout, raw.stderr, raw.returncode, observation,
+                raw.capture_diagnostics,
+            )
+
+        def run(self, args, *, cwd, **kwargs):
+            if tuple(args) == ("git", "status", "--porcelain"):
+                path = Path(cwd) / "GEMINI.md"
+                snapshots_seen.append((path.exists(), path.read_text(encoding="utf-8") if path.exists() else ""))
+            return super().run(args, cwd=cwd, **kwargs)
+
+    output = "agy v0.8.0\nModel: Gemini 3.1 Pro (High)\nError: Cannot find module launcher.js\n"
+    runner = ObservedRunner(
+        antigravity_outputs=[(output, 1)],
+        git_probe_results=[
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": "", "returncode": 0},
+            {"stdout": "abc123\n", "returncode": 0},
+            {"stdout": "", "returncode": 0},
+        ],
+    )
+    config = make_config(tmp_path, antigravity_dir=agy_dir)
+    result = AntigravityBackend().run(runner, config, "Review.", role=role)
+
+    assert result.self_update_reason == "Antigravity executable changed during invocation"
+    assert result.self_update_replay_refusal_kind is None
+    assert len(snapshots_seen) == 2
+    assert snapshots_seen[1][0] is False
+    assert "Agent Loop Single-Shot Session" not in snapshots_seen[1][1]
+
+
+def test_antigravity_repair_skips_checkout_probes_and_replacement_metadata(tmp_path, monkeypatch):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+    from coding_review_agent_loop.agents.antigravity import AntigravityBackend
+
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: settings_file)
+    config = make_config(tmp_path, antigravity_dir=tmp_path / "agy")
+    runner = FakeRunner(antigravity_outputs=[("MODULE_NOT_FOUND", 1)])
+
+    result = AntigravityBackend().run_repair(
+        runner, config, "Repair this response.", model="ModelA"
+    )
+
+    assert runner.git_probe_calls == []
+    assert result.self_update_reason is None
+    assert result.self_update_replay_refusal_kind is None
+    assert result.self_update_replay_refusal_detail is None
+
 def test_antigravity_backend_lock_order_settings_outer_gemini_inner(tmp_path, monkeypatch):
     """Settings lock (outer) is acquired before GEMINI.md lock (inner);
     settings are restored before the settings lock is released."""

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -316,6 +316,7 @@ def test_gemini_replacement_rejects_progress_public_payload_and_artifacts(output
 def test_antigravity_replacement_accepts_startup_chrome_and_loader_failure(returncode):
     output = (
         "Antigravity CLI v0.8.0\n"
+        "Checking for agy updates...\n"
         "Model: Gemini 3.1 Pro (High)\n"
         "Error: Cannot find module '/opt/agy/launcher.js'\n"
         "code: 'MODULE_NOT_FOUND'\n"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -26,6 +26,10 @@ from coding_review_agent_loop.agents.gemini import (
     _OVERSIZED_PROMPT_DIRECTIVE,
     _normalize_gemini_usage,
     _parse_gemini_payload,
+    classify_gemini_executable_replacement_interruption,
+)
+from coding_review_agent_loop.agents.antigravity import (
+    classify_antigravity_executable_replacement_interruption,
 )
 
 from agent_loop_helpers import (
@@ -223,6 +227,124 @@ def _codex_result(
         observation,
         capture_diagnostics,
     )
+
+
+def _replacement_result(*, command, stdout="", returncode=1, changed=True, **kwargs):
+    before = ExecutableIdentity(
+        command, f"{command}-target", (1, 1, 90_000_000_000), (1, 2, 90_000_000_000)
+    )
+    after = (
+        ExecutableIdentity(
+            command, f"{command}-new-target", (1, 3, 100_000_000_000),
+            (1, 4, 100_000_000_000),
+        )
+        if changed else before
+    )
+    observation = ExecutionObservation(100, 100, 101, 1, before, after, kwargs.pop("interrupted", False))
+    return CommandResult(
+        [command], Path.cwd(), stdout, "", returncode, observation,
+        kwargs.pop("capture_diagnostics", ()),
+    )
+
+
+def _snapshot(head="abc123", status=""):
+    from coding_review_agent_loop.workdir_guard import GitProbeResult, WorkdirSnapshot
+
+    return WorkdirSnapshot(
+        GitProbeResult(("git", "rev-parse", "HEAD"), "available", head),
+        GitProbeResult(("git", "status", "--porcelain"), "available", status),
+    )
+
+
+def test_gemini_replacement_accepts_realistic_node_loader_failure_and_snapshot_gate():
+    output = (
+        "Gemini CLI v1.2.3\n"
+        "Using model: gemini-3.5-flash\n"
+        "node:internal/modules/cjs/loader:1228\n"
+        "throw err;\n"
+        "Error: Cannot find module '/opt/gemini/launcher.js'\n"
+        "code: 'MODULE_NOT_FOUND'\n"
+    )
+    result = _replacement_result(command="gemini", stdout=output)
+
+    evidence = classify_gemini_executable_replacement_interruption(
+        result, command="gemini", response_file_text=None,
+    )
+    assert evidence is not None
+    assert evidence.reason == "Gemini executable changed during invocation"
+
+    accepted = classify_gemini_executable_replacement_interruption(
+        result,
+        command="gemini",
+        response_file_text=None,
+        before_snapshot=_snapshot(),
+        after_snapshot=_snapshot(),
+    )
+    assert accepted is not None
+    assert accepted.replay_refusal_kind is None
+
+    refused = classify_gemini_executable_replacement_interruption(
+        result,
+        command="gemini",
+        response_file_text=None,
+        before_snapshot=_snapshot(),
+        after_snapshot=_snapshot(status=" M changed.py\n"),
+    )
+    assert refused is not None
+    assert refused.replay_refusal_kind == "changed-status"
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "I will inspect the repository before responding.",
+        f"{PUBLIC_RESPONSE_MARKER}\nSTATE: approved",
+        json.dumps({"response": "STATE: approved", "session_id": "s"}),
+    ],
+)
+def test_gemini_replacement_rejects_progress_public_payload_and_artifacts(output):
+    result = _replacement_result(command="gemini", stdout=output)
+    assert classify_gemini_executable_replacement_interruption(
+        result, command="gemini", response_file_text=None,
+    ) is None
+    assert classify_gemini_executable_replacement_interruption(
+        result, command="gemini", response_file_text="malformed but present",
+    ) is None
+
+
+@pytest.mark.parametrize("returncode", [0, 1])
+def test_antigravity_replacement_accepts_startup_chrome_and_loader_failure(returncode):
+    output = (
+        "Antigravity CLI v0.8.0\n"
+        "Model: Gemini 3.1 Pro (High)\n"
+        "Error: Cannot find module '/opt/agy/launcher.js'\n"
+        "code: 'MODULE_NOT_FOUND'\n"
+    )
+    result = _replacement_result(command="agy", stdout=output, returncode=returncode)
+    evidence = classify_antigravity_executable_replacement_interruption(
+        result,
+        command="agy",
+        response_file_text=None,
+        before_snapshot=_snapshot(),
+        after_snapshot=_snapshot(),
+    )
+    assert evidence is not None
+    assert evidence.reason == "Antigravity executable changed during invocation"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"interrupted": True},
+        {"capture_diagnostics": ("capture_read_failed:OSError: injected",)},
+        {"returncode": None},
+    ],
+)
+def test_antigravity_replacement_rejects_unhealthy_capture(kwargs):
+    result = _replacement_result(command="agy", stdout="", **kwargs)
+    assert classify_antigravity_executable_replacement_interruption(
+        result, command="agy", response_file_text=None,
+    ) is None
 
 
 @pytest.mark.parametrize("returncode", [0, 1])

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -3,6 +3,27 @@ from agent_loop_helpers import *  # noqa: F403
 from coding_review_agent_loop.usage import RunUsageContext, UsageMetadata
 
 
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "executable_replacement_interruption",
+        "self_update_replay_refused_changed_workdir",
+        "self_update_replay_refused_unavailable_workdir",
+    ],
+)
+def test_replacement_outcomes_are_serialized_without_provider_specific_values(tmp_path, outcome):
+    context = RunUsageContext(run_id="run-usage", summary_path=tmp_path / "usage.json")
+    context.add_record(
+        agent="gemini",
+        session_id=None,
+        returncode=1,
+        usage=UsageMetadata(mode="estimated", input_tokens=1, output_tokens=1, total_tokens=2),
+        outcome=outcome,
+    )
+
+    assert context.records[0].to_dict()["outcome"] == outcome
+
+
 def test_completion_recovery_role_survives_record_and_summary(tmp_path):
     context = RunUsageContext(run_id="run-1", summary_path=tmp_path / "usage.json")
     record = context.add_record(

--- a/tests/test_workdir_guard.py
+++ b/tests/test_workdir_guard.py
@@ -2,7 +2,10 @@ from agent_loop_helpers import *  # noqa: F403
 
 from coding_review_agent_loop.workdir_guard import (
     capture_workdir_snapshot,
+    gate_workdir_replay,
+    GitProbeResult,
     read_workdir_head,
+    WorkdirSnapshot,
 )
 from coding_review_agent_loop.orchestrator import _read_assigned_workdir_head
 
@@ -103,6 +106,28 @@ def test_workdir_snapshot_tolerates_agent_loop_error_and_oserror_per_probe(tmp_p
     assert snapshot.head.exception_type == "AgentLoopError"
     assert snapshot.status.kind == "exception"
     assert snapshot.status.exception_type == "OSError"
+
+
+def test_workdir_replay_gate_preserves_provider_label_and_changed_status_refusal():
+    before = WorkdirSnapshot(
+        GitProbeResult(("git", "rev-parse", "HEAD"), "available", "abc123"),
+        GitProbeResult(("git", "status", "--porcelain"), "available", ""),
+    )
+    after = WorkdirSnapshot(
+        GitProbeResult(("git", "rev-parse", "HEAD"), "available", "abc123"),
+        GitProbeResult(("git", "status", "--porcelain"), "available", " M file.py\n"),
+    )
+
+    evidence = gate_workdir_replay(
+        "Gemini executable replacement",
+        "Gemini executable changed during invocation",
+        before_snapshot=before,
+        after_snapshot=after,
+    )
+
+    assert evidence.reason == "Gemini executable changed during invocation"
+    assert evidence.replay_refusal_kind == "changed-status"
+    assert "Gemini executable replacement" in evidence.replay_refusal_detail
 
 
 def test_head_only_probe_does_not_invoke_status_and_strict_mode_reraises(tmp_path):


### PR DESCRIPTION
## Summary

- Harden PTY capture so unexpected master read/select failures retain captured output and expose diagnostics.
- Add shared snapshot-gated replacement evidence for Gemini and Antigravity, including locked Antigravity GEMINI.md lifecycle and repair exclusion.
- Extend provider-specific stability replay budgets, terminal diagnostics, focused regression coverage, and operator documentation.

## Verification

- Focused backend/orchestration/workdir/usage suites: 623 passed.
- Full suite: 2378 passed.

Fixes #687