### PR TITLE
Retire legacy CI check selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,9 +909,9 @@ starts from fresh PR state. One timeout and attempt budget is shared across
 watcher polls and any coder-failure or head-change rounds. Auto-merge timeout,
 bounded-startup, and already-exhausted-budget stops retain resumable diagnostics
 and return non-zero; explicit manual `--watch-pending-ci` stops return zero
-without merging. `--ci-check-name` and `--no-watch-pending-ci` remain parseable
-compatibility options, but do not select or disable this auto-merge gate and
-warn when explicitly supplied with auto-merge. Without `--auto-merge`,
+without merging. `--no-watch-pending-ci` remains a parseable compatibility
+option, but does not disable this auto-merge gate and warns when explicitly
+supplied with auto-merge. Without `--auto-merge`,
 agent-loop reports an approved PR as merge-ready and does not wait for CI,
 unless `--watch-pending-ci` is passed explicitly, in which case it still
 watches the check board and reports merge-ready without merging.

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1445,10 +1445,10 @@ must pass. Partial or unavailable snapshots remain fail-closed and are polled;
 an otherwise reliable empty board is bounded startup, not success. The live
 head is re-read immediately before an exact-head merge proof is sent to GitHub.
 
-`--ci-check-name` and `--no-watch-pending-ci` remain parseable compatibility
-options, but neither selects nor disables the ordinary auto-merge gate; an
-explicit use with auto-merge emits a warning. One timeout and attempt budget is
-shared across watcher polls, coder-failure rounds, and head-change rounds.
+`--no-watch-pending-ci` remains parseable for compatibility, but does not
+disable the ordinary auto-merge gate; an explicit use with auto-merge emits a
+warning. One timeout and attempt budget is shared across watcher polls,
+coder-failure rounds, and head-change rounds.
 Auto-merge timeout, bounded-startup, and already-exhausted-budget stops retain
 their resumable diagnostics and return a non-zero exit. An explicit manual
 `--watch-pending-ci` run keeps the same watcher outcomes but stops cleanly
@@ -1828,9 +1828,9 @@ recovery trigger for this path.
 
 For repositories not using managed exact-head CI, ordinary `--auto-merge`
 always enters the full-board watcher, regardless of the effective
-`--watch-pending-ci` value. `--ci-check-name` and `--no-watch-pending-ci` remain
-parseable for compatibility and produce a warning when explicitly supplied
-with auto-merge; they do not select or weaken that gate. An explicit
+`--watch-pending-ci` value. `--no-watch-pending-ci` remains parseable for
+compatibility and produces a warning when explicitly supplied with auto-merge;
+it does not weaken that gate. An explicit
 `--watch-pending-ci` without `--auto-merge` watches ordinary checks after
 approval and reports merge-ready without merging. It does not activate
 suppression or replace managed exact-head qualification; when `--managed-ci` is

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -85,7 +85,6 @@ def make_minimal_config(
         gemini_args=("--skip-trust",),
         test_command=None,
         pre_review_tests=False,
-        ci_check_name="",
         ci_timeout_seconds=300,
         ci_poll_interval_seconds=30,
         quiet=False,

--- a/helpers/run_external.py
+++ b/helpers/run_external.py
@@ -336,7 +336,6 @@ def main() -> None:
         gemini_args=("--skip-trust",),
         test_command=None,
         pre_review_tests=False,
-        ci_check_name="",
         ci_timeout_seconds=300,
         ci_poll_interval_seconds=30,
         quiet=False,

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -333,15 +333,6 @@ def build_parser() -> argparse.ArgumentParser:
             help="Do not run --test-command before reviewer rounds.",
         )
         subparser.add_argument(
-            "--ci-check-name",
-            default=None,
-            help=(
-                "Retained for compatibility (default: test); ordinary --auto-merge now "
-                "gates on the complete full-board check snapshot, so this name does not "
-                "select the merge gate."
-            ),
-        )
-        subparser.add_argument(
             "--ci-timeout-seconds",
             type=int,
             default=1200,
@@ -887,13 +878,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             if not (args.managed_ci_trusted_actor or "").strip():
                 raise AgentLoopError("--managed-ci requires --managed-ci-trusted-actor.")
         config = config_from_args(args, runner, invocation_argv=invocation)
-        if config.auto_merge and config.ci_check_name_explicit:
-            print(
-                "agent-loop: warning: --ci-check-name is retained for compatibility and "
-                "no longer selects the ordinary auto-merge gate; the complete full-board "
-                "watcher is used.",
-                file=sys.stderr,
-            )
         if config.auto_merge and config.watch_pending_ci_explicit and not config.watch_pending_ci:
             print(
                 "agent-loop: warning: --no-watch-pending-ci is retained for compatibility "

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -84,7 +84,6 @@ class AgentLoopConfig:
     gemini_args: tuple[str, ...]
     test_command: tuple[str, ...] | None
     pre_review_tests: bool
-    ci_check_name: str
     ci_timeout_seconds: int
     ci_poll_interval_seconds: int
     quiet: bool
@@ -218,10 +217,9 @@ class AgentLoopConfig:
     # Separate bounded startup observation for CI that has not materialized a
     # run/check yet.  Empty boards are never evidence that CI succeeded.
     ci_startup_timeout_seconds: int = 120
-    # CLI provenance for compatibility options. These are intentionally kept
-    # separate from their effective values so auto-merge can warn when an old
-    # selector or opt-out no longer changes the full-board gate.
-    ci_check_name_explicit: bool = False
+    # CLI provenance for the compatibility opt-out. It remains separate from
+    # its effective value so auto-merge can warn when the old opt-out no longer
+    # changes the full-board gate.
     watch_pending_ci_explicit: bool = False
     # The first source that resolved ``base``.  This is carried across an
     # issue-to-PR handoff so a repository-default base cannot silently replace
@@ -1077,7 +1075,6 @@ def config_from_args(
         review_parallel=getattr(args, "review_parallel", False),
         test_command=test_command,
         pre_review_tests=args.pre_review_tests,
-        ci_check_name=getattr(args, "ci_check_name", None) or "test",
         ci_timeout_seconds=args.ci_timeout_seconds,
         ci_poll_interval_seconds=args.ci_poll_interval_seconds,
         ci_startup_timeout_seconds=getattr(args, "ci_startup_timeout_seconds", 120),
@@ -1086,7 +1083,6 @@ def config_from_args(
             if getattr(args, "watch_pending_ci", None) is None
             else bool(args.watch_pending_ci)
         ),
-        ci_check_name_explicit=getattr(args, "ci_check_name", None) is not None,
         watch_pending_ci_explicit=getattr(args, "watch_pending_ci", None) is not None,
         managed_ci_trusted_actor=getattr(args, "managed_ci_trusted_actor", None),
         managed_ci=getattr(args, "managed_ci", False),

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -1243,7 +1243,7 @@ _RECOVERY_VALUE_OPTIONS = frozenset({
     "--codex-model", "--codex-reasoning-effort", "--gemini-model", "--claude-model",
     "--gh-cmd",
     "--claude-arg", "--codex-arg", "--gemini-arg", "--antigravity-arg",
-    "--test-command", "--ci-check-name", "--ci-timeout-seconds",
+    "--test-command", "--ci-timeout-seconds",
     "--ci-poll-interval-seconds", "--ci-startup-timeout-seconds",
     "--ci-queued-grace-seconds", "--mergeability-poll-attempts",
     "--mergeability-poll-interval-seconds", "--log-dir", "--subprocess-log-dir",

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -1498,7 +1498,6 @@ def make_config(tmp_path, *, create_dirs=True, **overrides):
         "gemini_args": (),
         "test_command": None,
         "pre_review_tests": True,
-        "ci_check_name": "test",
         "ci_timeout_seconds": 1200,
         "ci_poll_interval_seconds": 30,
         "quiet": True,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1643,12 +1643,13 @@ def test_config_allows_disabling_auto_merge_ci_watch(tmp_path):
     assert config.watch_pending_ci_explicit is True
 
 
-@pytest.mark.parametrize("legacy_option", ["--ci" "-check-name", "--ci" "-check-name=legacy-ci"])
-def test_retired_ci_name_option_is_rejected(legacy_option, capsys):
+@pytest.mark.parametrize(
+    "legacy_args",
+    [["--ci-check-name", "legacy-ci"], ["--ci-check-name=legacy-ci"]],
+)
+def test_retired_ci_name_option_is_rejected(legacy_args, capsys):
     parser = build_parser()
-    arguments = ["pr", "77", "--repo", "OWNER/REPO", "--auto-merge", legacy_option]
-    if legacy_option == "--ci" "-check-name":
-        arguments.append("legacy-ci")
+    arguments = ["pr", "77", "--repo", "OWNER/REPO", "--auto-merge", *legacy_args]
 
     with pytest.raises(SystemExit) as exc_info:
         parser.parse_args(arguments)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1446,8 +1446,6 @@ def test_config_enables_ci_watch_with_auto_merge_without_rebuilding_antigravity_
     )
     assert config.watch_pending_ci is True
     assert config.watch_pending_ci_explicit is False
-    assert config.ci_check_name == "test"
-    assert config.ci_check_name_explicit is False
     assert config.managed_ci_pr_mode is True
     assert config.invocation_argv[-1] == "77"
     assert config.antigravity_models == ("Gemini 3.1 Pro (High)",)
@@ -1645,25 +1643,25 @@ def test_config_allows_disabling_auto_merge_ci_watch(tmp_path):
     assert config.watch_pending_ci_explicit is True
 
 
-def test_config_records_explicit_legacy_ci_name_without_changing_effective_name(tmp_path):
+@pytest.mark.parametrize("legacy_option", ["--ci" "-check-name", "--ci" "-check-name=legacy-ci"])
+def test_retired_ci_name_option_is_rejected(legacy_option, capsys):
     parser = build_parser()
-    args = parser.parse_args([
-        "pr", "77", "--repo", "OWNER/REPO", "--auto-merge", "--ci-check-name", "legacy-ci",
-    ])
+    arguments = ["pr", "77", "--repo", "OWNER/REPO", "--auto-merge", legacy_option]
+    if legacy_option == "--ci" "-check-name":
+        arguments.append("legacy-ci")
 
-    config = config_from_args(args, FakeRunner())
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(arguments)
 
-    assert config.ci_check_name == "legacy-ci"
-    assert config.ci_check_name_explicit is True
-    assert config.watch_pending_ci is True
+    assert exc_info.value.code == 2
+    assert "unrecognized arguments" in capsys.readouterr().err
 
 
-def test_auto_merge_compatibility_options_emit_warnings(tmp_path, monkeypatch, capsys):
+def test_auto_merge_legacy_ci_watch_option_emits_warning(tmp_path, monkeypatch, capsys):
     config = make_config(
         tmp_path,
         auto_merge=True,
         watch_pending_ci=False,
-        ci_check_name_explicit=True,
         watch_pending_ci_explicit=True,
     )
     monkeypatch.setattr(cli_module, "config_from_args", lambda *args, **kwargs: config)
@@ -1671,11 +1669,10 @@ def test_auto_merge_compatibility_options_emit_warnings(tmp_path, monkeypatch, c
 
     assert main([
         "pr", "77", "--repo", "OWNER/REPO", "--auto-merge",
-        "--ci-check-name", "legacy-ci", "--no-watch-pending-ci",
+        "--no-watch-pending-ci",
     ]) == 0
 
     warning = capsys.readouterr().err
-    assert "--ci-check-name is retained for compatibility" in warning
     assert "--no-watch-pending-ci is retained for compatibility" in warning
 
 

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -132,7 +132,7 @@ def test_watch_docs_define_full_board_policy_and_compatibility_behavior():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     normalized_text = " ".join(text.split())
     readme_text = README.read_text(encoding="utf-8")
-    retired_option = "--ci" "-check-name"
+    retired_option = "--ci-check-name"
 
     assert "ordinary `--auto-merge` always enters the full-board watcher" in normalized_text
     assert "reliable, non-empty current-head board" in normalized_text

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -131,12 +131,16 @@ def test_readme_links_to_managed_exact_head_ci_and_scopes_watch_mode():
 def test_watch_docs_define_full_board_policy_and_compatibility_behavior():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     normalized_text = " ".join(text.split())
+    readme_text = README.read_text(encoding="utf-8")
+    retired_option = "--ci" "-check-name"
 
     assert "ordinary `--auto-merge` always enters the full-board watcher" in normalized_text
     assert "reliable, non-empty current-head board" in normalized_text
     assert "shared across all watcher entries" in normalized_text
     assert "Auto-merge timeout, `not_started`, and pre-poll exhaustion" in normalized_text
-    assert "legacy single `--ci-check-name` waiter" not in normalized_text
+    assert f"legacy single `{retired_option}` waiter" not in normalized_text
+    assert retired_option not in text
+    assert retired_option not in readme_text
 
 
 def test_managed_ci_docs_describe_explicit_existing_pr_adoption_and_opt_out():

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -979,6 +979,13 @@ def test_recovery_value_option_table_covers_all_recovery_subparsers():
             f"{sorted(value_options - managed_ci._RECOVERY_VALUE_OPTIONS)}"
         )
 
+    assert "--ci" "-check-name" not in managed_ci._RECOVERY_VALUE_OPTIONS
+    assert {
+        "--ci-timeout-seconds",
+        "--ci-poll-interval-seconds",
+        "--ci-startup-timeout-seconds",
+    } <= managed_ci._RECOVERY_VALUE_OPTIONS
+
 
 def test_issue_created_tuple_actor_refusal_includes_trusted_actor_remediation(tmp_path):
     body = f"Fixes #643\n\n{UNPROTECTED_OVERRIDE_TRAILER} nonce=fresh"

--- a/tests/test_managed_ci.py
+++ b/tests/test_managed_ci.py
@@ -979,7 +979,7 @@ def test_recovery_value_option_table_covers_all_recovery_subparsers():
             f"{sorted(value_options - managed_ci._RECOVERY_VALUE_OPTIONS)}"
         )
 
-    assert "--ci" "-check-name" not in managed_ci._RECOVERY_VALUE_OPTIONS
+    assert "--ci-check-name" not in managed_ci._RECOVERY_VALUE_OPTIONS
     assert {
         "--ci-timeout-seconds",
         "--ci-poll-interval-seconds",

--- a/tests/test_orchestrator_pr.py
+++ b/tests/test_orchestrator_pr.py
@@ -1923,7 +1923,7 @@ def test_disabled_watch_mode_preserves_manual_path_and_auto_merge_uses_full_boar
         assert any("checks are still pending" in comment for comment in runner.comments)
 
 
-def test_auto_merge_green_board_ignores_legacy_check_name_and_merges_once(
+def test_auto_merge_green_full_board_merges_once(
     tmp_path, monkeypatch
 ):
     runner = FakeRunner(
@@ -1940,7 +1940,6 @@ def test_auto_merge_green_board_ignores_legacy_check_name_and_merges_once(
         tmp_path,
         auto_merge=True,
         watch_pending_ci=False,
-        ci_check_name="legacy-ci",
     )
     with patch.object(orchestrator, "watch_pr_checks", wraps=orchestrator.watch_pr_checks) as watch_spy:
         assert run_pr_loop(runner, pr_number=77, config=config) == 0


### PR DESCRIPTION
## Summary

- Remove the retired CI-check selector from the CLI, configuration, and recovery command surface.
- Keep full-board auto-merge behavior and the separate pending-CI compatibility warning.
- Update helpers, documentation, and regression coverage for rejected legacy syntax.

## Testing

- `timeout 1800s python3 -m pytest`

Fixes #713