### PR TITLE
Fix managed-CI resume lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,9 +798,11 @@ reauthenticating the issue-to-PR handoff. Direct `pr` mode is the fallback for
 a known PR. Ready/unlabeled reconstruction requires an explicit `--managed-ci`
 request. An implicit `--auto-merge` retry leaves an authenticated PR ready and
 unlabeled, performs no label/body/comment/dispatch/readiness write, and prints
-the exact retry with `--managed-ci`. The recovery path accepts only
-draft/labeled or ready/unlabeled lifecycle states and treats historical audit
-records as provenance, never as reusable authority or something to delete.
+the exact retry with `--managed-ci`. The recovery path accepts draft/labeled
+and ready/unlabeled lifecycle states; after an explicit managed-CI failure it
+can also re-admit draft/unlabeled only with an explicit `--managed-ci` request.
+Other mixed states stop before agents run. Historical audit records remain
+provenance, never reusable authority or something to delete.
 
 Base provenance is retained across the issue-to-PR boundary. If an inherited
 repository-default base differs from the live PR base, the run stops before

--- a/README.md
+++ b/README.md
@@ -792,6 +792,23 @@ manual run, rerun `agent-loop pr <number> --managed-ci
 the previous manual-merge command is suspended until a fresh review and
 qualification succeeds. A changed head always needs a new cycle.
 
+For a canonical issue handoff, rerun the original `agent-loop issue <number>`
+command first; it preserves the planning/implementation shape while
+reauthenticating the issue-to-PR handoff. Direct `pr` mode is the fallback for
+a known PR. Ready/unlabeled reconstruction requires an explicit `--managed-ci`
+request. An implicit `--auto-merge` retry leaves an authenticated PR ready and
+unlabeled, performs no label/body/comment/dispatch/readiness write, and prints
+the exact retry with `--managed-ci`. The recovery path accepts only
+draft/labeled or ready/unlabeled lifecycle states and treats historical audit
+records as provenance, never as reusable authority or something to delete.
+
+Base provenance is retained across the issue-to-PR boundary. If an inherited
+repository-default base differs from the live PR base, the run stops before
+workdir setup and prints a retry with the live `--base` explicitly included;
+an operator-supplied `--base` remains authoritative. Recovery commands replay
+parser-valid original arguments, preserving repeated common options and safe
+shell quoting while removing only selectors invalid for the target subcommand.
+
 Already-open PRs remain ordinary CI by default. A repository can separately
 advertise safe adoption and an operator can explicitly request it only with
 `agent-loop pr <n> --auto-merge --managed-ci-trusted-actor <login>

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1528,6 +1528,28 @@ editable body nonce never grants authority or gets reused. The audit's
 repository/base fields must match, and missing, malformed, ambiguous, or raced
 audit/timeline data fails closed to deliberate ordinary release.
 
+The preferred recovery for a canonical issue handoff is to rerun the original
+`agent-loop issue <number>` command. That preserves its planning and
+implementation shape and reuses the authenticated issue-to-PR association;
+`agent-loop pr <number>` is the direct fallback when the PR is already known.
+An authenticated ready/unlabeled issue-created or `managed-pr` PR may be
+reconstructed only when the new invocation has an explicit `--managed-ci`.
+An implicit `--auto-merge` invocation leaves that state ready and unlabeled,
+prints the exact flow-preserving retry, and performs no label, body, comment,
+dispatch, or readiness write. Draft/labeled and ready/unlabeled are the only
+accepted lifecycle states; mixed states stop before agents run.
+
+Base resolution records whether the value came from an explicit `--base`, the
+repository default, or live PR metadata. This base provenance crosses the
+issue-to-PR boundary unchanged. If an inherited repository default differs
+from the live PR base, the run stops before workdir setup and prints a retry
+with the live base explicitly supplied. An operator-provided `--base` remains
+authoritative. Recovery commands replay parser-valid invocation tokens,
+including repeated common options and shell metacharacters, and remove only
+options that the target subcommand cannot accept. Historical audit records and
+old qualification ledgers are provenance only: recovery mints fresh authority
+and never asks the operator to delete durable records.
+
 A successful resume records a fresh audit, nonce, and invocation intent
 generation. Earlier ledger entries and attached workflow runs remain history:
 even a queued, successful, failed, or rejected prior run is logged as the

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1536,8 +1536,10 @@ An authenticated ready/unlabeled issue-created or `managed-pr` PR may be
 reconstructed only when the new invocation has an explicit `--managed-ci`.
 An implicit `--auto-merge` invocation leaves that state ready and unlabeled,
 prints the exact flow-preserving retry, and performs no label, body, comment,
-dispatch, or readiness write. Draft/labeled and ready/unlabeled are the only
-accepted lifecycle states; mixed states stop before agents run.
+dispatch, or readiness write. Draft/labeled and ready/unlabeled are the normal
+accepted lifecycle states; an explicit `--managed-ci` retry may also re-admit
+the draft/unlabeled state left by a failed explicit managed run. Other mixed
+states stop before agents run.
 
 Base resolution records whether the value came from an explicit `--base`, the
 repository default, or live PR metadata. This base provenance crosses the

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -377,12 +377,6 @@ def resolve_base_branch(
         return replace(config, base="main", base_provenance="repository-default")
 
     if live_pr_base:
-        if config.base_provenance == "repository-default" and config.base and config.base != live_pr_base:
-            raise mismatch_message(config.base, live_pr_base)
-        if config.base_provenance == "pr-metadata" and config.base and config.base != live_pr_base:
-            raise mismatch_message(config.base, live_pr_base)
-        if config.base and config.base == live_pr_base and config.base_provenance is not None:
-            return config
         return replace(config, base=live_pr_base, base_provenance="pr-metadata")
 
     default_branch = get_repo_default_branch(

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -59,6 +59,7 @@ DISCUSS_RESEARCH_MODES: frozenset[str] = frozenset({"none", "required", "auto"})
 # Discuss-mode debater failure policy values (#475).
 DISCUSS_DEBATER_FAILURE_MODES: frozenset[str] = frozenset({"fail", "partial"})
 DISCUSS_RESULT_MODES: frozenset[str] = frozenset({"triage", "answer"})
+BASE_PROVENANCE_VALUES = frozenset({"explicit", "repository-default", "pr-metadata"})
 
 
 @dataclass(frozen=True)
@@ -222,6 +223,10 @@ class AgentLoopConfig:
     # selector or opt-out no longer changes the full-board gate.
     ci_check_name_explicit: bool = False
     watch_pending_ci_explicit: bool = False
+    # The first source that resolved ``base``.  This is carried across an
+    # issue-to-PR handoff so a repository-default base cannot silently replace
+    # the live PR base on a later invocation.
+    base_provenance: str | None = None
 
     @property
     def effective_managed_ci(self) -> bool:
@@ -295,6 +300,10 @@ class AgentLoopConfig:
         object.__setattr__(self, "expected_closing_issue_ids", normalized_expected)
         if self.pr_origin_flow not in {"direct-pr", "managed-pr"}:
             raise AgentLoopError("pr_origin_flow must be 'direct-pr' or 'managed-pr'.")
+        if self.base_provenance is not None and self.base_provenance not in BASE_PROVENANCE_VALUES:
+            raise AgentLoopError(
+                "base_provenance must be 'explicit', 'repository-default', or 'pr-metadata'."
+            )
 
 
 def reviewers(config: AgentLoopConfig) -> tuple[AgentName, ...]:
@@ -321,15 +330,60 @@ def resolve_base_branch(
     cwd: Path | None = None,
 ) -> AgentLoopConfig:
     explicit_base = (config.base or "").strip()
+    live_pr_base = (pr_metadata.base_branch or "").strip() if pr_metadata is not None else ""
+
+    def mismatch_message(expected: str, actual: str) -> AgentLoopError:
+        invocation = list(config.invocation_argv)
+        if invocation:
+            rewritten: list[str] = []
+            index = 0
+            while index < len(invocation):
+                token = invocation[index]
+                if token == "--base":
+                    index += 2
+                    continue
+                if token.startswith("--base="):
+                    index += 1
+                    continue
+                rewritten.append(token)
+                index += 1
+            rewritten.extend(("--base", actual))
+            retry = shlex.join(rewritten)
+        else:
+            retry = f"agent-loop issue <issue-number> --base {shlex.quote(actual)}"
+        return AgentLoopError(
+            f"Configured base {expected!r} ({config.base_provenance or 'unrecorded'}) "
+            f"differs from the live PR base {actual!r}. No workdir setup or remote write was performed. "
+            f"Rerun the canonical issue command with an explicit live base: {retry}"
+        )
+
+    if (
+        explicit_base
+        and live_pr_base
+        and config.base_provenance in {"repository-default", "pr-metadata"}
+        and explicit_base != live_pr_base
+    ):
+        raise mismatch_message(explicit_base, live_pr_base)
+
     if explicit_base:
-        return config if explicit_base == config.base else replace(config, base=explicit_base)
+        resolved = config if explicit_base == config.base else replace(config, base=explicit_base)
+        if resolved.base_provenance is None:
+            resolved = replace(resolved, base_provenance="explicit")
+        # An operator-supplied --base is authoritative.  The live PR is still
+        # validated by the managed tuple and ordinary review gates.
+        return resolved
 
     if config.dry_run:
-        return replace(config, base="main")
+        return replace(config, base="main", base_provenance="repository-default")
 
-    pr_base = (pr_metadata.base_branch or "").strip() if pr_metadata is not None else ""
-    if pr_base:
-        return replace(config, base=pr_base)
+    if live_pr_base:
+        if config.base_provenance == "repository-default" and config.base and config.base != live_pr_base:
+            raise mismatch_message(config.base, live_pr_base)
+        if config.base_provenance == "pr-metadata" and config.base and config.base != live_pr_base:
+            raise mismatch_message(config.base, live_pr_base)
+        if config.base and config.base == live_pr_base and config.base_provenance is not None:
+            return config
+        return replace(config, base=live_pr_base, base_provenance="pr-metadata")
 
     default_branch = get_repo_default_branch(
         runner,
@@ -337,7 +391,7 @@ def resolve_base_branch(
         cwd=cwd or github_bootstrap_cwd(config),
     )
     if default_branch:
-        return replace(config, base=default_branch)
+        return replace(config, base=default_branch, base_provenance="repository-default")
 
     raise AgentLoopError(
         f"Unable to resolve a base branch for {config.repo}. "
@@ -964,6 +1018,7 @@ def config_from_args(
         coder=args.coder,
         reviewer=configured_reviewers,
         base=getattr(args, "base", None),
+        base_provenance="explicit" if getattr(args, "base", None) else None,
         max_rounds=args.max_rounds,
         auto_merge=args.auto_merge,
         dry_run=args.dry_run,

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -143,6 +143,11 @@ class ManagedCiContract:
     # delayed dispatch-time fallback so a suppressed draft is released only
     # when that same workflow advertises an unlabeled CI route.
     ordinary_recovery_capable: bool = False
+    # Explicit lifecycle provenance.  These fields are intentionally not
+    # inferred from public mode flags after activation.
+    origin: Literal["issue-created", "source-managed"] | None = None
+    lifecycle: Literal["creation", "draft-labeled", "ready-unlabeled-reentry"] | None = None
+    authenticated_resume: "AuthenticatedManagedResume | None" = None
 
 
 @dataclass(frozen=True)
@@ -186,6 +191,25 @@ class AuthenticatedIssueCreatedHandoff:
     protection_mode: str
     override_nonce: str | None
     active_label_event_id: int | None = None
+    lifecycle: Literal["draft-labeled", "ready-unlabeled-reentry"] = "draft-labeled"
+
+
+@dataclass(frozen=True)
+class AuthenticatedManagedResume:
+    """Read-only authority for a managed-CI resume.
+
+    A resume is distinct from a just-created handoff.  The latter authorizes
+    the first activation only; this record is minted by re-reading a durable
+    PR and carries the lifecycle state that was actually authenticated.
+    """
+
+    origin: Literal["issue-created", "source-managed"]
+    lifecycle: Literal["draft-labeled", "ready-unlabeled-reentry"]
+    issue_created_handoff: AuthenticatedIssueCreatedHandoff | None = None
+    source_branch: str | None = None
+    source_sha: str | None = None
+    managed_branch: str | None = None
+    override_nonce: str | None = None
 
 
 def parse_managed_ci_override_record(
@@ -317,6 +341,8 @@ def activate_managed_ci(
     config: AgentLoopConfig,
     pr_number: int,
     metadata: PullRequestMetadata,
+    managed_resume: AuthenticatedManagedResume | None = None,
+    resume_origin: Literal["issue-created", "source-managed"] | None = None,
 ) -> ManagedCiContract | None:
     """Activate a repository-advertised managed-CI contract.
 
@@ -381,6 +407,8 @@ def activate_managed_ci(
             config=config,
             pr_number=pr_number,
             metadata=metadata,
+            managed_resume=managed_resume,
+            resume_origin=resume_origin,
         )
         if contract is not None or not config.managed_ci_adopt_existing_pr:
             if contract is None and config.managed_ci:
@@ -827,6 +855,7 @@ def _issue_created_tuple(
     expected_branch: str,
     expected_nonce: str | None,
     protection_mode: str,
+    lifecycle: Literal["draft-labeled", "ready-unlabeled"] = "draft-labeled",
 ) -> AuthenticatedIssueCreatedHandoff:
     """Read and verify the immutable tuple before any handoff publication.
 
@@ -879,13 +908,22 @@ def _issue_created_tuple(
         sha = head.get("sha") if isinstance(head.get("sha"), str) else None
         branch = head.get("ref") if isinstance(head.get("ref"), str) else None
         rest_body = pr.get("body") if isinstance(pr.get("body"), str) else ""
+        lifecycle_matches = (
+            pr.get("draft") is True and MANAGED_LABEL in labels
+            if lifecycle == "draft-labeled"
+            else pr.get("draft") is False and MANAGED_LABEL not in labels
+        )
         if (
             pr.get("state") not in {"open", "OPEN"}
-            or pr.get("draft") is not True
+            or not lifecycle_matches
             or head_repo.get("full_name", "").casefold() != config.repo.casefold()
             or branch != expected_branch
             or base.get("ref") != config.base
-            or MANAGED_LABEL not in labels
+            or (
+                MANAGED_LABEL not in labels
+                if lifecycle == "draft-labeled"
+                else MANAGED_LABEL in labels
+            )
             or author.get("login", "").casefold() != actor_login.casefold()
             or author.get("id") != actor_id
             or sha != metadata.head_sha
@@ -913,6 +951,9 @@ def _issue_created_tuple(
         trusted_actor_id=actor_id,
         protection_mode=protection_mode,
         override_nonce=record.nonce if record is not None else None,
+        lifecycle=(
+            "ready-unlabeled-reentry" if lifecycle == "ready-unlabeled" else "draft-labeled"
+        ),
     )
 
 
@@ -935,6 +976,7 @@ def authenticate_issue_created_handoff(
         expected_branch=intent.branch,
         expected_nonce=intent.audit_nonce,
         protection_mode=intent.protection_mode,
+        lifecycle="draft-labeled",
     )
 
 
@@ -957,6 +999,11 @@ def revalidate_issue_created_handoff(
         expected_branch=handoff.branch,
         expected_nonce=handoff.override_nonce,
         protection_mode=handoff.protection_mode,
+        lifecycle=(
+            "ready-unlabeled"
+            if handoff.lifecycle == "ready-unlabeled-reentry"
+            else "draft-labeled"
+        ),
     )
     if handoff.active_label_event_id is not None:
         event = _active_managed_label_event(runner, config=config, pr_number=handoff.pr_number)
@@ -977,26 +1024,51 @@ def recover_issue_created_handoff(
     config: AgentLoopConfig,
     pr_number: int,
     metadata: PullRequestMetadata,
+    issue_number: int | None = None,
 ) -> AuthenticatedIssueCreatedHandoff | None:
-    """Reconstruct provenance for a direct PR resume without reusing authority.
+    """Reconstruct a durable issue-created resume without reusing authority.
 
-    This only recognizes the nonce-bearing unprotected body form.  Strict
-    issue-created drafts retain their existing label/timeline activation path;
-    source-managed PRs are handled by ``managed_pr`` before this function.
+    Canonical issue reruns and direct PR reruns use the same read-only proof.
+    The body nonce, when present, is provenance only; the current lifecycle,
+    head, author, base, label, and issue association are reauthenticated.
     """
-    if not config.managed_ci_pr_mode:
+    if not (config.managed_ci_pr_mode or issue_number is not None):
         return None
     body = metadata.body or ""
-    if UNPROTECTED_OVERRIDE_TRAILER not in body:
-        return None
-    record = parse_managed_ci_override_record(
-        body, surface=PR_BODY_SURFACE, schema="body", required=True,
-    )
     branch = metadata.head_branch or ""
     match = re.fullmatch(r"agent-loop/managed-([1-9]\d*)", branch)
     if match is None:
-        raise AgentLoopError("Managed-CI direct resume requires the exact issue-created managed branch.")
-    issue_number = int(match.group(1))
+        return None
+    branch_issue_number = int(match.group(1))
+    if issue_number is not None and issue_number != branch_issue_number:
+        raise AgentLoopError(
+            f"Managed-CI issue association targets issue #{issue_number}, but the authenticated "
+            f"managed branch targets issue #{branch_issue_number}. The PR was left unchanged."
+        )
+    issue_number = branch_issue_number
+    record = None
+    if UNPROTECTED_OVERRIDE_TRAILER in body:
+        record = parse_managed_ci_override_record(
+            body, surface=PR_BODY_SURFACE, schema="body", required=True,
+        )
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    labels = {
+        item.get("name") for item in (pr.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    draft = pr.get("draft")
+    if draft is True and MANAGED_LABEL in labels:
+        lifecycle = "draft-labeled"
+    elif draft is False and MANAGED_LABEL not in labels:
+        lifecycle = "ready-unlabeled"
+    else:
+        state = "draft/labeled" if draft is True and MANAGED_LABEL in labels else (
+            "ready/labeled" if draft is False and MANAGED_LABEL in labels else "draft/unlabeled"
+        )
+        raise AgentLoopError(
+            f"Managed-CI issue-created resume for PR #{pr_number} observed mixed lifecycle state "
+            f"{state}; expected draft/labeled or ready/unlabeled. The PR was left unchanged."
+        )
     # A resumed nonce is provenance only.  Its value is checked against the
     # live body, then activation mints a fresh audit/generation.
     handoff = _issue_created_tuple(
@@ -1006,52 +1078,257 @@ def recover_issue_created_handoff(
         issue_number=issue_number,
         metadata=metadata,
         expected_branch=branch,
-        expected_nonce=record.nonce,
-        protection_mode="voluntary",
+        expected_nonce=record.nonce if record is not None else None,
+        protection_mode="voluntary" if record is not None else "strict",
+        lifecycle=lifecycle,
     )
-    event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
-    if (
-        event is None
-        or event[1].casefold() != handoff.trusted_actor_login.casefold()
-        or event[2] != handoff.trusted_actor_id
-    ):
-        raise AgentLoopError("Managed-CI direct resume requires an actor-owned active managed-label event.")
-    comments = _api_list(runner, config, f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100")
-    if comments is None:
-        raise AgentLoopError("Managed-CI direct resume could not inspect override audit provenance.")
-    if any(
-        UNPROTECTED_OVERRIDE_TRAILER in (comment.get("body") if isinstance(comment.get("body"), str) else "")
-        for comment in comments
-    ) and _find_resume_audit(
-        runner,
-        config=config,
-        pr_number=pr_number,
-        actor_login=handoff.trusted_actor_login,
-        actor_id=handoff.trusted_actor_id,
-        base_ref=handoff.base_ref,
-    ) is None:
-        raise AgentLoopError("Managed-CI direct resume found malformed or uncorrelated override audit provenance.")
-    return replace(handoff, active_label_event_id=event[0])
+    if lifecycle == "draft-labeled":
+        event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        if (
+            event is None
+            or event[1].casefold() != handoff.trusted_actor_login.casefold()
+            or event[2] != handoff.trusted_actor_id
+        ):
+            raise AgentLoopError(
+                "Managed-CI issue-created resume requires an actor-owned active managed-label event."
+            )
+        handoff = replace(handoff, active_label_event_id=event[0])
+    if record is not None:
+        comments = _api_list(
+            runner, config, f"repos/{config.repo}/issues/{pr_number}/comments?per_page=100"
+        )
+        if comments is None:
+            raise AgentLoopError("Managed-CI issue-created resume could not inspect override audit provenance.")
+        if any(
+            UNPROTECTED_OVERRIDE_TRAILER in (
+                comment.get("body") if isinstance(comment.get("body"), str) else ""
+            )
+            for comment in comments
+        ) and _find_resume_audit(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            actor_login=handoff.trusted_actor_login,
+            actor_id=handoff.trusted_actor_id,
+            base_ref=handoff.base_ref,
+        ) is None:
+            raise AgentLoopError(
+                "Managed-CI issue-created resume found malformed or uncorrelated override audit provenance."
+            )
+    return handoff
+
+
+def authenticate_source_managed_resume(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    pr_number: int,
+    source_branch: str,
+    source_sha: str,
+    managed_branch: str,
+    override_nonce: str | None,
+) -> AuthenticatedManagedResume:
+    """Authenticate the durable lifecycle of a recovered managed-pr origin."""
+    pr = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
+    labels = {
+        item.get("name") for item in (pr.get("labels") or [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    if pr.get("draft") is True and MANAGED_LABEL in labels:
+        lifecycle: Literal["draft-labeled", "ready-unlabeled-reentry"] = "draft-labeled"
+    elif pr.get("draft") is False and MANAGED_LABEL not in labels:
+        lifecycle = "ready-unlabeled-reentry"
+    else:
+        state = "ready/labeled" if pr.get("draft") is False else "draft/unlabeled"
+        raise AgentLoopError(
+            f"Managed source PR #{pr_number} observed mixed lifecycle state {state}; "
+            "expected draft/labeled or authenticated ready/unlabeled. The PR was left unchanged."
+        )
+    return AuthenticatedManagedResume(
+        origin="source-managed",
+        lifecycle=lifecycle,
+        source_branch=source_branch,
+        source_sha=source_sha,
+        managed_branch=managed_branch,
+        override_nonce=override_nonce,
+    )
+
+
+_RECOVERY_VALUE_OPTIONS = frozenset({
+    "--base", "--claude-dir", "--codex-dir", "--gemini-dir", "--antigravity-dir",
+    "--coder", "--reviewer", "--max-rounds", "--managed-ci-trusted-actor",
+    "--implementation-coder", "--implementation-coder-model",
+    "--implementation-codex-reasoning-effort", "--claude-cmd", "--codex-cmd",
+    "--gemini-cmd", "--antigravity-cmd", "--antigravity-print-timeout-seconds",
+    "--repair-backend", "--repair-model", "--repair-timeout-seconds",
+    "--antigravity-model", "--antigravity-models", "--antigravity-quota-signatures",
+    "--codex-model", "--codex-reasoning-effort", "--gemini-model", "--claude-model",
+    "--claude-arg", "--codex-arg", "--gemini-arg", "--antigravity-arg",
+    "--test-command", "--ci-check-name", "--ci-timeout-seconds",
+    "--ci-poll-interval-seconds", "--ci-startup-timeout-seconds",
+    "--ci-queued-grace-seconds", "--mergeability-poll-attempts",
+    "--mergeability-poll-interval-seconds", "--log-dir", "--subprocess-log-dir",
+    "--progress-interval-seconds", "--agent-max-retries", "--agent-retry-backoff-seconds",
+    "--agent-memory-dir", "--salvage-comment-patch-max-bytes", "--planning-context-mode",
+    "--pr-review-context-mode", "--expected-closing-issue",
+    "--plan-execution-mode", "--split-stage", "--head", "--title", "--body-file",
+})
+_ISSUE_ONLY_RECOVERY_OPTIONS = frozenset({
+    "--plan-first", "--implement-after-approval", "--plan-execution-mode",
+    "--materialize-split-issues", "--split-stage", "--implementation-coder",
+    "--implementation-coder-model", "--implementation-codex-reasoning-effort",
+})
+_PR_ONLY_RECOVERY_OPTIONS = frozenset({"--managed-ci-adopt-existing-pr"})
+_MANAGED_PR_ONLY_RECOVERY_OPTIONS = frozenset({"--head", "--title", "--body-file"})
+_MANAGED_RECOVERY_OPTIONS = frozenset({
+    "--managed-ci", "--managed-ci-trusted-actor", "--allow-unprotected-managed-ci",
+    "--managed-ci-adopt-existing-pr",
+})
+_RECOVERY_BOOL_OPTIONS = frozenset({
+    "--auto-merge", "--dry-run", "--allow-shared-dir", "--dangerous-agent-permissions",
+    "--pre-review-tests", "--no-pre-review-tests", "--quiet", "--refresh-agent-memory",
+    "--refresh-test-profile", "--salvage-comments", "--no-salvage-comments",
+    "--review-parallel", "--watch-pending-ci", "--no-watch-pending-ci", "--agent-memory",
+    "--no-agent-memory", "--supersede-expected-closing-contract",
+})
+
+
+def _option_name(token: str) -> str:
+    return token.split("=", 1)[0]
+
+
+def _strip_recovery_options(
+    argv: list[str], *, names: frozenset[str]
+) -> list[str]:
+    result: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        name = _option_name(token)
+        if name in names:
+            index += 1
+            if "=" not in token and name in _RECOVERY_VALUE_OPTIONS:
+                # `nargs='+'` options consume a variable number of values.  The
+                # target parser's next option is the only reliable delimiter.
+                while index < len(argv) and not argv[index].startswith("-"):
+                    index += 1
+            continue
+        result.append(token)
+        index += 1
+    return result
+
+
+def _has_option(argv: list[str], name: str) -> bool:
+    return any(_option_name(token) == name for token in argv)
+
+
+def _render_recovery_command(
+    config: AgentLoopConfig,
+    *,
+    target: Literal["issue", "pr"],
+    identifier: int,
+    managed_ci: bool,
+    include_context: bool = True,
+) -> str:
+    """Build one parser-valid, shell-quoted recovery command.
+
+    Invocation tokens are replayed when available.  Retargeting removes only
+    options that the target subparser cannot accept, while preserving repeated
+    common options and their complete value payloads.
+    """
+    if not config.invocation_argv:
+        if not include_context:
+            command = ["agent-loop", target, str(identifier)]
+            if config.auto_merge:
+                command.append("--auto-merge")
+            elif config.watch_pending_ci:
+                command.append("--watch-pending-ci")
+            return shlex.join(command)
+        command = ["agent-loop", target, str(identifier), "--repo", config.repo]
+        if config.base:
+            command.extend(("--base", config.base))
+        if config.auto_merge:
+            command.append("--auto-merge")
+        if config.watch_pending_ci and not config.auto_merge:
+            command.append("--watch-pending-ci")
+        if managed_ci:
+            command.append("--managed-ci")
+            if config.managed_ci_trusted_actor:
+                command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
+            if config.allow_unprotected_managed_ci:
+                command.append("--allow-unprotected-managed-ci")
+        return shlex.join(command)
+
+    command = list(config.invocation_argv)
+    command_index = next(
+        (index for index, token in enumerate(command) if token in {"issue", "pr", "managed-pr"}),
+        None,
+    )
+    if command_index is None:
+        # Programmatic callers occasionally preserve only a binary path.  A
+        # deterministic fallback is safer than attaching options to an
+        # unknown parser shape.
+        command = ["agent-loop", target, str(identifier), "--repo", config.repo]
+    else:
+        source = command[command_index]
+        remove = set()
+        if target == "pr":
+            remove.update(_ISSUE_ONLY_RECOVERY_OPTIONS)
+            remove.update(_MANAGED_PR_ONLY_RECOVERY_OPTIONS)
+        else:
+            remove.update(_PR_ONLY_RECOVERY_OPTIONS)
+            if source == "managed-pr":
+                remove.update(_MANAGED_PR_ONLY_RECOVERY_OPTIONS)
+        if not managed_ci:
+            remove.update(_MANAGED_RECOVERY_OPTIONS)
+        if config.auto_merge:
+            remove.update({"--watch-pending-ci", "--no-watch-pending-ci"})
+        command = _strip_recovery_options(command, names=frozenset(remove))
+        command_index = next(
+            index for index, token in enumerate(command) if token in {"issue", "pr", "managed-pr"}
+        )
+        command[command_index] = target
+        if command_index + 1 >= len(command) or command[command_index + 1].startswith("-"):
+            command.insert(command_index + 1, str(identifier))
+        else:
+            command[command_index + 1] = str(identifier)
+
+    if managed_ci:
+        if not _has_option(command, "--managed-ci"):
+            command.append("--managed-ci")
+        if config.managed_ci_trusted_actor and not _has_option(command, "--managed-ci-trusted-actor"):
+            command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
+        if config.allow_unprotected_managed_ci and not _has_option(command, "--allow-unprotected-managed-ci"):
+            command.append("--allow-unprotected-managed-ci")
+    return shlex.join(command)
 
 
 def render_managed_ci_resume_command(
-    config: AgentLoopConfig, *, pr_number: int, managed_ci: bool
+    config: AgentLoopConfig, *, pr_number: int, managed_ci: bool, include_context: bool = True
 ) -> str:
-    """Render the deterministic, shell-quoted public recovery contract."""
-    command = ["agent-loop", "pr", str(pr_number), "--repo", config.repo]
-    if config.base:
-        command.extend(("--base", config.base))
-    if config.auto_merge:
-        command.append("--auto-merge")
-    if config.watch_pending_ci and not config.auto_merge:
-        command.append("--watch-pending-ci")
-    if managed_ci:
-        command.append("--managed-ci")
-        if config.managed_ci_trusted_actor:
-            command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
-        if config.allow_unprotected_managed_ci:
-            command.append("--allow-unprotected-managed-ci")
-    return " ".join(shlex.quote(part) for part in command)
+    """Render the deterministic, parser-valid, shell-quoted recovery contract."""
+    target: Literal["issue", "pr"] = "pr"
+    identifier = pr_number
+    if config.invocation_argv:
+        command_index = next(
+            (
+                index
+                for index, token in enumerate(config.invocation_argv)
+                if token in {"issue", "pr", "managed-pr"}
+            ),
+            None,
+        )
+        if command_index is not None and config.invocation_argv[command_index] == "issue":
+            target = "issue"
+            if command_index + 1 < len(config.invocation_argv):
+                try:
+                    identifier = int(config.invocation_argv[command_index + 1])
+                except ValueError:
+                    identifier = pr_number
+    return _render_recovery_command(
+        config, target=target, identifier=identifier, managed_ci=managed_ci,
+        include_context=include_context,
+    )
 
 
 def _restore_ordinary_ci_after_v2_fallback(
@@ -1247,6 +1524,8 @@ def _activate_v2_managed_ci(
     config: AgentLoopConfig,
     pr_number: int,
     metadata: PullRequestMetadata,
+    managed_resume: AuthenticatedManagedResume | None = None,
+    resume_origin: Literal["issue-created", "source-managed"] | None = None,
 ) -> ManagedCiContract | None:
     """Validate the non-forgeable v2 opening tuple without mutating a PR.
 
@@ -1322,22 +1601,68 @@ def _activate_v2_managed_ci(
     if not immutable_tuple:
         return None
 
-    # A successful explicit manual run leaves an issue-created PR ready and
-    # unlabeled. Re-entry deliberately suspends that prior manual-merge
-    # affordance before reconstructing suppression, so every invocation gets a
-    # fresh exact-head qualification ledger.
-    if pr.get("draft") is not True:
-        if not (config.managed_ci and config.managed_ci_pr_mode and MANAGED_LABEL not in labels):
+    # Explicit existing-PR adoption has a separate tuple and label handshake;
+    # never let the issue-created lifecycle classifier intercept it.
+    if (
+        managed_resume is None
+        and resume_origin is None
+        and config.managed_ci_adopt_existing_pr
+    ):
+        return None
+
+    # Keep the low-level activation API safe for callers that enter through the
+    # public PR mode without first calling the orchestration recovery helper.
+    # The immutable tuple above is still authenticated before this lifecycle
+    # is selected; the orchestrator supplies the richer resume record itself.
+    if managed_resume is None and config.managed_ci_pr_mode:
+        if pr.get("draft") is False and MANAGED_LABEL not in labels:
+            lifecycle = "ready-unlabeled-reentry"
+        elif pr.get("draft") is True and MANAGED_LABEL in labels:
+            lifecycle = "draft-labeled"
+        else:
+            # The orchestration recovery path reports mixed lifecycle states;
+            # retain the low-level API's historical no-match result for an
+            # unrecognized pre-authenticated PR.
             return None
+        managed_resume = AuthenticatedManagedResume(
+            origin="issue-created", lifecycle=lifecycle,
+        )
+
+    origin = (
+        managed_resume.origin
+        if managed_resume is not None
+        else resume_origin
+        or ("source-managed" if config.pr_origin_flow == "managed-pr" else "issue-created")
+    )
+    lifecycle = managed_resume.lifecycle if managed_resume is not None else "draft-labeled"
+
+    # A successful explicit manual run leaves a managed PR ready and
+    # unlabeled. Re-entry is a privileged mutation: it is allowed only when
+    # the authenticated lifecycle record and the invocation both request
+    # managed CI explicitly. Implicit auto-merge must leave this state alone.
+    if lifecycle == "ready-unlabeled-reentry":
+        if not config.managed_ci:
+            command = render_managed_ci_resume_command(
+                config, pr_number=pr_number, managed_ci=True,
+            )
+            raise AgentLoopError(
+                f"PR #{pr_number} is an authenticated managed {origin} PR in the ready/unlabeled "
+                "re-entry state. It was left unchanged; rerun with explicit `--managed-ci`: "
+                f"{command}"
+            )
         undo = runner.run(
             [config.gh_cmd, "pr", "ready", "--undo", str(pr_number), "--repo", config.repo],
             cwd=active_workdir(config), check=False,
         )
         refreshed = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
-        if undo.returncode != 0 and refreshed.get("draft") is not True:
+        refreshed_labels = {
+            item.get("name") for item in (refreshed.get("labels") or [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        if undo.returncode != 0 or refreshed.get("draft") is not True or MANAGED_LABEL in refreshed_labels:
             raise AgentLoopError(
-                f"--managed-ci re-entry could not make PR #{pr_number} a draft; its prior "
-                "qualified/manual-merge state remains suspended until the PR is safely reconstructed."
+                f"--managed-ci re-entry could not make PR #{pr_number} draft and unlabeled; "
+                "its prior qualified/manual-merge state remains unchanged and no qualification was claimed."
             )
         pr = refreshed
         head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
@@ -1358,6 +1683,7 @@ def _activate_v2_managed_ci(
             or head_repo.get("full_name", "").casefold() != config.repo.casefold()
             or author.get("login") != actor_login
             or author.get("id") != actor_id
+            or labels and MANAGED_LABEL in labels
         ):
             # There is no trusted active label to remove in the unlabeled
             # re-entry case. Report the draft/unlabeled state without claiming
@@ -1367,11 +1693,15 @@ def _activate_v2_managed_ci(
                 "the ready-to-draft transition; the head is NOT qualified by this run. "
                 "The PR must be draft and unlabeled before rerunning managed qualification."
             )
-    if MANAGED_LABEL not in labels:
-        # Implicit auto-merge keeps the historical existing-PR behavior: only
-        # an already authenticated issue-created managed draft is resumable.
-        if not config.managed_ci:
+    elif pr.get("draft") is not True or MANAGED_LABEL not in labels:
+        if managed_resume is None and resume_origin is None:
             return None
+        state = "ready/labeled" if pr.get("draft") is False else "draft/unlabeled"
+        raise AgentLoopError(
+            f"Managed-CI {origin} resume for PR #{pr_number} observed {state}; "
+            "expected draft/labeled or authenticated ready/unlabeled. The PR was left unchanged."
+        )
+    if MANAGED_LABEL not in labels:
         if not ensure_managed_label(runner, config=config):
             raise AgentLoopError(f"Unable to create the `{MANAGED_LABEL}` label.")
         applied_label = runner.run(
@@ -1432,7 +1762,7 @@ def _activate_v2_managed_ci(
             context=ManagedCiProbeContext(config.repo, config.gh_cmd, active_workdir(config)),
             base=base_ref,
         )
-        if protection.state != "strict" and config.managed_ci_pr_mode:
+        if protection.state != "strict" and managed_resume is not None:
             if not config.allow_unprotected_managed_ci or protection.state not in {"voluntary", "plan_limited"}:
                 recovery = _release_for_ordinary_recovery(
                     runner, config=config, pr_number=pr_number, base_ref=base_ref,
@@ -1518,7 +1848,7 @@ def _activate_v2_managed_ci(
     else:
         audit_id = None
 
-    if config.managed_ci_pr_mode:
+    if managed_resume is not None:
         # Re-read both the PR and the active timeline event immediately before
         # the audit write. A successful earlier probe cannot authorize a raced
         # head/base/draft/label transition.
@@ -1527,13 +1857,21 @@ def _activate_v2_managed_ci(
         live_base = live_pr.get("base") if isinstance(live_pr.get("base"), dict) else {}
         live_author = live_pr.get("user") if isinstance(live_pr.get("user"), dict) else {}
         live_event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
+        live_labels = {
+            item.get("name") for item in (live_pr.get("labels") or [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
         if (
-            live_pr.get("draft") is not True
+            live_pr.get("state") not in {None, "open", "OPEN"}
+            or live_pr.get("draft") is not True
             or live_base.get("ref") != base_ref
             or live_head.get("sha") != live_sha
+            or live_head.get("ref") != head_ref
             or live_head.get("repo", {}).get("full_name", "").casefold() != config.repo.casefold()
             or live_author.get("login") != actor_login
             or live_author.get("id") != actor_id
+            or MANAGED_LABEL not in live_labels
+            or live_pr.get("body") != pr.get("body")
             or live_event != active_event
         ):
             recovery = _release_for_ordinary_recovery(
@@ -1587,11 +1925,11 @@ def _activate_v2_managed_ci(
             audit_id = None
     workflow_revision = _api_json(runner, config, f"repos/{config.repo}/commits/{base_ref}", quiet=True)
     revision = workflow_revision.get("sha") if isinstance(workflow_revision.get("sha"), str) else None
-    generation = secrets.token_urlsafe(16) if (config.managed_ci_pr_mode or config.managed_ci) else None
+    generation = secrets.token_urlsafe(16) if (managed_resume is not None or config.managed_ci) else None
     log(
         config,
         f"PR #{pr_number}: selected managed resume (fresh generation)"
-        if config.managed_ci_pr_mode
+        if managed_resume is not None
         else f"PR #{pr_number}: activated authenticated managed exact-head CI v2",
     )
     return ManagedCiContract(
@@ -1605,9 +1943,12 @@ def _activate_v2_managed_ci(
         audit_comment_id=audit_id if isinstance(audit_id, int) else None,
         intent_generation=generation,
         active_label_event_id=active_event[0] if active_event is not None else None,
-        issue_created_pr=True,
+        issue_created_pr=origin == "issue-created",
         invocation_applied_label=label_applied,
         ordinary_recovery_capable=ordinary_recovery_capable,
+        origin=origin,
+        lifecycle=lifecycle,
+        authenticated_resume=managed_resume,
     )
 
 
@@ -1858,7 +2199,11 @@ def release_adopted_managed_ci(
     our claimed suppression.  It is then removed unconditionally; when an
     event ID was recorded, retain the normal fresh event-ID ownership check.
     """
-    if not (contract.adopted_existing_pr or contract.issue_created_pr) or (
+    if not (
+        contract.adopted_existing_pr
+        or contract.issue_created_pr
+        or contract.origin == "source-managed"
+    ) or (
         not contract.invocation_applied_label and not force
     ):
         return True
@@ -2185,7 +2530,7 @@ def _dispatch_v2_qualification(
             runner, config=config, pr_number=pr_number, expected_head_sha=expected_head_sha, contract=contract
         )
     except AgentLoopError as exc:
-        if not config.managed_ci_pr_mode:
+        if not config.managed_ci_pr_mode and contract.authenticated_resume is None:
             raise
         event = _active_managed_label_event(runner, config=config, pr_number=pr_number)
         recovery = _release_for_ordinary_recovery(

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -146,7 +146,9 @@ class ManagedCiContract:
     # Explicit lifecycle provenance.  These fields are intentionally not
     # inferred from public mode flags after activation.
     origin: Literal["issue-created", "source-managed"] | None = None
-    lifecycle: Literal["creation", "draft-labeled", "ready-unlabeled-reentry"] | None = None
+    lifecycle: Literal[
+        "creation", "draft-labeled", "draft-unlabeled-reentry", "ready-unlabeled-reentry"
+    ] | None = None
     authenticated_resume: "AuthenticatedManagedResume | None" = None
 
 
@@ -191,7 +193,9 @@ class AuthenticatedIssueCreatedHandoff:
     protection_mode: str
     override_nonce: str | None
     active_label_event_id: int | None = None
-    lifecycle: Literal["draft-labeled", "ready-unlabeled-reentry"] = "draft-labeled"
+    lifecycle: Literal[
+        "draft-labeled", "draft-unlabeled-reentry", "ready-unlabeled-reentry"
+    ] = "draft-labeled"
 
 
 @dataclass(frozen=True)
@@ -204,7 +208,9 @@ class AuthenticatedManagedResume:
     """
 
     origin: Literal["issue-created", "source-managed"]
-    lifecycle: Literal["draft-labeled", "ready-unlabeled-reentry"]
+    lifecycle: Literal[
+        "draft-labeled", "draft-unlabeled-reentry", "ready-unlabeled-reentry"
+    ]
     issue_created_handoff: AuthenticatedIssueCreatedHandoff | None = None
     source_branch: str | None = None
     source_sha: str | None = None
@@ -855,7 +861,7 @@ def _issue_created_tuple(
     expected_branch: str,
     expected_nonce: str | None,
     protection_mode: str,
-    lifecycle: Literal["draft-labeled", "ready-unlabeled"] = "draft-labeled",
+    lifecycle: Literal["draft-labeled", "draft-unlabeled", "ready-unlabeled"] = "draft-labeled",
 ) -> AuthenticatedIssueCreatedHandoff:
     """Read and verify the immutable tuple before any handoff publication.
 
@@ -911,6 +917,8 @@ def _issue_created_tuple(
         lifecycle_matches = (
             pr.get("draft") is True and MANAGED_LABEL in labels
             if lifecycle == "draft-labeled"
+            else pr.get("draft") is True and MANAGED_LABEL not in labels
+            if lifecycle == "draft-unlabeled"
             else pr.get("draft") is False and MANAGED_LABEL not in labels
         )
         if (
@@ -919,11 +927,8 @@ def _issue_created_tuple(
             or head_repo.get("full_name", "").casefold() != config.repo.casefold()
             or branch != expected_branch
             or base.get("ref") != config.base
-            or (
-                MANAGED_LABEL not in labels
-                if lifecycle == "draft-labeled"
-                else MANAGED_LABEL in labels
-            )
+            or (lifecycle == "draft-labeled" and MANAGED_LABEL not in labels)
+            or (lifecycle != "draft-labeled" and MANAGED_LABEL in labels)
             or author.get("login", "").casefold() != actor_login.casefold()
             or author.get("id") != actor_id
             or sha != metadata.head_sha
@@ -951,9 +956,11 @@ def _issue_created_tuple(
         trusted_actor_id=actor_id,
         protection_mode=protection_mode,
         override_nonce=record.nonce if record is not None else None,
-        lifecycle=(
-            "ready-unlabeled-reentry" if lifecycle == "ready-unlabeled" else "draft-labeled"
-        ),
+        lifecycle={
+            "draft-labeled": "draft-labeled",
+            "draft-unlabeled": "draft-unlabeled-reentry",
+            "ready-unlabeled": "ready-unlabeled-reentry",
+        }[lifecycle],
     )
 
 
@@ -1002,6 +1009,8 @@ def revalidate_issue_created_handoff(
         lifecycle=(
             "ready-unlabeled"
             if handoff.lifecycle == "ready-unlabeled-reentry"
+            else "draft-unlabeled"
+            if handoff.lifecycle == "draft-unlabeled-reentry"
             else "draft-labeled"
         ),
     )
@@ -1041,9 +1050,16 @@ def recover_issue_created_handoff(
         return None
     branch_issue_number = int(match.group(1))
     if issue_number is not None and issue_number != branch_issue_number:
+        command = render_managed_ci_resume_command(
+            config,
+            pr_number=pr_number,
+            issue_number=issue_number,
+            managed_ci=True,
+        )
         raise AgentLoopError(
             f"Managed-CI issue association targets issue #{issue_number}, but the authenticated "
-            f"managed branch targets issue #{branch_issue_number}. The PR was left unchanged."
+            f"managed branch targets issue #{branch_issue_number}. The PR was left unchanged. "
+            f"Rerun the canonical issue command after correcting the issue association: `{command}`"
         )
     issue_number = branch_issue_number
     record = None
@@ -1059,15 +1075,30 @@ def recover_issue_created_handoff(
     draft = pr.get("draft")
     if draft is True and MANAGED_LABEL in labels:
         lifecycle = "draft-labeled"
+    elif draft is True and MANAGED_LABEL not in labels and config.managed_ci:
+        # A failed explicit managed-CI invocation deliberately releases its
+        # suppression label.  Re-admit that durable draft state only when the
+        # operator explicitly asks for managed qualification again.
+        lifecycle = "draft-unlabeled"
     elif draft is False and MANAGED_LABEL not in labels:
         lifecycle = "ready-unlabeled"
     else:
-        state = "draft/labeled" if draft is True and MANAGED_LABEL in labels else (
-            "ready/labeled" if draft is False and MANAGED_LABEL in labels else "draft/unlabeled"
+        if draft is True:
+            state = "draft/labeled" if MANAGED_LABEL in labels else "draft/unlabeled"
+        elif draft is False:
+            state = "ready/labeled" if MANAGED_LABEL in labels else "ready/unlabeled"
+        else:
+            state = "unknown/labeled" if MANAGED_LABEL in labels else "unknown/unlabeled"
+        command = render_managed_ci_resume_command(
+            config,
+            pr_number=pr_number,
+            issue_number=issue_number,
+            managed_ci=True,
         )
         raise AgentLoopError(
             f"Managed-CI issue-created resume for PR #{pr_number} observed mixed lifecycle state "
-            f"{state}; expected draft/labeled or ready/unlabeled. The PR was left unchanged."
+            f"{state}; expected draft/labeled, draft/unlabeled with explicit managed CI, or "
+            f"ready/unlabeled. The PR was left unchanged. Resume with `{command}`."
         )
     # A resumed nonce is provenance only.  Its value is checked against the
     # live body, then activation mints a fresh audit/generation.
@@ -1135,14 +1166,26 @@ def authenticate_source_managed_resume(
         if isinstance(item, dict) and isinstance(item.get("name"), str)
     }
     if pr.get("draft") is True and MANAGED_LABEL in labels:
-        lifecycle: Literal["draft-labeled", "ready-unlabeled-reentry"] = "draft-labeled"
+        lifecycle: Literal[
+            "draft-labeled", "draft-unlabeled-reentry", "ready-unlabeled-reentry"
+        ] = "draft-labeled"
+    elif pr.get("draft") is True and MANAGED_LABEL not in labels and config.managed_ci:
+        lifecycle = "draft-unlabeled-reentry"
     elif pr.get("draft") is False and MANAGED_LABEL not in labels:
         lifecycle = "ready-unlabeled-reentry"
     else:
-        state = "ready/labeled" if pr.get("draft") is False else "draft/unlabeled"
+        draft = pr.get("draft")
+        if draft is True:
+            state = "draft/labeled" if MANAGED_LABEL in labels else "draft/unlabeled"
+        elif draft is False:
+            state = "ready/labeled" if MANAGED_LABEL in labels else "ready/unlabeled"
+        else:
+            state = "unknown/labeled" if MANAGED_LABEL in labels else "unknown/unlabeled"
+        command = render_managed_ci_resume_command(config, pr_number=pr_number, managed_ci=True)
         raise AgentLoopError(
             f"Managed source PR #{pr_number} observed mixed lifecycle state {state}; "
-            "expected draft/labeled or authenticated ready/unlabeled. The PR was left unchanged."
+            f"expected draft/labeled, draft/unlabeled with explicit managed CI, or authenticated "
+            f"ready/unlabeled. The PR was left unchanged. Resume with `{command}`."
         )
     return AuthenticatedManagedResume(
         origin="source-managed",
@@ -1155,7 +1198,7 @@ def authenticate_source_managed_resume(
 
 
 _RECOVERY_VALUE_OPTIONS = frozenset({
-    "--base", "--claude-dir", "--codex-dir", "--gemini-dir", "--antigravity-dir",
+    "--repo", "--base", "--claude-dir", "--codex-dir", "--gemini-dir", "--antigravity-dir",
     "--coder", "--reviewer", "--max-rounds", "--managed-ci-trusted-actor",
     "--implementation-coder", "--implementation-coder-model",
     "--implementation-codex-reasoning-effort", "--claude-cmd", "--codex-cmd",
@@ -1172,6 +1215,10 @@ _RECOVERY_VALUE_OPTIONS = frozenset({
     "--agent-memory-dir", "--salvage-comment-patch-max-bytes", "--planning-context-mode",
     "--pr-review-context-mode", "--expected-closing-issue",
     "--plan-execution-mode", "--split-stage", "--head", "--title", "--body-file",
+    "--approved-followups",
+})
+_RECOVERY_NARGS_VALUE_OPTIONS = frozenset({
+    "--antigravity-models", "--antigravity-quota-signatures", "--agent-retry-backoff-seconds",
 })
 _ISSUE_ONLY_RECOVERY_OPTIONS = frozenset({
     "--plan-first", "--implement-after-approval", "--plan-execution-mode",
@@ -1184,17 +1231,43 @@ _MANAGED_RECOVERY_OPTIONS = frozenset({
     "--managed-ci", "--managed-ci-trusted-actor", "--allow-unprotected-managed-ci",
     "--managed-ci-adopt-existing-pr",
 })
-_RECOVERY_BOOL_OPTIONS = frozenset({
-    "--auto-merge", "--dry-run", "--allow-shared-dir", "--dangerous-agent-permissions",
-    "--pre-review-tests", "--no-pre-review-tests", "--quiet", "--refresh-agent-memory",
-    "--refresh-test-profile", "--salvage-comments", "--no-salvage-comments",
-    "--review-parallel", "--watch-pending-ci", "--no-watch-pending-ci", "--agent-memory",
-    "--no-agent-memory", "--supersede-expected-closing-contract",
-})
-
-
 def _option_name(token: str) -> str:
     return token.split("=", 1)[0]
+
+
+def _recovery_option_end(argv: list[str], index: int) -> int:
+    """Return the first token after one option and its value payload."""
+    token = argv[index]
+    name = _option_name(token)
+    if "=" in token or name not in _RECOVERY_VALUE_OPTIONS:
+        return index + 1
+    if name in _RECOVERY_NARGS_VALUE_OPTIONS:
+        index += 1
+        while index < len(argv) and (
+            not argv[index].startswith("-") or argv[index] == "-"
+        ):
+            index += 1
+        return index
+    if index + 1 < len(argv) and (
+        not argv[index + 1].startswith("-") or argv[index + 1] == "-"
+    ):
+        return index + 2
+    return index + 1
+
+
+def _find_recovery_positional_index(argv: list[str], command_index: int) -> int | None:
+    """Find an issue/PR identifier even when options precede it."""
+    index = command_index + 1
+    while index < len(argv):
+        if argv[index].startswith("-"):
+            index = _recovery_option_end(argv, index)
+            continue
+        try:
+            int(argv[index])
+        except ValueError:
+            return None
+        return index
+    return None
 
 
 def _strip_recovery_options(
@@ -1206,12 +1279,7 @@ def _strip_recovery_options(
         token = argv[index]
         name = _option_name(token)
         if name in names:
-            index += 1
-            if "=" not in token and name in _RECOVERY_VALUE_OPTIONS:
-                # `nargs='+'` options consume a variable number of values.  The
-                # target parser's next option is the only reliable delimiter.
-                while index < len(argv) and not argv[index].startswith("-"):
-                    index += 1
+            index = _recovery_option_end(argv, index)
             continue
         result.append(token)
         index += 1
@@ -1228,6 +1296,7 @@ def _render_recovery_command(
     target: Literal["issue", "pr"],
     identifier: int,
     managed_ci: bool,
+    preserve_managed_options: bool = False,
     include_context: bool = True,
 ) -> str:
     """Build one parser-valid, shell-quoted recovery command.
@@ -1280,10 +1349,17 @@ def _render_recovery_command(
             if source == "managed-pr":
                 remove.update(_MANAGED_PR_ONLY_RECOVERY_OPTIONS)
         if not managed_ci:
-            remove.update(_MANAGED_RECOVERY_OPTIONS)
+            if not preserve_managed_options:
+                remove.update(_MANAGED_RECOVERY_OPTIONS)
         if config.auto_merge:
             remove.update({"--watch-pending-ci", "--no-watch-pending-ci"})
         command = _strip_recovery_options(command, names=frozenset(remove))
+        if source in {"issue", "pr"}:
+            # Remove the source command's positional before inserting the
+            # retargeted identifier. This also handles `issue --repo X 123`.
+            positional_index = _find_recovery_positional_index(command, command_index)
+            if positional_index is not None:
+                del command[positional_index]
         command_index = next(
             index for index, token in enumerate(command) if token in {"issue", "pr", "managed-pr"}
         )
@@ -1304,7 +1380,13 @@ def _render_recovery_command(
 
 
 def render_managed_ci_resume_command(
-    config: AgentLoopConfig, *, pr_number: int, managed_ci: bool, include_context: bool = True
+    config: AgentLoopConfig,
+    *,
+    pr_number: int,
+    managed_ci: bool,
+    preserve_managed_options: bool = False,
+    issue_number: int | None = None,
+    include_context: bool = True,
 ) -> str:
     """Render the deterministic, parser-valid, shell-quoted recovery contract."""
     target: Literal["issue", "pr"] = "pr"
@@ -1320,13 +1402,19 @@ def render_managed_ci_resume_command(
         )
         if command_index is not None and config.invocation_argv[command_index] == "issue":
             target = "issue"
-            if command_index + 1 < len(config.invocation_argv):
-                try:
-                    identifier = int(config.invocation_argv[command_index + 1])
-                except ValueError:
-                    identifier = pr_number
+            identifier = issue_number if issue_number is not None else pr_number
+            if issue_number is None:
+                positional_index = _find_recovery_positional_index(
+                    list(config.invocation_argv), command_index
+                )
+                if positional_index is not None:
+                    identifier = int(config.invocation_argv[positional_index])
     return _render_recovery_command(
-        config, target=target, identifier=identifier, managed_ci=managed_ci,
+        config,
+        target=target,
+        identifier=identifier,
+        managed_ci=managed_ci,
+        preserve_managed_options=preserve_managed_options,
         include_context=include_context,
     )
 
@@ -1619,6 +1707,8 @@ def _activate_v2_managed_ci(
             lifecycle = "ready-unlabeled-reentry"
         elif pr.get("draft") is True and MANAGED_LABEL in labels:
             lifecycle = "draft-labeled"
+        elif pr.get("draft") is True and MANAGED_LABEL not in labels:
+            lifecycle = "draft-unlabeled-reentry"
         else:
             # The orchestration recovery path reports mixed lifecycle states;
             # retain the low-level API's historical no-match result for an
@@ -1683,7 +1773,7 @@ def _activate_v2_managed_ci(
             or head_repo.get("full_name", "").casefold() != config.repo.casefold()
             or author.get("login") != actor_login
             or author.get("id") != actor_id
-            or labels and MANAGED_LABEL in labels
+            or MANAGED_LABEL in labels
         ):
             # There is no trusted active label to remove in the unlabeled
             # re-entry case. Report the draft/unlabeled state without claiming
@@ -1693,13 +1783,44 @@ def _activate_v2_managed_ci(
                 "the ready-to-draft transition; the head is NOT qualified by this run. "
                 "The PR must be draft and unlabeled before rerunning managed qualification."
             )
-    elif pr.get("draft") is not True or MANAGED_LABEL not in labels:
+    elif lifecycle == "draft-unlabeled-reentry" and (
+        pr.get("draft") is not True or MANAGED_LABEL in labels
+    ):
+        draft = pr.get("draft")
+        if draft is True:
+            state = "draft/labeled"
+        elif draft is False:
+            state = "ready/labeled" if MANAGED_LABEL in labels else "ready/unlabeled"
+        else:
+            state = "unknown/labeled" if MANAGED_LABEL in labels else "unknown/unlabeled"
+        command = render_managed_ci_resume_command(config, pr_number=pr_number, managed_ci=True)
+        raise AgentLoopError(
+            f"Managed-CI {origin} draft re-entry for PR #{pr_number} observed {state}; "
+            f"the PR was left unchanged. Resume with `{command}` after restoring draft/unlabeled state."
+        )
+    elif lifecycle == "draft-unlabeled-reentry" and not config.managed_ci:
+        command = render_managed_ci_resume_command(config, pr_number=pr_number, managed_ci=True)
+        raise AgentLoopError(
+            f"PR #{pr_number} is an authenticated managed {origin} draft/unlabeled re-entry. "
+            f"It was left unchanged; rerun with explicit `--managed-ci`: {command}"
+        )
+    elif lifecycle != "draft-unlabeled-reentry" and (
+        pr.get("draft") is not True or MANAGED_LABEL not in labels
+    ):
         if managed_resume is None and resume_origin is None:
             return None
-        state = "ready/labeled" if pr.get("draft") is False else "draft/unlabeled"
+        draft = pr.get("draft")
+        if draft is True:
+            state = "draft/labeled" if MANAGED_LABEL in labels else "draft/unlabeled"
+        elif draft is False:
+            state = "ready/labeled" if MANAGED_LABEL in labels else "ready/unlabeled"
+        else:
+            state = "unknown/labeled" if MANAGED_LABEL in labels else "unknown/unlabeled"
+        command = render_managed_ci_resume_command(config, pr_number=pr_number, managed_ci=True)
         raise AgentLoopError(
             f"Managed-CI {origin} resume for PR #{pr_number} observed {state}; "
-            "expected draft/labeled or authenticated ready/unlabeled. The PR was left unchanged."
+            f"expected draft/labeled, draft/unlabeled, or authenticated ready/unlabeled. "
+            f"The PR was left unchanged. Resume with `{command}`."
         )
     if MANAGED_LABEL not in labels:
         if not ensure_managed_label(runner, config=config):

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -918,6 +918,9 @@ def _issue_created_tuple(
             ) + " --managed-ci-trusted-actor '<trusted-actor>'"
         raise AgentLoopError(
             "Managed-CI issue handoff actor authentication does not match repository settings. "
+            f"Observed identities: gh login=`{actor_login or '<missing>'}`, "
+            f"--managed-ci-trusted-actor=`{configured or '<missing>'}`, "
+            f"AGENT_LOOP_MANAGED_ACTOR=`{advertised or '<missing>'}`; expected all three to match. "
             f"Rerun with the configured trusted actor: `{remediation}`."
         )
 
@@ -1405,7 +1408,10 @@ def _render_recovery_command(
     if managed_ci:
         if not _has_option(command, "--managed-ci"):
             command.append("--managed-ci")
-        if config.managed_ci_trusted_actor and not _has_option(command, "--managed-ci-trusted-actor"):
+        if config.managed_ci_trusted_actor:
+            command = _strip_recovery_options(
+                command, names=frozenset({"--managed-ci-trusted-actor"})
+            )
             command.extend(("--managed-ci-trusted-actor", config.managed_ci_trusted_actor))
         if config.allow_unprotected_managed_ci and not _has_option(command, "--allow-unprotected-managed-ci"):
             command.append("--allow-unprotected-managed-ci")

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -900,7 +900,33 @@ def _issue_created_tuple(
         or actor_login.casefold() != configured.casefold()
         or actor_login.casefold() != advertised.casefold()
     ):
-        raise AgentLoopError("Managed-CI issue handoff actor authentication does not match repository settings.")
+        trusted_actor = advertised or actor_login or configured
+        if trusted_actor:
+            remediation_config = replace(config, managed_ci_trusted_actor=trusted_actor)
+            remediation = render_managed_ci_resume_command(
+                remediation_config,
+                pr_number=pr_number,
+                issue_number=issue_number,
+                managed_ci=True,
+            )
+        else:
+            remediation = render_managed_ci_resume_command(
+                config,
+                pr_number=pr_number,
+                issue_number=issue_number,
+                managed_ci=True,
+            ) + " --managed-ci-trusted-actor '<trusted-actor>'"
+        raise AgentLoopError(
+            "Managed-CI issue handoff actor authentication does not match repository settings. "
+            f"Rerun with the configured trusted actor: `{remediation}`."
+        )
+
+    remediation = render_managed_ci_resume_command(
+        config,
+        pr_number=pr_number,
+        issue_number=issue_number,
+        managed_ci=True,
+    )
 
     def check_rest(pr: dict[str, object]) -> tuple[str, str]:
         head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
@@ -936,7 +962,10 @@ def _issue_created_tuple(
             or base.get("ref") != metadata.base_branch
             or rest_body != body
         ):
-            raise AgentLoopError("Managed-CI issue-created opening tuple is missing or changed.")
+            raise AgentLoopError(
+                "Managed-CI issue-created opening tuple is missing or changed. "
+                f"The PR was left unchanged. Resume with `{remediation}`."
+            )
         return sha, branch
 
     first = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
@@ -944,7 +973,10 @@ def _issue_created_tuple(
     second = _api_json(runner, config, f"repos/{config.repo}/pulls/{pr_number}", quiet=True)
     live_sha, live_branch = check_rest(second)
     if (live_sha, live_branch) != (sha, branch):
-        raise AgentLoopError("Managed-CI issue-created opening tuple changed during validation.")
+        raise AgentLoopError(
+            "Managed-CI issue-created opening tuple changed during validation. "
+            f"The PR was left unchanged. Resume with `{remediation}`."
+        )
     return AuthenticatedIssueCreatedHandoff(
         pr_number=pr_number,
         issue_number=issue_number,
@@ -1206,6 +1238,7 @@ _RECOVERY_VALUE_OPTIONS = frozenset({
     "--repair-backend", "--repair-model", "--repair-timeout-seconds",
     "--antigravity-model", "--antigravity-models", "--antigravity-quota-signatures",
     "--codex-model", "--codex-reasoning-effort", "--gemini-model", "--claude-model",
+    "--gh-cmd",
     "--claude-arg", "--codex-arg", "--gemini-arg", "--antigravity-arg",
     "--test-command", "--ci-check-name", "--ci-timeout-seconds",
     "--ci-poll-interval-seconds", "--ci-startup-timeout-seconds",

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -521,7 +521,16 @@ class ExactHeadCiProof:
 def _render_ci_rerun_command(config: AgentLoopConfig, *, pr_number: int) -> str:
     """Render local CI recovery guidance through the shared token builder."""
     return render_managed_ci_resume_command(
-        config, pr_number=pr_number, managed_ci=False, include_context=False,
+        config,
+        pr_number=pr_number,
+        managed_ci=config.managed_ci,
+        preserve_managed_options=(
+            config.managed_ci
+            or config.managed_ci_trusted_actor is not None
+            or config.allow_unprotected_managed_ci
+            or config.managed_ci_adopt_existing_pr
+        ),
+        include_context=False,
     )
 
 
@@ -4394,6 +4403,7 @@ def _implement_approved_issue(
             config=implementation_config,
             issue_context=issue_context,
             usage_context=usage_context,
+            managed_ci_issue_number=issue_number,
         )
 
     salvage_summary = latest_salvage_context(
@@ -5821,6 +5831,7 @@ def _run_plan_first_loop(
                             config=config,
                             issue_context=target_issue_context,
                             usage_context=usage_context,
+                            managed_ci_issue_number=target_issue_number,
                         )
                     else:
                         print(

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -125,12 +125,14 @@ from .evidence_reconciliation import (
 )
 from .memory import AgentMemoryContext, prepare_agent_memory
 from .managed_ci import (
+    AuthenticatedManagedResume,
     AuthenticatedIssueCreatedHandoff,
     FINAL_CONTEXT,
     MANAGED_LABEL,
     ManagedCiOutcome,
     OrdinaryRecoveryCapability,
     activate_managed_ci,
+    authenticate_source_managed_resume,
     authenticate_issue_created_handoff,
     dispatch_final_qualification,
     intermediate_managed_checks,
@@ -517,20 +519,9 @@ class ExactHeadCiProof:
 
 
 def _render_ci_rerun_command(config: AgentLoopConfig, *, pr_number: int) -> str:
-    """Render local CI recovery guidance without retired auto-merge selectors."""
-    if config.invocation_argv:
-        argv = config.invocation_argv
-        if config.auto_merge:
-            argv = tuple(
-                token
-                for token in argv
-                if token not in {"--watch-pending-ci", "--no-watch-pending-ci"}
-            )
-        return shlex.join(argv)
-    return (
-        f"agent-loop pr {pr_number} --auto-merge"
-        if config.auto_merge
-        else f"agent-loop pr {pr_number} --watch-pending-ci"
+    """Render local CI recovery guidance through the shared token builder."""
+    return render_managed_ci_resume_command(
+        config, pr_number=pr_number, managed_ci=False, include_context=False,
     )
 
 
@@ -5761,6 +5752,7 @@ def _run_plan_first_loop(
                         config=config,
                         issue_context=target_issue_context,
                         usage_context=usage_context,
+                        managed_ci_issue_number=target_issue_number,
                     )
 
                 existing_handoff = find_existing_one_shot_impl_handoff(
@@ -6141,6 +6133,7 @@ def run_issue_loop(
                 config=config,
                 issue_context=issue_context,
                 usage_context=usage_context,
+                managed_ci_issue_number=issue_number,
             )
 
         memory = prepare_agent_memory(runner, config)
@@ -6784,6 +6777,7 @@ def run_pr_loop(
     pre_review_test_pending: bool = False,
     managed_pr_origin: tuple[str, str, str, str | None] | None = None,
     managed_ci_handoff: AuthenticatedIssueCreatedHandoff | None = None,
+    managed_ci_issue_number: int | None = None,
 ) -> int:
     owned_usage_context = usage_context is None
     usage_context = usage_context or _new_usage_context(config)
@@ -6792,12 +6786,22 @@ def run_pr_loop(
     ordinary_recovery_selected = False
     managed_ci_qualified = False
     managed_pr_recovered = False
+    authenticated_managed_resume: AuthenticatedManagedResume | None = None
     try:
         bootstrap_cwd = github_bootstrap_cwd(config)
         initial_pr_context = get_pr_review_context(
             runner,
             config=config,
             pr_number=pr_number,
+            cwd=bootstrap_cwd,
+        )
+        # Resolve the live PR base before any managed-CI authentication or
+        # workdir setup.  An inherited repository default is provenance, not
+        # permission to reinterpret a PR targeting another branch.
+        config = resolve_base_branch(
+            config,
+            runner,
+            pr_metadata=initial_pr_context.metadata,
             cwd=bootstrap_cwd,
         )
         if managed_ci_handoff is not None:
@@ -6821,6 +6825,7 @@ def run_pr_loop(
                     config=config,
                     pr_number=pr_number,
                     metadata=initial_pr_context.metadata,
+                    issue_number=managed_ci_issue_number,
                 )
                 if managed_ci_handoff is None:
                     reject_forged_protocol_markers(initial_pr_context.metadata.body or "")
@@ -6830,6 +6835,12 @@ def run_pr_loop(
                         config=config,
                         handoff=managed_ci_handoff,
                         metadata=initial_pr_context.metadata,
+                    )
+                    authenticated_managed_resume = AuthenticatedManagedResume(
+                        origin="issue-created",
+                        lifecycle=managed_ci_handoff.lifecycle,
+                        issue_created_handoff=managed_ci_handoff,
+                        override_nonce=managed_ci_handoff.override_nonce,
                     )
         if managed_pr_origin is not None:
             source_branch, source_sha, managed_branch, override_nonce = managed_pr_origin
@@ -6845,6 +6856,16 @@ def run_pr_loop(
                 expected_base_branch=config.base,
                 require_creation_head_sha=not managed_pr_recovered,
             )
+            if managed_pr_recovered and authenticated_managed_resume is None and config.effective_managed_ci:
+                authenticated_managed_resume = authenticate_source_managed_resume(
+                    runner,
+                    config=config,
+                    pr_number=pr_number,
+                    source_branch=source_branch,
+                    source_sha=source_sha,
+                    managed_branch=managed_branch,
+                    override_nonce=override_nonce,
+                )
         recorded_pr_contract = find_latest_pr_contract(
             initial_pr_context.comments,
             repository=config.repo,
@@ -7013,16 +7034,45 @@ def run_pr_loop(
                     "Issue-side and PR-side expected closing contracts disagree before "
                     "supersession; no durable metadata changed."
                 )
-        config = resolve_base_branch(
-            config,
-            runner,
-            pr_metadata=initial_pr_context.metadata,
-            cwd=bootstrap_cwd,
-        )
         if not workdirs_ready:
             ensure_agent_workdirs(config, runner)
         if config.review_parallel:
             _ensure_parallel_reviewer_workdirs(config, flag_name="--review-parallel", role_label="reviewer")
+        # Select managed activation before any PR-side contract/comment write.
+        # In particular, an authenticated ready/unlabeled re-entry reached by
+        # implicit auto-merge must be able to stop with the PR untouched.
+        activation = activate_managed_ci(
+            runner,
+            config=config,
+            pr_number=pr_number,
+            metadata=initial_pr_context.metadata,
+            managed_resume=authenticated_managed_resume,
+            resume_origin=(
+                "source-managed"
+                if managed_pr_origin is not None and authenticated_managed_resume is None
+                else None
+            ),
+        )
+        if activation is not None and activation.activation_path == "ordinary_fallback":
+            ordinary_recovery_selected = True
+            ordinary_recovery = activation.ordinary_recovery
+            managed_ci = None
+            log(
+                config,
+                f"PR #{pr_number}: ordinary recovery selected; "
+                "the previous managed activation is not being resumed",
+            )
+            if ordinary_recovery is None:
+                command = render_managed_ci_resume_command(
+                    config, pr_number=pr_number, managed_ci=True,
+                )
+                print(
+                    f"PR #{pr_number} remains draft and unmerged because managed recovery provenance or "
+                    f"an unlabeled CI route is unavailable. Resume with `{command}`."
+                )
+                return 0
+        else:
+            managed_ci = activation
         log(config, f"Validating PR #{pr_number}")
         validate_open_pr(runner, config=config, pr_number=pr_number)
         if closing_contract is not None:
@@ -7069,33 +7119,6 @@ def run_pr_loop(
                     expected_closing_issue_ids=closing_contract.expected_closing_issue_ids,
                     supersedes_hash=closing_contract.supersedes_hash,
                 )
-        activation = activate_managed_ci(
-            runner,
-            config=config,
-            pr_number=pr_number,
-            metadata=initial_pr_context.metadata,
-        )
-        if activation is not None and activation.activation_path == "ordinary_fallback":
-            ordinary_recovery_selected = True
-            ordinary_recovery = activation.ordinary_recovery
-            managed_ci = None
-            log(
-                config,
-                f"PR #{pr_number}: ordinary recovery selected; "
-                "the previous managed activation is not being resumed",
-            )
-            if ordinary_recovery is None:
-                command = render_managed_ci_resume_command(
-                    config, pr_number=pr_number, managed_ci=True,
-                )
-                print(
-                    f"PR #{pr_number} remains draft and unmerged because managed recovery provenance or "
-                    f"an unlabeled CI route is unavailable. Resume with `{command}`."
-                )
-                return 0
-        else:
-            managed_ci = activation
-
         def managed_ci_active(metadata: PullRequestMetadata) -> bool:
             """Drop adopted filtering immediately when its live handshake changes."""
             nonlocal managed_ci
@@ -7104,7 +7127,7 @@ def run_pr_loop(
             if revalidate_adopted_managed_ci(
                 runner, config=config, pr_number=pr_number, metadata=metadata, contract=managed_ci
             ):
-                if managed_ci.issue_created_pr:
+                if managed_ci.origin in {"issue-created", "source-managed"} or managed_ci.issue_created_pr:
                     label_state = managed_label_present(
                         runner, config=config, pr_number=pr_number,
                     )
@@ -9001,7 +9024,11 @@ def run_pr_loop(
             managed_ci is not None
             and not managed_ci_qualified
         ):
-            should_release = managed_ci.adopted_existing_pr or config.managed_ci
+            should_release = (
+                managed_ci.adopted_existing_pr
+                or managed_ci.origin in {"issue-created", "source-managed"}
+                or config.managed_ci
+            )
             if should_release and not release_adopted_managed_ci(
                 runner,
                 config=config,

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -158,6 +158,20 @@ def test_managed_ci_docs_describe_safe_issue_draft_resume_and_fallback():
     assert "remains ready" in text
 
 
+def test_managed_ci_docs_describe_lifecycle_gated_issue_resume_and_base_provenance():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    readme_text = README.read_text(encoding="utf-8")
+    for document in (text, readme_text):
+        normalized_document = document.lower()
+        assert "canonical issue" in normalized_document
+        assert "ready/unlabeled" in normalized_document
+        assert "explicit `--managed-ci`" in normalized_document
+        assert "historical audit" in normalized_document or "historical records" in normalized_document
+        assert "base provenance" in normalized_document
+    assert "prints the exact flow-preserving retry" in text
+    assert "never asks the operator to delete durable records" in text
+
+
 def test_managed_ci_docs_describe_precreation_managed_pr_mode():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert "agent-loop managed-pr" in text

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import shlex
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from coding_review_agent_loop.github import (
     merge_pr,
 )
 from coding_review_agent_loop.managed_ci import (
+    AuthenticatedManagedResume,
     FINAL_CONTEXT,
     MANAGED_LABEL,
     MANAGED_OPT_OUT_LABEL,
@@ -39,6 +41,7 @@ from coding_review_agent_loop.managed_ci import (
     preflight_managed_ci_creation,
     parse_managed_ci_override_record,
     render_managed_ci_resume_command,
+    _render_recovery_command,
     recover_issue_created_handoff,
     revalidate_issue_created_handoff,
     prepare_v2_merge,
@@ -58,6 +61,8 @@ from coding_review_agent_loop.orchestrator import (
     _stop_on_terminal_without_status,
 )
 from coding_review_agent_loop.runner import CommandResult
+from coding_review_agent_loop.cli import build_parser
+from coding_review_agent_loop.config import resolve_base_branch
 
 from agent_loop_helpers import FakeRunner, make_config
 
@@ -636,6 +641,188 @@ def test_direct_resume_reconstructs_issue_override_as_provenance_before_writes(t
         runner, config=config, handoff=handoff, metadata=metadata,
     ).override_nonce == "old"
     assert not any("--method" in command for command, _ in runner.commands)
+
+
+def _ready_issue_metadata(body="Fixes #643", base_branch="main"):
+    return PullRequestMetadata(
+        number=7,
+        repo="OWNER/REPO",
+        title="Managed CI",
+        head_branch="agent-loop/managed-643",
+        base_branch=base_branch,
+        head_sha="abc123",
+        url="https://github.com/OWNER/REPO/pull/7",
+        body=body,
+    )
+
+
+def test_strict_ready_unlabeled_issue_resume_reauthenticates_then_restores_label(tmp_path):
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_pr_mode=True,
+        managed_ci_trusted_actor="agent-loop",
+    )
+    runner = ManualQualificationRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        rest_pr={
+            "state": "open",
+            "draft": False,
+            "labels": [],
+            "body": "Fixes #643",
+        },
+        issue_events=[],
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+
+    handoff = recover_issue_created_handoff(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=_ready_issue_metadata(),
+    )
+    assert handoff is not None
+    assert handoff.lifecycle == "ready-unlabeled-reentry"
+    resume = AuthenticatedManagedResume(
+        origin="issue-created",
+        lifecycle=handoff.lifecycle,
+        issue_created_handoff=handoff,
+    )
+    contract = activate_managed_ci(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=_ready_issue_metadata(),
+        managed_resume=resume,
+    )
+
+    assert contract is not None
+    assert contract.origin == "issue-created"
+    assert contract.lifecycle == "ready-unlabeled-reentry"
+    assert contract.intent_generation
+    assert contract.audit_nonce is None
+    commands = [command for command, _cwd in runner.commands]
+    undo_index = next(index for index, command in enumerate(commands) if "--undo" in command)
+    label_index = next(
+        index
+        for index, command in enumerate(commands)
+        if command[:5] == [
+            "gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"
+        ]
+    )
+    assert undo_index < label_index
+    assert not any(UNPROTECTED_OVERRIDE_TRAILER in " ".join(command) for command in commands)
+
+
+@pytest.mark.parametrize("origin", ["issue-created", "source-managed"])
+def test_implicit_auto_merge_leaves_ready_unlabeled_resume_unchanged(tmp_path, origin):
+    config = make_config(
+        tmp_path,
+        auto_merge=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+        managed_ci_pr_mode=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        rest_pr={"state": "open", "draft": False, "labels": [], "body": "Fixes #643"},
+        issue_events=[],
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+    resume = AuthenticatedManagedResume(origin=origin, lifecycle="ready-unlabeled-reentry")
+
+    with pytest.raises(AgentLoopError, match="explicit `--managed-ci`"):
+        activate_managed_ci(
+            runner,
+            config=config,
+            pr_number=7,
+            metadata=_ready_issue_metadata(),
+            managed_resume=resume,
+        )
+
+    assert not any(
+        command[:3] == ["gh", "pr", "ready"]
+        or ("--method" in command and "POST" in command)
+        or ("--method" in command and "PATCH" in command)
+        for command, _cwd in runner.commands
+    )
+
+
+def test_repository_default_base_mismatch_prints_explicit_live_base_retry(tmp_path):
+    runner = V2ManagedRunner(base_ref="release")
+    config = make_config(
+        tmp_path,
+        base=None,
+        invocation_argv=("agent-loop", "issue", "643", "--auto-merge"),
+    )
+    resolved = resolve_base_branch(
+        config, runner, pr_metadata=_ready_issue_metadata(base_branch="release")
+    )
+    assert resolved.base == "release"
+    assert resolved.base_provenance == "pr-metadata"
+
+    inherited = resolve_base_branch(make_config(tmp_path, base=None), V2ManagedRunner())
+    assert inherited.base == "main"
+    assert inherited.base_provenance == "repository-default"
+    with pytest.raises(AgentLoopError, match=r"repository-default.*--base release"):
+        resolve_base_branch(
+            inherited,
+            runner,
+            pr_metadata=_ready_issue_metadata(base_branch="release"),
+        )
+
+
+def test_recovery_renderer_retargets_both_directions_with_parser_valid_argv(tmp_path):
+    parser = build_parser()
+    issue_to_pr = make_config(
+        tmp_path,
+        invocation_argv=(
+            "agent-loop", "issue", "643", "--plan-first", "--plan-execution-mode",
+            "implement-one-shot", "--implementation-coder", "codex", "--split-stage", "700",
+            "--reviewer", "codex", "--reviewer=gemini", "--codex-arg=--literal=$HOME;echo",
+        ),
+    )
+    rendered = _render_recovery_command(
+        issue_to_pr, target="pr", identifier=7, managed_ci=True,
+    )
+    args = parser.parse_args(shlex.split(rendered)[1:])
+    assert args.command == "pr"
+    assert args.pr_number == 7
+    assert not hasattr(args, "plan_first")
+    assert args.reviewer == ["codex", "gemini"]
+    assert args.codex_arg == ["--literal=$HOME;echo"]
+
+    pr_to_issue = make_config(
+        tmp_path,
+        invocation_argv=(
+            "agent-loop", "pr", "7", "--managed-ci-adopt-existing-pr",
+            "--managed-ci", "--managed-ci-trusted-actor=agent-loop",
+            "--reviewer", "codex",
+        ),
+    )
+    rendered = _render_recovery_command(
+        pr_to_issue, target="issue", identifier=643, managed_ci=True,
+    )
+    args = parser.parse_args(shlex.split(rendered)[1:])
+    assert args.command == "issue"
+    assert args.issue_number == 643
+    assert not hasattr(args, "managed_ci_adopt_existing_pr")
+    assert args.managed_ci_trusted_actor == "agent-loop"
+
+    managed_pr_to_issue = make_config(
+        tmp_path,
+        invocation_argv=(
+            "agent-loop", "managed-pr", "--head", "feature/ref",
+            "--title=Managed PR", "--body-file", "/tmp/body.md",
+            "--reviewer", "codex",
+        ),
+    )
+    rendered = _render_recovery_command(
+        managed_pr_to_issue, target="issue", identifier=643, managed_ci=False,
+    )
+    args = parser.parse_args(shlex.split(rendered)[1:])
+    assert args.command == "issue"
+    assert args.issue_number == 643
 
 
 def _resume_audit(*, head="old-head", repo="OWNER/REPO", base="main"):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -935,7 +935,7 @@ def test_recovery_renderer_finds_issue_identifier_after_options_and_consumes_std
     config = make_config(
         tmp_path,
         invocation_argv=(
-            "agent-loop", "issue", "--repo", "OWNER/REPO", "643",
+            "agent-loop", "issue", "--repo", "OWNER/REPO", "--gh-cmd", "gh", "643",
             "--managed-ci", "--managed-ci-trusted-actor", "agent-loop",
         ),
     )
@@ -944,6 +944,7 @@ def test_recovery_renderer_finds_issue_identifier_after_options_and_consumes_std
     assert args.command == "issue"
     assert args.issue_number == 643
     assert args.repo == "OWNER/REPO"
+    assert args.gh_cmd == "gh"
 
     managed_pr = make_config(
         tmp_path,
@@ -958,6 +959,93 @@ def test_recovery_renderer_finds_issue_identifier_after_options_and_consumes_std
     args = parser.parse_args(shlex.split(rendered)[1:])
     assert args.command == "issue"
     assert args.issue_number == 643
+
+
+def test_recovery_value_option_table_covers_all_recovery_subparsers():
+    parser = build_parser()
+    subparsers = next(action for action in parser._actions if action.dest == "command")
+
+    for command in ("issue", "pr", "managed-pr"):
+        subparser = subparsers.choices[command]
+        value_options = {
+            option
+            for action in subparser._actions
+            if action.nargs != 0
+            for option in action.option_strings
+            if option.startswith("--")
+        }
+        assert value_options <= managed_ci._RECOVERY_VALUE_OPTIONS, (
+            f"{command} value-taking recovery options are not classified: "
+            f"{sorted(value_options - managed_ci._RECOVERY_VALUE_OPTIONS)}"
+        )
+
+
+def test_issue_created_tuple_actor_refusal_includes_trusted_actor_remediation(tmp_path):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        invocation_argv=("agent-loop", "issue", "643", "--repo", "OWNER/REPO"),
+    )
+    runner = V2ManagedRunner(rest_pr={"state": "open", "body": body})
+    metadata = replace(_ready_issue_metadata(body=body), head_sha="abc123")
+    intent = managed_ci.ManagedCiCreationIntent(
+        branch="agent-loop/managed-643",
+        trusted_actor="agent-loop",
+        protection_mode="voluntary",
+        audit_nonce="fresh",
+    )
+
+    with pytest.raises(AgentLoopError, match=r"--managed-ci-trusted-actor agent-loop"):
+        authenticate_issue_created_handoff(
+            runner,
+            config=config,
+            intent=intent,
+            issue_number=643,
+            pr_number=7,
+            metadata=metadata,
+        )
+
+
+def test_issue_created_tuple_mismatch_includes_shell_quoted_resume_command(tmp_path):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_trusted_actor="agent-loop",
+        invocation_argv=(
+            "agent-loop", "issue", "643", "--repo", "OWNER/REPO", "--gh-cmd", "gh",
+        ),
+    )
+    runner = V2ManagedRunner(
+        rest_pr={"state": "open", "body": body, "head": {
+            "repo": {"full_name": "OWNER/REPO"},
+            "sha": "changed-head",
+            "ref": "agent-loop/managed-643",
+        }},
+    )
+    metadata = replace(_ready_issue_metadata(body=body), head_sha="abc123")
+    intent = managed_ci.ManagedCiCreationIntent(
+        branch="agent-loop/managed-643",
+        trusted_actor="agent-loop",
+        protection_mode="voluntary",
+        audit_nonce="fresh",
+    )
+
+    with pytest.raises(AgentLoopError) as error:
+        authenticate_issue_created_handoff(
+            runner,
+            config=config,
+            intent=intent,
+            issue_number=643,
+            pr_number=7,
+            metadata=metadata,
+        )
+
+    message = str(error.value)
+    assert "opening tuple is missing or changed" in message
+    assert "agent-loop issue 643 --repo OWNER/REPO --gh-cmd gh" in message
+    assert "--managed-ci-trusted-actor agent-loop" in message
 
 
 def test_ci_timeout_renderer_preserves_explicit_managed_options(tmp_path):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -58,6 +58,7 @@ from coding_review_agent_loop.managed_ci import (
 from coding_review_agent_loop.protocol_markers import PR_BODY_SURFACE, PR_COMMENT_SURFACE
 from coding_review_agent_loop.orchestrator import (
     _finalize_ordinary_recovery_merge,
+    _render_ci_rerun_command,
     _stop_on_terminal_without_status,
 )
 from coding_review_agent_loop.runner import CommandResult
@@ -643,6 +644,52 @@ def test_direct_resume_reconstructs_issue_override_as_provenance_before_writes(t
     assert not any("--method" in command for command, _ in runner.commands)
 
 
+@pytest.mark.parametrize(
+    ("managed_ci_pr_mode", "issue_number"),
+    [(False, 643), (True, None)],
+)
+def test_issue_and_pr_resume_authenticate_nonce_bearing_advanced_head(
+    tmp_path, managed_ci_pr_mode, issue_number
+):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=after-coder-round"
+    advanced_sha = "coder-round-head"
+    runner = V2ManagedRunner(
+        rest_pr={
+            "state": "open",
+            "draft": True,
+            "labels": [{"name": MANAGED_LABEL}],
+            "body": body,
+            "head": {
+                "repo": {"full_name": "OWNER/REPO"},
+                "sha": advanced_sha,
+                "ref": "agent-loop/managed-643",
+            },
+        },
+        issue_events=[label_event()],
+    )
+    config = make_config(
+        tmp_path,
+        managed_ci=managed_ci_pr_mode,
+        managed_ci_pr_mode=managed_ci_pr_mode,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    metadata = replace(_ready_issue_metadata(body=body), head_sha=advanced_sha)
+
+    handoff = recover_issue_created_handoff(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=metadata,
+        issue_number=issue_number,
+    )
+
+    assert handoff is not None
+    assert handoff.head_sha == advanced_sha
+    assert handoff.lifecycle == "draft-labeled"
+    assert not any("--method" in command for command, _ in runner.commands)
+
+
 def _ready_issue_metadata(body="Fixes #643", base_branch="main"):
     return PullRequestMetadata(
         number=7,
@@ -712,6 +759,64 @@ def test_strict_ready_unlabeled_issue_resume_reauthenticates_then_restores_label
     )
     assert undo_index < label_index
     assert not any(UNPROTECTED_OVERRIDE_TRAILER in " ".join(command) for command in commands)
+
+
+def test_explicit_managed_issue_resume_reclaims_draft_unlabeled_state(tmp_path):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=old"
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+    )
+    runner = V2ManagedRunner(
+        workflow=SUPPRESSING_V2_WORKFLOW,
+        rest_pr={
+            "state": "open",
+            "draft": True,
+            "labels": [],
+            "body": body,
+            "head": {
+                "repo": {"full_name": "OWNER/REPO"},
+                "sha": "coder-round-head",
+                "ref": "agent-loop/managed-643",
+            },
+        },
+        issue_events=[],
+        pr_branch_protection_payload={"contexts": [FINAL_CONTEXT]},
+    )
+    metadata = replace(_ready_issue_metadata(body=body), head_sha="coder-round-head")
+
+    handoff = recover_issue_created_handoff(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=metadata,
+        issue_number=643,
+    )
+    assert handoff is not None
+    assert handoff.lifecycle == "draft-unlabeled-reentry"
+
+    contract = activate_managed_ci(
+        runner,
+        config=config,
+        pr_number=7,
+        metadata=metadata,
+        managed_resume=AuthenticatedManagedResume(
+            origin="issue-created",
+            lifecycle=handoff.lifecycle,
+            issue_created_handoff=handoff,
+        ),
+    )
+
+    assert contract is not None
+    assert contract.lifecycle == "draft-unlabeled-reentry"
+    assert any(
+        command[:5] == [
+            "gh", "api", "--method", "POST", "repos/OWNER/REPO/issues/7/labels"
+        ]
+        for command, _cwd in runner.commands
+    )
 
 
 @pytest.mark.parametrize("origin", ["issue-created", "source-managed"])
@@ -823,6 +928,56 @@ def test_recovery_renderer_retargets_both_directions_with_parser_valid_argv(tmp_
     args = parser.parse_args(shlex.split(rendered)[1:])
     assert args.command == "issue"
     assert args.issue_number == 643
+
+
+def test_recovery_renderer_finds_issue_identifier_after_options_and_consumes_stdin_value(tmp_path):
+    parser = build_parser()
+    config = make_config(
+        tmp_path,
+        invocation_argv=(
+            "agent-loop", "issue", "--repo", "OWNER/REPO", "643",
+            "--managed-ci", "--managed-ci-trusted-actor", "agent-loop",
+        ),
+    )
+    rendered = render_managed_ci_resume_command(config, pr_number=7, managed_ci=True)
+    args = parser.parse_args(shlex.split(rendered)[1:])
+    assert args.command == "issue"
+    assert args.issue_number == 643
+    assert args.repo == "OWNER/REPO"
+
+    managed_pr = make_config(
+        tmp_path,
+        invocation_argv=(
+            "agent-loop", "managed-pr", "--head", "feature/ref",
+            "--title", "Managed PR", "--body-file", "-", "--reviewer", "codex",
+        ),
+    )
+    rendered = _render_recovery_command(
+        managed_pr, target="issue", identifier=643, managed_ci=False,
+    )
+    args = parser.parse_args(shlex.split(rendered)[1:])
+    assert args.command == "issue"
+    assert args.issue_number == 643
+
+
+def test_ci_timeout_renderer_preserves_explicit_managed_options(tmp_path):
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_trusted_actor="agent-loop",
+        allow_unprotected_managed_ci=True,
+        auto_merge=True,
+        invocation_argv=(
+            "agent-loop", "issue", "643", "--auto-merge", "--managed-ci",
+            "--managed-ci-trusted-actor", "agent-loop", "--allow-unprotected-managed-ci",
+        ),
+    )
+
+    command = _render_ci_rerun_command(config, pr_number=7)
+
+    assert "--managed-ci" in command
+    assert "--managed-ci-trusted-actor agent-loop" in command
+    assert "--allow-unprotected-managed-ci" in command
 
 
 def _resume_audit(*, head="old-head", repo="OWNER/REPO", base="main"):

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -1007,6 +1007,46 @@ def test_issue_created_tuple_actor_refusal_includes_trusted_actor_remediation(tm
         )
 
 
+def test_issue_created_tuple_actor_refusal_replaces_existing_trusted_actor(tmp_path):
+    body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"
+    config = make_config(
+        tmp_path,
+        managed_ci=True,
+        managed_ci_trusted_actor="operator-actor",
+        invocation_argv=(
+            "agent-loop", "issue", "643", "--repo", "OWNER/REPO", "--managed-ci",
+            "--managed-ci-trusted-actor", "operator-actor",
+        ),
+    )
+    runner = V2ManagedRunner(rest_pr={"state": "open", "body": body})
+    metadata = replace(_ready_issue_metadata(body=body), head_sha="abc123")
+    intent = managed_ci.ManagedCiCreationIntent(
+        branch="agent-loop/managed-643",
+        trusted_actor="agent-loop",
+        protection_mode="voluntary",
+        audit_nonce="fresh",
+    )
+
+    with pytest.raises(AgentLoopError) as error:
+        authenticate_issue_created_handoff(
+            runner,
+            config=config,
+            intent=intent,
+            issue_number=643,
+            pr_number=7,
+            metadata=metadata,
+        )
+
+    message = str(error.value)
+    assert "gh login=`agent-loop`" in message
+    assert "--managed-ci-trusted-actor=`operator-actor`" in message
+    assert "AGENT_LOOP_MANAGED_ACTOR=`agent-loop`" in message
+    remediation = message.split("`", 7)[7]
+    assert remediation.count("--managed-ci-trusted-actor") == 1
+    assert "--managed-ci-trusted-actor agent-loop" in remediation
+    assert "operator-actor" not in remediation
+
+
 def test_issue_created_tuple_mismatch_includes_shell_quoted_resume_command(tmp_path):
     body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"
     config = make_config(


### PR DESCRIPTION
## Summary

- Reauthenticate canonical issue and source-managed PR resumes using live lifecycle and immutable tuple state.
- Preserve base provenance across issue-to-PR recovery and render parser-valid, shell-quoted retry commands.
- Require explicit managed-CI intent before reconstructing ready/unlabeled PRs, with focused documentation and regression coverage.

Fixes #714

## Tests

- `python3 -m pytest tests/test_managed_ci.py tests/test_managed_pr.py tests/test_issue_pr_handoff.py tests/test_orchestrator_issue.py tests/test_orchestrator_pr.py tests/test_docs_guidance.py -q`
- `python3 -m pytest -q`