### PR TITLE
Consolidate ordinary auto-merge onto full-board watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,17 +877,25 @@ For repositories without that contract, `--auto-merge` foreground-polls the
 complete check board after approval with
 `--ci-timeout-seconds` and
 `--ci-poll-interval-seconds`, without invoking agents while checks are pending.
-Failure resumes the coder with the failed-check details; only a non-empty
-successful board is mergeable. An empty rollup is a bounded startup state, not
-CI success: after `--ci-startup-timeout-seconds` it stops with a resumable PR
-command and does not ready or merge the PR. The watcher is synchronous and interruptible: Ctrl-C leaves
-no worker behind, and a rerun starts from fresh PR state. On timeout the local
-terminal prints a shell-quoted rerun command; PR comments intentionally contain
-no captured command arguments. Use `--no-watch-pending-ci` with `--auto-merge`
-to retain the previous behavior. Without `--auto-merge`, agent-loop reports an
-approved PR as merge-ready and does not wait for CI, unless `--watch-pending-ci`
-is passed explicitly, in which case it still watches the check board and
-reports merge-ready without merging.
+Failure resumes the coder with the failed-check details; only a reliable,
+non-empty current-head board is mergeable. Reliability requires an available
+check query and branch-protection result, no pending or missing required
+checks, and passing reported checks. Partial or unavailable snapshots remain
+fail-closed and are polled; an otherwise reliable empty board is bounded
+startup, not CI success. After `--ci-startup-timeout-seconds` it stops with a
+resumable PR command and does not ready or merge the PR. The live head is
+re-read immediately before the exact-head merge proof. The watcher is
+synchronous and interruptible: Ctrl-C leaves no worker behind, and a rerun
+starts from fresh PR state. One timeout and attempt budget is shared across
+watcher polls and any coder-failure or head-change rounds. Auto-merge timeout,
+bounded-startup, and already-exhausted-budget stops retain resumable diagnostics
+and return non-zero; explicit manual `--watch-pending-ci` stops return zero
+without merging. `--ci-check-name` and `--no-watch-pending-ci` remain parseable
+compatibility options, but do not select or disable this auto-merge gate and
+warn when explicitly supplied with auto-merge. Without `--auto-merge`,
+agent-loop reports an approved PR as merge-ready and does not wait for CI,
+unless `--watch-pending-ci` is passed explicitly, in which case it still
+watches the check board and reports merge-ready without merging.
 
 By default Claude is the coder and Codex is the reviewer. Reverse that with:
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1434,15 +1434,25 @@ Auto-merge is disabled by default. Enable it explicitly:
 ```bash
 agent-loop pr 123 \
   --repo OWNER/REPO \
-  --auto-merge \
-  --ci-check-name test
+  --auto-merge
 ```
 
-For repositories without the managed exact-head CI contract, enabling auto-merge
-with the full-board watcher (the default — see "Watch pending CI" below) makes
-the tool foreground-poll the whole PR check board before merging.
-With `--no-watch-pending-ci`, it instead waits for the single configured
-`--ci-check-name` check-run to pass before merging, as in earlier releases.
+For repositories without the managed exact-head CI contract, auto-merge always
+uses the full-board watcher. A merge permit requires a reliable, non-empty
+current-head board: the check query and branch protection must be available,
+there must be no pending or missing required checks, and all reported checks
+must pass. Partial or unavailable snapshots remain fail-closed and are polled;
+an otherwise reliable empty board is bounded startup, not success. The live
+head is re-read immediately before an exact-head merge proof is sent to GitHub.
+
+`--ci-check-name` and `--no-watch-pending-ci` remain parseable compatibility
+options, but neither selects nor disables the ordinary auto-merge gate; an
+explicit use with auto-merge emits a warning. One timeout and attempt budget is
+shared across watcher polls, coder-failure rounds, and head-change rounds.
+Auto-merge timeout, bounded-startup, and already-exhausted-budget stops retain
+their resumable diagnostics and return a non-zero exit. An explicit manual
+`--watch-pending-ci` run keeps the same watcher outcomes but stops cleanly
+without merging.
 Local `--test-command` is an additional local gate, not a replacement for CI.
 By default, `--test-command` also runs after coder-created or coder-updated
 changes before reviewer rounds, so reviewers are less likely to spend rounds
@@ -1763,7 +1773,7 @@ invocation-owned managed label is released and the next invocation
 re-adopts/reapplies managed mode. A corrected head requires a fresh exact-head
 review. The managed route is selected independently of `--watch-pending-ci`;
 neither that flag nor `--no-watch-pending-ci` replaces exact-head
-qualification with an ordinary full-board or named-check wait.
+qualification with ordinary full-board watching.
 
 #### Managed-CI GitHub CLI compatibility
 
@@ -1792,29 +1802,41 @@ recovery trigger for this path.
 
 ### Watch pending CI
 
-For repositories not using managed exact-head CI, `--watch-pending-ci` is
-enabled by default whenever `--auto-merge` is set;
-pass `--no-watch-pending-ci` to fall back to the legacy single
-`--ci-check-name` waiter described above. It can also be passed explicitly
-without `--auto-merge`, in which case it watches ordinary checks after approval
-and reports merge-ready without merging. It does not activate suppression or
-replace managed exact-head qualification; when `--managed-ci` is active it is
-inert for that managed route.
+For repositories not using managed exact-head CI, ordinary `--auto-merge`
+always enters the full-board watcher, regardless of the effective
+`--watch-pending-ci` value. `--ci-check-name` and `--no-watch-pending-ci` remain
+parseable for compatibility and produce a warning when explicitly supplied
+with auto-merge; they do not select or weaken that gate. An explicit
+`--watch-pending-ci` without `--auto-merge` watches ordinary checks after
+approval and reports merge-ready without merging. It does not activate
+suppression or replace managed exact-head qualification; when `--managed-ci` is
+active it is inert for that managed route.
 
 When active, it foreground-polls the full PR check/status/required-check board
 using the existing timeout and poll interval controls. It does not call
 reviewers or the coder while checks remain pending. A completed actionable
 failure resumes the normal coder loop with the check name, conclusion, and
-URL; success or a reliable no-check board is merge-ready, or merges directly
-with `--auto-merge`. A new head is re-reviewed, and the final-round
-CI-failure path receives one bounded extra round.
+URL. A merge permit requires a reliable, non-empty current-head board with no
+pending or missing required checks, and all reported checks passing. Unavailable
+or partial queries, unavailable protection, pending checks, and missing
+required checks remain fail-closed polling states; only a reliable empty board
+uses the bounded `not_started` startup outcome. A new head is re-reviewed, and
+the final-round CI-failure path receives one bounded extra round.
+
+One deadline and attempt budget is shared across all watcher entries in an
+invocation, including rounds caused by a CI failure or head change. If that
+budget is already exhausted, the loop records that no fresh poll occurred.
+Auto-merge timeout, `not_started`, and pre-poll exhaustion retain resumable
+diagnostics and exit non-zero; explicit manual watch-only runs stop cleanly
+with exit zero. A passing board is consumed immediately by the exact-head merge
+proof, so it does not enter a second CI wait.
 
 The watch runs synchronously with interruptible `sleep` subprocesses, so Ctrl-C
 and restarts leave no hidden worker. Timeout and transient API snapshots remain
 bounded and print a shell-quoted rerun command only locally; GitHub comments do
 not repeat invocation arguments. Dry-run previews the watch without polling,
-sleeping, resuming agents, or merging. `--no-watch-pending-ci` retains the
-legacy named-check-only behavior described above.
+sleeping, resuming agents, or merging. `--no-watch-pending-ci` does not disable
+the ordinary auto-merge watcher.
 
 ### External CI infrastructure stalls
 

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -38,13 +38,11 @@ from .managed_ci import (
 from .managed_pr import create_managed_pr
 from .github import (
     detect_repo,
-    get_check_status,
     get_pr_head_sha,
     merge_pr,
     post_pr_comment,
     validate_open_issue,
     validate_open_pr,
-    wait_for_ci,
 )
 from .logging import agent_log_path, log
 from .orchestrator import (
@@ -336,20 +334,24 @@ def build_parser() -> argparse.ArgumentParser:
         )
         subparser.add_argument(
             "--ci-check-name",
-            default="test",
-            help="GitHub check-run name required before --auto-merge (default: test).",
+            default=None,
+            help=(
+                "Retained for compatibility (default: test); ordinary --auto-merge now "
+                "gates on the complete full-board check snapshot, so this name does not "
+                "select the merge gate."
+            ),
         )
         subparser.add_argument(
             "--ci-timeout-seconds",
             type=int,
             default=1200,
-            help="Maximum time to wait for the CI check before auto-merge (default: 1200).",
+            help="Maximum time to watch the full CI board before auto-merge (default: 1200).",
         )
         subparser.add_argument(
             "--ci-poll-interval-seconds",
             type=int,
             default=30,
-            help="Polling interval for the CI check before auto-merge (default: 30).",
+            help="Polling interval for the full CI board before auto-merge (default: 30).",
         )
         subparser.add_argument(
             "--ci-startup-timeout-seconds",
@@ -366,9 +368,10 @@ def build_parser() -> argparse.ArgumentParser:
             dest="watch_pending_ci",
             default=None,
             help=(
-                "For ordinary CI, foreground-poll the full GitHub check board after approval "
-                "and resume the coder if CI fails (enabled by default with --auto-merge). "
-                "Managed exact-head qualification remains its own gate."
+                "For ordinary CI without --auto-merge, foreground-poll the full GitHub check "
+                "board after approval and resume the coder if CI fails. Ordinary --auto-merge "
+                "always uses this full-board gate; --no-watch-pending-ci is retained only as a "
+                "compatibility warning. Managed exact-head qualification remains its own gate."
             ),
         )
         subparser.add_argument(
@@ -884,6 +887,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             if not (args.managed_ci_trusted_actor or "").strip():
                 raise AgentLoopError("--managed-ci requires --managed-ci-trusted-actor.")
         config = config_from_args(args, runner, invocation_argv=invocation)
+        if config.auto_merge and config.ci_check_name_explicit:
+            print(
+                "agent-loop: warning: --ci-check-name is retained for compatibility and "
+                "no longer selects the ordinary auto-merge gate; the complete full-board "
+                "watcher is used.",
+                file=sys.stderr,
+            )
+        if config.auto_merge and config.watch_pending_ci_explicit and not config.watch_pending_ci:
+            print(
+                "agent-loop: warning: --no-watch-pending-ci is retained for compatibility "
+                "and no longer disables the ordinary auto-merge full-board watcher.",
+                file=sys.stderr,
+            )
         implementation_override_requested = (
             args.implementation_coder is not None
             or args.implementation_coder_model

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -178,7 +178,8 @@ class AgentLoopConfig:
     mergeability_poll_interval_seconds: int = 5
     # Foreground full-board CI watch after reviewer approval (#587). CLI
     # invocations enable this automatically with --auto-merge; direct config
-    # constructions remain conservative unless they set it explicitly.
+    # constructions remain conservative unless they set it explicitly. Ordinary
+    # auto-merge uses the watcher regardless of this compatibility value.
     watch_pending_ci: bool = False
     # Explicit request to activate managed exact-head CI without requesting a
     # merge. `auto_merge` remains an implicit managed-CI eligibility signal so
@@ -216,6 +217,11 @@ class AgentLoopConfig:
     # Separate bounded startup observation for CI that has not materialized a
     # run/check yet.  Empty boards are never evidence that CI succeeded.
     ci_startup_timeout_seconds: int = 120
+    # CLI provenance for compatibility options. These are intentionally kept
+    # separate from their effective values so auto-merge can warn when an old
+    # selector or opt-out no longer changes the full-board gate.
+    ci_check_name_explicit: bool = False
+    watch_pending_ci_explicit: bool = False
 
     @property
     def effective_managed_ci(self) -> bool:
@@ -1022,7 +1028,7 @@ def config_from_args(
         review_parallel=getattr(args, "review_parallel", False),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
-        ci_check_name=args.ci_check_name,
+        ci_check_name=getattr(args, "ci_check_name", None) or "test",
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
         ci_startup_timeout_seconds=getattr(args, "ci_startup_timeout_seconds", 120),
@@ -1031,6 +1037,8 @@ def config_from_args(
             if getattr(args, "watch_pending_ci", None) is None
             else bool(args.watch_pending_ci)
         ),
+        ci_check_name_explicit=getattr(args, "ci_check_name", None) is not None,
+        watch_pending_ci_explicit=getattr(args, "watch_pending_ci", None) is not None,
         managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
         managed_ci=getattr(args, "managed_ci", False),
         managed_ci_adopt_existing_pr=getattr(args, "managed_ci_adopt_existing_pr", False),

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -1185,8 +1185,8 @@ def _dedupe_checks(checks: list[PullRequestCheck]) -> tuple[PullRequestCheck, ..
 def _parse_check_runs_payload(payload: object) -> tuple[list[PullRequestCheck], list[str]]:
     """Parse the `commits/{sha}/check-runs` response into `PullRequestCheck`s.
 
-    Shared by `get_pr_checks` (full board) and `get_check_record` (a single
-    configured check's full timestamped record for the auto-merge wait loop).
+    The full-board `get_pr_checks` query and its watcher both rely on this
+    parser; it deliberately does not select a named merge gate.
     """
     checks: list[PullRequestCheck] = []
     errors: list[str] = []
@@ -1913,42 +1913,9 @@ def get_pr_head_sha(runner: Runner, config: AgentLoopConfig, pr_number: int) -> 
     return sha
 
 
-def get_check_record(runner: Runner, config: AgentLoopConfig, head_sha: str) -> PullRequestCheck | None:
-    """Full timestamped record for `config.ci_check_name`, or None if absent/unavailable."""
-    result = runner.run(
-        [config.gh_cmd, "api", f"repos/{config.repo}/commits/{head_sha}/check-runs"],
-        cwd=active_workdir(config),
-        check=False,
-    )
-    if result.returncode != 0:
-        return None
-    try:
-        payload = json.loads(result.stdout or "{}")
-    except json.JSONDecodeError:
-        return None
-    checks, _errors = _parse_check_runs_payload(payload)
-    for check in checks:
-        if check.name == config.ci_check_name:
-            return check
-    return None
-
-
-def get_check_status(runner: Runner, config: AgentLoopConfig, head_sha: str) -> str:
-    record = get_check_record(runner, config, head_sha)
-    return record.status if record is not None else "pending"
-
-
-@dataclass(frozen=True)
-class CiWaitOutcome:
-    status: Literal["passed", "infrastructure_stall", "merge_conflict"]
-    stall: CiInfrastructureStall | None = None
-    pr_checks: PullRequestChecks | None = None
-    mergeability: PullRequestMergeability | None = None
-
-
 @dataclass(frozen=True)
 class CiWatchOutcome:
-    """Terminal result from the opt-in full-board post-approval watcher."""
+    """Terminal result from the full-board post-approval watcher."""
 
     status: Literal[
         "passed",
@@ -1979,7 +1946,6 @@ def watch_pr_checks(
 ) -> CiWatchOutcome:
     """Synchronously watch the complete current-head check board.
 
-    This deliberately sits beside the legacy single-check ``wait_for_ci``.
     It has no worker or persisted process; interrupting the foreground runner
     stops it immediately and a later invocation simply fetches fresh state.
     """
@@ -2025,14 +1991,14 @@ def watch_pr_checks(
                 stall=CiInfrastructureStall(checks=snapshot.infrastructure_stalls),
                 attempts_used=attempt + 1,
             )
-        if snapshot.state == "failing":
+        reliable = snapshot.check_query_status == "ok" and snapshot.branch_protection_status in {
+            "configured", "not_found", "forbidden",
+        }
+        if snapshot.state == "failing" and reliable and not snapshot.missing_required:
             return CiWatchOutcome(
                 status="failed", pr_checks=snapshot, failed_checks=snapshot.failing,
                 head_sha=current_head, attempts_used=attempt + 1,
             )
-        reliable = snapshot.check_query_status == "ok" and snapshot.branch_protection_status in {
-            "configured", "not_found", "forbidden",
-        }
         if snapshot.state == "passing" and reliable and not snapshot.pending and not snapshot.missing_required:
             return CiWatchOutcome(
                 status="passed", pr_checks=snapshot, head_sha=current_head,
@@ -2057,70 +2023,6 @@ def watch_pr_checks(
             )
         runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
     raise AssertionError("CI watch loop must return a terminal outcome")
-
-
-def wait_for_ci(
-    runner: Runner,
-    config: AgentLoopConfig,
-    pr_number: int,
-    *,
-    metadata: PullRequestMetadata,
-) -> CiWaitOutcome:
-    """Poll the configured CI check before auto-merge.
-
-    A queued-too-long or pre-execution-cancelled check is not, by itself,
-    grounds to stop: a stall on the single configured check only ends the
-    wait once a full `get_pr_checks` snapshot confirms the whole PR check
-    board is wholly infrastructure-blocked (`is_wholly_infrastructure_blocked`).
-    Otherwise this keeps today's contract exactly: keep polling and ultimately
-    raise `AgentLoopError` on a genuine terminal failure or `ci_timeout_seconds`
-    expiry.
-
-    Each poll also re-checks GitHub mergeability first (#606): once the base
-    advances or a rebase-required situation appears, the PR's current-head CI
-    is no longer a reliable merge signal, so a confirmed conflict ends the
-    wait immediately without attempting a merge.
-    """
-    log(config, f"Waiting for GitHub check '{config.ci_check_name}' before merge")
-    head_sha = get_pr_head_sha(runner, config, pr_number)
-    attempts = max(1, config.ci_timeout_seconds // config.ci_poll_interval_seconds)
-    terminal_failures = {
-        "failure",
-        "cancelled",
-        "timed_out",
-        "action_required",
-        "startup_failure",
-        "skipped",
-    }
-    for attempt in range(attempts):
-        mergeability = get_pr_mergeability(runner, config=config, pr_number=pr_number)
-        if mergeability.state == "conflicted":
-            log(config, f"PR #{pr_number}: GitHub reports a merge conflict; stopping CI wait")
-            return CiWaitOutcome(status="merge_conflict", mergeability=mergeability)
-
-        record = get_check_record(runner, config, head_sha)
-        status = record.status if record is not None else "pending"
-        log(config, f"GitHub check '{config.ci_check_name}' status: {status}")
-        if status == "success":
-            return CiWaitOutcome(status="passed")
-
-        stall = classify_ci_infrastructure_stall(
-            [record] if record is not None else [],
-            now=datetime.datetime.now(datetime.timezone.utc),
-            grace_seconds=config.ci_queued_grace_seconds,
-        )
-        if stall.is_stalled:
-            snapshot = get_pr_checks(runner, config=config, metadata=metadata)
-            if is_wholly_infrastructure_blocked(snapshot):
-                return CiWaitOutcome(status="infrastructure_stall", stall=stall, pr_checks=snapshot)
-
-        if status in terminal_failures:
-            raise AgentLoopError(f"CI check '{config.ci_check_name}' failed with status: {status}")
-        if attempt < attempts - 1:
-            runner.run(["sleep", str(config.ci_poll_interval_seconds)], cwd=active_workdir(config))
-    raise AgentLoopError(
-        f"CI check '{config.ci_check_name}' did not pass within {config.ci_timeout_seconds}s"
-    )
 
 
 def merge_pr(

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -1994,7 +1994,11 @@ def watch_pr_checks(
         reliable = snapshot.check_query_status == "ok" and snapshot.branch_protection_status in {
             "configured", "not_found", "forbidden",
         }
-        if snapshot.state == "failing" and reliable and not snapshot.missing_required:
+        # A positively observed failure is actionable even when another query
+        # was partial or a required check has not materialized yet. Those
+        # conditions can delay a passing decision, but they must not hide a
+        # concrete failing check from the coder.
+        if snapshot.state == "failing":
             return CiWatchOutcome(
                 status="failed", pr_checks=snapshot, failed_checks=snapshot.failing,
                 head_sha=current_head, attempts_used=attempt + 1,

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -1043,12 +1043,8 @@ def render_managed_ci_resume_command(
         command.extend(("--base", config.base))
     if config.auto_merge:
         command.append("--auto-merge")
-    if config.watch_pending_ci:
+    if config.watch_pending_ci and not config.auto_merge:
         command.append("--watch-pending-ci")
-    elif config.auto_merge:
-        # CLI invocations enable this by default with --auto-merge, so an
-        # explicit opt-out is required to faithfully reproduce this stop.
-        command.append("--no-watch-pending-ci")
     if managed_ci:
         command.append("--managed-ci")
         if config.managed_ci_trusted_actor:

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -179,6 +179,7 @@ from .prompts import (
 )
 from .protocol import (
     AgentUnavailable,
+    ApprovedFollowup,
     ApprovedFollowups,
     DISCUSS_FAILED_OUTCOME,
     DISCUSS_RESEARCH_TARGET_VALUES,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -6708,6 +6708,68 @@ def _stop_on_terminal_without_status(
     return 0
 
 
+def _stop_after_ci_watch_timeout(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    round_number: int,
+    head_sha: str | None,
+    pr_comments: Sequence[object],
+    followups: list[ApprovedFollowup],
+    details: list[str],
+    reason: Literal["budget_exhausted", "timeout"],
+) -> int:
+    """Publish resumable guidance for a watch that cannot continue or finish."""
+    _publish_approved_followups(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        pr_comments=pr_comments,
+        followups=followups,
+    )
+    post_pr_comment(
+        runner,
+        config=config,
+        pr_number=pr_number,
+        body=_pending_ci_stop_message(pr_number, "pending", details),
+    )
+    rerun = _render_ci_rerun_command(config, pr_number=pr_number)
+    note = (
+        ""
+        if config.invocation_argv
+        else " (deterministic fallback; original invocation unavailable)"
+    )
+    if reason == "budget_exhausted":
+        log(
+            config,
+            f"Round {round_number}: PR #{pr_number} shared CI watch budget was "
+            "exhausted before a fresh poll; no merge attempted",
+        )
+        print(
+            f"PR #{pr_number} CI watch budget was exhausted by earlier rounds; "
+            f"no fresh poll was performed and no merge was attempted. "
+            f"Rerun: {rerun}{note}"
+        )
+        if config.auto_merge:
+            raise AgentLoopError(
+                f"PR #{pr_number} full-board CI watch budget was exhausted before "
+                "a fresh poll; no merge attempted."
+            )
+    else:
+        print(
+            f"PR #{pr_number} CI watch timed out: {'; '.join(details)}. "
+            f"Rerun: {rerun}{note}"
+        )
+        if config.auto_merge:
+            raise AgentLoopError(
+                f"PR #{pr_number} full-board CI watch did not pass within "
+                f"{config.ci_timeout_seconds}s; no merge attempted."
+            )
+    return 0
+
+
 def run_pr_loop(
     runner: Runner,
     *,
@@ -8208,6 +8270,22 @@ def run_pr_loop(
                             1,
                             config.ci_timeout_seconds // config.ci_poll_interval_seconds,
                         )
+                    assert watch_attempts_remaining is not None
+                    if watch_attempts_remaining <= 0:
+                        return _stop_after_ci_watch_timeout(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            round_number=round_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=future_followups,
+                            details=[
+                                "The shared CI watch budget was exhausted by earlier watcher rounds; "
+                                "no fresh CI poll was performed."
+                            ],
+                            reason="budget_exhausted",
+                        )
                     watching_message = (
                         f"Reviewers approved PR #{pr_number}; watching GitHub checks "
                         "in the foreground. "
@@ -8220,48 +8298,6 @@ def run_pr_loop(
                         pr_number=pr_number,
                         body=watching_message + "\n\n-- coding-review-agent-loop",
                     )
-                    assert watch_attempts_remaining is not None
-                    if watch_attempts_remaining <= 0:
-                        _publish_approved_followups(
-                            runner,
-                            config=config,
-                            pr_number=pr_number,
-                            head_sha=pr_metadata.head_sha,
-                            pr_comments=pr_comments,
-                            followups=future_followups,
-                        )
-                        details = [
-                            "The shared CI watch budget was exhausted by earlier watcher rounds; "
-                            "no fresh CI poll was performed."
-                        ]
-                        post_pr_comment(
-                            runner,
-                            config=config,
-                            pr_number=pr_number,
-                            body=_pending_ci_stop_message(pr_number, "pending", details),
-                        )
-                        rerun = _render_ci_rerun_command(config, pr_number=pr_number)
-                        note = (
-                            ""
-                            if config.invocation_argv
-                            else " (deterministic fallback; original invocation unavailable)"
-                        )
-                        log(
-                            config,
-                            f"Round {round_number}: PR #{pr_number} shared CI watch budget was "
-                            "exhausted before a fresh poll; no merge attempted",
-                        )
-                        print(
-                            f"PR #{pr_number} CI watch budget was exhausted by earlier rounds; "
-                            f"no fresh poll was performed and no merge was attempted. "
-                            f"Rerun: {rerun}{note}"
-                        )
-                        if config.auto_merge:
-                            raise AgentLoopError(
-                                f"PR #{pr_number} full-board CI watch budget was exhausted before "
-                                "a fresh poll; no merge attempted."
-                            )
-                        return 0
                     watch_outcome = watch_pr_checks(
                         runner,
                         config,
@@ -8351,41 +8387,22 @@ def run_pr_loop(
                         print(f"PR #{pr_number} CI watch stopped: external CI infrastructure is stalled.")
                         return 0
                     if watch_outcome.status == "timeout":
-                        _publish_approved_followups(
-                            runner,
-                            config=config,
-                            pr_number=pr_number,
-                            head_sha=pr_metadata.head_sha,
-                            pr_comments=pr_comments,
-                            followups=future_followups,
-                        )
                         details = (
                             _pr_check_details(watch_outcome.pr_checks)
                             if watch_outcome.pr_checks
                             else ["No reliable check snapshot was available."]
                         )
-                        post_pr_comment(
+                        return _stop_after_ci_watch_timeout(
                             runner,
                             config=config,
                             pr_number=pr_number,
-                            body=_pending_ci_stop_message(pr_number, "pending", details),
+                            round_number=round_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=future_followups,
+                            details=details,
+                            reason="timeout",
                         )
-                        rerun = _render_ci_rerun_command(config, pr_number=pr_number)
-                        note = (
-                            ""
-                            if config.invocation_argv
-                            else " (deterministic fallback; original invocation unavailable)"
-                        )
-                        print(
-                            f"PR #{pr_number} CI watch timed out: {'; '.join(details)}. "
-                            f"Rerun: {rerun}{note}"
-                        )
-                        if config.auto_merge:
-                            raise AgentLoopError(
-                                f"PR #{pr_number} full-board CI watch did not pass within "
-                                f"{config.ci_timeout_seconds}s; no merge attempted."
-                            )
-                        return 0
                     if watch_outcome.status == "head_changed":
                         log(config, f"PR #{pr_number} head changed while watching; re-review is required")
                         # Consume a fresh review round without dispatching the
@@ -8707,7 +8724,6 @@ def run_pr_loop(
                                 for item in unresolved_items
                                 if item.status in {"blocking", "same-pr"}
                             ]
-                            wait_outcome = None
                         elif ordinary_recovery_selected:
                             if ordinary_recovery is None:
                                 raise AgentLoopError(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -82,7 +82,6 @@ from .github import (
     validate_pr_expected_closing_issues,
     validate_pr_references_issue,
     validate_pull_request_provenance,
-    wait_for_ci,
     watch_pr_checks,
 )
 from .issue_pr_handoff import (
@@ -514,6 +513,24 @@ class ExactHeadCiProof:
 
     head_sha: str
     source: str
+
+
+def _render_ci_rerun_command(config: AgentLoopConfig, *, pr_number: int) -> str:
+    """Render local CI recovery guidance without retired auto-merge selectors."""
+    if config.invocation_argv:
+        argv = config.invocation_argv
+        if config.auto_merge:
+            argv = tuple(
+                token
+                for token in argv
+                if token not in {"--watch-pending-ci", "--no-watch-pending-ci"}
+            )
+        return shlex.join(argv)
+    return (
+        f"agent-loop pr {pr_number} --auto-merge"
+        if config.auto_merge
+        else f"agent-loop pr {pr_number} --watch-pending-ci"
+    )
 
 
 def _merge_with_exact_head_proof(
@@ -8174,7 +8191,17 @@ def run_pr_loop(
                     if merged:
                         print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
                     return 0
-                if not must_fix_items and config.watch_pending_ci and not managed_ci_active(pr_metadata):
+                if (
+                    not must_fix_items
+                    and (config.auto_merge or config.watch_pending_ci)
+                    and not managed_ci_active(pr_metadata)
+                    # A failure already visible in the approval snapshot is
+                    # existing actionable reviewer feedback; preserve the
+                    # normal coder-routing path. The watcher handles failures
+                    # discovered by a fresh poll after an otherwise clean
+                    # approval snapshot.
+                    and (pr_checks is None or pr_checks.state != "failing")
+                ):
                     if watch_deadline is None:
                         watch_deadline = time.monotonic() + config.ci_timeout_seconds
                         watch_attempts_remaining = max(
@@ -8195,16 +8222,54 @@ def run_pr_loop(
                     )
                     assert watch_attempts_remaining is not None
                     if watch_attempts_remaining <= 0:
-                        watch_outcome = CiWatchOutcome(status="timeout")
-                    else:
-                        watch_outcome = watch_pr_checks(
+                        _publish_approved_followups(
                             runner,
-                            config,
-                            pr_number,
-                            metadata=pr_metadata,
-                            deadline=watch_deadline,
-                            attempts=watch_attempts_remaining,
+                            config=config,
+                            pr_number=pr_number,
+                            head_sha=pr_metadata.head_sha,
+                            pr_comments=pr_comments,
+                            followups=future_followups,
                         )
+                        details = [
+                            "The shared CI watch budget was exhausted by earlier watcher rounds; "
+                            "no fresh CI poll was performed."
+                        ]
+                        post_pr_comment(
+                            runner,
+                            config=config,
+                            pr_number=pr_number,
+                            body=_pending_ci_stop_message(pr_number, "pending", details),
+                        )
+                        rerun = _render_ci_rerun_command(config, pr_number=pr_number)
+                        note = (
+                            ""
+                            if config.invocation_argv
+                            else " (deterministic fallback; original invocation unavailable)"
+                        )
+                        log(
+                            config,
+                            f"Round {round_number}: PR #{pr_number} shared CI watch budget was "
+                            "exhausted before a fresh poll; no merge attempted",
+                        )
+                        print(
+                            f"PR #{pr_number} CI watch budget was exhausted by earlier rounds; "
+                            f"no fresh poll was performed and no merge was attempted. "
+                            f"Rerun: {rerun}{note}"
+                        )
+                        if config.auto_merge:
+                            raise AgentLoopError(
+                                f"PR #{pr_number} full-board CI watch budget was exhausted before "
+                                "a fresh poll; no merge attempted."
+                            )
+                        return 0
+                    watch_outcome = watch_pr_checks(
+                        runner,
+                        config,
+                        pr_number,
+                        metadata=pr_metadata,
+                        deadline=watch_deadline,
+                        attempts=watch_attempts_remaining,
+                    )
                     watch_attempts_remaining -= watch_outcome.attempts_used
                     if watch_outcome.status == "dry_run":
                         print(f"PR #{pr_number} approval found; dry-run preview did not perform live CI watching.")
@@ -8220,12 +8285,17 @@ def run_pr_loop(
                         )
                         run_optional_tests(runner, config)
                         if config.auto_merge:
+                            if not watch_outcome.head_sha:
+                                raise AgentLoopError(
+                                    f"PR #{pr_number} full-board CI passed without a current-head "
+                                    "proof; no merge attempted."
+                                )
                             _merge_with_exact_head_proof(
                                 runner,
                                 config=config,
                                 pr_number=pr_number,
                                 proof=ExactHeadCiProof(
-                                    head_sha=pr_metadata.head_sha or "",
+                                    head_sha=watch_outcome.head_sha,
                                     source="full-board",
                                 ),
                             )
@@ -8246,27 +8316,11 @@ def run_pr_loop(
                             f"PR #{pr_number} has no materialized current-head CI board. No merge was "
                             f"attempted; resume with `{command}`."
                         )
-                        return 0
-                    # Compatibility fail-safe for an older watcher/provider
-                    # that still emits the retired outcome. It is never a
-                    # merge permit; unreadable managed suppression remains a
-                    # hard error rather than silently becoming ordinary CI.
-                    if watch_outcome.status == "no_checks":
-                        label_live = managed_label_present(
-                            runner, config=config, pr_number=pr_number
-                        )
-                        if label_live is not False:
+                        if config.auto_merge:
                             raise AgentLoopError(
-                                f"PR #{pr_number} has no ordinary CI checks while `{MANAGED_LABEL}` "
-                                "is present or unreadable; remove the label and wait for real CI before merging."
+                                f"PR #{pr_number} full-board CI did not start within the bounded "
+                                "startup window; no merge attempted."
                             )
-                        command = render_managed_ci_resume_command(
-                            config, pr_number=pr_number, managed_ci=False,
-                        )
-                        print(
-                            f"PR #{pr_number} has an empty CI board. No merge was attempted; "
-                            f"resume with `{command}`."
-                        )
                         return 0
                     if watch_outcome.status == "infrastructure_stall":
                         _publish_approved_followups(
@@ -8316,11 +8370,7 @@ def run_pr_loop(
                             pr_number=pr_number,
                             body=_pending_ci_stop_message(pr_number, "pending", details),
                         )
-                        rerun = (
-                            shlex.join(config.invocation_argv)
-                            if config.invocation_argv
-                            else f"agent-loop pr {pr_number} --watch-pending-ci"
-                        )
+                        rerun = _render_ci_rerun_command(config, pr_number=pr_number)
                         note = (
                             ""
                             if config.invocation_argv
@@ -8330,6 +8380,11 @@ def run_pr_loop(
                             f"PR #{pr_number} CI watch timed out: {'; '.join(details)}. "
                             f"Rerun: {rerun}{note}"
                         )
+                        if config.auto_merge:
+                            raise AgentLoopError(
+                                f"PR #{pr_number} full-board CI watch did not pass within "
+                                f"{config.ci_timeout_seconds}s; no merge attempted."
+                            )
                         return 0
                     if watch_outcome.status == "head_changed":
                         log(config, f"PR #{pr_number} head changed while watching; re-review is required")
@@ -8668,67 +8723,10 @@ def run_pr_loop(
                             if merged:
                                 print(f"PR #{pr_number} merged after deliberate ordinary recovery.")
                             return 0
-                        else:
-                            wait_outcome = wait_for_ci(
-                                runner, config, pr_number, metadata=pr_metadata
-                            )
-                        if wait_outcome is None:
-                            pass
-                        elif wait_outcome.status == "infrastructure_stall":
-                            assert wait_outcome.stall is not None
-                            post_pr_comment(
-                                runner,
-                                config=config,
-                                pr_number=pr_number,
-                                body=_format_ci_infrastructure_comment(pr_number, wait_outcome.stall),
-                            )
-                            post_pr_comment(
-                                runner,
-                                config=config,
-                                pr_number=pr_number,
-                                body=_ci_infrastructure_stop_message(pr_number, wait_outcome.stall, []),
-                            )
-                            log(
-                                config,
-                                f"Round {round_number}: PR #{pr_number} CI wait stopped on external "
-                                "infrastructure blocking; no merge attempted",
-                            )
-                            print(
-                                f"PR #{pr_number} was approved by "
-                                f"{format_agent_list(configured_reviewers)}, but external GitHub "
-                                "Actions infrastructure is blocking CI "
-                                f"({'; '.join(_ci_infrastructure_details(wait_outcome.stall))}). "
-                                "No merge was attempted; rerun the same command once GitHub Actions "
-                                "runners recover."
-                            )
-                            return 0
-                        elif wait_outcome.status == "merge_conflict":
-                            assert wait_outcome.mergeability is not None
-                            latest_mergeability = wait_outcome.mergeability
-                            unresolved_items = _reconcile_merge_conflict_item(
-                                unresolved_items,
-                                mergeability=wait_outcome.mergeability,
-                                source_round=round_number,
-                                current_head_sha=pr_metadata.head_sha,
-                            )
-                            must_fix_items = [
-                                item for item in unresolved_items if item.status in {"blocking", "same-pr"}
-                            ]
-                            log(
-                                config,
-                                f"Round {round_number}: PR #{pr_number} became conflicted with "
-                                f"{wait_outcome.mergeability.base_branch or config.base or 'the base branch'} "
-                                "during the CI wait; no merge attempted",
-                            )
-                        else:
-                            _merge_with_exact_head_proof(
-                                runner,
-                                config=config,
-                                pr_number=pr_number,
-                                proof=ExactHeadCiProof(
-                                    head_sha=pr_metadata.head_sha or "",
-                                    source="configured CI",
-                                ),
+                        elif config.auto_merge:
+                            raise AgentLoopError(
+                                f"PR #{pr_number} reached the ordinary auto-merge path without "
+                                "consuming a full-board CI watcher result; no merge attempted."
                             )
                     if not must_fix_items:
                         print(f"PR #{pr_number} approved by {format_agent_list(configured_reviewers)}.")

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -948,7 +948,13 @@ class FakeRunner(Runner):
 
         if cmd[:3] == ["gh", "pr", "view"]:
             if "--jq" in cmd and ".headRefOid" in cmd:
-                return CommandResult(cmd, cwd_path, "abc123\n", "", 0)
+                return CommandResult(
+                    cmd,
+                    cwd_path,
+                    f"{self.pr_payload.get('headRefOid', 'abc123')}\n",
+                    "",
+                    0,
+                )
             return CommandResult(cmd, cwd_path, json_dumps(self.pr_payload), "", 0)
 
         if cmd[:3] == ["gh", "repo", "view"] and "defaultBranchRef" in cmd:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -35,7 +35,7 @@ from coding_review_agent_loop.config import (
     resolve_base_branch,
 )
 from coding_review_agent_loop.errors import AgentInvocationError, QuotaResetExceededError
-from coding_review_agent_loop.github import CiWatchOutcome, IssueComment
+from coding_review_agent_loop.github import IssueComment
 from coding_review_agent_loop.managed_ci import ManagedCiReadiness, ProtectionAssessment
 from coding_review_agent_loop.managed_pr import ManagedPrHandoff
 from coding_review_agent_loop.runner import CommandResult, ExecutableIdentity, ExecutionObservation
@@ -1445,6 +1445,9 @@ def test_config_enables_ci_watch_with_auto_merge_without_rebuilding_antigravity_
         invocation_argv=("agent-loop", "pr", "77"),
     )
     assert config.watch_pending_ci is True
+    assert config.watch_pending_ci_explicit is False
+    assert config.ci_check_name == "test"
+    assert config.ci_check_name_explicit is False
     assert config.managed_ci_pr_mode is True
     assert config.invocation_argv[-1] == "77"
     assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
@@ -1621,18 +1624,6 @@ def test_managed_ci_preflight_uses_documented_nonready_exit_codes(monkeypatch, s
     assert main(["managed-ci", "preflight", "--repo", "OWNER/REPO", "--trusted-actor", "agent-loop"]) == expected
 
 
-def test_no_checks_never_merges_when_managed_label_state_is_unreadable(tmp_path):
-    runner = FakeRunner(codex_outputs=["LGTM.\n<!-- AGENT_STATE: approved -->\n-- OpenAI Codex"])
-    config = make_config(tmp_path, auto_merge=True, watch_pending_ci=True)
-
-    with (
-        patch.object(orchestrator_module, "watch_pr_checks", return_value=CiWatchOutcome(status="no_checks")),
-        patch.object(orchestrator_module, "managed_label_present", return_value=None),
-        pytest.raises(AgentLoopError, match="present or unreadable"),
-    ):
-        run_pr_loop(runner, pr_number=77, config=config)
-
-
 def test_config_does_not_enable_ci_watch_without_auto_merge(tmp_path):
     parser = build_parser()
     args = parser.parse_args(["pr", "77", "--repo", "OWNER/REPO"])
@@ -1651,6 +1642,41 @@ def test_config_allows_disabling_auto_merge_ci_watch(tmp_path):
     config = config_from_args(args, FakeRunner())
 
     assert config.watch_pending_ci is False
+    assert config.watch_pending_ci_explicit is True
+
+
+def test_config_records_explicit_legacy_ci_name_without_changing_effective_name(tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge", "--ci-check-name", "legacy-ci",
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.ci_check_name == "legacy-ci"
+    assert config.ci_check_name_explicit is True
+    assert config.watch_pending_ci is True
+
+
+def test_auto_merge_compatibility_options_emit_warnings(tmp_path, monkeypatch, capsys):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        watch_pending_ci=False,
+        ci_check_name_explicit=True,
+        watch_pending_ci_explicit=True,
+    )
+    monkeypatch.setattr(cli_module, "config_from_args", lambda *args, **kwargs: config)
+    monkeypatch.setattr(cli_module, "run_pr_loop", lambda *args, **kwargs: 0)
+
+    assert main([
+        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge",
+        "--ci-check-name", "legacy-ci", "--no-watch-pending-ci",
+    ]) == 0
+
+    warning = capsys.readouterr().err
+    assert "--ci-check-name is retained for compatibility" in warning
+    assert "--no-watch-pending-ci is retained for compatibility" in warning
 
 
 def test_config_honors_explicit_ci_watch_without_auto_merge(tmp_path):

--- a/tests/test_ci_health.py
+++ b/tests/test_ci_health.py
@@ -16,8 +16,6 @@ from coding_review_agent_loop.github import (
     PullRequestCheck as GithubPullRequestCheck,
     PullRequestChecks as GithubPullRequestChecks,
     PullRequestMetadata,
-    get_check_record,
-    get_check_status,
     get_pr_checks,
 )
 from coding_review_agent_loop.runner import CommandResult, Runner
@@ -403,34 +401,6 @@ def test_reexported_names_import_from_github_module():
     assert GithubPullRequestChecks is PullRequestChecks
 
 
-def test_get_check_record_returns_full_record(tmp_path):
-    config = make_config(tmp_path)
-    runner = _StubGhRunner(
-        check_runs_payload={
-            "check_runs": [
-                {
-                    "id": 42,
-                    "name": "test",
-                    "status": "completed",
-                    "conclusion": "success",
-                    "started_at": "2026-05-23T11:00:00Z",
-                    "completed_at": "2026-05-23T11:05:00Z",
-                }
-            ]
-        }
-    )
-
-    record = get_check_record(runner, config, "abc123")
-
-    assert record is not None
-    assert record.check_id == 42
-    assert record.status == "success"
-    assert get_check_status(runner, config, "abc123") == "success"
-
-
-def test_get_check_record_missing_check_returns_none(tmp_path):
-    config = make_config(tmp_path)
-    runner = _StubGhRunner(check_runs_payload={"check_runs": []})
-
-    assert get_check_record(runner, config, "abc123") is None
-    assert get_check_status(runner, config, "abc123") == "pending"
+def test_full_board_types_remain_reexported_for_current_callers():
+    assert github_module.PullRequestCheck.__name__ == "PullRequestCheck"
+    assert github_module.PullRequestChecks.__name__ == "PullRequestChecks"

--- a/tests/test_ci_watch.py
+++ b/tests/test_ci_watch.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from coding_review_agent_loop.ci_health import PullRequestCheck, PullRequestChecks
 from coding_review_agent_loop.errors import AgentLoopError
 from coding_review_agent_loop.github import PullRequestMetadata, PullRequestMergeability, watch_pr_checks
@@ -24,10 +26,18 @@ def _metadata():
     return PullRequestMetadata(7, "OWNER/REPO", "title", "head", "main", "sha", "url")
 
 
-def _checks(state, *, failing=(), pending=(), query="ok", protection="configured"):
+def _checks(
+    state,
+    *,
+    failing=(),
+    pending=(),
+    missing_required=(),
+    query="ok",
+    protection="configured",
+):
     return PullRequestChecks(
         state=state, required_checks=(), passing=(), pending=pending, failing=failing,
-        missing_required=(), branch_protection_status=protection, branch_protection_note=None,
+        missing_required=tuple(missing_required), branch_protection_status=protection, branch_protection_note=None,
         check_query_status=query, check_query_errors=(), infrastructure_stalls=(),
     )
 
@@ -51,6 +61,39 @@ def test_watch_pending_to_failure_reports_failed_records_and_sleeps(tmp_path):
     assert outcome.status == "failed"
     assert outcome.failed_checks == (failed,)
     assert [command[0] for command in runner.commands] == ["sleep"]
+
+
+@pytest.mark.parametrize(
+    ("missing_required", "query"),
+    [(("build",), "ok"), ((), "partial")],
+)
+def test_watch_reports_observed_failure_despite_incomplete_board_metadata(
+    tmp_path, missing_required, query
+):
+    runner = _Runner()
+    failed = PullRequestCheck(
+        name="test", kind="check_run", status="failure", url="https://checks/1"
+    )
+    with patch("coding_review_agent_loop.github.get_pr_head_sha", return_value="sha"), \
+         patch("coding_review_agent_loop.github.get_pr_mergeability", return_value=_mergeability()), \
+         patch(
+             "coding_review_agent_loop.github.get_pr_checks",
+             return_value=_checks(
+                 "failing",
+                 failing=(failed,),
+                 missing_required=missing_required,
+                 query=query,
+             ),
+         ):
+        outcome = watch_pr_checks(
+            runner,
+            make_config(tmp_path, watch_pending_ci=True),
+            7,
+            metadata=_metadata(),
+        )
+    assert outcome.status == "failed"
+    assert outcome.failed_checks == (failed,)
+    assert runner.commands == []
 
 
 def test_watch_success_and_head_change_are_terminal(tmp_path):

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -128,6 +128,17 @@ def test_readme_links_to_managed_exact_head_ci_and_scopes_watch_mode():
     )
 
 
+def test_watch_docs_define_full_board_policy_and_compatibility_behavior():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    normalized_text = " ".join(text.split())
+
+    assert "ordinary `--auto-merge` always enters the full-board watcher" in normalized_text
+    assert "reliable, non-empty current-head board" in normalized_text
+    assert "shared across all watcher entries" in normalized_text
+    assert "Auto-merge timeout, `not_started`, and pre-poll exhaustion" in normalized_text
+    assert "legacy single `--ci-check-name` waiter" not in normalized_text
+
+
 def test_managed_ci_docs_describe_explicit_existing_pr_adoption_and_opt_out():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert "#### Optional adoption of an existing PR" in text

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -527,9 +527,7 @@ def test_ordinary_resume_command_preserves_merge_and_watch_mode_without_managed_
         managed_ci=False,
     )
 
-    assert command == (
-        "agent-loop pr 42 --repo OWNER/REPO --base main --auto-merge --watch-pending-ci"
-    )
+    assert command == "agent-loop pr 42 --repo OWNER/REPO --base main --auto-merge"
 
 
 def test_managed_resume_command_retains_managed_ci_configuration(tmp_path):
@@ -547,19 +545,19 @@ def test_managed_resume_command_retains_managed_ci_configuration(tmp_path):
     )
 
     assert command == (
-        "agent-loop pr 42 --repo OWNER/REPO --base main --auto-merge --watch-pending-ci "
+        "agent-loop pr 42 --repo OWNER/REPO --base main --auto-merge "
         "--managed-ci --managed-ci-trusted-actor agent-loop --allow-unprotected-managed-ci"
     )
 
 
-def test_resume_command_preserves_explicit_ordinary_watch_opt_out(tmp_path):
+def test_resume_command_omits_retired_ordinary_watch_opt_out(tmp_path):
     command = render_managed_ci_resume_command(
         make_config(tmp_path, auto_merge=True, watch_pending_ci=False),
         pr_number=42,
         managed_ci=False,
     )
 
-    assert command.endswith("--auto-merge --no-watch-pending-ci")
+    assert command.endswith("--auto-merge")
 
 
 def test_issue_created_handoff_authenticates_override_before_any_remote_write(tmp_path):

--- a/tests/test_merge_conflict.py
+++ b/tests/test_merge_conflict.py
@@ -62,7 +62,7 @@ def test_conflict_at_round_start_skips_reviewers_and_routes_to_coder(tmp_path):
     assert check_runs_index_before_claude == []
 
 
-def test_conflict_after_review_before_merge_blocks_ci_wait_and_merge(tmp_path):
+def test_conflict_after_review_before_merge_blocks_watcher_and_merge(tmp_path):
     runner = FakeRunner(
         claude_outputs=["Resolved the conflict.\n<!-- AGENT_STATE: blocking -->\n-- Anthropic Claude"],
         codex_outputs=[
@@ -87,15 +87,16 @@ def test_conflict_after_review_before_merge_blocks_ci_wait_and_merge(tmp_path):
     config = make_config(tmp_path, auto_merge=True)
 
     with patch(
-        "coding_review_agent_loop.orchestrator.wait_for_ci", wraps=orchestrator.wait_for_ci
-    ) as wait_spy, patch("coding_review_agent_loop.orchestrator.merge_pr") as merge_spy:
+        "coding_review_agent_loop.orchestrator.watch_pr_checks",
+        wraps=orchestrator.watch_pr_checks,
+    ) as watch_spy, patch("coding_review_agent_loop.orchestrator.merge_pr") as merge_spy:
         result = run_pr_loop(runner, pr_number=77, config=config)
 
     assert result == 0
     # The merge-gate probe (right before CI checks) caught the conflict, so
     # CI was never polled and the merge was never attempted in round 1;
     # both only happen after the coder resolves and round 2 re-approves.
-    assert wait_spy.call_count == 1
+    assert watch_spy.call_count == 1
     assert merge_spy.call_count == 1
     assert len(_codex_exec_commands(runner)) == 2
     assert len(_claude_commands(runner)) == 1

--- a/tests/test_mergeability.py
+++ b/tests/test_mergeability.py
@@ -1,4 +1,4 @@
-"""Tests for GitHub mergeability probing and its use in wait_for_ci (#606)."""
+"""Tests for GitHub mergeability probing and its full-board watcher use (#606)."""
 import json
 
 from coding_review_agent_loop.comment_rendering import _format_unresolved_item_label
@@ -6,7 +6,7 @@ from coding_review_agent_loop.github import (
     PullRequestMergeability,
     PullRequestMetadata,
     get_pr_mergeability,
-    wait_for_ci,
+    watch_pr_checks,
 )
 from coding_review_agent_loop.protocol import UnresolvedReviewItem, validate_structured_coder_followup
 from coding_review_agent_loop.runner import CommandResult, Runner
@@ -52,6 +52,10 @@ class _StubMergeabilityRunner(Runner):
         if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/check-runs"):
             payload = self.check_runs_responses.pop(0) if self.check_runs_responses else {"check_runs": []}
             return CommandResult(cmd, cwd, json.dumps(payload), "", 0)
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/status"):
+            return CommandResult(cmd, cwd, json.dumps({"statuses": []}), "", 0)
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/protection/required_status_checks"):
+            return CommandResult(cmd, cwd, json.dumps({"contexts": []}), "", 0)
         raise AssertionError(f"unexpected command: {cmd}")
 
 
@@ -189,10 +193,10 @@ def test_dry_run_never_calls_gh(tmp_path):
     assert runner.commands == []
 
 
-# --- wait_for_ci merge_conflict outcome -------------------------------------
+# --- full-board watcher mergeability outcomes -------------------------------
 
 
-def test_wait_for_ci_returns_merge_conflict_on_first_poll(tmp_path):
+def test_watcher_returns_merge_conflict_before_check_board_poll(tmp_path):
     config = make_config(tmp_path, ci_timeout_seconds=120, ci_poll_interval_seconds=10)
     runner = _StubMergeabilityRunner(
         mergeability_responses=[
@@ -200,7 +204,7 @@ def test_wait_for_ci_returns_merge_conflict_on_first_poll(tmp_path):
         ],
     )
 
-    outcome = wait_for_ci(runner, config, 77, metadata=_metadata())
+    outcome = watch_pr_checks(runner, config, 77, metadata=_metadata())
 
     assert outcome.status == "merge_conflict"
     assert outcome.mergeability is not None
@@ -210,7 +214,7 @@ def test_wait_for_ci_returns_merge_conflict_on_first_poll(tmp_path):
     assert runner.sleep_calls == []
 
 
-def test_wait_for_ci_passes_when_not_conflicted(tmp_path):
+def test_watcher_passes_full_board_when_not_conflicted(tmp_path):
     config = make_config(tmp_path, ci_timeout_seconds=120, ci_poll_interval_seconds=10)
     runner = _StubMergeabilityRunner(
         mergeability_responses=[
@@ -218,13 +222,13 @@ def test_wait_for_ci_passes_when_not_conflicted(tmp_path):
         ],
     )
 
-    outcome = wait_for_ci(runner, config, 77, metadata=_metadata())
+    outcome = watch_pr_checks(runner, config, 77, metadata=_metadata())
 
     assert outcome.status == "passed"
-    assert outcome.mergeability is None
+    assert outcome.head_sha == "headsha1"
 
 
-def test_wait_for_ci_reprobes_conflict_on_later_poll(tmp_path):
+def test_watcher_reprobes_conflict_on_later_poll(tmp_path):
     config = make_config(tmp_path, ci_timeout_seconds=120, ci_poll_interval_seconds=10)
     runner = _StubMergeabilityRunner(
         mergeability_responses=[
@@ -236,7 +240,7 @@ def test_wait_for_ci_reprobes_conflict_on_later_poll(tmp_path):
         ],
     )
 
-    outcome = wait_for_ci(runner, config, 77, metadata=_metadata())
+    outcome = watch_pr_checks(runner, config, 77, metadata=_metadata())
 
     assert outcome.status == "merge_conflict"
     assert outcome.mergeability is not None

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -26,7 +26,6 @@ from coding_review_agent_loop.followups import (
     reconcile_plan_approved_followups,
 )
 from coding_review_agent_loop.github import (
-    CiWaitOutcome,
     CiWatchOutcome,
     HumanReviewRequirement,
     IssueComment,
@@ -1176,7 +1175,7 @@ def _watch_check_board(
 
 
 @pytest.mark.parametrize("auto_merge", [False, True])
-def test_watch_mode_success_skips_legacy_wait_for_ci(
+def test_watch_mode_success_uses_full_board_without_second_wait(
     tmp_path, monkeypatch, auto_merge
 ):
     runner = FakeRunner(codex_outputs=[structured_pr_review(state="approved", summary="Approved.")])
@@ -1184,12 +1183,9 @@ def test_watch_mode_success_skips_legacy_wait_for_ci(
     monkeypatch.setattr(
         orchestrator,
         "watch_pr_checks",
-        lambda *args, **kwargs: CiWatchOutcome(status="passed", attempts_used=1),
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "wait_for_ci",
-        lambda *args, **kwargs: pytest.fail("legacy CI waiter must not run in watch mode"),
+        lambda *args, **kwargs: CiWatchOutcome(
+            status="passed", head_sha="abc123", attempts_used=1
+        ),
     )
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
     assert any("watching GitHub checks" in comment for comment in runner.comments)
@@ -1597,7 +1593,7 @@ def test_watch_failure_on_final_round_dispatches_coder_with_check_diagnostic(
                 failed_checks=(failed_check,),
                 attempts_used=1,
             ),
-            CiWatchOutcome(status="passed", attempts_used=1),
+            CiWatchOutcome(status="passed", head_sha="abc123", attempts_used=1),
         ]
     )
     runner = FakeRunner(
@@ -1858,7 +1854,7 @@ def test_watch_dry_run_previews_without_poll_sleep_coder_or_merge(tmp_path, caps
 
 
 @pytest.mark.parametrize("auto_merge", [False, True])
-def test_disabled_watch_mode_preserves_legacy_pending_and_auto_merge_paths(
+def test_disabled_watch_mode_preserves_manual_path_and_auto_merge_uses_full_board(
     tmp_path, monkeypatch, auto_merge
 ):
     runner = FakeRunner(
@@ -1870,28 +1866,55 @@ def test_disabled_watch_mode_preserves_legacy_pending_and_auto_merge_paths(
         },
     )
     config = make_config(tmp_path, watch_pending_ci=False, auto_merge=auto_merge)
-    monkeypatch.setattr(
-        orchestrator,
-        "watch_pr_checks",
-        lambda *args, **kwargs: pytest.fail("disabled watch mode must not invoke watcher"),
-    )
-    wait_calls = []
+    watch_calls = []
 
-    def legacy_wait(*args, **kwargs):
-        wait_calls.append((args, kwargs))
-        return CiWaitOutcome(status="passed")
+    def watch(*args, **kwargs):
+        watch_calls.append((args, kwargs))
+        return CiWatchOutcome(status="passed", head_sha="abc123", attempts_used=1)
 
-    monkeypatch.setattr(orchestrator, "wait_for_ci", legacy_wait)
+    monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
 
     assert run_pr_loop(runner, pr_number=77, config=config) == 0
 
-    assert bool(wait_calls) is auto_merge
+    assert bool(watch_calls) is auto_merge
     merge_commands = [
         cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "pr", "merge"]
     ]
     assert bool(merge_commands) is auto_merge
     if not auto_merge:
         assert any("checks are still pending" in comment for comment in runner.comments)
+
+
+def test_auto_merge_green_board_ignores_legacy_check_name_and_merges_once(
+    tmp_path, monkeypatch
+):
+    runner = FakeRunner(
+        codex_outputs=[structured_pr_review(state="approved", summary="Approved.")],
+        pr_check_runs_payload={
+            "check_runs": [
+                {"name": "lint", "status": "completed", "conclusion": "success"}
+            ]
+        },
+        pr_status_payload={"state": "success", "statuses": []},
+        pr_branch_protection_payload={"contexts": []},
+    )
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        watch_pending_ci=False,
+        ci_check_name="legacy-ci",
+    )
+    with patch.object(orchestrator, "watch_pr_checks", wraps=orchestrator.watch_pr_checks) as watch_spy:
+        assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert watch_spy.call_count == 1
+    merge_commands = [
+        cmd for cmd, _cwd in runner.commands if cmd[:3] == ["gh", "pr", "merge"]
+    ]
+    assert merge_commands == [[
+        "gh", "pr", "merge", "77", "--repo", "OWNER/REPO", "--merge",
+        "--match-head-commit", "abc123",
+    ]]
 
 
 def test_watch_publishes_approved_followups_only_after_terminal_success(
@@ -1947,7 +1970,7 @@ def test_watch_publishes_approved_followups_only_after_terminal_success(
                 failed_checks=(failed_check,),
                 attempts_used=1,
             )
-        return CiWatchOutcome(status="passed", attempts_used=1)
+        return CiWatchOutcome(status="passed", head_sha="abc123", attempts_used=1)
 
     monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
 
@@ -2138,10 +2161,11 @@ def test_pr_loop_downgrades_pending_ci_only_blocking_review_with_auto_merge(tmp_
     )
     config = make_config(tmp_path, auto_merge=True)
 
-    assert run_pr_loop(runner, pr_number=77, config=config) == 0
+    with pytest.raises(AgentLoopError, match="full-board CI watch did not pass within"):
+        run_pr_loop(runner, pr_number=77, config=config)
 
     assert not any(cmd[:1] == ["claude"] for cmd, _cwd in runner.commands)
-    assert any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
+    assert not any(cmd[:3] == ["gh", "pr", "merge"] for cmd, _cwd in runner.commands)
     review_comment = runner.comments[0]
     assert review_comment.startswith("**Review verdict:** Approved")
 
@@ -2822,7 +2846,7 @@ def test_pr_loop_requires_all_reviewers_to_approve(tmp_path):
 
     agent_commands = [cmd[:2] for cmd, _cwd in runner.commands if cmd[:1] in (["claude"], ["codex"])]
     assert agent_commands == [["codex", "exec"], ["claude", "--print"]]
-    assert len(runner.comments) == 2
+    assert len(runner.comments) == 3
     commands = [cmd for cmd, _cwd in runner.commands]
     metadata_fetches = [
         cmd

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1833,6 +1833,44 @@ def test_watch_timeout_renders_local_rerun_without_leaking_it_to_comment(
     assert all("token value" not in comment for comment in runner.comments)
 
 
+@pytest.mark.parametrize("auto_merge", [False, True])
+def test_watch_budget_exhaustion_stops_before_announcing_new_poll(
+    tmp_path, monkeypatch, capsys, auto_merge
+):
+    runner = FakeRunner(
+        codex_outputs=[
+            structured_pr_review(state="approved", summary="Old head approved."),
+            structured_pr_review(state="approved", summary="New head approved."),
+        ]
+    )
+    config = make_config(
+        tmp_path,
+        watch_pending_ci=True,
+        auto_merge=auto_merge,
+        max_rounds=1,
+        ci_timeout_seconds=20,
+        ci_poll_interval_seconds=10,
+    )
+    watch_calls = []
+
+    def watch(*args, **kwargs):
+        watch_calls.append(kwargs)
+        runner.pr_payload["headRefOid"] = "new-head"
+        return CiWatchOutcome(status="head_changed", head_sha="new-head", attempts_used=2)
+
+    monkeypatch.setattr(orchestrator, "watch_pr_checks", watch)
+
+    if auto_merge:
+        with pytest.raises(AgentLoopError, match="watch budget was exhausted"):
+            run_pr_loop(runner, pr_number=77, config=config)
+    else:
+        assert run_pr_loop(runner, pr_number=77, config=config) == 0
+
+    assert len(watch_calls) == 1
+    assert sum("watching GitHub checks" in comment for comment in runner.comments) == 1
+    assert sum("CI watch budget was exhausted" in line for line in capsys.readouterr().out.splitlines()) == 1
+
+
 def test_watch_dry_run_previews_without_poll_sleep_coder_or_merge(tmp_path, capsys):
     runner = FakeRunner(
         codex_outputs=[structured_pr_review(state="approved", summary="Approved.")]


### PR DESCRIPTION
## Summary

- Route ordinary auto-merge through the full-board CI watcher regardless of the compatibility opt-out value.
- Preserve fail-closed board reliability, bounded startup handling, shared per-invocation watch budget, and exact-head merge proof semantics.
- Remove the retired named-check waiter, retain explicit compatibility flags with warnings, and update resume guidance and documentation.

## Verification

- Focused CI/orchestrator/CLI/managed-CI/mergeability/conflict/docs tests: 670 passed.
- Full test suite: 2392 passed.

Fixes #611