### PR TITLE
Add structured issue implementation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,16 @@ original issue body:
 agent-loop issue 123 --repo OWNER/REPO
 ```
 
+Issue implementation turns use a strict `issue_implementation` result. The
+result contains the implementation summary, a positive `pr_number` or `null`,
+an auditable `human_requirement_dispositions` ledger, and optional structured
+`tests_run` commands. A null PR is rendered as a readable terminal issue
+comment and does not enter PR review or handoff. If a signed requirement is
+found blocked after a PR was opened, the result keeps the actual PR reference
+in its summary or evidence but uses `pr_number: null`; the issue comment
+records the rejected handoff for operator follow-up. A created PR may not be
+reported alongside a blocked signed requirement.
+
 For larger or ambiguous issues, add `--plan-first` to run a plan review on the
 issue before code is written. The coder may inspect the checkout but must not
 edit files, push, or open a PR during planning. Reviewers approve or block with
@@ -329,14 +339,15 @@ by the backward-compatible `--implement-after-approval` flag. `decompose-only`
 asks the coder to turn the approved plan into ordered phases, always creates
 one GitHub child issue per phase, posts a parent summary table, and stops.
 `implement-by-phase` creates every child issue, then implements only the first
-`agent-pr` phase and stops after that PR review loop. Before entering that child
-implementation, the parent issue records a one-time handoff marker. Parent
-reruns after that marker do not re-run the child implementation; resume directly
-with `agent-loop issue <child>`. If decomposition already exists without a
-handoff marker, the first child is treated as not yet attempted and the handoff
-is recorded once. If the first phase is `human-action` or `manual-close`, the
-loop creates and reports all child issues but stops so a human can do the
-required work, add a remark/update, and close that child issue.
+`agent-pr` phase and stops after that PR review loop. The parent issue records a
+one-time handoff only after the child implementation returns an accepted PR, so
+null-PR and rejected-conflict terminal results never create a misleading
+handoff. Parent reruns after that marker do not re-run the child implementation;
+resume directly with `agent-loop issue <child>`. If decomposition already exists
+without a handoff marker, the first child is treated as not yet attempted and
+the handoff is recorded once. If the first phase is `human-action` or
+`manual-close`, the loop creates and reports all child issues but stops so a
+human can do the required work, add a remark/update, and close that child issue.
 
 Plan-first implementation can use a different implementation agent than the
 planning agent. Planning and plan revisions still use `--coder`; the override

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -226,6 +226,18 @@ Issue mode includes the issue title, body, and comments in the coder prompt and
 issue-origin review prompts. Comments are ordered oldest to newest so later
 discussion can refine or supersede the original body.
 
+The issue implementation coder uses the structured `issue_implementation`
+contract. It reports a non-blank summary, a positive `pr_number` or `null`, an
+exact signed-human-requirement disposition ledger, and optional `tests_run`
+command strings. The orchestrator validates supplied commands inside the
+assigned checkout. A null-PR result is posted as a readable issue-level
+terminal comment and stops before PR operations. If a signed requirement is
+blocked after a PR was opened, the coder must retain the real PR number or URL
+in the summary or disposition evidence while setting `pr_number` to `null`;
+the conflict is posted once without retrying or entering handoff, review, or
+merge gates. Accepted created-PR results are rendered for GitHub and retain the
+raw structured payload in round metadata so resume can restore the typed result.
+
 Run issue mode as plan-first discussion before implementation:
 
 ```bash
@@ -286,7 +298,8 @@ The modes are:
   This is also what `--implement-after-approval` selects for compatibility.
 - `implement-by-phase`: create/link every phase issue, implement only the first
   `agent-pr` child issue, then stop after that PR review loop. The parent issue
-  records a one-time handoff before child implementation starts; parent reruns
+  records a one-time handoff only after an accepted positive implementation PR;
+  null-PR and rejected-conflict results stop without a handoff. Parent reruns
   after that handoff do not re-run the child and should be resumed directly with
   `agent-loop issue <child>`. Older decomposition summaries without this marker
   are treated as not yet handed off, so the first child handoff is recorded once.

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -51,7 +51,8 @@ The skill helpers reuse the same library entry points used by the headless CLI:
 
 - `_validate_plan_review_response` / `_validate_review_response` (unresolved_items)
 - `_resume_plan_round` / `_resume_pr_round` (round_state)
-- `parse_plan_state` / `validate_structured_plan_revision` (protocol)
+- `parse_plan_state` / `validate_structured_plan_revision` /
+  `validate_structured_issue_implementation` (protocol)
 
 GitHub comment metadata markers (`AGENT_LOOP_META`) written by the skill are
 identical to those written by the headless CLI, so mixed-mode operation (start
@@ -73,12 +74,16 @@ mirroring the CLI's `--coder` / `--reviewer` reversal — so an external agent
   `pending`. The host reads the posted plan/PR, writes its structured review
   there, and finalizes it with `complete-host-review --dir <dir>` (works for both
   plan and PR rounds); re-running the round then recomputes the final state.
-- **Implement, reversed**: after a plan is approved, an external coder implements
-  it and opens a PR — see [Approved-plan execution helpers](#approved-plan-execution-helpers)
-  — which the host then reviews with `run-pr-round`. If that review blocks,
-  `run-pr-fix --coder X --reviewers ... --workdir <push-capable clone>` sends the
-  same external coder back to the open PR branch, posts a coder follow-up for the
-  new head, and hands the PR back to `run-pr-round`.
+- **Implement, reversed**: after a plan is approved, an external coder emits the
+  typed `issue_implementation` result and may open a PR — see [Approved-plan
+  execution helpers](#approved-plan-execution-helpers) — which the host then
+  reviews with `run-pr-round`. A null-PR result is posted to the issue and stops
+  before handoff. A positive PR combined with a blocked signed requirement is
+  posted once as a rejected terminal conflict, preserving the real PR reference
+  in the summary/evidence without retrying or entering review/merge gates. If
+  that review blocks, `run-pr-fix --coder X --reviewers ... --workdir <push-capable
+  clone>` sends the same external coder back to the open PR branch, posts a coder
+  follow-up for the new head, and hands the PR back to `run-pr-round`.
 
 End to end: external coder plans -> reviewers review -> external coder implements
 (one-shot / decompose / by-phase) -> host + external reviewers review the PR ->
@@ -116,8 +121,11 @@ Skill mode also exposes the external-coder execution helpers used after a plan
 has already been approved:
 
 - `run-implement` performs the existing one-shot reverse implementation. It
-  keeps using the durable `AGENT_PLAN_ONE_SHOT_IMPL` marker and is unchanged by
-  by-phase support.
+  validates and renders the external coder's `issue_implementation` result,
+  validates structured test commands inside the assigned workdir, preserves the
+  raw payload in accepted PR metadata, and stops before handoff for null-PR or
+  rejected-conflict terminal results. It keeps using the durable
+  `AGENT_PLAN_ONE_SHOT_IMPL` marker and is unchanged by by-phase support.
 - `run-decompose` decomposes an approved plan into child phase issues with mode
   `decompose-only`.
 - `run-implement-by-phase` decomposes with mode `implement-by-phase`, then
@@ -144,9 +152,10 @@ python -m helpers.skill_runner run-implement-by-phase \
 ```
 
 Live by-phase implementation creates or reuses child phase issues, posts the
-parent decomposition summary, posts a phase implementation handoff before
-running the child implementation, and then runs the external coder in the
-push-capable workdir. Reruns with an existing phase handoff stop with a child
+parent decomposition summary, runs the external coder in the push-capable
+workdir, and posts a phase implementation handoff only after the coder returns
+an accepted positive PR. Null-PR and rejected-conflict terminal results stop
+without handoff. Reruns with an existing phase handoff stop with a child
 issue resume hint rather than invoking the coder again. If phase 1 is
 `human-action` or `manual-close`, the command stops after decomposition and
 reports the child issue that needs human work.

--- a/helpers/render_response.py
+++ b/helpers/render_response.py
@@ -7,7 +7,7 @@ Usage:
     [--reviewer REVIEWER] \\
     [--context-file PATH]
 
-Kinds: pr_review, plan_review, coder_followup, plan_revision, plan_state
+Kinds: pr_review, plan_review, coder_followup, issue_implementation, plan_revision, plan_state
 
 Exit 0 on success; exit 1 with diagnostic on failure.
 """
@@ -50,7 +50,7 @@ def main() -> None:
     parser.add_argument(
         "--kind",
         required=True,
-        choices=["pr_review", "plan_review", "coder_followup", "plan_revision", "plan_state"],
+        choices=["pr_review", "plan_review", "coder_followup", "issue_implementation", "plan_revision", "plan_state"],
     )
     parser.add_argument("--output", required=True, help="Path to write rendered markdown.")
     parser.add_argument("--reviewer", default="Codex", help="Reviewer display name.")
@@ -103,6 +103,35 @@ def main() -> None:
                 parsed=parsed,
                 agent=args.reviewer,
                 prior_items=prior_items,
+                model_used=model_used,
+            )
+        elif args.kind == "issue_implementation":
+            from coding_review_agent_loop.orchestrator import _validate_issue_implementation_response
+
+            raw_requirements = ctx.get("human_requirements", [])
+            requirements = []
+            from coding_review_agent_loop.github import HumanReviewRequirement
+
+            for item in raw_requirements:
+                if isinstance(item, dict):
+                    requirements.append(
+                        HumanReviewRequirement(
+                            source_type=str(item.get("source_type", "issue")),
+                            author=str(item.get("author", "")) or None,
+                            created_at=str(item.get("created_at", "")) or None,
+                            url=str(item.get("url", "")) or None,
+                            body=str(item.get("body", item.get("text", ""))),
+                        )
+                    )
+            parsed_result = _validate_issue_implementation_response(
+                text,
+                human_requirements=requirements,
+            )
+            parsed = getattr(parsed_result, "parsed", parsed_result)
+            rendered = render_public_agent_comment(
+                kind="issue_implementation",
+                parsed=parsed,
+                agent=args.reviewer,
                 model_used=model_used,
             )
         elif args.kind == "plan_revision":

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -3,7 +3,7 @@ Run an external agent (Codex or Gemini) for one reviewer or coder turn.
 
 In --dry-run mode, writes a canned approved stub to --output and exits 0:
   --role reviewer → plan_review stub
-  --role coder    → plan_state stub
+  --role coder    → plan_state stub, or issue_implementation for --flow pr
 In live mode, invokes the agent CLI and writes the response to --output.
 
 Usage:
@@ -71,15 +71,24 @@ _CANNED_PLAN_STATE = """\
 -- Codex (dry-run stub)
 """
 
-# Coder implementation turn (reversed roles, #316). Reports a PR number and makes
-# no out-of-workdir test claims, so the workdir test guard passes trivially.
-_CANNED_IMPLEMENTATION = """\
-Implemented the approved plan (dry-run stub): created a branch, made the changes,
-and opened a pull request.
-
-<!-- AGENT_PR: 1 -->
--- Codex (dry-run stub)
-"""
+# Coder implementation turn (reversed roles, #316). The dry-run follows the
+# same typed result contract as a live issue implementation.
+_CANNED_IMPLEMENTATION = json.dumps(
+    {
+        "schema_version": 1,
+        "kind": "issue_implementation",
+        "state": "blocking",
+        "summary": "Dry-run stub: created a branch, made the changes, and opened a pull request.",
+        "pr_number": 1,
+        "human_requirements": {
+            "addressed_ids": [],
+            "checked_discussion_directly": False,
+        },
+        "human_requirement_dispositions": [],
+        "tests_run": None,
+    },
+    indent=2,
+) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex (dry-run stub)\n"
 
 _CANNED_PLAN_DECOMPOSITION = json.dumps(
     {

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -2817,30 +2817,40 @@ def _validate_coder_implementation_response(
     *,
     workdir: str,
     human_requirements,
-) -> int:
-    """Validate an external coder's implementation response; return the PR number.
+) -> object:
+    """Validate an external coder's typed implementation response.
 
-    Mirrors the guards in ``orchestrator._implement_approved_issue``: a valid
-    ``<!-- AGENT_PR: N -->`` marker, the signed-human-requirements acknowledgement
-    (when any were surfaced), and that the coder's reported test commands ran inside
-    the assigned workdir. Raises ``AgentLoopError`` on any failure (the caller treats
-    that as non-retryable). Factored out so the guards are directly unit-testable.
+    Mirrors the guards in the local implementation path.  The returned value
+    is a ``StructuredIssueImplementation`` or one of the existing terminal
+    alternatives, and all reported commands are checked before PR operations.
     """
     from coding_review_agent_loop.orchestrator import (
-        _require_pr_number,
-        _validate_response_with_human_requirements,
+        _TerminalIssueImplementationConflict,
+        _TerminalNoPrImplementation,
+        _validate_issue_implementation_response,
     )
-    from coding_review_agent_loop.workdir_guard import validate_response_tests_within_workdir
+    from coding_review_agent_loop.protocol import StructuredIssueImplementation
+    from coding_review_agent_loop.workdir_guard import (
+        validate_response_tests_within_workdir,
+        validate_test_commands_within_workdir,
+    )
 
-    pr_number = _validate_response_with_human_requirements(
+    result = _validate_issue_implementation_response(
         coder_output,
-        marker_validator=_require_pr_number,
         human_requirements=human_requirements,
-        requirement_scope="implementation requirements",
-        full_omission_fallback="Fetch the issue discussion directly before implementing.",
     )
-    validate_response_tests_within_workdir(coder_output, assigned_workdir=Path(workdir))
-    return int(pr_number)
+    if isinstance(result, (StructuredIssueImplementation, _TerminalIssueImplementationConflict)):
+        parsed = result if isinstance(result, StructuredIssueImplementation) else result.parsed
+        validate_test_commands_within_workdir(
+            parsed.tests_run,
+            assigned_workdir=Path(workdir),
+        )
+    elif isinstance(result, _TerminalNoPrImplementation):
+        validate_response_tests_within_workdir(
+            coder_output,
+            assigned_workdir=Path(workdir),
+        )
+    return result
 
 
 def _load_required_plan_file(path_text: str, *, action: str) -> str:
@@ -2979,6 +2989,7 @@ def _run_child_or_one_shot_implementation(
     external_args: tuple[str, ...] = (),
 ) -> dict:
     from coding_review_agent_loop.config import sync_coder_base_before_implementation
+    from coding_review_agent_loop.comment_rendering import render_public_agent_comment
     from coding_review_agent_loop.decomposition import (
         approved_plan_hash,
         format_one_shot_impl_handoff_comment,
@@ -2988,6 +2999,11 @@ def _run_child_or_one_shot_implementation(
         validate_open_pr,
         validate_pr_references_issue,
     )
+    from coding_review_agent_loop.orchestrator import (
+        _TerminalIssueImplementationConflict,
+        _TerminalNoPrImplementation,
+    )
+    from coding_review_agent_loop.protocol import StructuredIssueImplementation
     from coding_review_agent_loop.workdir_guard import validate_assigned_head_advanced
     from helpers.prompt_builders import build_implementation_prompt_for_skill
 
@@ -3039,7 +3055,7 @@ def _run_child_or_one_shot_implementation(
                 coder_usage = None
 
         try:
-            pr_number = _validate_coder_implementation_response(
+            implementation_result = _validate_coder_implementation_response(
                 coder_output,
                 workdir=str(workdir),
                 human_requirements=issue_context.human_requirements,
@@ -3055,6 +3071,49 @@ def _run_child_or_one_shot_implementation(
                 file=sys.stderr,
             )
             sys.exit(1)
+
+        if isinstance(implementation_result, (StructuredIssueImplementation, _TerminalIssueImplementationConflict)):
+            parsed = (
+                implementation_result
+                if isinstance(implementation_result, StructuredIssueImplementation)
+                else implementation_result.parsed
+            )
+            rendered = render_public_agent_comment(
+                kind="issue_implementation",
+                parsed=parsed,
+                agent=coder,
+                config=config,
+                model_used=_model_used_from_usage(usage_file),
+            )
+            rendered_output = tmpdir / "impl-rendered.md"
+            _write_text(rendered_output, rendered)
+            if parsed.pr_number is None or isinstance(implementation_result, _TerminalIssueImplementationConflict):
+                if not dry_run:
+                    _run_helper(
+                        "helpers.gh_ops", "post-issue-comment",
+                        "--issue", str(issue), "--file", str(rendered_output), "--repo", repo,
+                    )
+                result_json: dict = {
+                    "pr": None,
+                    "issue": issue,
+                    "terminal": "conflict" if isinstance(implementation_result, _TerminalIssueImplementationConflict) else "blocking",
+                }
+                usage = _aggregate_reviewer_usage([{"usage": coder_usage}] if coder_usage else [])
+                if usage is not None:
+                    result_json["usage"] = usage
+                return result_json
+            pr_number = parsed.pr_number
+        elif isinstance(implementation_result, _TerminalNoPrImplementation):
+            rendered_output = tmpdir / "impl-rendered.md"
+            _write_text(rendered_output, coder_output)
+            if not dry_run:
+                _run_helper(
+                    "helpers.gh_ops", "post-issue-comment",
+                    "--issue", str(issue), "--file", str(rendered_output), "--repo", repo,
+                )
+            return {"pr": None, "issue": issue, "terminal": implementation_result.state}
+        else:
+            raise AgentLoopError("Unexpected issue implementation result type.")
 
         if dry_run:
             head_sha = "dry-run-sha"
@@ -3072,10 +3131,21 @@ def _run_child_or_one_shot_implementation(
                 runner, config=config, pr_number=pr_number,
             ).metadata.head_sha or "unknown"
 
+        rendered_output = tmpdir / "impl-rendered.md"
+        _write_text(
+            rendered_output,
+            render_public_agent_comment(
+                kind="issue_implementation",
+                parsed=implementation_result,
+                agent=coder,
+                config=config,
+                model_used=_model_used_from_usage(usage_file),
+            ),
+        )
         tagged = tmpdir / "impl-tagged.md"
         _run_helper(
             "helpers.state_manager", "attach-metadata",
-            "--body-file", str(raw_output),
+            "--body-file", str(rendered_output),
             "--output", str(tagged),
             "--flow", "pr",
             "--role", "coder",
@@ -3083,6 +3153,7 @@ def _run_child_or_one_shot_implementation(
             "--round-number", "1",
             "--subject", str(head_sha),
             "--state", "approved",
+            "--raw-structured-coder-response-file", str(raw_output),
         )
         if not dry_run:
             _run_helper(
@@ -3200,6 +3271,8 @@ def cmd_run_implement(args: argparse.Namespace) -> None:
         external_args=_run_external_antigravity_args(args),
     )
     print(json.dumps(result_json, indent=2))
+    if result_json.get("pr") is None:
+        return
     print(
         f"hint: PR #{result_json['pr']} opened — review it with: python -m helpers.skill_runner "
         f"run-pr-round --pr {result_json['pr']} --repo {repo} --reviewers claude gemini",
@@ -3922,16 +3995,6 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
         )
         return
 
-    post_phase_implementation_handoff_comment(
-        decompose_runner,
-        config=decompose_config,
-        parent_issue=issue,
-        mode=mode,
-        plan_hash=plan_hash,
-        phase_index=1,
-        created=first_phase,
-    )
-
     impl_config = _implementation_config(
         repo=repo, coder=coder, workdir=workdir, base=base, dry_run=False,
     )
@@ -3954,6 +4017,29 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
         runner=impl_runner,
         post_one_shot_handoff=False,
         external_args=_run_external_antigravity_args(args),
+    )
+    if impl_result.get("pr") is None:
+        result_json.update({
+            "state": "blocked",
+            "handoff_posted": False,
+            "child_issue": first_phase.issue_number,
+            "child_implementation": impl_result,
+        })
+        print(json.dumps(result_json, indent=2))
+        print(
+            f"hint: phase 1 implementation for child issue #{first_phase.issue_number} "
+            "did not produce an accepted PR; no phase handoff was posted.",
+            file=sys.stderr,
+        )
+        return
+    post_phase_implementation_handoff_comment(
+        decompose_runner,
+        config=decompose_config,
+        parent_issue=issue,
+        mode=mode,
+        plan_hash=plan_hash,
+        phase_index=1,
+        created=first_phase,
     )
     result_json.update({
         "state": "implemented",

--- a/helpers/validate_response.py
+++ b/helpers/validate_response.py
@@ -10,6 +10,7 @@ Kinds:
   plan_review      -- reviewer plan review structured JSON
   pr_review        -- reviewer PR review structured JSON
   coder_followup   -- coder follow-up structured JSON
+  issue_implementation -- issue implementation structured JSON
   plan_revision    -- coder plan revision structured JSON
 
 The optional --context-file is a JSON file with schema:
@@ -34,7 +35,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.errors import AgentLoopError, UnknownPriorItemDispositionError
-from coding_review_agent_loop.protocol import parse_plan_state, validate_structured_plan_revision
+from coding_review_agent_loop.protocol import (
+    parse_plan_state,
+    validate_structured_plan_revision,
+)
 from coding_review_agent_loop.unresolved_items import (
     _validate_plan_review_response,
     _validate_review_response,
@@ -44,7 +48,7 @@ from coding_review_agent_loop.round_state import _deserialize_unresolved_item
 from coding_review_agent_loop.github import HumanReviewRequirement
 
 
-_KINDS = ("plan_state", "plan_review", "pr_review", "coder_followup", "plan_revision")
+_KINDS = ("plan_state", "plan_review", "pr_review", "coder_followup", "issue_implementation", "plan_revision")
 
 
 def _load_context(path: str | None) -> dict[str, object]:
@@ -152,6 +156,13 @@ def validate_response_text(
             text,
             unresolved_items=deserialized_prior,
             human_requirements=deserialized_requirements or None,
+        )
+    if kind == "issue_implementation":
+        from coding_review_agent_loop.orchestrator import _validate_issue_implementation_response
+
+        return _validate_issue_implementation_response(
+            text,
+            human_requirements=deserialized_requirements,
         )
 
     parsed = validate_structured_plan_revision(text)

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -31,6 +31,7 @@ from .protocol import (
     ParsedReview,
     ReviewItemDisposition,
     StructuredCoderFollowup,
+    StructuredIssueImplementation,
     StructuredPlanState,
     StructuredPlanRevision,
     UnresolvedReviewItem,
@@ -677,6 +678,44 @@ def _render_public_coder_followup_comment(
     return "\n\n".join(section for section in sections if section)
 
 
+def _render_public_issue_implementation_comment(
+    parsed: StructuredIssueImplementation,
+    *,
+    agent: str,
+    config: AgentLoopConfig | None = None,
+    model_used: str | None = None,
+) -> str:
+    """Render an implementation result without exposing its JSON envelope."""
+    has_blocked_requirement = any(
+        item.disposition == "blocked"
+        for item in parsed.human_requirement_dispositions
+    )
+    if has_blocked_requirement and parsed.pr_number is not None:
+        result = (
+            f"Rejected for handoff: reported PR #{parsed.pr_number} was not accepted "
+            "because a signed human requirement is blocked."
+        )
+    elif parsed.pr_number is None:
+        result = "No pull request was accepted for handoff."
+    else:
+        result = f"Pull request reported: #{parsed.pr_number}."
+    sections = ["## Issue implementation", parsed.summary.strip(), f"### Result\n{result}"]
+    if parsed.tests_run:
+        sections.append("\n".join(["### Tests run", *[f"- {test}" for test in parsed.tests_run]]))
+    human_section = render_human_requirement_dispositions(
+        parsed.human_requirement_dispositions
+    )
+    if human_section:
+        sections.append(human_section)
+    sections.extend(
+        [
+            f"<!-- AGENT_STATE: {parsed.state} -->",
+            f"-- {_comment_signature(agent, config, model_used)}",
+        ]
+    )
+    return "\n\n".join(section for section in sections if section)
+
+
 def _extract_plan_revision_human_requirements_block(text: str) -> str:
     stripped = text.lstrip()
     if not stripped.startswith("{"):
@@ -778,6 +817,7 @@ def render_public_agent_comment(
         | StructuredPlanRevision
         | StructuredPlanState
         | ParsedDiscussReview
+        | StructuredIssueImplementation
     ),
     agent: str,
     config: AgentLoopConfig | None = None,
@@ -825,6 +865,17 @@ def render_public_agent_comment(
             parsed,
             agent=agent,
             prior_items=prior_items,
+            config=config,
+            model_used=model_used,
+        )
+    if kind == "issue_implementation":
+        if not isinstance(parsed, StructuredIssueImplementation):
+            raise AgentLoopError(
+                "render_public_agent_comment expected StructuredIssueImplementation."
+            )
+        return _render_public_issue_implementation_comment(
+            parsed,
+            agent=agent,
             config=config,
             model_used=model_used,
         )

--- a/src/coding_review_agent_loop/errors.py
+++ b/src/coding_review_agent_loop/errors.py
@@ -28,6 +28,24 @@ class UnknownPriorItemDispositionError(AgentLoopError):
         super().__init__(message)
 
 
+class IssueImplementationConflictError(AgentLoopError):
+    """A parsed implementation result cannot be handed off as reported.
+
+    A coder may discover a signed human requirement is blocked after opening a
+    PR.  The payload is still valuable operator evidence, but a positive PR
+    identity combined with a blocked requirement is not an accepted
+    implementation result.  Retain the parsed payload so the orchestrator can
+    publish that terminal conflict without retrying or entering PR gates.
+    """
+
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        super().__init__(
+            "issue_implementation cannot report a positive PR while a signed "
+            "human requirement is blocked."
+        )
+
+
 class AgentInvocationError(AgentLoopError):
     """Raised when an agent invocation fails after retries/repair.
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -207,8 +207,6 @@ from .protocol import (
     StructuredPlanState,
     StructuredPlanRevision,
     UnresolvedReviewItem,
-    PrReference,
-    classify_pr_reference,
     human_requirements_resolved,
     is_clarification_request,
     parse_human_requirements_acknowledgement,
@@ -1932,8 +1930,8 @@ def _run_structured_repair(
 class CompletionRecoveryPolicy:
     """Explicit opt-in for the bounded same-session completion-recovery pass (#588).
 
-    Passed only by the direct issue-implementation call sites that already
-    validate with `_require_issue_implementation_result`; every other
+    Passed only by the direct issue-implementation call sites that validate
+    structured `issue_implementation` results; every other
     `_run_validated_agent` caller (planning, plan/PR review, discuss, task,
     and the coder follow-up/PR loop) leaves this `None` and is therefore
     ineligible by construction -- eligibility is never inferred from the
@@ -2031,7 +2029,6 @@ def _attempt_claude_completion_recovery(
     """
     recovery_prompt = build_completion_recovery_prompt(
         config,
-        issue_number=completion_recovery.issue_number,
         issue_context=completion_recovery.issue_context,
     )
     recovery_result = run_agent_result(
@@ -3271,33 +3268,6 @@ def _validate_issue_implementation_response(
     return parsed
 
 
-def _require_issue_implementation_result(text: str) -> int | _TerminalNoPrImplementation:
-    """Accept a positive PR, or an explicit terminal blocking/clarify outcome."""
-    reference: PrReference = classify_pr_reference(text)
-    if reference.is_valid:
-        assert reference.number is not None
-        return reference.number
-
-    if is_clarification_request(text):
-        return _TerminalNoPrImplementation("clarification")
-    try:
-        state = parse_agent_state(text)
-    except AgentLoopError:
-        state = None
-    if state == "blocking":
-        return _TerminalNoPrImplementation("blocking")
-
-    reference_error = (
-        "the AGENT_PR marker or PR URL present was invalid"
-        if reference.kind == "invalid"
-        else "response did not include a PR marker or PR URL"
-    )
-    raise AgentLoopError(
-        f"Coder did not create a valid PR: {reference_error} "
-        "or a terminal blocking/clarification marker."
-    )
-
-
 def _post_no_pr_implementation_terminal_comment(
     runner: Runner,
     *,
@@ -4123,15 +4093,16 @@ def _advisory_issue_pr_provenance(
         )
 
 
-def _validate_response_tests_with_post_pr_context(
-    text: str,
+def _validate_tests_with_post_pr_context(
+    validate_tests: Callable[[], None],
     *,
     runner: Runner,
     config: AgentLoopConfig,
     pr_number: int,
+    report_description: str,
 ) -> None:
     try:
-        validate_response_tests_within_workdir(text, assigned_workdir=active_workdir(config))
+        validate_tests()
     except AgentLoopError as exc:
         try:
             validate_open_pr(runner, config=config, pr_number=pr_number)
@@ -4139,16 +4110,34 @@ def _validate_response_tests_with_post_pr_context(
             raise AgentLoopError(
                 f"{exc}\n\n"
                 f"The coder reported PR #{pr_number}, but the orchestrator could not confirm it is open. "
-                "The handoff/reviewer comments were not posted because the test report was invalid. "
+                f"The handoff/reviewer comments were not posted because the {report_description} was invalid. "
                 "Inspect the PR state on GitHub before deciding whether to resume the existing PR or rerun "
                 "implementation."
             ) from pr_exc
         raise AgentLoopError(
             f"{exc}\n\n"
             f"PR #{pr_number} was confirmed open, but the handoff/reviewer comments were not posted because "
-            "the test report was invalid. Correct the PR/comment if needed, then continue safely with "
+            f"the {report_description} was invalid. Correct the PR/comment if needed, then continue safely with "
             f"`agent-loop pr {pr_number}` instead of rerunning implementation and creating a duplicate PR."
         ) from exc
+
+
+def _validate_response_tests_with_post_pr_context(
+    text: str,
+    *,
+    runner: Runner,
+    config: AgentLoopConfig,
+    pr_number: int,
+) -> None:
+    _validate_tests_with_post_pr_context(
+        lambda: validate_response_tests_within_workdir(
+            text, assigned_workdir=active_workdir(config)
+        ),
+        runner=runner,
+        config=config,
+        pr_number=pr_number,
+        report_description="test report",
+    )
 
 
 def _validate_structured_response_tests_with_post_pr_context(
@@ -4159,28 +4148,16 @@ def _validate_structured_response_tests_with_post_pr_context(
     pr_number: int,
 ) -> None:
     """Validate structured test commands with the same confirmed-PR diagnostic."""
-    try:
-        validate_test_commands_within_workdir(
+    _validate_tests_with_post_pr_context(
+        lambda: validate_test_commands_within_workdir(
             tests_run,
             assigned_workdir=active_workdir(config),
-        )
-    except AgentLoopError as exc:
-        try:
-            validate_open_pr(runner, config=config, pr_number=pr_number)
-        except Exception as pr_exc:
-            raise AgentLoopError(
-                f"{exc}\n\n"
-                f"The coder reported PR #{pr_number}, but the orchestrator could not confirm it is open. "
-                "The handoff/reviewer comments were not posted because the structured test report was invalid. "
-                "Inspect the PR state on GitHub before deciding whether to resume the existing PR or rerun "
-                "implementation."
-            ) from pr_exc
-        raise AgentLoopError(
-            f"{exc}\n\n"
-            f"PR #{pr_number} was confirmed open, but the handoff/reviewer comments were not posted because "
-            "the structured test report was invalid. Correct the PR/comment if needed, then continue safely with "
-            f"`agent-loop pr {pr_number}` instead of rerunning implementation and creating a duplicate PR."
-        ) from exc
+        ),
+        runner=runner,
+        config=config,
+        pr_number=pr_number,
+        report_description="structured test report",
+    )
 
 
 def _round_ledger_may_be_incomplete(
@@ -4281,6 +4258,9 @@ def _implement_approved_issue(
     implementation_session_id = coder_session_id if reuse_planning_session else None
     plan_hash = approved_plan_hash(approved_plan)
     plan_additions = _extract_current_expected_closing_issue_ids(approved_plan)
+    implementation_human_requirements_context = render_coder_human_requirements_prompt_context(
+        issue_context.human_requirements,
+    )
 
     # A prior implementation attempt may have created a PR and then aborted
     # before recording any handoff marker/comment (e.g. the #493 test-report
@@ -4450,12 +4430,8 @@ def _implement_approved_issue(
         usage_context=usage_context,
         use_repair=True,
         repair_expected_kind="issue_implementation",
-        repair_surfaced_requirement_ids=render_coder_human_requirements_prompt_context(
-            issue_context.human_requirements,
-        ).surfaced_requirement_ids,
-        repair_requires_direct_discussion_ack=render_coder_human_requirements_prompt_context(
-            issue_context.human_requirements,
-        ).requires_direct_discussion_ack,
+        repair_surfaced_requirement_ids=implementation_human_requirements_context.surfaced_requirement_ids,
+        repair_requires_direct_discussion_ack=implementation_human_requirements_context.requires_direct_discussion_ack,
         salvage_context=SalvageContext(
             repo=implementation_config.repo,
             issue_number=issue_number,
@@ -6175,6 +6151,9 @@ def run_issue_loop(
             expected_closing_contract_resolved=True,
         )
 
+        implementation_human_requirements_context = render_coder_human_requirements_prompt_context(
+            issue_context.human_requirements,
+        )
         sync_coder_base_before_implementation(config, runner)
         managed_ci_creation_intent = None
         if config.managed_ci:
@@ -6219,12 +6198,8 @@ def run_issue_loop(
             usage_context=usage_context,
             use_repair=True,
             repair_expected_kind="issue_implementation",
-            repair_surfaced_requirement_ids=render_coder_human_requirements_prompt_context(
-                issue_context.human_requirements,
-            ).surfaced_requirement_ids,
-            repair_requires_direct_discussion_ack=render_coder_human_requirements_prompt_context(
-                issue_context.human_requirements,
-            ).requires_direct_discussion_ack,
+            repair_surfaced_requirement_ids=implementation_human_requirements_context.surfaced_requirement_ids,
+            repair_requires_direct_discussion_ack=implementation_human_requirements_context.requires_direct_discussion_ack,
             salvage_context=SalvageContext(
                 repo=config.repo,
                 issue_number=issue_number,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -47,6 +47,7 @@ from .decomposition import (
 from .errors import (
     AgentInvocationError,
     AgentLoopError,
+    IssueImplementationConflictError,
     QuotaResetExceededError,
     UnknownPriorItemDispositionError,
 )
@@ -202,6 +203,7 @@ from .protocol import (
     PUBLIC_RESPONSE_MARKER,
     ReviewItemDisposition,
     StructuredCoderFollowup,
+    StructuredIssueImplementation,
     StructuredPlanState,
     StructuredPlanRevision,
     UnresolvedReviewItem,
@@ -222,6 +224,8 @@ from .protocol import (
     validate_human_requirements_acknowledgement,
     validate_human_requirement_dispositions,
     validate_structured_coder_followup,
+    validate_structured_human_requirements_acknowledgement,
+    validate_structured_issue_implementation,
     validate_structured_plan_state,
     validate_structured_plan_revision,
     validate_structured_discuss_agenda,
@@ -406,7 +410,7 @@ PUBLIC_RESPONSE_ARTIFACT_PREFIX_RE = re.compile(
     re.I,
 )
 STRUCTURED_PUBLIC_RESPONSE_KINDS = frozenset(
-    {"plan_state", "plan_review", "pr_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_semantic_comparison", "discuss_answer_confirmation"}
+    {"plan_state", "plan_review", "pr_review", "coder_followup", "issue_implementation", "plan_revision", "discuss_review", "discuss_answer", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 )
 PLAN_REVISION_FOOTER_RE = re.compile(r"(?m)^<!--\s*AGENT_PLAN_STATE:\s*(approved|blocking)\s*-->\s*$")
 STRUCTURED_FENCE_RE = re.compile(
@@ -1706,6 +1710,8 @@ def _operation_description_from_context(
         return "PR review"
     if repair_expected_kind == "coder_followup":
         return "structured PR feedback follow-up repair"
+    if repair_expected_kind == "issue_implementation":
+        return "issue implementation response repair"
     if repair_expected_kind == "discuss_review":
         return "discuss review"
     if repair_expected_kind == "discuss_agenda":
@@ -1935,6 +1941,7 @@ class CompletionRecoveryPolicy:
     """
 
     issue_number: int
+    issue_context: IssueContext | None = None
 
 
 @dataclass(frozen=True)
@@ -2022,7 +2029,11 @@ def _attempt_claude_completion_recovery(
 
     In every terminal case there is exactly one ``--resume`` call total.
     """
-    recovery_prompt = build_completion_recovery_prompt(config)
+    recovery_prompt = build_completion_recovery_prompt(
+        config,
+        issue_number=completion_recovery.issue_number,
+        issue_context=completion_recovery.issue_context,
+    )
     recovery_result = run_agent_result(
         runner,
         agent="claude",
@@ -2965,7 +2976,7 @@ def _run_validated_agent(
                     repair_kwargs: dict[str, object] = {"expected_kind": repair_expected_kind}
                     if repair_unresolved_item_ids is not None:
                         repair_kwargs["unresolved_item_ids"] = tuple(repair_unresolved_item_ids)
-                    if repair_expected_kind in {"plan_state", "plan_revision"}:
+                    if repair_expected_kind in {"issue_implementation", "plan_state", "plan_revision"}:
                         repair_kwargs["surfaced_requirement_ids"] = tuple(
                             repair_surfaced_requirement_ids or ()
                         )
@@ -3203,6 +3214,63 @@ class _TerminalNoPrImplementation:
     state: str
 
 
+@dataclass(frozen=True)
+class _TerminalIssueImplementationConflict:
+    """A valid implementation payload rejected from handoff by semantics."""
+
+    parsed: StructuredIssueImplementation
+
+
+def _validate_issue_implementation_contract(
+    parsed: StructuredIssueImplementation,
+    *,
+    human_requirements,
+) -> None:
+    prompt_context = render_coder_human_requirements_prompt_context(
+        human_requirements,
+        requirement_scope="implementation requirements",
+        full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
+    validate_human_requirement_dispositions(
+        parsed.human_requirement_dispositions,
+        surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+        context="issue_implementation.human_requirement_dispositions",
+    )
+    validate_structured_human_requirements_acknowledgement(
+        parsed.human_requirements.addressed_ids,
+        dispositions=parsed.human_requirement_dispositions,
+        checked_discussion_directly=parsed.human_requirements.checked_discussion_directly,
+        surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+        requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+    )
+
+
+def _validate_issue_implementation_response(
+    text: str,
+    *,
+    human_requirements,
+) -> StructuredIssueImplementation | _TerminalNoPrImplementation | _TerminalIssueImplementationConflict:
+    """Validate an implementation result and isolate the terminal conflict path."""
+    if is_clarification_request(text):
+        return _TerminalNoPrImplementation("clarification")
+    try:
+        parsed = validate_structured_issue_implementation(text)
+    except IssueImplementationConflictError as exc:
+        parsed = exc.payload
+        if not isinstance(parsed, StructuredIssueImplementation):
+            raise AgentLoopError("Issue implementation conflict did not retain a typed payload.") from exc
+        # A conflict is terminal only after the normal acknowledgement and
+        # exact-ledger contract has been proven valid for this issue.
+        _validate_issue_implementation_contract(parsed, human_requirements=human_requirements)
+        return _TerminalIssueImplementationConflict(parsed)
+    if parsed is None:
+        raise AgentLoopError(
+            "Issue implementation response must use the required structured `issue_implementation` format."
+        )
+    _validate_issue_implementation_contract(parsed, human_requirements=human_requirements)
+    return parsed
+
+
 def _require_issue_implementation_result(text: str) -> int | _TerminalNoPrImplementation:
     """Accept a positive PR, or an explicit terminal blocking/clarify outcome."""
     reference: PrReference = classify_pr_reference(text)
@@ -3252,6 +3320,29 @@ def _post_no_pr_implementation_terminal_comment(
             agent=config.coder,
             config=config,
             model_used=coder_response.model_used,
+        ),
+    )
+
+
+def _post_structured_issue_implementation_terminal_comment(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    issue_number: int,
+    parsed: StructuredIssueImplementation,
+    model_used: str | None,
+) -> None:
+    """Publish a typed no-PR or rejected-conflict implementation result."""
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=issue_number,
+        body=render_public_agent_comment(
+            kind="issue_implementation",
+            parsed=parsed,
+            agent=config.coder,
+            config=config,
+            model_used=model_used,
         ),
     )
 
@@ -4060,6 +4151,38 @@ def _validate_response_tests_with_post_pr_context(
         ) from exc
 
 
+def _validate_structured_response_tests_with_post_pr_context(
+    tests_run: Sequence[str] | None,
+    *,
+    runner: Runner,
+    config: AgentLoopConfig,
+    pr_number: int,
+) -> None:
+    """Validate structured test commands with the same confirmed-PR diagnostic."""
+    try:
+        validate_test_commands_within_workdir(
+            tests_run,
+            assigned_workdir=active_workdir(config),
+        )
+    except AgentLoopError as exc:
+        try:
+            validate_open_pr(runner, config=config, pr_number=pr_number)
+        except Exception as pr_exc:
+            raise AgentLoopError(
+                f"{exc}\n\n"
+                f"The coder reported PR #{pr_number}, but the orchestrator could not confirm it is open. "
+                "The handoff/reviewer comments were not posted because the structured test report was invalid. "
+                "Inspect the PR state on GitHub before deciding whether to resume the existing PR or rerun "
+                "implementation."
+            ) from pr_exc
+        raise AgentLoopError(
+            f"{exc}\n\n"
+            f"PR #{pr_number} was confirmed open, but the handoff/reviewer comments were not posted because "
+            "the structured test report was invalid. Correct the PR/comment if needed, then continue safely with "
+            f"`agent-loop pr {pr_number}` instead of rerunning implementation and creating a duplicate PR."
+        ) from exc
+
+
 def _round_ledger_may_be_incomplete(
     *,
     current_resume: ResumedReviewRound | None,
@@ -4319,9 +4442,20 @@ def _implement_approved_issue(
             managed_ci_creation_intent=managed_ci_creation_intent,
         ),
         session_id=implementation_session_id,
-        marker_description="positive <!-- AGENT_PR: <number> -->, PR URL, blocking, or clarification",
-        validate=_require_issue_implementation_result,
+        marker_description="structured issue_implementation result, blocking, or clarification",
+        validate=lambda text: _validate_issue_implementation_response(
+            text,
+            human_requirements=issue_context.human_requirements,
+        ),
         usage_context=usage_context,
+        use_repair=True,
+        repair_expected_kind="issue_implementation",
+        repair_surfaced_requirement_ids=render_coder_human_requirements_prompt_context(
+            issue_context.human_requirements,
+        ).surfaced_requirement_ids,
+        repair_requires_direct_discussion_ack=render_coder_human_requirements_prompt_context(
+            issue_context.human_requirements,
+        ).requires_direct_discussion_ack,
         salvage_context=SalvageContext(
             repo=implementation_config.repo,
             issue_number=issue_number,
@@ -4331,11 +4465,53 @@ def _implement_approved_issue(
             approved_plan_hash=plan_hash,
         ),
         operation_description="approved-plan implementation",
-        completion_recovery=CompletionRecoveryPolicy(issue_number=issue_number),
+        completion_recovery=CompletionRecoveryPolicy(
+            issue_number=issue_number,
+            issue_context=issue_context,
+        ),
     )
     coder_output = coder_response.text
     implementation_result = coder_response.marker_value
-    if isinstance(implementation_result, _TerminalNoPrImplementation):
+    if isinstance(implementation_result, _TerminalIssueImplementationConflict):
+        validate_test_commands_within_workdir(
+            implementation_result.parsed.tests_run,
+            assigned_workdir=active_workdir(implementation_config),
+        )
+        _post_structured_issue_implementation_terminal_comment(
+            runner,
+            config=implementation_config,
+            issue_number=issue_number,
+            parsed=implementation_result.parsed,
+            model_used=coder_response.model_used,
+        )
+        raise AgentLoopError(
+            "Coder implementation result was not accepted for handoff because a signed "
+            "human requirement is blocked."
+        )
+    if isinstance(implementation_result, StructuredIssueImplementation):
+        if implementation_result.pr_number is None:
+            validate_test_commands_within_workdir(
+                implementation_result.tests_run,
+                assigned_workdir=active_workdir(implementation_config),
+            )
+            _post_structured_issue_implementation_terminal_comment(
+                runner,
+                config=implementation_config,
+                issue_number=issue_number,
+                parsed=implementation_result,
+                model_used=coder_response.model_used,
+            )
+            raise AgentLoopError(
+                "Coder did not create a valid PR; implementation is blocking."
+            )
+        _validate_structured_response_tests_with_post_pr_context(
+            implementation_result.tests_run,
+            runner=runner,
+            config=implementation_config,
+            pr_number=implementation_result.pr_number,
+        )
+        pr_number = implementation_result.pr_number
+    elif isinstance(implementation_result, _TerminalNoPrImplementation):
         _post_no_pr_implementation_terminal_comment(
             runner,
             config=implementation_config,
@@ -4345,20 +4521,8 @@ def _implement_approved_issue(
         raise AgentLoopError(
             "Coder did not create a valid PR; implementation is " + implementation_result.state + "."
         )
-    pr_number = int(implementation_result)
-    _validate_response_with_human_requirements(
-        coder_output,
-        marker_validator=_require_pr_number,
-        human_requirements=issue_context.human_requirements,
-        requirement_scope="implementation requirements",
-        full_omission_fallback="Fetch the issue discussion directly before implementing.",
-    )
-    _validate_response_tests_with_post_pr_context(
-        coder_output,
-        runner=runner,
-        config=implementation_config,
-        pr_number=pr_number,
-    )
+    else:
+        raise AgentLoopError("Issue implementation validator returned an unknown result type.")
     validate_assigned_head_advanced(
         before_head=assigned_head_before,
         after_head=_read_assigned_workdir_head(runner, implementation_config),
@@ -4454,8 +4618,9 @@ def _implement_approved_issue(
             pr_head_sha=initial_pr_context.metadata.head_sha,
         )
     initial_coder_body = _attach_round_metadata(
-        normalize_freeform_signature(
-            coder_output,
+        render_public_agent_comment(
+            kind="issue_implementation",
+            parsed=implementation_result,
             agent=implementation_config.coder,
             config=implementation_config,
             model_used=coder_response.model_used,
@@ -4467,6 +4632,7 @@ def _implement_approved_issue(
             round_number=1,
             subject=str(initial_pr_context.metadata.head_sha or "unknown"),
             prior_items=(),
+            raw_structured_coder_response=coder_output,
             model_used=coder_response.model_used,
             acquisition_outcome=coder_response.acquisition_outcome,
             acquisition_returncode=coder_response.acquisition_returncode,
@@ -5435,22 +5601,13 @@ def _run_plan_first_loop(
                         f"`agent-loop issue {handoff.child_issue_number}`."
                     )
                     return 0
-                post_phase_implementation_handoff_comment(
-                    runner,
-                    config=config,
-                    parent_issue=issue_number,
-                    mode=mode,
-                    plan_hash=plan_hash,
-                    phase_index=1,
-                    created=first_agent_phase,
-                )
                 child_issue_context = get_issue_context(
                     runner,
                     config=config,
                     issue_number=first_agent_phase.issue_number,
                 )
                 phase_parent_context = first_agent_phase.phase.parent_context or current_plan
-                return _implement_approved_issue(
+                implementation_result = _implement_approved_issue(
                     runner,
                     issue_number=first_agent_phase.issue_number,
                     approved_plan=phase_parent_context,
@@ -5460,6 +5617,16 @@ def _run_plan_first_loop(
                     coder_session_id=coder_session_id,
                     usage_context=usage_context,
                 )
+                post_phase_implementation_handoff_comment(
+                    runner,
+                    config=config,
+                    parent_issue=issue_number,
+                    mode=mode,
+                    plan_hash=plan_hash,
+                    phase_index=1,
+                    created=first_agent_phase,
+                )
+                return implementation_result
 
             if mode == "implement-one-shot":
                 plan_hash = approved_plan_hash(current_plan)
@@ -6044,9 +6211,20 @@ def run_issue_loop(
                 staged_parent_issue=staged_parent_issue,
                 managed_ci_creation_intent=managed_ci_creation_intent,
             ),
-            marker_description="positive <!-- AGENT_PR: <number> -->, PR URL, blocking, or clarification",
-            validate=_require_issue_implementation_result,
+            marker_description="structured issue_implementation result, blocking, or clarification",
+            validate=lambda text: _validate_issue_implementation_response(
+                text,
+                human_requirements=issue_context.human_requirements,
+            ),
             usage_context=usage_context,
+            use_repair=True,
+            repair_expected_kind="issue_implementation",
+            repair_surfaced_requirement_ids=render_coder_human_requirements_prompt_context(
+                issue_context.human_requirements,
+            ).surfaced_requirement_ids,
+            repair_requires_direct_discussion_ack=render_coder_human_requirements_prompt_context(
+                issue_context.human_requirements,
+            ).requires_direct_discussion_ack,
             salvage_context=SalvageContext(
                 repo=config.repo,
                 issue_number=issue_number,
@@ -6055,35 +6233,68 @@ def run_issue_loop(
                 run_id=usage_context.run_id,
             ),
             operation_description="issue implementation",
-            completion_recovery=CompletionRecoveryPolicy(issue_number=issue_number),
+            completion_recovery=CompletionRecoveryPolicy(
+                issue_number=issue_number,
+                issue_context=issue_context,
+            ),
         )
         coder_output = coder_response.text
         coder_session_id = coder_response.session_id
         implementation_result = coder_response.marker_value
-        if isinstance(implementation_result, _TerminalNoPrImplementation):
-            _post_no_pr_implementation_terminal_comment(
+        if isinstance(implementation_result, _TerminalIssueImplementationConflict):
+            validate_test_commands_within_workdir(
+                implementation_result.parsed.tests_run,
+                assigned_workdir=active_workdir(config),
+            )
+            _post_structured_issue_implementation_terminal_comment(
                 runner,
                 config=config,
                 issue_number=issue_number,
-                coder_response=coder_response,
+                parsed=implementation_result.parsed,
+                model_used=coder_response.model_used,
             )
             raise AgentLoopError(
-                "Coder did not create a valid PR; implementation is " + implementation_result.state + "."
+                "Coder implementation result was not accepted for handoff because a signed "
+                "human requirement is blocked."
             )
-        pr_number = int(implementation_result)
-        _validate_response_with_human_requirements(
-            coder_output,
-            marker_validator=_require_pr_number,
-            human_requirements=issue_context.human_requirements,
-            requirement_scope="implementation requirements",
-            full_omission_fallback="Fetch the issue discussion directly before implementing.",
-        )
-        _validate_response_tests_with_post_pr_context(
-            coder_output,
-            runner=runner,
-            config=config,
-            pr_number=pr_number,
-        )
+        if isinstance(implementation_result, StructuredIssueImplementation):
+            if implementation_result.pr_number is None:
+                validate_test_commands_within_workdir(
+                    implementation_result.tests_run,
+                    assigned_workdir=active_workdir(config),
+                )
+                _post_structured_issue_implementation_terminal_comment(
+                    runner,
+                    config=config,
+                    issue_number=issue_number,
+                    parsed=implementation_result,
+                    model_used=coder_response.model_used,
+                )
+                raise AgentLoopError(
+                    "Coder did not create a valid PR; implementation is blocking."
+                )
+            _validate_structured_response_tests_with_post_pr_context(
+                implementation_result.tests_run,
+                runner=runner,
+                config=config,
+                pr_number=implementation_result.pr_number,
+            )
+            pr_number = implementation_result.pr_number
+        else:
+            # Clarification remains the legacy terminal alternative.
+            if isinstance(implementation_result, _TerminalNoPrImplementation):
+                _post_no_pr_implementation_terminal_comment(
+                    runner,
+                    config=config,
+                    issue_number=issue_number,
+                    coder_response=coder_response,
+                )
+                raise AgentLoopError(
+                    "Coder did not create a valid PR; implementation is "
+                    + implementation_result.state
+                    + "."
+                )
+            raise AgentLoopError("Issue implementation validator returned an unknown result type.")
         validate_assigned_head_advanced(
             before_head=assigned_head_before,
             after_head=_read_assigned_workdir_head(runner, config),
@@ -6164,8 +6375,9 @@ def run_issue_loop(
             expected_closing_issue_ids=closing_contract.issue_ids,
         )
         initial_coder_body = _attach_round_metadata(
-            normalize_freeform_signature(
-                coder_output,
+            render_public_agent_comment(
+                kind="issue_implementation",
+                parsed=implementation_result,
                 agent=config.coder,
                 config=config,
                 model_used=coder_response.model_used,
@@ -6177,6 +6389,7 @@ def run_issue_loop(
                 round_number=1,
                 subject=str(initial_pr_metadata.head_sha or "unknown"),
                 prior_items=(),
+                raw_structured_coder_response=coder_output,
                 model_used=coder_response.model_used,
                 acquisition_outcome=coder_response.acquisition_outcome,
                 acquisition_returncode=coder_response.acquisition_returncode,
@@ -6358,6 +6571,14 @@ def _extract_structured_coder_summary(text: str | None) -> str | None:
     if not text:
         return None
     try:
+        try:
+            implementation = validate_structured_issue_implementation(text)
+        except IssueImplementationConflictError as exc:
+            implementation = exc.payload
+        except AgentLoopError:
+            implementation = None
+        if isinstance(implementation, StructuredIssueImplementation):
+            return implementation.summary
         parsed = validate_structured_coder_followup(text)
         return parsed.summary if parsed else None
     except AgentLoopError:
@@ -6368,6 +6589,14 @@ def _extract_structured_coder_tests_run(text: str | None) -> tuple[str, ...] | N
     if not text:
         return None
     try:
+        try:
+            implementation = validate_structured_issue_implementation(text)
+        except IssueImplementationConflictError as exc:
+            implementation = exc.payload
+        except AgentLoopError:
+            implementation = None
+        if isinstance(implementation, StructuredIssueImplementation):
+            return implementation.tests_run
         parsed = validate_structured_coder_followup(text)
         return parsed.tests_run if parsed else None
     except AgentLoopError:

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -658,19 +658,17 @@ def _issue_implementation_terminal_marker_guidance(
     """
     return f"""{_agent_unavailable_guidance(coder_signature)}
 Do not wait for {reviewer_name} yourself; this local orchestrator will run
-{reviewer_name} after you create the PR. Use blocking here to hand the PR to
-{reviewer_name} for review. If you cannot safely proceed and cannot create a
-PR, explain the blocker and end with `AGENT_STATE: blocking` (without an
-`AGENT_PR` marker), or ask a final focused question with `AGENT_CLARIFY`.
-Otherwise, use a positive PR number. Do not invent placeholder identifiers such
-as `AGENT_PR: 0`. Do not place your signature before the AGENT_STATE marker.
-Your response must end with, in this exact order for a completed implementation:
+{reviewer_name} after you create the PR. Use the structured
+`issue_implementation` JSON contract above. A positive `pr_number` hands the
+PR to {reviewer_name} for review; `pr_number: null` is the terminal no-PR
+blocking result. A signed requirement discovered to be blocked after a PR was
+opened requires `pr_number: null` with the real PR reference retained in the
+summary or disposition evidence. Do not invent a placeholder PR identity or
+add an `AGENT_PR` marker to the structured result. For clarification, use the
+separate `AGENT_CLARIFY` terminal alternative.
 
-<!-- AGENT_PR: <number> -->
-<!-- AGENT_STATE: blocking -->
--- {coder_signature}
+The structured response must end with this exact footer and signature:
 
-For a no-PR blocking result:
 <!-- AGENT_STATE: blocking -->
 -- {coder_signature}
 
@@ -744,6 +742,78 @@ def _structured_coder_followup_guidance(
             "No signed human requirements are surfaced in this prompt, so structured replies must set both `human_requirement_dispositions` and `human_requirements.addressed_ids` to `[]`, with `checked_discussion_directly` false. Do not put issue numbers, issue acceptance criteria, reviewer item IDs, reviewer comments, summaries, or arbitrary labels in `addressed_ids`; only exact surfaced signed requirement labels are valid when such labels are actually shown."
         )
     return "\n".join(lines) + "\n"
+
+
+def _structured_issue_implementation_guidance(
+    *,
+    human_requirements_context: CoderHumanRequirementsPromptContext,
+    coder_signature: str,
+) -> str:
+    """Return the one structured result contract shared by implementation turns."""
+    if human_requirements_context.surfaced_requirement_ids:
+        disposition_example = [
+            {
+                "requirement_id": requirement_id,
+                "disposition": "addressed",
+                "evidence": "The implementation and tests cover this requirement.",
+            }
+            for requirement_id in human_requirements_context.surfaced_requirement_ids
+        ]
+        addressed_ids = list(human_requirements_context.surfaced_requirement_ids)
+        checked_directly = False
+        requirement_rules = (
+            "`human_requirement_dispositions` must contain exactly one object for every surfaced "
+            "label, with non-empty evidence. Put exactly the addressed labels in "
+            "`human_requirements.addressed_ids`; blocked and not-applicable labels do not belong "
+            "there. Each evidence note must explain how you addressed that item or why it could "
+            "not be satisfied safely."
+        )
+    elif human_requirements_context.requires_direct_discussion_ack:
+        disposition_example = []
+        addressed_ids = []
+        checked_directly = True
+        requirement_rules = (
+            "The detailed signed requirements were omitted for context bounds. Use an empty "
+            "disposition ledger and set `checked_discussion_directly` true only after checking "
+            "the GitHub discussion directly."
+        )
+    else:
+        disposition_example = []
+        addressed_ids = []
+        checked_directly = False
+        requirement_rules = (
+            "No signed human requirements were surfaced, so both the disposition ledger and "
+            "`addressed_ids` must be empty and `checked_discussion_directly` must be false."
+        )
+    example = {
+        "schema_version": 1,
+        "kind": "issue_implementation",
+        "state": "blocking",
+        "summary": "Implemented the approved plan and opened the pull request.",
+        "pr_number": 123,
+        "human_requirements": {
+            "addressed_ids": addressed_ids,
+            "checked_discussion_directly": checked_directly,
+        },
+        "human_requirement_dispositions": disposition_example,
+        "tests_run": ["python -m pytest tests/test_protocol.py -q"],
+    }
+    return f"""Use this mandatory structured `issue_implementation` result so the orchestrator can validate the implementation deterministically:
+
+{json.dumps(example, indent=2)}
+
+Rules:
+- `schema_version` is 1, `kind` is `issue_implementation`, and `state` is `blocking`.
+- `summary` is non-blank and must explain the implementation outcome. `pr_number` is either a positive integer for the newly reported PR or `null` when no PR was accepted for handoff.
+- {requirement_rules}
+- A created-PR result may not contain a `blocked` signed-requirement disposition. If a signed requirement is discovered to be blocked after a PR was opened, set `pr_number` to `null`, keep the real PR number or URL in the summary or disposition evidence so the operator can locate it, and describe the conflict.
+- A null-PR blocker unrelated to signed requirements is valid with the empty ledger required by the rules above.
+- `tests_run` is optional and may be absent, `null`, or an empty array when no tests ran. When supplied, it contains only exact command strings; report why tests could not run in `summary`.
+- Start directly with exactly one top-level JSON object. Put the `<!-- AGENT_STATE: blocking -->` footer immediately after it and only your standalone signature after the footer.
+
+The structured result is the public implementation record. Do not add prose,
+code fences, a `Tests:` section, an `AGENT_PR` marker, or another footer to it.
+{_agent_unavailable_guidance(coder_signature)}"""
 
 
 def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewItem] | None) -> str:
@@ -1263,13 +1333,13 @@ Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
 {provenance_guidance}
 {managed_creation_guidance}
-{human_requirements_context.block}{_coder_human_requirements_guidance(
-    human_requirements_context,
-    requirement_label="implementation requirements",
+{human_requirements_context.block}{_structured_issue_implementation_guidance(
+    human_requirements_context=human_requirements_context,
+    coder_signature=coder_signature,
 )}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
@@ -1863,13 +1933,13 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
 {pr_reference_guidance}
 {provenance_guidance}
 {managed_creation_guidance}
-{human_requirements_context.block}{_coder_human_requirements_guidance(
-    human_requirements_context,
-    requirement_label="implementation requirements",
+{human_requirements_context.block}{_structured_issue_implementation_guidance(
+    human_requirements_context=human_requirements_context,
+    coder_signature=coder_signature,
 )}
 {_issue_context_block(issue_context)}
 {_memory_block(memory)}
@@ -1882,7 +1952,12 @@ Approved implementation plan:
 {_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
 
-def build_completion_recovery_prompt(config: AgentLoopConfig) -> str:
+def build_completion_recovery_prompt(
+    config: AgentLoopConfig,
+    *,
+    issue_number: int | None = None,
+    issue_context: IssueContext | None = None,
+) -> str:
     """One bounded same-session continuation for a stalled implementation turn (#588).
 
     Sent via ``claude --resume <session>`` when a prior implementation turn
@@ -1893,6 +1968,15 @@ def build_completion_recovery_prompt(config: AgentLoopConfig) -> str:
     """
     reviewer_name = format_agent_list(reviewers(config))
     coder_signature = agent_signature(config.coder, config)
+    human_requirements_context = _issue_human_requirements_prompt_context(
+        issue_context,
+        requirement_scope="implementation requirements",
+        full_omission_fallback="Fetch the issue discussion directly before implementing.",
+    )
+    implementation_contract = _structured_issue_implementation_guidance(
+        human_requirements_context=human_requirements_context,
+        coder_signature=coder_signature,
+    )
     return f"""Your previous turn on this same implementation ended without a valid
 terminal response, and its text suggested required work (tests, a build, or
 similar) was left running in the background instead of being finished before
@@ -1910,7 +1994,9 @@ task-output file. If you know its process ID, terminate it once (a single
 foreground under the bounded timeout below, waiting for it to finish; launch
 nothing new in the background. Then commit, push, and open the pull request if
 that is not already done, or continue exactly where you left off.
-{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{human_requirements_context.block}
+{implementation_contract}
 {_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
 
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -812,8 +812,7 @@ Rules:
 - Start directly with exactly one top-level JSON object. Put the `<!-- AGENT_STATE: blocking -->` footer immediately after it and only your standalone signature after the footer.
 
 The structured result is the public implementation record. Do not add prose,
-code fences, a `Tests:` section, an `AGENT_PR` marker, or another footer to it.
-{_agent_unavailable_guidance(coder_signature)}"""
+code fences, a `Tests:` section, an `AGENT_PR` marker, or another footer to it."""
 
 
 def _format_unresolved_review_items(unresolved_items: Sequence[UnresolvedReviewItem] | None) -> str:
@@ -1955,7 +1954,6 @@ Approved implementation plan:
 def build_completion_recovery_prompt(
     config: AgentLoopConfig,
     *,
-    issue_number: int | None = None,
     issue_context: IssueContext | None = None,
 ) -> str:
     """One bounded same-session continuation for a stalled implementation turn (#588).

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 import dataclasses
 from dataclasses import dataclass, field
 
-from .errors import AgentLoopError
+from .errors import AgentLoopError, IssueImplementationConflictError
 
 PUBLIC_RESPONSE_MARKER = "=== AGENT_LOOP_PUBLIC_RESPONSE_BELOW ==="
 
@@ -232,6 +232,20 @@ class StructuredCoderFollowup:
     disputed_items: tuple[str, ...] = ()
     dispute_evidence: dict[str, str] = field(default_factory=dict)
     human_requirement_dispositions: tuple[HumanRequirementDisposition, ...] = ()
+
+
+@dataclass(frozen=True)
+class StructuredIssueImplementation:
+    """The strict terminal result emitted by an issue implementation coder."""
+
+    schema_version: int
+    kind: str
+    state: str
+    summary: str
+    pr_number: int | None
+    human_requirements: StructuredHumanRequirementsPayload
+    human_requirement_dispositions: tuple[HumanRequirementDisposition, ...]
+    tests_run: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -1487,6 +1501,23 @@ def _extract_structured_coder_followup_payload(text: str) -> dict[str, object] |
     )
 
 
+def _extract_structured_issue_implementation_payload(
+    text: str,
+) -> dict[str, object] | None:
+    text, _status = normalize_response_file_structured_text(text)
+    extracted = _extract_json_object_prefix(text)
+    if extracted is None:
+        return None
+    payload, trailing = extracted
+    return _consume_structured_footer_and_signature(
+        payload=payload,
+        trailing=trailing,
+        state_re=STATE_RE,
+        state_marker_name="AGENT_STATE",
+        context_label="Structured issue implementation",
+    )
+
+
 def _require_supported_schema_version(payload: dict[str, object]) -> None:
     if "schema_version" not in payload:
         raise AgentLoopError("Structured response is missing required field: schema_version")
@@ -1940,6 +1971,104 @@ def validate_structured_coder_followup(text: str) -> StructuredCoderFollowup | N
         disputed_items=disputed_items,
         dispute_evidence=dispute_evidence,
     )
+
+
+def validate_structured_issue_implementation(
+    text: str,
+) -> StructuredIssueImplementation | None:
+    """Parse and validate the strict issue-implementation result envelope.
+
+    Context-sensitive requirement coverage is applied by the orchestrator,
+    because only the caller knows which signed labels were surfaced.  Basic
+    payload shape is validated here so malformed responses remain repairable.
+    """
+    payload = _extract_structured_issue_implementation_payload(text)
+    if payload is None:
+        return None
+    _require_supported_schema_version(payload)
+    if payload.get("kind") != "issue_implementation":
+        raise AgentLoopError(
+            "Structured response kind mismatch: expected `issue_implementation`."
+        )
+    _expect_exact_keys(
+        payload,
+        context="issue_implementation",
+        required={
+            "schema_version",
+            "kind",
+            "state",
+            "summary",
+            "pr_number",
+            "human_requirements",
+            "human_requirement_dispositions",
+        },
+        optional={"tests_run"},
+    )
+    state = _expect_non_empty_string(payload["state"], context="issue_implementation.state")
+    if state != "blocking":
+        raise AgentLoopError("issue_implementation.state must be `blocking`.")
+    summary = _expect_non_empty_string(
+        payload["summary"], context="issue_implementation.summary"
+    )
+    pr_value = payload["pr_number"]
+    if pr_value is None:
+        pr_number = None
+    else:
+        pr_number = _expect_int(pr_value, context="issue_implementation.pr_number")
+        if pr_number <= 0:
+            raise AgentLoopError(
+                "issue_implementation.pr_number must be a positive integer or null."
+            )
+    human_payload = _expect_object(
+        payload["human_requirements"], context="issue_implementation.human_requirements"
+    )
+    _expect_exact_keys(
+        human_payload,
+        context="issue_implementation.human_requirements",
+        required={"addressed_ids", "checked_discussion_directly"},
+    )
+    dispositions = _expect_human_requirement_dispositions(
+        payload["human_requirement_dispositions"],
+        context="issue_implementation.human_requirement_dispositions",
+    )
+    tests_value = payload.get("tests_run")
+    tests_run = (
+        _expect_string_list(
+            tests_value,
+            context="issue_implementation.tests_run",
+            item_context="issue_implementation.tests_run",
+        )
+        if tests_value is not None
+        else None
+    )
+    parsed = StructuredIssueImplementation(
+        schema_version=1,
+        kind="issue_implementation",
+        state=state,
+        summary=summary,
+        pr_number=pr_number,
+        human_requirements=StructuredHumanRequirementsPayload(
+            addressed_ids=_expect_requirement_id_list(
+                human_payload["addressed_ids"],
+                context="issue_implementation.human_requirements.addressed_ids",
+            ),
+            checked_discussion_directly=_expect_bool(
+                human_payload["checked_discussion_directly"],
+                context="issue_implementation.human_requirements.checked_discussion_directly",
+            ),
+        ),
+        human_requirement_dispositions=dispositions,
+        tests_run=tests_run,
+    )
+    # Keep this semantic contradiction visible to callers as a dedicated error
+    # with the typed payload attached.  The orchestration adapter first
+    # re-applies caller-specific requirement coverage before treating it as a
+    # terminal conflict.
+    if parsed.pr_number is not None and any(
+        item.disposition == "blocked" for item in parsed.human_requirement_dispositions
+    ):
+        raise IssueImplementationConflictError(parsed)
+    return parsed
 
 
 def validate_structured_plan_revision(text: str) -> StructuredPlanRevision | None:

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -92,7 +92,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"plan_state", "pr_review", "plan_review", "plan_revision", "coder_followup", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
+    if expected_kind not in {"plan_state", "pr_review", "plan_review", "plan_revision", "coder_followup", "issue_implementation", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
         return None
 
     stripped = raw.lstrip()
@@ -207,6 +207,8 @@ You are a format-repair assistant. An AI agent produced an initial plan state, c
 
 {expected_kind_instruction}
 
+{issue_implementation_instruction}
+
 {coder_followup_required_items_instruction}
 
 {coder_followup_human_requirements_instruction}
@@ -278,6 +280,32 @@ You are a format-repair assistant. An AI agent produced an initial plan state, c
 This is a blocking example because it has a `blocked` human-requirement disposition.
 For an approved coder follow-up, use `"state": "approved"`, an
 `<!-- AGENT_STATE: approved -->` footer, and no `blocked` dispositions.
+
+## Valid Format D — Issue Implementation:
+
+{
+  "schema_version": 1,
+  "kind": "issue_implementation",
+  "state": "blocking",
+  "summary": "<implementation outcome, including any blocker>",
+  "pr_number": 123,
+  "human_requirements": {
+    "addressed_ids": [],
+    "checked_discussion_directly": false
+  },
+  "human_requirement_dispositions": [],
+  "tests_run": ["<exact command>"]
+}
+<!-- AGENT_STATE: blocking -->
+-- <Coder Name>
+
+For issue implementation repair, preserve the original PR identity and
+requirement semantics. Use `pr_number: null` for a no-PR result or for a
+blocked signed requirement discovered after a PR was opened, and retain the
+real PR number or URL in the summary or disposition evidence. A positive PR
+with a blocked disposition remains a terminal conflict after repair; do not
+relabel or silently remove that blocker. `tests_run` may be absent, null, or
+an empty array, but supplied values must be exact command strings.
 
 ## Valid Format E — Discuss Review:
 
@@ -1019,7 +1047,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"plan_state", "pr_review", "plan_review", "coder_followup", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
+_SUPPORTED_EXPECTED_KINDS = {"plan_state", "pr_review", "plan_review", "coder_followup", "issue_implementation", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
     "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",
@@ -1085,11 +1113,16 @@ def _build_repair_prompt(
         raise ValueError(f"Unsupported expected repair kind: {expected_kind}")
     if (
         (surfaced_requirement_ids is not None or requires_direct_discussion_ack)
-        and expected_kind not in {"coder_followup", "plan_state", "plan_revision"}
+        and expected_kind not in {"coder_followup", "issue_implementation", "plan_state", "plan_revision"}
     ):
         raise ValueError(
-            "surfaced_requirement_ids may only be used for coder_followup, plan_state, or plan_revision repair"
+            "surfaced_requirement_ids may only be used for coder_followup, issue_implementation, plan_state, or plan_revision repair"
         )
+    issue_implementation_instruction = _issue_implementation_instruction(
+        expected_kind,
+        surfaced_requirement_ids,
+        requires_direct_discussion_ack,
+    )
     coder_followup_required_items_instruction = _coder_followup_required_items_instruction(
         expected_kind, unresolved_item_ids
     )
@@ -1123,6 +1156,7 @@ def _build_repair_prompt(
     )
     prompt = _REPAIR_PROMPT.replace("{expected_kind_instruction}", expected_kind_instruction, 1)
     replacements = (
+        ("{issue_implementation_instruction}", issue_implementation_instruction),
         ("{coder_followup_required_items_instruction}", coder_followup_required_items_instruction),
         ("{coder_followup_human_requirements_instruction}", coder_followup_human_requirements_instruction),
         ("{planning_human_requirements_instruction}", planning_human_requirements_instruction),
@@ -1133,6 +1167,40 @@ def _build_repair_prompt(
     for placeholder, value in replacements:
         prompt = prompt.replace(placeholder, value, 1)
     return prompt
+
+
+def _issue_implementation_instruction(
+    expected_kind: str | None,
+    surfaced_requirement_ids: Sequence[str] | None,
+    requires_direct_discussion_ack: bool,
+) -> str:
+    if expected_kind != "issue_implementation":
+        return ""
+    ids = tuple(surfaced_requirement_ids or ())
+    if ids:
+        requirement_rule = (
+            "Include exactly one disposition with non-empty evidence for each of: "
+            + ", ".join(f"`{item}`" for item in ids)
+            + ". Put only addressed IDs in addressed_ids."
+        )
+    elif requires_direct_discussion_ack:
+        requirement_rule = (
+            "The detailed signed requirements were omitted. Keep both ledgers empty and set "
+            "checked_discussion_directly true only when the discussion was checked directly."
+        )
+    else:
+        requirement_rule = (
+            "No signed requirements were surfaced. Keep both ledgers empty and set "
+            "checked_discussion_directly false."
+        )
+    return (
+        "## Issue implementation repair rules:\n"
+        "Repair only the issue_implementation envelope. Preserve `summary`, `pr_number`, "
+        "tests_run`, and the meaning of every disposition; do not invent a PR identity. "
+        + requirement_rule
+        + " A positive PR with a blocked disposition remains a terminal conflict after repair; "
+        "do not relabel or silently remove that blocker.\n"
+    )
 
 
 def execute_repair(

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -281,7 +281,7 @@ This is a blocking example because it has a `blocked` human-requirement disposit
 For an approved coder follow-up, use `"state": "approved"`, an
 `<!-- AGENT_STATE: approved -->` footer, and no `blocked` dispositions.
 
-## Valid Format D — Issue Implementation:
+## Valid Format K — Issue Implementation:
 
 {
   "schema_version": 1,
@@ -534,9 +534,13 @@ The active planning human-requirements context above is authoritative. Do not us
 ## STATE RULES (Format D):
 ### BLOCKING only. plan_revision.state must be "blocking" and must include at least one plan_steps string.
 
+## STATE RULES (Format K):
+### BLOCKING only. issue_implementation.state must be "blocking".
+
 ## FORMAT SELECTION:
 - If an expected response kind is provided above, use ONLY that format. Do not infer a different kind from keywords in the malformed response.
 - Use Format C if the original contains "coder_followup" or "addressed_items" or "remaining_items".
+- Use Format K if the original contains "issue_implementation" or "pr_number".
 - Use Format D if the original contains "plan_revision".
 - Use Format J if the original contains "plan_state" or "plan_steps".
 - Use Format H if the original contains "discuss_semantic_comparison" or "remaining_decisions".
@@ -1196,7 +1200,7 @@ def _issue_implementation_instruction(
     return (
         "## Issue implementation repair rules:\n"
         "Repair only the issue_implementation envelope. Preserve `summary`, `pr_number`, "
-        "tests_run`, and the meaning of every disposition; do not invent a PR identity. "
+        "`tests_run`, and the meaning of every disposition; do not invent a PR identity. "
         + requirement_rule
         + " A positive PR with a blocked disposition remains a terminal conflict after repair; "
         "do not relabel or silently remove that blocker.\n"

--- a/src/coding_review_agent_loop/unresolved_items.py
+++ b/src/coding_review_agent_loop/unresolved_items.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 
-from .errors import AgentLoopError, UnknownPriorItemDispositionError
+from .errors import (
+    AgentLoopError,
+    IssueImplementationConflictError,
+    UnknownPriorItemDispositionError,
+)
 from .github import PullRequestMergeability
 from .prompts import render_coder_human_requirements_prompt_context
 from .protocol import (
@@ -13,12 +17,14 @@ from .protocol import (
     ParsedReview,
     ReviewItemDisposition,
     StructuredCoderFollowup,
+    StructuredIssueImplementation,
     UnresolvedReviewItem,
     parse_plan_review,
     parse_pr_review,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
     validate_structured_human_requirements_acknowledgement,
+    validate_structured_issue_implementation,
     validate_human_requirement_dispositions,
 )
 
@@ -239,26 +245,47 @@ def _reconcile_human_requirements_ack_item(
     if not prompt_context.surfaced_requirement_ids and not prompt_context.requires_direct_discussion_ack:
         return _clear_human_requirements_ack_item(unresolved_items)
     try:
-        structured_followup = validate_structured_coder_followup(coder_output)
-        if structured_followup is not None:
+        structured_followup = None
+        try:
+            structured_implementation = validate_structured_issue_implementation(coder_output)
+        except IssueImplementationConflictError as exc:
+            structured_implementation = exc.payload
+        except AgentLoopError:
+            structured_implementation = None
+        if isinstance(structured_implementation, StructuredIssueImplementation):
             validate_human_requirement_dispositions(
-                structured_followup.human_requirement_dispositions,
+                structured_implementation.human_requirement_dispositions,
                 surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
-                context="coder_followup.human_requirement_dispositions",
+                context="issue_implementation.human_requirement_dispositions",
             )
             validate_structured_human_requirements_acknowledgement(
-                structured_followup.human_requirements.addressed_ids,
-                dispositions=structured_followup.human_requirement_dispositions,
-                checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
+                structured_implementation.human_requirements.addressed_ids,
+                dispositions=structured_implementation.human_requirement_dispositions,
+                checked_discussion_directly=structured_implementation.human_requirements.checked_discussion_directly,
                 surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
                 requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
             )
         else:
-            validate_human_requirements_acknowledgement(
-                coder_output,
-                surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
-                requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
-            )
+            structured_followup = validate_structured_coder_followup(coder_output)
+            if structured_followup is None:
+                validate_human_requirements_acknowledgement(
+                    coder_output,
+                    surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+                    requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+                )
+            else:
+                validate_human_requirement_dispositions(
+                    structured_followup.human_requirement_dispositions,
+                    surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+                    context="coder_followup.human_requirement_dispositions",
+                )
+                validate_structured_human_requirements_acknowledgement(
+                    structured_followup.human_requirements.addressed_ids,
+                    dispositions=structured_followup.human_requirement_dispositions,
+                    checked_discussion_directly=structured_followup.human_requirements.checked_discussion_directly,
+                    surfaced_requirement_ids=prompt_context.surfaced_requirement_ids,
+                    requires_direct_discussion_ack=prompt_context.requires_direct_discussion_ack,
+                )
     except AgentLoopError as exc:
         return _upsert_human_requirements_ack_item(
             unresolved_items,

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -73,6 +73,7 @@ from coding_review_agent_loop.comment_rendering import (
     _render_public_plan_review_comment,
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
+    _render_public_issue_implementation_comment,
     normalize_freeform_signature,
 )
 from coding_review_agent_loop.decomposition import (
@@ -179,6 +180,7 @@ from coding_review_agent_loop.protocol import (
     UnresolvedReviewItem,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
+    validate_structured_issue_implementation,
     validate_structured_human_requirements_acknowledgement,
     validate_structured_plan_state,
     validate_structured_plan_revision,
@@ -473,6 +475,47 @@ class FakeRunner(Runner):
                     if HUMAN_REQUIREMENTS_ADDRESSED_MARKER in output
                     else ""
                 ),
+                )
+        if '"kind": "issue_implementation"' in prompt and (
+            "<!-- AGENT_STATE:" in output or parse_pr_number(output) is not None
+        ):
+            pr_number = parse_pr_number(output)
+            summary = _review_freeform_summary_text(output) or "Implementation completed."
+            labels = sorted(
+                set(re.findall(r"\bRequirement\s+\d+\b", output, re.I)),
+                key=lambda value: int(value.split()[-1]),
+            )
+            labels = [f"Requirement {value.split()[-1]}" for value in labels]
+            blocked = {
+                label
+                for label in labels
+                if re.search(
+                    rf"{re.escape(label)}.{{0,160}}(?:blocked|cannot|unavailable|impossible)",
+                    output,
+                    re.I | re.S,
+                )
+            }
+            dispositions = [
+                {
+                    "requirement_id": label,
+                    "disposition": "blocked" if label in blocked else "addressed",
+                    "evidence": (
+                        f"{label} is blocked according to the legacy implementation response."
+                        if label in blocked
+                        else f"{label} is covered by the legacy implementation response."
+                    ),
+                }
+                for label in labels
+            ]
+            return structured_issue_implementation(
+                state="blocking",
+                summary=summary,
+                pr_number=pr_number,
+                human_requirement_dispositions=dispositions,
+                human_requirement_ids=[label for label in labels if label not in blocked],
+                checked_discussion_directly=HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK in output,
+                tests_run=list(extract_reported_tests_from_response(output)) or None,
+                reviewer=signature,
             )
         if '"kind": "coder_followup"' in prompt and "<!-- AGENT_STATE:" in output:
             item_ids = sorted(set(re.findall(r"\[(item-[A-Za-z0-9._-]+)\]", prompt)))
@@ -523,7 +566,42 @@ class FakeRunner(Runner):
     def _maybe_advance_git_head_for_agent_pr(self, text: str) -> None:
         if not self.advance_git_head_on_pr:
             return
-        if "<!-- AGENT_PR:" not in text and "github.com/OWNER/REPO/pull/" not in text:
+        has_pr_identity = "<!-- AGENT_PR:" in text or "github.com/OWNER/REPO/pull/" in text
+        if not has_pr_identity and text.lstrip().startswith("{"):
+            try:
+                payload, _ = json.JSONDecoder().raw_decode(text.lstrip())
+            except json.JSONDecodeError:
+                payload = None
+            has_pr_identity = (
+                isinstance(payload, dict)
+                and payload.get("kind") == "issue_implementation"
+                and isinstance(payload.get("pr_number"), int)
+                and not isinstance(payload.get("pr_number"), bool)
+                and payload["pr_number"] > 0
+            )
+            if not has_pr_identity and isinstance(payload, dict):
+                for key in ("response", "result"):
+                    value = payload.get(key)
+                    if isinstance(value, str):
+                        has_pr_identity = (
+                            "<!-- AGENT_PR:" in value
+                            or "github.com/OWNER/REPO/pull/" in value
+                        )
+                        if not has_pr_identity and value.lstrip().startswith("{"):
+                            try:
+                                nested, _ = json.JSONDecoder().raw_decode(value.lstrip())
+                            except json.JSONDecodeError:
+                                nested = None
+                            has_pr_identity = (
+                                isinstance(nested, dict)
+                                and nested.get("kind") == "issue_implementation"
+                                and isinstance(nested.get("pr_number"), int)
+                                and not isinstance(nested.get("pr_number"), bool)
+                                and nested["pr_number"] > 0
+                            )
+                        if has_pr_identity:
+                            break
+        if not has_pr_identity:
             return
         self._agent_pr_counter += 1
         self.git_head = f"{self.git_head}-agent-{self._agent_pr_counter}"
@@ -1349,6 +1427,46 @@ def structured_coder_followup(
         payload["disputed_items"] = disputed_items
     if dispute_evidence is not None:
         payload["dispute_evidence"] = dispute_evidence
+    return json.dumps(payload) + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
+
+
+def structured_issue_implementation(
+    *,
+    state: str = "blocking",
+    summary: str = "Implemented the requested change.",
+    pr_number: int | None = 77,
+    human_requirement_ids: list[str] | None = None,
+    human_requirement_dispositions: list[dict[str, str]] | None = None,
+    checked_discussion_directly: bool = False,
+    tests_run: list[str] | None = None,
+    reviewer: str = "Anthropic Claude",
+) -> str:
+    ids = human_requirement_ids or []
+    payload: dict = {
+        "schema_version": 1,
+        "kind": "issue_implementation",
+        "state": state,
+        "summary": summary,
+        "pr_number": pr_number,
+        "human_requirements": {
+            "addressed_ids": ids,
+            "checked_discussion_directly": checked_discussion_directly,
+        },
+        "human_requirement_dispositions": (
+            human_requirement_dispositions
+            if human_requirement_dispositions is not None
+            else [
+                {
+                    "requirement_id": requirement_id,
+                    "disposition": "addressed",
+                    "evidence": "The implementation covers the surfaced requirement.",
+                }
+                for requirement_id in ids
+            ]
+        ),
+    }
+    if tests_run is not None:
+        payload["tests_run"] = tests_run
     return json.dumps(payload) + f"\n<!-- AGENT_STATE: {state} -->\n-- {reviewer}"
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -69,6 +69,7 @@ from coding_review_agent_loop.protocol import (
     parse_plan_item_dispositions,
     parse_plan_review,
     parse_pr_review,
+    validate_structured_issue_implementation,
     validate_structured_coder_followup,
     validate_structured_plan_revision,
 )
@@ -80,6 +81,7 @@ from agent_loop_helpers import (
     prior_item_dispositions,
     prior_plan_item_dispositions,
     structured_coder_followup,
+    structured_issue_implementation,
     structured_plan_review,
     structured_plan_revision,
     structured_plan_state,
@@ -2160,9 +2162,10 @@ def test_issue_loop_plan_first_can_switch_implementation_coder_end_to_end(tmp_pa
     pr_review_text = structured_pr_review(state="approved", summary="PR approved.")
     plan_review_marker = parse_plan_review(plan_review_text, reviewer="Google Gemini")
     pr_review_marker = parse_pr_review(pr_review_text, reviewer="Google Gemini")
-    implementation_text = (
-        "Created PR.\nTests: python -m pytest passed.\n"
-        "<!-- AGENT_PR: 77 -->\n-- OpenAI Codex"
+    implementation_text = structured_issue_implementation(
+        summary="Created PR 77.",
+        pr_number=77,
+        reviewer="OpenAI Codex",
     )
     calls = []
     runner = FakeRunner(pr_payload={"body": "Fixes #56"})
@@ -2207,7 +2210,7 @@ def test_issue_loop_plan_first_can_switch_implementation_coder_end_to_end(tmp_pa
                 text=implementation_text,
                 model_used="gpt-5.5 (high)",
                 session_id="implementation-session",
-                marker_value="77",
+                marker_value=validate_structured_issue_implementation(implementation_text),
             )
         return ValidatedAgentResponse(
             text=pr_review_text,

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -8,6 +8,7 @@ import re
 
 import pytest
 
+from coding_review_agent_loop.github import HumanReviewRequirement
 from coding_review_agent_loop.comment_rendering import (
     _render_public_coder_followup_comment,
     _render_public_discuss_review_comment,
@@ -30,6 +31,8 @@ from coding_review_agent_loop.orchestrator import (
     _format_unresolved_item_label,
     _render_public_review_comment,
     _review_freeform_summary_text,
+    _TerminalIssueImplementationConflict,
+    _validate_issue_implementation_response,
     render_canonical_plan_revision,
     render_canonical_plan_steps,
     render_public_agent_comment,
@@ -82,6 +85,43 @@ def test_render_issue_implementation_no_pr_keeps_summary_tests_and_result_identi
     assert "No pull request was accepted for handoff." in rendered
     assert "No safe PR was accepted." in rendered
     assert "python3 -m pytest tests/test_protocol.py -q" in rendered
+    assert '"kind": "issue_implementation"' not in rendered
+
+
+def test_render_issue_implementation_conflict_explains_rejected_pr_handoff():
+    text = structured_issue_implementation(
+        pr_number=77,
+        summary="PR #77 was opened, but Requirement 1 is blocked.",
+        human_requirement_dispositions=[
+            {
+                "requirement_id": "Requirement 1",
+                "disposition": "blocked",
+                "evidence": "The required integration is unavailable.",
+            }
+        ],
+    )
+    result = _validate_issue_implementation_response(
+        text,
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue comment",
+                author="maintainer",
+                created_at="2026-01-01T00:00:00Z",
+                url="https://example.test/issue-comment",
+                body="Preserve the integration.",
+            ),
+        ),
+    )
+
+    assert isinstance(result, _TerminalIssueImplementationConflict)
+    rendered = _render_public_issue_implementation_comment(
+        result.parsed,
+        agent="claude",
+        model_used="claude-test",
+    )
+
+    assert "Rejected for handoff: reported PR #77 was not accepted" in rendered
+    assert "PR #77 was opened, but Requirement 1 is blocked." in rendered
     assert '"kind": "issue_implementation"' not in rendered
 
 

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -14,6 +14,7 @@ from coding_review_agent_loop.comment_rendering import (
     _render_public_plan_review_comment,
     _render_public_plan_revision_comment,
     _render_public_pr_review_comment,
+    _render_public_issue_implementation_comment,
     decode_deferred_stages_marker,
     normalize_freeform_signature,
     render_agent_unavailable_comment,
@@ -43,6 +44,7 @@ from coding_review_agent_loop.protocol import (
     parse_structured_plan_review,
     parse_unresolved_item_dispositions,
     validate_structured_coder_followup,
+    validate_structured_issue_implementation,
     validate_structured_plan_revision,
     validate_structured_plan_state,
 )
@@ -53,11 +55,34 @@ from agent_loop_helpers import (
     prior_item_dispositions,
     prior_plan_item_dispositions,
     structured_coder_followup,
+    structured_issue_implementation,
     structured_plan_review,
     structured_plan_revision,
     structured_plan_state,
     structured_pr_review,
 )
+
+
+def test_render_issue_implementation_no_pr_keeps_summary_tests_and_result_identity():
+    parsed = validate_structured_issue_implementation(
+        structured_issue_implementation(
+            pr_number=None,
+            summary="No safe PR was accepted.",
+            tests_run=["python3 -m pytest tests/test_protocol.py -q"],
+        )
+    )
+
+    assert parsed is not None
+    rendered = _render_public_issue_implementation_comment(
+        parsed,
+        agent="claude",
+        model_used="claude-test",
+    )
+
+    assert "No pull request was accepted for handoff." in rendered
+    assert "No safe PR was accepted." in rendered
+    assert "python3 -m pytest tests/test_protocol.py -q" in rendered
+    assert '"kind": "issue_implementation"' not in rendered
 
 
 def test_render_agent_unavailable_comment_round_trips_through_parser():

--- a/tests/test_completion_recovery.py
+++ b/tests/test_completion_recovery.py
@@ -19,8 +19,6 @@ from coding_review_agent_loop.orchestrator import (
     ValidatedAgentResponse,
     _attempt_claude_completion_recovery,
     _new_usage_context,
-    _require_issue_implementation_result,
-    _TerminalNoPrImplementation,
 )
 from coding_review_agent_loop.protocol import (
     AgentUnavailable,
@@ -30,6 +28,15 @@ from coding_review_agent_loop.protocol import (
 )
 
 from agent_loop_helpers import FakeRunner, make_config, structured_issue_implementation
+
+
+def _validate_structured_implementation_result(text):
+    parsed = validate_structured_issue_implementation(text)
+    if parsed is None:
+        raise AgentLoopError(
+            "Issue implementation response must use the required structured `issue_implementation` format."
+        )
+    return parsed
 
 
 def _claude_resume_commands(runner):
@@ -49,7 +56,7 @@ def test_recovery_success_returns_validated_response_and_resumes_session(tmp_pat
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=validate_structured_issue_implementation,
+        validate=_validate_structured_implementation_result,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -75,7 +82,10 @@ def test_recovery_success_returns_validated_response_and_resumes_session(tmp_pat
 def test_recovery_success_no_pr_blocking_result_is_not_posted_by_helper(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Cannot proceed.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            structured_issue_implementation(
+                pr_number=None,
+                summary="Cannot proceed safely.",
+            ),
         ],
     )
     config = make_config(tmp_path, coder="claude")
@@ -85,7 +95,7 @@ def test_recovery_success_no_pr_blocking_result_is_not_posted_by_helper(tmp_path
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=validate_structured_issue_implementation,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -94,8 +104,8 @@ def test_recovery_success_no_pr_blocking_result_is_not_posted_by_helper(tmp_path
     )
 
     assert outcome.validated is not None
-    assert isinstance(outcome.validated.marker_value, _TerminalNoPrImplementation)
-    assert outcome.validated.marker_value.state == "blocking"
+    assert isinstance(outcome.validated.marker_value, StructuredIssueImplementation)
+    assert outcome.validated.marker_value.pr_number is None
     # Posting a genuine no-PR terminal to the issue is the caller's job
     # (_post_no_pr_implementation_terminal_comment), not this helper's.
     assert runner.comments == []
@@ -124,7 +134,7 @@ def test_recovery_agent_declared_unavailable_is_terminal_regardless_of_retryable
 
     def _validate(text):
         validate_calls.append(text)
-        return _require_issue_implementation_result(text)
+        return _validate_structured_implementation_result(text)
 
     outcome = _attempt_claude_completion_recovery(
         runner,
@@ -161,7 +171,7 @@ def test_recovery_transport_failure_nonzero_exit_synthesizes_unavailable(tmp_pat
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=_validate_structured_implementation_result,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -214,7 +224,7 @@ def test_recovery_transport_failure_empty_output_synthesizes_unavailable(tmp_pat
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=_validate_structured_implementation_result,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -236,7 +246,7 @@ def test_recovery_transport_failure_timeout_synthesizes_unavailable(tmp_path):
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=_validate_structured_implementation_result,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -266,7 +276,7 @@ def test_recovery_repeated_background_wait_is_deterministic_not_unavailable(tmp_
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=_validate_structured_implementation_result,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -319,7 +329,7 @@ def test_recovery_response_file_is_attempt_local_even_when_original_file_still_h
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=_validate_structured_implementation_result,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -337,7 +347,7 @@ def test_recovery_response_file_is_attempt_local_even_when_original_file_still_h
         "I'll wait for the background test run to finish."
     )
     assert outcome.validated is None
-    assert "did not create a valid PR" in outcome.error
+    assert "required structured" in outcome.error
 
 
 def test_issue_loop_recovers_after_one_bounded_resume_then_succeeds(tmp_path):
@@ -349,7 +359,7 @@ def test_issue_loop_recovers_after_one_bounded_resume_then_succeeds(tmp_path):
                     "session_id": "sess-1",
                 }
             ),
-            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            structured_issue_implementation(pr_number=77, summary="Created PR."),
             "Fixed review.\n<!-- AGENT_STATE: blocking -->",
         ],
         codex_outputs=[
@@ -386,7 +396,7 @@ def test_issue_loop_recovers_from_claude_waiting_on_background_wording(tmp_path)
                     "session_id": "sess-waiting-on",
                 }
             ),
-            "Created PR.\n<!-- AGENT_PR: 88 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            structured_issue_implementation(pr_number=88, summary="Created PR."),
             "Fixed review.\n<!-- AGENT_STATE: blocking -->",
         ],
         codex_outputs=[
@@ -485,7 +495,7 @@ def test_coder_followup_pr_loop_never_resumes_even_with_backgrounding_language(t
     backgrounded_followup_failure = "I'll wait for the background test run to finish."
     runner = FakeRunner(
         claude_outputs=[
-            "Created PR.\n<!-- AGENT_PR: 77 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            structured_issue_implementation(pr_number=77, summary="Created PR."),
         ]
         + [backgrounded_followup_failure] * (config.agent_max_retries + 1),
         codex_outputs=[

--- a/tests/test_completion_recovery.py
+++ b/tests/test_completion_recovery.py
@@ -22,9 +22,14 @@ from coding_review_agent_loop.orchestrator import (
     _require_issue_implementation_result,
     _TerminalNoPrImplementation,
 )
-from coding_review_agent_loop.protocol import AgentUnavailable, parse_agent_unavailable
+from coding_review_agent_loop.protocol import (
+    AgentUnavailable,
+    StructuredIssueImplementation,
+    parse_agent_unavailable,
+    validate_structured_issue_implementation,
+)
 
-from agent_loop_helpers import FakeRunner, make_config
+from agent_loop_helpers import FakeRunner, make_config, structured_issue_implementation
 
 
 def _claude_resume_commands(runner):
@@ -34,7 +39,7 @@ def _claude_resume_commands(runner):
 def test_recovery_success_returns_validated_response_and_resumes_session(tmp_path):
     runner = FakeRunner(
         claude_outputs=[
-            "Created PR.\n<!-- AGENT_PR: 99 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude",
+            structured_issue_implementation(pr_number=99),
         ],
     )
     config = make_config(tmp_path, coder="claude")
@@ -44,7 +49,7 @@ def test_recovery_success_returns_validated_response_and_resumes_session(tmp_pat
         config=config,
         completion_recovery=CompletionRecoveryPolicy(issue_number=56),
         session_id="sess-1",
-        validate=_require_issue_implementation_result,
+        validate=validate_structured_issue_implementation,
         usage_context=_new_usage_context(config),
         run_id="run-1",
         role=None,
@@ -54,7 +59,8 @@ def test_recovery_success_returns_validated_response_and_resumes_session(tmp_pat
 
     assert outcome.validated is not None
     assert isinstance(outcome.validated, ValidatedAgentResponse)
-    assert outcome.validated.marker_value == 99
+    assert isinstance(outcome.validated.marker_value, StructuredIssueImplementation)
+    assert outcome.validated.marker_value.pr_number == 99
     assert outcome.terminal_public_response is None
     claude_commands = _claude_resume_commands(runner)
     assert len(claude_commands) == 1
@@ -176,7 +182,7 @@ def test_recovery_transport_failure_nonzero_exit_synthesizes_unavailable(tmp_pat
 
 @pytest.mark.parametrize("returncode", [1, None])
 def test_recovery_accepts_valid_response_file_after_failed_exit(tmp_path, returncode):
-    valid = "Created PR.\n<!-- AGENT_PR: 99 -->\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"
+    valid = structured_issue_implementation(pr_number=99)
     runner = FakeRunner(
         claude_outputs=[("Error: timeout waiting for response", returncode)],
         public_response_outputs=[valid],
@@ -185,7 +191,7 @@ def test_recovery_accepts_valid_response_file_after_failed_exit(tmp_path, return
     config = make_config(tmp_path, coder="claude")
     outcome = _attempt_claude_completion_recovery(
         runner, config=config, completion_recovery=CompletionRecoveryPolicy(issue_number=56),
-        session_id="sess-1", validate=_require_issue_implementation_result,
+        session_id="sess-1", validate=validate_structured_issue_implementation,
         usage_context=usage, run_id="run-1", role=None, label=None, timeout_seconds=30.0,
     )
     assert outcome.validated is not None

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -563,13 +563,13 @@ def test_issue_loop_plan_first_implement_by_phase_implements_first_agent_phase(t
     decomposition_index = next(
         index for index, comment in enumerate(runner.comments) if "<!-- AGENT_PLAN_DECOMPOSITION:" in comment
     )
+    implementation_index = next(
+        index for index, comment in enumerate(runner.comments) if comment.startswith("## Issue implementation")
+    )
     handoff_index = next(
         index for index, comment in enumerate(runner.comments) if "<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment
     )
-    implementation_index = next(
-        index for index, comment in enumerate(runner.comments) if comment.startswith("Implemented first phase.")
-    )
-    assert decomposition_index < handoff_index < implementation_index
+    assert decomposition_index < implementation_index < handoff_index
     claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
     assert len(claude_calls) == 3
     assert "GitHub issue #99" in claude_calls[2][-1]

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -619,7 +619,7 @@ def test_issue_loop_rejects_missing_initial_issue_human_requirements_acknowledge
     )
     config = make_config(tmp_path)
 
-    with pytest.raises(AgentLoopError, match="missing required signed human requirements marker"):
+    with pytest.raises(AgentLoopError, match="missing requirement ID"):
         run_issue_loop(runner, issue_number=56, config=config)
 
 def test_issue_loop_accepts_initial_issue_human_requirements_acknowledgement(tmp_path):
@@ -2330,7 +2330,7 @@ def test_issue_loop_plan_first_can_implement_after_approval(tmp_path):
     assert len(runner.comments) == 7
     assert "<!-- AGENT_ISSUE_PR_HANDOFF:" in runner.comments[3]
     assert "<!-- AGENT_PLAN_ONE_SHOT_IMPL:" in runner.comments[4]
-    assert runner.comments[5].startswith("Implemented approved plan.")
+    assert runner.comments[5].startswith("## Issue implementation")
     assert runner.comments[6].startswith("**Review verdict:** Approved\n\nLGTM.")
 
 
@@ -2374,7 +2374,7 @@ def test_issue_loop_plan_first_can_override_implementation_model(tmp_path):
     assert claude_calls[0][claude_calls[0].index("--model") + 1] == "claude-fable-5"
     assert claude_calls[1][claude_calls[1].index("--model") + 1] == "claude-sonnet-5"
     assert "--resume" not in claude_calls[1]
-    assert runner.comments[5].startswith("Implemented approved plan.")
+    assert runner.comments[5].startswith("## Issue implementation")
 
 
 def test_issue_loop_rejects_pr_without_issue_reference_in_body(tmp_path):
@@ -2999,7 +2999,7 @@ def test_codex_issue_loop_creates_pr_then_claude_approves(tmp_path):
     assert ["claude", "--print"] in command_names
     assert len(runner.comments) == 3
     assert "<!-- AGENT_ISSUE_PR_HANDOFF:" in runner.comments[0]
-    assert runner.comments[1].startswith("Fixed issue.")
+    assert runner.comments[1].startswith("## Issue implementation")
     assert runner.comments[2].startswith("**Review verdict:** Approved\n\nLooks good.")
 
 def test_codex_issue_loop_alternates_until_claude_approval(tmp_path):
@@ -3051,7 +3051,14 @@ def test_issue_loop_stops_before_pr_lookup_for_invalid_pr_terminal_result(
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
     # A genuine coder-declared no-PR terminal is posted to the issue like a
     # PR-success implementation result already is (#588).
-    assert runner.comments == [f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}\n-- OpenAI Codex"]
+    if expected_state == "blocking":
+        assert runner.comments[0].startswith("## Issue implementation")
+        assert "Cannot proceed." in runner.comments[0]
+        assert "No pull request was accepted for handoff." in runner.comments[0]
+    else:
+        assert runner.comments == [
+            f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}\n-- OpenAI Codex"
+        ]
 
 
 def test_issue_loop_invalid_pr_without_terminal_state_is_protocol_error(tmp_path):
@@ -3060,7 +3067,7 @@ def test_issue_loop_invalid_pr_without_terminal_state_is_protocol_error(tmp_path
 
     with pytest.raises(
         AgentLoopError,
-        match="AGENT_PR marker or PR URL present was invalid",
+        match="required structured `issue_implementation` format",
     ):
         run_issue_loop(runner, issue_number=56, config=config)
 
@@ -3234,7 +3241,7 @@ def test_gemini_issue_loop_creates_pr_then_codex_approves(tmp_path):
     assert agent_commands == [["gemini", "--prompt"], ["codex", "exec"]]
     assert len(runner.comments) == 3
     assert "<!-- AGENT_ISSUE_PR_HANDOFF:" in runner.comments[0]
-    assert runner.comments[1].startswith("Fixed issue.")
+    assert runner.comments[1].startswith("## Issue implementation")
     assert runner.comments[2].startswith("**Review verdict:** Approved\n\nLooks good.")
 
 def test_gemini_issue_loop_resumes_session_for_followup(tmp_path):
@@ -3838,7 +3845,7 @@ def test_approved_plan_no_pr_terminal_result_bypasses_human_requirements_and_pr_
     tmp_path, terminal_marker, expected_state
 ):
     runner = FakeRunner(
-        issue_payload={"body": "Keep the public API stable.\n\n-- Human Reviewer"},
+        issue_payload={"body": "Keep the public API stable."},
         claude_outputs=[f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}"],
     )
     config = make_config(tmp_path)
@@ -3860,7 +3867,14 @@ def test_approved_plan_no_pr_terminal_result_bypasses_human_requirements_and_pr_
     assert not any(cmd[:1] == ["codex"] for cmd, _cwd in runner.commands)
     # A genuine coder-declared no-PR terminal is posted to the issue like a
     # PR-success implementation result already is (#588).
-    assert runner.comments == [f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}\n-- Anthropic Claude"]
+    if expected_state == "blocking":
+        assert runner.comments[0].startswith("## Issue implementation")
+        assert "Cannot proceed." in runner.comments[0]
+        assert "No pull request was accepted for handoff." in runner.comments[0]
+    else:
+        assert runner.comments == [
+            f"Cannot proceed.\n<!-- AGENT_PR: 0 -->\n{terminal_marker}\n-- Anthropic Claude"
+        ]
 
 
 def test_approved_plan_implementation_rerun_ignores_remote_salvage_on_plan_hash_mismatch(tmp_path):

--- a/tests/test_orchestrator_issue.py
+++ b/tests/test_orchestrator_issue.py
@@ -8,7 +8,12 @@ import coding_review_agent_loop.orchestrator as orchestrator_module
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
 from coding_review_agent_loop.decomposition import approved_plan_hash, format_one_shot_impl_handoff_comment
 from coding_review_agent_loop.errors import QuotaResetExceededError
-from coding_review_agent_loop.github import IssueComment, IssueContext, get_issue_context
+from coding_review_agent_loop.github import (
+    HumanReviewRequirement,
+    IssueComment,
+    IssueContext,
+    get_issue_context,
+)
 from coding_review_agent_loop.managed_ci import (
     AuthenticatedIssueCreatedHandoff,
     ManagedCiContract,
@@ -59,6 +64,7 @@ from agent_loop_helpers import (
     structured_plan_revision,
     structured_plan_state,
     structured_pr_review,
+    structured_issue_implementation,
 )
 
 
@@ -78,6 +84,40 @@ def _provenance_pages(message: str):
         }
     }
     return [page, page]
+
+
+def _blocked_issue_implementation(pr_number: int = 77) -> str:
+    return structured_issue_implementation(
+        summary=f"PR #{pr_number} was opened, but Requirement 1 is blocked.",
+        pr_number=pr_number,
+        human_requirement_dispositions=[
+            {
+                "requirement_id": "Requirement 1",
+                "disposition": "blocked",
+                "evidence": "The required integration is unavailable.",
+            }
+        ],
+    )
+
+
+def _issue_context_with_blocked_requirement() -> IssueContext:
+    return IssueContext(
+        number=56,
+        repo="OWNER/REPO",
+        title="Issue",
+        body="Issue body",
+        url="https://github.com/OWNER/REPO/issues/56",
+        comments=(),
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue comment",
+                author="maintainer",
+                created_at="2026-01-01T00:00:00Z",
+                url="https://github.com/OWNER/REPO/issues/56#issuecomment-1",
+                body="Preserve the required integration.",
+            ),
+        ),
+    )
 
 
 def _managed_issue_handoff(*, nonce: str) -> AuthenticatedIssueCreatedHandoff:
@@ -210,6 +250,85 @@ def test_direct_issue_managed_draft_nonce_reaches_review_and_exact_head_merge(tm
     assert [dispatch["expected_head_sha"] for dispatch in dispatches] == ["abc123"]
     assert prepared_heads == ["abc123"]
     assert merged_heads == ["abc123"]
+
+
+def test_direct_issue_conflict_posts_once_and_stops_before_pr_handoff_gates(tmp_path, monkeypatch):
+    runner = FakeRunner(claude_outputs=[_blocked_issue_implementation()])
+    config = make_config(tmp_path)
+    issue_context = _issue_context_with_blocked_requirement()
+    gate_calls = []
+
+    monkeypatch.setattr(orchestrator_module, "validate_open_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(orchestrator_module, "get_issue_context", lambda *args, **kwargs: issue_context)
+    monkeypatch.setattr(orchestrator_module, "resolve_canonical_pr_for_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(orchestrator_module, "prepare_agent_memory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(orchestrator_module, "sync_coder_base_before_implementation", lambda *args, **kwargs: None)
+
+    def unexpected_gate(name):
+        def _fail(*args, **kwargs):
+            gate_calls.append(name)
+            raise AssertionError(f"{name} must not run after an implementation conflict")
+
+        return _fail
+
+    for name in (
+        "validate_open_pr",
+        "get_pr_review_context",
+        "post_issue_pr_handoff_comment",
+        "run_pr_loop",
+    ):
+        monkeypatch.setattr(orchestrator_module, name, unexpected_gate(name))
+
+    with pytest.raises(AgentLoopError, match="not accepted for handoff"):
+        run_issue_loop(runner, issue_number=56, config=config)
+
+    assert gate_calls == []
+    assert len(runner.comments) == 1
+    assert runner.comments[0].count("Rejected for handoff: reported PR #77") == 1
+
+
+def test_approved_plan_implementation_conflict_posts_once_and_stops_before_pr_gates(
+    tmp_path, monkeypatch
+):
+    runner = FakeRunner(claude_outputs=[_blocked_issue_implementation()])
+    config = make_config(tmp_path)
+    issue_context = _issue_context_with_blocked_requirement()
+    gate_calls = []
+
+    monkeypatch.setattr(orchestrator_module, "resolve_canonical_pr_for_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(orchestrator_module, "sync_coder_base_before_implementation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(orchestrator_module, "preflight_managed_ci_creation", lambda *args, **kwargs: None)
+
+    def unexpected_gate(name):
+        def _fail(*args, **kwargs):
+            gate_calls.append(name)
+            raise AssertionError(f"{name} must not run after an implementation conflict")
+
+        return _fail
+
+    for name in (
+        "validate_open_pr",
+        "get_pr_review_context",
+        "post_issue_pr_handoff_comment",
+        "run_pr_loop",
+    ):
+        monkeypatch.setattr(orchestrator_module, name, unexpected_gate(name))
+
+    with pytest.raises(AgentLoopError, match="not accepted for handoff"):
+        orchestrator_module._implement_approved_issue(
+            runner,
+            issue_number=56,
+            approved_plan="Approved implementation plan.",
+            config=config,
+            memory=None,
+            issue_context=issue_context,
+            coder_session_id=None,
+            usage_context=orchestrator_module._new_usage_context(config),
+        )
+
+    assert gate_calls == []
+    assert len(runner.comments) == 1
+    assert runner.comments[0].count("Rejected for handoff: reported PR #77") == 1
 
 
 def test_plan_first_issue_managed_draft_nonce_is_authenticated_before_pr_review(tmp_path, monkeypatch):

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -66,6 +66,7 @@ from coding_review_agent_loop.protocol import (
     parse_pr_review,
     parse_review,
     parse_unresolved_item_dispositions,
+    validate_structured_issue_implementation,
     validate_structured_coder_followup,
 )
 from agent_loop_helpers import (
@@ -75,6 +76,7 @@ from agent_loop_helpers import (
     make_config,
     prior_item_dispositions,
     structured_coder_followup,
+    structured_issue_implementation,
     structured_plan_review,
     structured_pr_review,
 )
@@ -5769,11 +5771,10 @@ def test_pr_initial_coder_post_includes_model(tmp_path):
     plan_text = "Plan content.\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
     plan_review_text = structured_plan_review(summary="Approved.")
     plan_review_marker = parse_plan_review(plan_review_text, reviewer="OpenAI Codex")
-    pr_coder_text = (
-        "Implemented the feature.\n"
-        "<!-- AGENT_PR: 77 -->\n"
-        "<!-- AGENT_STATE: blocking -->\n"
-        "-- Anthropic Claude"
+    pr_coder_text = structured_issue_implementation(
+        summary="Implemented the feature in PR 77.",
+        pr_number=77,
+        reviewer="Anthropic Claude",
     )
     pr_review_text = structured_pr_review(state="approved", summary="LGTM.")
     pr_review_marker = parse_pr_review(pr_review_text, reviewer="OpenAI Codex")
@@ -5794,7 +5795,7 @@ def test_pr_initial_coder_post_includes_model(tmp_path):
                 text=pr_coder_text,
                 model_used="gpt-5.5 (medium)",
                 session_id=None,
-                marker_value=77,
+                marker_value=validate_structured_issue_implementation(pr_coder_text),
             )
         if call_count[0] == 2:
             return ValidatedAgentResponse(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -231,19 +231,20 @@ def test_completion_recovery_prompt_shares_terminal_marker_grammar_with_implemen
 
     recovery_prompt = build_completion_recovery_prompt(config)
     implementation_prompt = build_issue_implementation_prompt(56, "1. Fix it.", config)
+    issue_prompt = build_issue_prompt(56, config)
 
-    for marker_line in (
-        "<!-- AGENT_STATE: blocking -->",
-        "<!-- AGENT_CLARIFY -->",
-        "<!-- AGENT_UNAVAILABLE -->",
-        "For clarification:",
-    ):
-        assert marker_line in recovery_prompt
-        assert marker_line in implementation_prompt
-    assert "`pr_number: null`" in recovery_prompt
-    assert "`pr_number: null`" in implementation_prompt
-    assert "<!-- AGENT_PR:" not in recovery_prompt
-    assert "<!-- AGENT_PR:" not in implementation_prompt
+    for prompt in (recovery_prompt, implementation_prompt, issue_prompt):
+        for marker_line in (
+            "<!-- AGENT_STATE: blocking -->",
+            "<!-- AGENT_CLARIFY -->",
+            "<!-- AGENT_UNAVAILABLE -->",
+            "For clarification:",
+        ):
+            assert marker_line in prompt
+        assert prompt.count('"kind": "agent_unavailable"') == 1
+    for prompt in (recovery_prompt, implementation_prompt, issue_prompt):
+        assert "`pr_number: null`" in prompt
+        assert "<!-- AGENT_PR:" not in prompt
 
 
 def test_issue_plan_prompt_requires_complete_structured_plan_state_contract(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -233,15 +233,17 @@ def test_completion_recovery_prompt_shares_terminal_marker_grammar_with_implemen
     implementation_prompt = build_issue_implementation_prompt(56, "1. Fix it.", config)
 
     for marker_line in (
-        "<!-- AGENT_PR: <number> -->",
         "<!-- AGENT_STATE: blocking -->",
         "<!-- AGENT_CLARIFY -->",
         "<!-- AGENT_UNAVAILABLE -->",
-        "For a no-PR blocking result:",
         "For clarification:",
     ):
         assert marker_line in recovery_prompt
         assert marker_line in implementation_prompt
+    assert "`pr_number: null`" in recovery_prompt
+    assert "`pr_number: null`" in implementation_prompt
+    assert "<!-- AGENT_PR:" not in recovery_prompt
+    assert "<!-- AGENT_PR:" not in implementation_prompt
 
 
 def test_issue_plan_prompt_requires_complete_structured_plan_state_contract(tmp_path):
@@ -1494,8 +1496,10 @@ def test_non_plan_prompts_request_human_requirement_dispositions_not_plan_dispos
 
     assert '"human_requirement_dispositions"' in prompts[0]
     assert '"human_requirement_dispositions"' in prompts[1]
-    for prompt in prompts[2:]:
+    for prompt in prompts[2:4]:
         assert '"human_requirement_dispositions"' not in prompt
+    for prompt in prompts[4:]:
+        assert '"human_requirement_dispositions"' in prompt
 
 
 def test_coder_followup_guidance_renders_valid_blocked_requirement_example(tmp_path):
@@ -1892,21 +1896,25 @@ def test_coder_prompts_require_focused_bounded_local_tests(tmp_path, builder):
 
 
 @pytest.mark.parametrize(
-    "builder",
+    ("builder", "structured"),
     [
-        lambda config: build_issue_prompt(56, config),
-        lambda config: build_issue_implementation_prompt(56, "1. Fix it.", config),
-        lambda config: build_completion_recovery_prompt(config),
-        lambda config: build_task_prompt("Fix the bug.", config),
-        lambda config: build_task_clarification_prompt("Fix the bug.", [], config),
+        (lambda config: build_issue_prompt(56, config), True),
+        (lambda config: build_issue_implementation_prompt(56, "1. Fix it.", config), True),
+        (lambda config: build_completion_recovery_prompt(config), True),
+        (lambda config: build_task_prompt("Fix the bug.", config), False),
+        (lambda config: build_task_clarification_prompt("Fix the bug.", [], config), False),
     ],
 )
-def test_free_form_coder_prompts_report_tests_via_tests_line(tmp_path, builder):
+def test_coder_prompts_report_tests_using_the_selected_contract(tmp_path, builder, structured):
     config = make_config(tmp_path)
     prompt = " ".join(builder(config).split())
 
-    assert "include a short `Tests:` line" in prompt
-    assert "next to the exact commands in the `Tests:` line" in prompt
+    if structured:
+        assert '"tests_run"' in prompt
+        assert "exact command strings" in prompt
+    else:
+        assert "include a short `Tests:` line" in prompt
+        assert "next to the exact commands in the `Tests:` line" in prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,7 +13,9 @@ from coding_review_agent_loop.cli import (
 )
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
+    _TerminalIssueImplementationConflict,
     _review_freeform_summary_text,
+    _validate_issue_implementation_response,
     _validate_coder_followup_response,
     _validate_plan_revision_response,
     _validate_review_response,
@@ -55,6 +57,7 @@ from coding_review_agent_loop.protocol import (
     parse_signed_human_requirement_body,
     parse_unresolved_item_dispositions,
     ReviewItemDisposition,
+    validate_structured_issue_implementation,
     UnresolvedReviewItem,
     validate_human_requirements_acknowledgement,
     validate_structured_coder_followup,
@@ -65,6 +68,73 @@ from coding_review_agent_loop.protocol import (
     validate_structured_plan_state,
     validate_structured_plan_revision,
 )
+
+
+def _issue_implementation_text(**overrides):
+    payload = {
+        "schema_version": 1,
+        "kind": "issue_implementation",
+        "state": "blocking",
+        "summary": "Implemented the change.",
+        "pr_number": None,
+        "human_requirements": {
+            "addressed_ids": [],
+            "checked_discussion_directly": False,
+        },
+        "human_requirement_dispositions": [],
+        "tests_run": None,
+    }
+    payload.update(overrides)
+    return json.dumps(payload) + "\n<!-- AGENT_STATE: blocking -->\n-- Coder"
+
+
+def test_issue_implementation_protocol_accepts_null_pr_and_nullable_tests():
+    parsed = validate_structured_issue_implementation(_issue_implementation_text())
+
+    assert parsed is not None
+    assert parsed.pr_number is None
+    assert parsed.tests_run is None
+
+
+def test_issue_implementation_protocol_preserves_positive_pr_blocked_conflict():
+    text = _issue_implementation_text(
+        summary="PR 77 exists, but the signed requirement is blocked.",
+        pr_number=77,
+        human_requirement_dispositions=[
+            {
+                "requirement_id": "Requirement 1",
+                "disposition": "blocked",
+                "evidence": "The required integration is unavailable.",
+            }
+        ],
+    )
+    from coding_review_agent_loop.github import HumanReviewRequirement
+
+    result = _validate_issue_implementation_response(
+        text,
+        human_requirements=(
+            HumanReviewRequirement(
+                source_type="Issue comment",
+                author="maintainer",
+                created_at="2026-01-01T00:00:00Z",
+                url="https://example.test/issue-comment",
+                body="Preserve the integration."
+            ),
+        ),
+    )
+
+    assert isinstance(result, _TerminalIssueImplementationConflict)
+    assert result.parsed.pr_number == 77
+    assert result.parsed.human_requirement_dispositions[0].evidence.endswith("unavailable.")
+
+
+def test_issue_implementation_protocol_rejects_wrong_footer_state():
+    text = _issue_implementation_text().replace(
+        "<!-- AGENT_STATE: blocking -->", "<!-- AGENT_STATE: approved -->"
+    )
+
+    with pytest.raises(AgentLoopError, match="footer AGENT_STATE"):
+        validate_structured_issue_implementation(text)
 
 
 def _discuss_answer_text(payload: dict) -> str:

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1653,6 +1653,19 @@ def test_repair_prompt_coder_followup_fenced_json_example():
     assert "NOT needed" in _REPAIR_PROMPT or "not needed" in _REPAIR_PROMPT.lower()
 
 
+def test_repair_prompt_uses_unique_issue_implementation_format_and_selection_rule():
+    assert _REPAIR_PROMPT.count("## Valid Format D — Plan Revision:") == 1
+    assert _REPAIR_PROMPT.count("## Valid Format K — Issue Implementation:") == 1
+    assert 'Use Format K if the original contains "issue_implementation" or "pr_number".' in _REPAIR_PROMPT
+
+    prompt = _build_repair_prompt(
+        '{"kind":"issue_implementation","pr_number":77}',
+        expected_kind="issue_implementation",
+    )
+    assert "Repair only the issue_implementation envelope." in prompt
+    assert "Preserve `summary`, `pr_number`, `tests_run`," in prompt
+
+
 def test_repair_prompt_coder_followup_examples_include_current_requirement_schema():
     format_c = _REPAIR_PROMPT.split("## Valid Format C — Coder Follow-up:", 1)[1].split(
         "## Valid Format E", 1

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2738,7 +2738,15 @@ class TestHostReviewerPR:
 # helpers/skill_runner.py — reverse implementation: run-implement (#316)
 # ---------------------------------------------------------------------------
 
-_IMPL_WITH_PR = "Implemented the plan.\n\n<!-- AGENT_PR: 5 -->\n-- Codex\n"
+_IMPL_WITH_PR = json.dumps({
+    "schema_version": 1,
+    "kind": "issue_implementation",
+    "state": "blocking",
+    "summary": "Implemented the plan and opened PR 5.",
+    "pr_number": 5,
+    "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+    "human_requirement_dispositions": [],
+}) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex\n"
 
 
 def _human_req():
@@ -2762,7 +2770,7 @@ class TestRunExternalImplStub:
                 "--dry-run",
             )
             assert result.returncode == 0
-            assert "<!-- AGENT_PR: 1 -->" in out.read_text(encoding="utf-8")
+            assert '"kind": "issue_implementation"' in out.read_text(encoding="utf-8")
 
 
 class TestRunExternalDecomposeStub:
@@ -2835,7 +2843,7 @@ class TestValidateCoderImplementationResponse:
         pr = _validate_coder_implementation_response(
             _IMPL_WITH_PR, workdir="/tmp/wd", human_requirements=(),
         )
-        assert pr == 5
+        assert pr.pr_number == 5
 
     def test_missing_human_ack_rejected(self) -> None:
         from coding_review_agent_loop.errors import AgentLoopError
@@ -2848,11 +2856,16 @@ class TestValidateCoderImplementationResponse:
     def test_out_of_workdir_test_rejected(self) -> None:
         from coding_review_agent_loop.errors import AgentLoopError
         from helpers.skill_runner import _validate_coder_implementation_response
-        bad = (
-            "Implemented the plan.\n"
-            "Tests: cd /nonexistent/other-dir && pytest passed.\n\n"
-            "<!-- AGENT_PR: 5 -->\n-- Codex\n"
-        )
+        bad = json.dumps({
+            "schema_version": 1,
+            "kind": "issue_implementation",
+            "state": "blocking",
+            "summary": "Implemented the plan and opened PR 5.",
+            "pr_number": 5,
+            "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+            "human_requirement_dispositions": [],
+            "tests_run": ["cd /nonexistent/other-dir && pytest"],
+        }) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex\n"
         with pytest.raises(AgentLoopError):
             _validate_coder_implementation_response(
                 bad, workdir="/tmp/wd", human_requirements=(),
@@ -3570,7 +3583,7 @@ class TestRunImplementByPhase:
 
         sr.cmd_run_implement_by_phase(self._args(tmp_path))
 
-        assert events == ["handoff:123", "implement:123"]
+        assert events == ["implement:123", "handoff:123"]
         output = self._last_json(capsys.readouterr().out)
         assert output["state"] == "implemented"
         assert output["child_implementation"]["pr"] == 456

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -2748,6 +2748,20 @@ _IMPL_WITH_PR = json.dumps({
     "human_requirement_dispositions": [],
 }) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex\n"
 
+_IMPL_WITH_BLOCKED_REQUIREMENT = json.dumps({
+    "schema_version": 1,
+    "kind": "issue_implementation",
+    "state": "blocking",
+    "summary": "PR 5 was opened, but Requirement 1 is blocked.",
+    "pr_number": 5,
+    "human_requirements": {"addressed_ids": [], "checked_discussion_directly": False},
+    "human_requirement_dispositions": [{
+        "requirement_id": "Requirement 1",
+        "disposition": "blocked",
+        "evidence": "The required integration is unavailable.",
+    }],
+}) + "\n<!-- AGENT_STATE: blocking -->\n-- Codex\n"
+
 
 def _human_req():
     from coding_review_agent_loop.github import HumanReviewRequirement
@@ -2870,6 +2884,19 @@ class TestValidateCoderImplementationResponse:
             _validate_coder_implementation_response(
                 bad, workdir="/tmp/wd", human_requirements=(),
             )
+
+    def test_blocked_positive_pr_is_returned_as_terminal_conflict(self) -> None:
+        from helpers.skill_runner import _validate_coder_implementation_response
+        from coding_review_agent_loop.orchestrator import _TerminalIssueImplementationConflict
+
+        result = _validate_coder_implementation_response(
+            _IMPL_WITH_BLOCKED_REQUIREMENT,
+            workdir="/tmp/wd",
+            human_requirements=(_human_req(),),
+        )
+
+        assert isinstance(result, _TerminalIssueImplementationConflict)
+        assert result.parsed.pr_number == 5
 
 
 # ---------------------------------------------------------------------------
@@ -3302,6 +3329,68 @@ class TestRunImplement:
             )
             assert result.returncode != 0
             assert "push-capable" in result.stderr
+
+    def test_conflict_posts_one_terminal_comment_without_handoff(self, monkeypatch, tmp_path) -> None:
+        import helpers.skill_runner as sr
+        from coding_review_agent_loop.github import IssueContext
+        from coding_review_agent_loop.runner import Runner
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        config = sr._implementation_config(
+            repo="o/r",
+            coder="codex",
+            workdir=str(workdir),
+            base="main",
+            dry_run=False,
+        )
+        runner = Runner(dry_run=False)
+        issue_context = IssueContext(
+            number=1,
+            repo="o/r",
+            title="Issue",
+            body="Body",
+            url="https://example/issue/1",
+            comments=(),
+            human_requirements=(_human_req(),),
+        )
+        helper_calls = []
+
+        def fake_run_helper(*args, **kwargs):
+            helper_calls.append(args)
+            if args[0] == "helpers.run_external":
+                output_path = Path(args[args.index("--output") + 1])
+                output_path.write_text(_IMPL_WITH_BLOCKED_REQUIREMENT, encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0)
+
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+        monkeypatch.setattr(sr, "_git_head", lambda workdir: "head")
+        monkeypatch.setattr(
+            "coding_review_agent_loop.config.sync_coder_base_before_implementation",
+            lambda *args, **kwargs: None,
+        )
+
+        result = sr._run_child_or_one_shot_implementation(
+            issue=1,
+            repo="o/r",
+            coder="codex",
+            base="main",
+            dry_run=False,
+            workdir=str(workdir),
+            approved_plan="Approved plan.",
+            issue_context=issue_context,
+            config=config,
+            runner=runner,
+            post_one_shot_handoff=True,
+        )
+
+        assert result["pr"] is None
+        assert result["terminal"] == "conflict"
+        post_comment_calls = [
+            call for call in helper_calls if call[:2] == ("helpers.gh_ops", "post-issue-comment")
+        ]
+        assert len(post_comment_calls) == 1
+        assert not any(call[:2] == ("helpers.state_manager", "attach-metadata") for call in helper_calls)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add the strict `issue_implementation` result contract with acknowledgement and disposition-ledger validation.
- Route positive PRs through the existing gates while publishing readable null-PR and rejected-conflict terminal results without retry or handoff.
- Align repair, completion recovery, reverse skill mode, legacy test fixtures, raw round metadata, and documentation with the new contract.

## Tests

- `python3 -m pytest tests/test_protocol.py tests/test_human_requirement_dispositions.py tests/test_prompts.py tests/test_comment_rendering.py tests/test_repair.py -q --tb=short --maxfail=1` — 621 passed; protocol, prompt, rendering, disposition, and repair coverage.
- `python3 -m pytest tests/test_agent_loop.py tests/test_split_orchestration.py tests/test_decomposition.py tests/test_task_loop.py tests/test_usage.py tests/test_skill_helpers.py tests/test_completion_recovery.py tests/test_orchestrator_issue.py tests/test_orchestrator_pr.py tests/test_round_transport.py tests/test_human_requirement_dispositions.py -q --tb=short --maxfail=1` — 878 passed; implementation, skill, recovery, orchestration, resume, and fixture regressions.
- `python3 -m pytest -q --tb=short --maxfail=1` — 2,384 passed; full suite.
- `python3 -m compileall -q src helpers tests` — passed.

Fixes #633
