### PR TITLE
Unify approved-plan child topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,11 @@ agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode implem
 
 `plan-only` is the default. `implement-one-shot` is the same behavior selected
 by the backward-compatible `--implement-after-approval` flag. `decompose-only`
-asks the coder to turn the approved plan into ordered phases, always creates
-one GitHub child issue per phase, posts a parent summary table, and stops.
+uses typed `child_stages` directly when the approved plan has them; otherwise it
+asks the coder to turn the approved plan into ordered phases. It creates one
+GitHub child issue per selected phase, posts a parent summary table, and stops.
+Typed stages are the plan's remainder; the primary scope remains owned by the
+parent and is recorded in the summary.
 `implement-by-phase` creates every child issue, then implements only the first
 `agent-pr` phase and stops after that PR review loop. The parent issue records a
 one-time handoff only after the child implementation returns an accepted PR, so
@@ -374,10 +377,10 @@ the implementation signature can name the model reliably.
 
 ### Choosing a child-issue mechanism
 
-`decompose-only` / `implement-by-phase` and `--materialize-split-issues` are
-two separate child-issue creation paths. Combining them files duplicate
-children — decompose modes already create one detailed issue per phase, and
-`--materialize-split-issues` is not suppressed by them.
+`decompose-only` / `implement-by-phase` and `--materialize-split-issues` select
+different workflows. The decomposition modes reject that combination before
+any GitHub write and use one topology source. All flat child workflows share
+one configurable parent-wide cap (`--flat-child-limit`, default 15).
 
 | Situation | Correct mechanism |
 | --- | --- |
@@ -397,19 +400,22 @@ agent-loop issue 123 --repo OWNER/REPO --plan-first --plan-execution-mode plan-o
 See [Phased decomposition versus split
 materialization](docs/local_agent_loop.md#phased-decomposition-versus-split-materialization)
 for the full decision rule, stop points, worked examples, and the
-duplicate-issue failure mode.
+duplicate-issue failure mode. The explicit topology choice prevents duplicate children.
 
 Each generated child issue copies the relevant parent-plan slice, constraints
 and invariants, dependency notes, scope and non-goals, rollout risk,
 validation/soak requirements, automation classification, and instructions for
-agent execution or human closure. Decomposition is capped at 8 phases; an
-over-cap response is rejected and must be consolidated, not truncated. This cap
-is separate from the approved-review follow-up issue cap used by
-`--approved-followups`.
+agent execution or human closure. The complete flat topology is preflighted
+before a checkpoint or issue create. It is capped at 15 children by default
+(override with `--flat-child-limit`); an over-limit plan is never truncated or
+partially filed and returns a structured human decision to consolidate or use
+the hierarchical design tracked in #720. Recovery reuses checkpoints and
+exact child identities, including closed children.
 
-If the approved plan narrows scope via explicit `child_stages`, pass
-`--materialize-split-issues` to file those bounded implementation stages as
-linked child issues. `external_dependencies`, `deferred_work`, `plan_actions`,
+If the approved plan narrows scope via explicit `child_stages`, decomposition
+modes file those bounded implementation stages as linked child issues;
+`--materialize-split-issues` is reserved for discuss `split` proposals and
+plan-only/one-shot split workflows. `external_dependencies`, `deferred_work`, `plan_actions`,
 and legacy structured `deferred_stages` are recorded only; legacy discuss
 `split` proposals remain eligible for filing. Materialization is off by default,
 and the orchestrator warns explicitly when eligible stages would otherwise go

--- a/SKILL.md
+++ b/SKILL.md
@@ -523,8 +523,10 @@ A response that fails validation is non-retryable — fix the cause and re-run.
 
 ### Decompose an approved plan into phase issues
 
-`run-decompose` has an **external coder** turn an approved plan into structured
-phase child issues:
+`run-decompose` has an **external coder** turn an untyped approved plan into
+structured phase child issues. When the plan contains typed `child_stages`, the
+helper adapts those stages directly and does not invoke the coder a second
+time:
 
 ```bash
 python -m helpers.skill_runner run-decompose \
@@ -536,10 +538,13 @@ python -m helpers.skill_runner run-decompose \
 
 Live runs are **side-effecting**: they create real GitHub child issues and post a
 parent summary marker. The command is idempotent by parent issue + approved-plan
-hash + `decompose-only` mode; re-running the same plan returns the recorded child
-issues instead of creating duplicates. `--dry-run` still exercises the
-decomposition parser and prints the child-issue preview JSON, but it does not
-create issues or post comments.
+hash + mode; re-running the same plan returns the recorded child issues instead
+of creating duplicates. Both phase commands accept `--flat-child-limit` (15 by
+default), preflight every title/body before a checkpoint or create, never
+truncate, and recover from checkpoints plus exact child identities. An
+over-limit result exits 2 with structured guidance to consolidate or use the
+hierarchical design tracked in #720. `--dry-run` parses, searches, adopts, and
+validates the full preview without posting state or creating issues.
 
 ---
 

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -290,10 +290,10 @@ agent-loop issue 56 --repo OWNER/REPO --plan-first --plan-execution-mode impleme
 The modes are:
 
 - `plan-only`: post the approved plan summary and stop. This is the default.
-- `decompose-only`: ask the coder to decompose the approved plan, validate the
-  structured JSON response, create one GitHub child issue per phase, post a
-  parent summary, and stop. The summary table is not a substitute for child
-  issues.
+- `decompose-only`: use typed `child_stages` directly when present; otherwise
+  ask the coder to decompose the approved plan. Create one child issue per
+  selected phase, post a parent summary, and stop. Typed stages are the
+  approved plan's remainder; its primary scope remains owned by the parent.
 - `implement-one-shot`: keep the existing post-approval implementation handoff.
   This is also what `--implement-after-approval` selects for compatibility.
 - `implement-by-phase`: create/link every phase issue, implement only the first
@@ -304,11 +304,9 @@ The modes are:
   `agent-loop issue <child>`. Older decomposition summaries without this marker
   are treated as not yet handed off, so the first child handoff is recorded once.
 
-`decompose-only` and `implement-by-phase` already create one detailed child
-issue per phase; see [Phased decomposition versus split
-materialization](#phased-decomposition-versus-split-materialization) before
-also passing `--materialize-split-issues`, which is a separate,
-non-suppressed child-issue creation path.
+`decompose-only` and `implement-by-phase` already select one detailed child
+topology. The CLI rejects `--materialize-split-issues` with either mode before
+any GitHub write.
 
 Before invoking a coder for an issue — in direct `agent-loop issue <n>` mode or
 approved-plan implementation alike — the orchestrator resolves the canonical
@@ -413,10 +411,13 @@ work or checkpoint, add the required remark/update, and close the issue. If
 `implement-by-phase` sees a human-only first phase, it stops instead of
 recording an implementation handoff.
 
-Plan decomposition allows at most 8 phases. Over-cap responses are validation
-failures and must be consolidated; phases are never silently truncated. This
-limit is independent of `--approved-followups`, whose issue mode still caps
-approved-review future follow-up issues separately. Decomposition also rejects
+Flat child topology allows 15 children by default; override it with
+`--flat-child-limit`. The count is shared by decomposition and split
+materialization, preflighted before a checkpoint or create, and never silently
+truncated. An over-limit result creates no children and returns a structured
+human decision to consolidate or use the hierarchical design tracked in #720.
+This limit is independent of `--approved-followups`, whose issue mode still
+caps approved-review future follow-up issues separately. Decomposition also rejects
 duplicate phase titles, invalid automation classes, unknown dependencies,
 self-dependencies, and forward dependencies; `depends_on` may reference only
 earlier phase titles. Parent decomposition metadata
@@ -888,8 +889,9 @@ Execution model:
 
 ### Phased decomposition versus split materialization
 
-There are two separate child-issue creation paths, and combining them files
-duplicate children. Pick the one row that matches your situation:
+Decomposition modes and split materialization select one child-issue path.
+They share a parent-wide flat cap; decomposition modes reject the split flag
+before any write. Pick the row that matches your situation:
 
 | Situation | Correct mechanism |
 | --- | --- |
@@ -900,15 +902,10 @@ duplicate children. Pick the one row that matches your situation:
 | Discuss `split` consensus, or plan-only deferred work with no detailed phase decomposition | `--materialize-split-issues` |
 
 **Do not combine `--materialize-split-issues` with `--plan-execution-mode
-decompose-only` or `implement-by-phase`.** Those two modes already create one
-detailed child issue per phase. `--materialize-split-issues` is a second,
-independent child-issue creation path — the CLI does not suppress it in
-decompose modes, and it is not suppressed by them either, so combining the
-two yields two overlapping sets of children: shallow generic `[#<parent>
-stage] ...` placeholders from split materialization *and* detailed per-phase
-issues from decomposition, describing overlapping work. Nothing closes the
-duplicates automatically; someone has to notice and close them by hand. This
-is the exact failure mode this section exists to prevent.
+decompose-only` or `implement-by-phase`.** The CLI rejects the combination
+before a checkpoint or child create. `decompose-only` uses typed child stages
+directly when present and otherwise invokes one model decomposition; it never
+materializes a competing topology.
 
 What each mechanism produces and where the run stops:
 
@@ -918,25 +915,28 @@ What each mechanism produces and where the run stops:
   still filed even in `plan-only`, because that materialization step runs
   before the mode is dispatched — `plan-only` only skips decomposition and
   implementation, not split materialization.
-- **`decompose-only`**: validates the coder's structured phase decomposition
-  (max 8 phases; an over-cap response is a validation failure and must be
-  consolidated, never silently truncated), creates one child issue per phase,
-  posts the parent summary table, and stops. The summary table is not a
-  substitute for the child issues.
+- **`decompose-only`**: uses typed `child_stages` directly when present;
+  otherwise it validates one model decomposition. The complete topology is
+  checked against the shared default cap of 15 (override with
+  `--flat-child-limit`) before any checkpoint or child create. An over-limit
+  result creates nothing and returns a structured decision to consolidate or
+  use hierarchical decomposition tracked in #720. Typed stages remain the
+  parent-owned plan remainder and are represented in the parent summary.
 - **`implement-by-phase`**: creates every phase child issue, records a
   one-time `AGENT_PLAN_PHASE_IMPLEMENTATION` handoff, then implements only the
   first `agent-pr` phase and stops after that phase's PR review loop. If the
   first phase is `human-action` or `manual-close`, it stops after creating the
   child issues without implementing anything. Resume the remaining phases with
   `agent-loop issue <child>`, not by rerunning the parent.
-- **`--materialize-split-issues`**: files one linked child issue only for an
-  approved plan's explicit `child_stages` entries (or legacy discuss `split`
-  proposals). Use `external_dependencies` for existing `#N`, issue URL, or
+- **`--materialize-split-issues`**: files one linked child issue for discuss
+  `split` proposals or plan-only/one-shot deferred work. Use
+  `external_dependencies` for existing `#N`, issue URL, or
   `owner/repo#N` references; `deferred_work` and `plan_actions` are recorded
   only. Legacy `deferred_stages` are record-only and are never auto-filed.
-  idempotent (tracked by the parent's `AGENT_DISCUSS_SPLIT` marker), capped at
-  8 children per parent, and files nothing from free-form prose narrowing
-  alone — only from the two structured signals above.
+  idempotent (tracked by the parent's `AGENT_DISCUSS_SPLIT` marker), capped by
+  the same 15-child parent budget, and files nothing from free-form prose
+  narrowing alone — only from the two structured signals above. It never
+  truncates; over-limit materialization returns the same structured decision.
 
 Copyable commands, one per workflow, each stopping where noted:
 
@@ -1058,9 +1058,13 @@ Materialization is idempotent and crash-safe:
 - Proposals are deduplicated by a normalized-title key across the whole
   parent, not just within one run, so subject-hash drift between a discuss
   consensus and a later plan-first run never refiles the same stage twice.
-- Materialization is capped at 8 child issues per parent; over-cap stages are
-  skipped with a logged note rather than silently dropped or endlessly
-  retried.
+- Materialization uses the shared default cap of 15 child issues per parent;
+  every desired stage is counted before mutation, and an over-limit request is
+  returned without a checkpoint, issue, warning, or partial topology.
+- Exact child identities and decomposition checkpoints make reruns adopt open
+  or closed children after a create-before-summary failure. Weak cross-workflow
+  title matches are open-only and require an explicit parent link; authorship
+  alone never makes a protocol record canonical.
 - `--dry-run` previews `gh issue create`/`gh issue list --search` commands
   without writing any state.
 

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -126,15 +126,18 @@ has already been approved:
   raw payload in accepted PR metadata, and stops before handoff for null-PR or
   rejected-conflict terminal results. It keeps using the durable
   `AGENT_PLAN_ONE_SHOT_IMPL` marker and is unchanged by by-phase support.
-- `run-decompose` decomposes an approved plan into child phase issues with mode
+- `run-decompose` uses typed `child_stages` directly when present, otherwise
+  decomposes an approved plan into child phase issues with mode
   `decompose-only`.
 - `run-implement-by-phase` decomposes with mode `implement-by-phase`, then
   implements phase 1 only when that phase is `agent-pr`.
 
-Both helpers already create one detailed child issue per phase; do not also
-pass `--materialize-split-issues` for the same run. See [Phased decomposition
-versus split materialization](local_agent_loop.md#phased-decomposition-versus-split-materialization)
-for the decision rule and the duplicate-issue failure mode it prevents.
+Both helpers use the shared parent-wide flat child cap (default 15, configurable
+with `--flat-child-limit`), preflight every draft before mutation, and recover
+from checkpoints and exact child identities. Over-limit requests return exit 2
+with a structured consolidation-versus-hierarchy decision referencing #720.
+Do not pass `--materialize-split-issues` to these commands; their topology is
+selected once. See [Phased decomposition versus split materialization](local_agent_loop.md#phased-decomposition-versus-split-materialization).
 - `run-pr-fix` addresses a settled blocking PR review for an externally opened
   PR. The target PR must be `OPEN`; `--reviewers` must exactly match the reviewer
   set used by the prior `run-pr-round`; and `--workdir` must be a clean,

--- a/helpers/prompt_builders.py
+++ b/helpers/prompt_builders.py
@@ -16,7 +16,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.agents.base import AgentName
-from coding_review_agent_loop.config import AgentLoopConfig
+from coding_review_agent_loop.config import AgentLoopConfig, DEFAULT_FLAT_CHILD_LIMIT
 from coding_review_agent_loop.github import IssueContext, IssueComment
 from coding_review_agent_loop.memory import AgentMemoryContext
 from coding_review_agent_loop.prompts import (
@@ -49,6 +49,7 @@ def make_minimal_config(
     agent_memory: bool = False,
     agent_memory_dir: Path | None = None,
     refresh_agent_memory: bool = False,
+    flat_child_limit: int = DEFAULT_FLAT_CHILD_LIMIT,
 ) -> AgentLoopConfig:
     tmp_base = Path(tempfile.gettempdir()) / "coding-review-agent-loop"
     legacy = tmp_base / "skill-runner"
@@ -99,6 +100,7 @@ def make_minimal_config(
         refresh_test_profile=False,
         auto_agent_dirs=tuple(reviewer_names),
         approved_followups=approved_followups,
+        flat_child_limit=flat_child_limit,
     )
 
 

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -108,7 +108,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from coding_review_agent_loop.agents.base import AgentName, normalize_agent_name
 from coding_review_agent_loop.agents.registry import agent_display_name
-from coding_review_agent_loop.config import ensure_temp_checkout
+from coding_review_agent_loop.config import DEFAULT_FLAT_CHILD_LIMIT, ensure_temp_checkout
 from coding_review_agent_loop.errors import AgentLoopError, UnknownPriorItemDispositionError
 from coding_review_agent_loop.followups import (
     _approved_followup_from_unresolved_item,
@@ -3621,8 +3621,9 @@ def _issue_context_for_decompose_preview(repo: str, issue: int):
 
 
 def _decomposition_phase_json(index: int, phase, *, issue_url: str | None = None,
-                              issue_number: int | None = None) -> dict:
-    return {
+                              issue_number: int | None = None,
+                              origin: str | None = None) -> dict:
+    result = {
         "index": index,
         "title": phase.title,
         "phase_title": f"Phase {index}: {phase.title}",
@@ -3637,6 +3638,9 @@ def _decomposition_phase_json(index: int, phase, *, issue_url: str | None = None
         "issue_url": issue_url,
         "issue_number": issue_number,
     }
+    if origin is not None:
+        result["origin"] = origin
+    return result
 
 
 def _existing_decomposition_json(existing) -> list[dict]:
@@ -3661,6 +3665,7 @@ def _created_phase_issues_from_existing(existing):
             phase=RecordedPhase(title=title, automation=automation),
             issue_url=url,
             issue_number=number,
+            origin="adopted",
         )
         for (title, url, number), automation in zip(existing.children, existing.automation, strict=False)
     )
@@ -3684,12 +3689,16 @@ def _run_decomposition_for_skill(
 
     from coding_review_agent_loop.decomposition import (
         approved_plan_hash,
+        adapt_typed_child_stages,
         CreatedPhaseIssue,
         create_decomposition_child_issues,
         find_existing_decomposition,
+        find_existing_topology_checkpoint,
         parse_plan_decomposition,
         post_decomposition_parent_summary,
     )
+    from coding_review_agent_loop.child_topology import NeedsHumanDecision
+    from coding_review_agent_loop.protocol import validate_structured_plan_state
     from coding_review_agent_loop.github import get_issue_context
     from helpers.prompt_builders import (
         build_plan_decomposition_prompt_for_skill,
@@ -3699,6 +3708,7 @@ def _run_decomposition_for_skill(
     config = dataclasses.replace(
         make_minimal_config(repo, coder, (coder,), reviewer=coder, workdir=str(workdir)),  # type: ignore[arg-type]
         dry_run=dry_run,
+        flat_child_limit=getattr(args, "flat_child_limit", DEFAULT_FLAT_CHILD_LIMIT),
     )
     runner = Runner(dry_run=dry_run)
     plan_hash = approved_plan_hash(approved_plan)
@@ -3722,88 +3732,174 @@ def _run_decomposition_for_skill(
             "mode": mode,
             "dry_run": dry_run,
             "reused": True,
+            "state": "reused",
+            "topology_source": existing.topology_source,
             "phase_count": existing.phase_count,
             "phases": _existing_decomposition_json(existing),
+            "adopted_children": _existing_decomposition_json(existing),
+            "created_children": [],
         }
+        if existing.retained_parent_scope is not None:
+            result["retained_parent_scope"] = {
+                "plan_subject": existing.retained_parent_scope.plan_subject,
+                "plan_hash": existing.retained_parent_scope.plan_hash,
+                "excerpt": existing.retained_parent_scope.excerpt,
+            }
         print(
             f"hint: issue #{issue} already has a {mode} decomposition for this plan.",
             file=sys.stderr,
         )
         return result, created, issue_context, config, runner, plan_hash, approved_plan, str(workdir)
 
-    prompt_text = build_plan_decomposition_prompt_for_skill(
-        issue_context, approved_plan, repo=repo, coder=coder, workdir=str(workdir),  # type: ignore[arg-type]
+    topology_source = "model"
+    retained_parent_scope = None
+    checkpoint = find_existing_topology_checkpoint(
+        issue_context.comments,
+        parent_issue=issue,
+        plan_hash=plan_hash,
+        mode=mode,
     )
+    decomposition = None
+    if checkpoint is not None:
+        from coding_review_agent_loop.decomposition import PlanDecomposition
 
-    with tempfile.TemporaryDirectory() as tmpstr:
-        tmpdir = Path(tmpstr)
-        prompt_file = tmpdir / "decompose-prompt.md"
-        raw_output = tmpdir / "decompose-raw.md"
-        usage_file = tmpdir / "decompose-usage.json"
-        _write_text(prompt_file, prompt_text)
-
-        _run_helper(
-            "helpers.run_external",
-            "--agent", coder,
-            "--role", "coder",
-            "--prompt-file", str(prompt_file),
-            "--output", str(raw_output),
-            "--workdir", str(workdir),
-            "--repo", repo,
-            "--flow", "decompose",
-            "--usage-output", str(usage_file),
-            *_run_external_antigravity_args(args),
-            *(["--dry-run"] if dry_run else []),
-        )
-        coder_output = raw_output.read_text(encoding="utf-8")
-        coder_usage: dict | None = None
-        if usage_file.exists():
-            try:
-                coder_usage = json.loads(usage_file.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                coder_usage = None
-
+        decomposition = PlanDecomposition(phases=checkpoint.phases)
+        topology_source = checkpoint.topology_source
+        retained_parent_scope = checkpoint.retained_parent_scope
+    else:
         try:
-            decomposition = parse_plan_decomposition(coder_output)
-        except AgentLoopError as exc:
-            debug_dir = _REPAIR_BASE / f"{issue}-decompose-debug"
-            debug_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(raw_output, debug_dir / "raw.md")
-            shutil.copy2(prompt_file, debug_dir / "prompt.md")
-            print(f"skill_runner: decomposition response rejected: {exc}", file=sys.stderr)
-            print(
-                f"skill_runner: raw response saved to {debug_dir}/raw.md — fix the "
-                f"underlying issue and re-run run-decompose (non-retryable).",
-                file=sys.stderr,
+            parsed_plan = validate_structured_plan_state(approved_plan)
+        except AgentLoopError:
+            parsed_plan = None
+        typed_stages = (
+            parsed_plan.typed_stages.child_stages
+            if parsed_plan is not None and mode == "decompose-only"
+            else ()
+        )
+        if typed_stages:
+            decomposition, retained_parent_scope = adapt_typed_child_stages(
+                typed_stages,
+                approved_plan=approved_plan,
+                plan_subject=_plan_subject(approved_plan),
             )
-            sys.exit(1)
+            topology_source = "typed"
 
-        result_json: dict = {
-            "issue": issue,
-            "plan_hash": plan_hash,
-            "mode": mode,
-            "dry_run": dry_run,
-            "reused": False,
-        }
-        if dry_run:
-            result_json["would_post_parent_summary"] = True
-            created = tuple(
-                CreatedPhaseIssue(phase=phase, issue_url=None, issue_number=None)
-                for phase in decomposition.phases
+    if decomposition is None:
+        prompt_text = build_plan_decomposition_prompt_for_skill(
+            issue_context,
+            approved_plan,
+            repo=repo,
+            coder=coder,
+            workdir=str(workdir),  # type: ignore[arg-type]
+        )
+
+        with tempfile.TemporaryDirectory() as tmpstr:
+            tmpdir = Path(tmpstr)
+            prompt_file = tmpdir / "decompose-prompt.md"
+            raw_output = tmpdir / "decompose-raw.md"
+            usage_file = tmpdir / "decompose-usage.json"
+            _write_text(prompt_file, prompt_text)
+
+            _run_helper(
+                "helpers.run_external",
+                "--agent", coder,
+                "--role", "coder",
+                "--prompt-file", str(prompt_file),
+                "--output", str(raw_output),
+                "--workdir", str(workdir),
+                "--repo", repo,
+                "--flow", "decompose",
+                "--usage-output", str(usage_file),
+                *_run_external_antigravity_args(args),
+                *(["--dry-run"] if dry_run else []),
             )
-            result_json["phases"] = [
-                _decomposition_phase_json(index, item.phase)
-                for index, item in enumerate(created, start=1)
-            ]
-            print("[dry-run] would create child phase issues and post parent decomposition marker")
-        else:
-            created = create_decomposition_child_issues(
+            coder_output = raw_output.read_text(encoding="utf-8")
+            coder_usage: dict | None = None
+            if usage_file.exists():
+                try:
+                    coder_usage = json.loads(usage_file.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    coder_usage = None
+
+            try:
+                decomposition = parse_plan_decomposition(coder_output)
+            except AgentLoopError as exc:
+                debug_dir = _REPAIR_BASE / f"{issue}-decompose-debug"
+                debug_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(raw_output, debug_dir / "raw.md")
+                shutil.copy2(prompt_file, debug_dir / "prompt.md")
+                print(f"skill_runner: decomposition response rejected: {exc}", file=sys.stderr)
+                print(
+                    f"skill_runner: raw response saved to {debug_dir}/raw.md — fix the "
+                    f"underlying issue and re-run run-decompose (non-retryable).",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+    else:
+        coder_usage = None
+
+    result_json: dict = {
+        "issue": issue,
+        "plan_hash": plan_hash,
+        "mode": mode,
+        "dry_run": dry_run,
+        "reused": False,
+        "state": "planned",
+        "topology_source": topology_source,
+        "would_post_checkpoint": True,
+        "would_post_parent_summary": True,
+    }
+    if retained_parent_scope is not None:
+        result_json["retained_parent_scope"] = {
+            "plan_subject": retained_parent_scope.plan_subject,
+            "plan_hash": retained_parent_scope.plan_hash,
+            "excerpt": retained_parent_scope.excerpt,
+        }
+    try:
+        created = create_decomposition_child_issues(
+            runner,
+            config=config,
+            parent_issue=issue,
+            approved_plan=approved_plan,
+            decomposition=decomposition,
+            topology_source=topology_source,
+            issue_comments=issue_context.comments,
+            mode=mode,
+            retained_parent_scope=retained_parent_scope,
+        )
+    except TypeError as exc:
+        if "unexpected keyword argument" not in str(exc):
+            raise
+        created = create_decomposition_child_issues(
+            runner,
+            config=config,
+            parent_issue=issue,
+            approved_plan=approved_plan,
+            decomposition=decomposition,
+        )
+    if isinstance(created, NeedsHumanDecision):
+        result_json["state"] = "needs-human"
+        result_json["decision"] = created.as_dict()
+        result_json["adopted_children"] = []
+        result_json["created_children"] = []
+        result_json["phases"] = []
+        result_json["phase_count"] = 0
+        return result_json, (), issue_context, config, runner, plan_hash, approved_plan, str(workdir)
+    if not dry_run:
+        try:
+            post_decomposition_parent_summary(
                 runner,
                 config=config,
                 parent_issue=issue,
-                approved_plan=approved_plan,
-                decomposition=decomposition,
+                mode=mode,
+                plan_hash=plan_hash,
+                created=created,
+                topology_source=topology_source,
+                retained_parent_scope=retained_parent_scope,
             )
+        except TypeError as exc:
+            if "unexpected keyword argument" not in str(exc):
+                raise
             post_decomposition_parent_summary(
                 runner,
                 config=config,
@@ -3812,19 +3908,26 @@ def _run_decomposition_for_skill(
                 plan_hash=plan_hash,
                 created=created,
             )
-            result_json["phases"] = [
-                _decomposition_phase_json(
-                    index, created_issue.phase,
-                    issue_url=created_issue.issue_url,
-                    issue_number=created_issue.issue_number,
-                )
-                for index, created_issue in enumerate(created, start=1)
-            ]
-        result_json["phase_count"] = len(result_json["phases"])
-        usage = _aggregate_reviewer_usage([{"usage": coder_usage}] if coder_usage else [])
-        if usage is not None:
-            result_json["usage"] = usage
-        return result_json, created, issue_context, config, runner, plan_hash, approved_plan, str(workdir)
+    result_json["phases"] = [
+        _decomposition_phase_json(
+            index, created_issue.phase,
+            issue_url=None if dry_run else created_issue.issue_url,
+            issue_number=None if dry_run else created_issue.issue_number,
+            origin=created_issue.origin,
+        )
+        for index, created_issue in enumerate(created, start=1)
+    ]
+    result_json["adopted_children"] = [
+        phase for phase in result_json["phases"] if phase.get("origin") == "adopted"
+    ]
+    result_json["created_children"] = [
+        phase for phase in result_json["phases"] if phase.get("origin") == "created"
+    ]
+    result_json["phase_count"] = len(result_json["phases"])
+    usage = _aggregate_reviewer_usage([{"usage": coder_usage}] if coder_usage else [])
+    if usage is not None:
+        result_json["usage"] = usage
+    return result_json, created, issue_context, config, runner, plan_hash, approved_plan, str(workdir)
 
 
 def cmd_run_decompose(args: argparse.Namespace) -> None:
@@ -3838,6 +3941,8 @@ def cmd_run_decompose(args: argparse.Namespace) -> None:
         mode="decompose-only",
     )
     print(json.dumps(result_json, indent=2))
+    if result_json.get("state") == "needs-human":
+        sys.exit(2)
 
 
 # ---------------------------------------------------------------------------
@@ -3883,6 +3988,10 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
         approved_plan=approved_plan,
     )
 
+    if decomposition_result.get("state") == "needs-human":
+        print(json.dumps(decomposition_result, indent=2))
+        sys.exit(2)
+
     if not created:
         raise AgentLoopError("Plan decomposition produced no phases.")
 
@@ -3892,7 +4001,11 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
         "plan_hash": plan_hash,
         "mode": mode,
         "dry_run": dry_run,
+        "state": "ready",
+        "topology_source": decomposition_result.get("topology_source", "model"),
         "decomposition_reused": bool(decomposition_result.get("reused")),
+        "adopted_children": decomposition_result.get("adopted_children", []),
+        "created_children": decomposition_result.get("created_children", []),
         "phase": _decomposition_phase_json(
             1,
             first_phase.phase,
@@ -3900,6 +4013,8 @@ def cmd_run_implement_by_phase(args: argparse.Namespace) -> None:
             issue_number=first_phase.issue_number,
         ),
     }
+    if "retained_parent_scope" in decomposition_result:
+        result_json["retained_parent_scope"] = decomposition_result["retained_parent_scope"]
 
     if first_phase.phase.automation != "agent-pr":
         result_json.update({
@@ -4245,6 +4360,10 @@ def main() -> None:
     p_impl_phase.add_argument("--workdir-gemini", default=None)
     p_impl_phase.add_argument("--workdir-antigravity", default=None)
     p_impl_phase.add_argument("--dry-run", action="store_true")
+    p_impl_phase.add_argument(
+        "--flat-child-limit", type=int, default=DEFAULT_FLAT_CHILD_LIMIT,
+        help=f"Maximum flat child issues for the parent (default: {DEFAULT_FLAT_CHILD_LIMIT}).",
+    )
     _add_antigravity_options(p_impl_phase)
 
     # run-decompose
@@ -4266,6 +4385,10 @@ def main() -> None:
     p_decompose.add_argument("--workdir-gemini", default=None)
     p_decompose.add_argument("--workdir-antigravity", default=None)
     p_decompose.add_argument("--dry-run", action="store_true")
+    p_decompose.add_argument(
+        "--flat-child-limit", type=int, default=DEFAULT_FLAT_CHILD_LIMIT,
+        help=f"Maximum flat child issues for the parent (default: {DEFAULT_FLAT_CHILD_LIMIT}).",
+    )
     _add_antigravity_options(p_decompose)
 
     # run-task-round

--- a/helpers/skill_runner.py
+++ b/helpers/skill_runner.py
@@ -3855,59 +3855,38 @@ def _run_decomposition_for_skill(
             "plan_hash": retained_parent_scope.plan_hash,
             "excerpt": retained_parent_scope.excerpt,
         }
-    try:
-        created = create_decomposition_child_issues(
-            runner,
-            config=config,
-            parent_issue=issue,
-            approved_plan=approved_plan,
-            decomposition=decomposition,
-            topology_source=topology_source,
-            issue_comments=issue_context.comments,
-            mode=mode,
-            retained_parent_scope=retained_parent_scope,
-        )
-    except TypeError as exc:
-        if "unexpected keyword argument" not in str(exc):
-            raise
-        created = create_decomposition_child_issues(
-            runner,
-            config=config,
-            parent_issue=issue,
-            approved_plan=approved_plan,
-            decomposition=decomposition,
-        )
+    created = create_decomposition_child_issues(
+        runner,
+        config=config,
+        parent_issue=issue,
+        approved_plan=approved_plan,
+        decomposition=decomposition,
+        topology_source=topology_source,
+        issue_comments=issue_context.comments,
+        mode=mode,
+        retained_parent_scope=retained_parent_scope,
+    )
     if isinstance(created, NeedsHumanDecision):
         result_json["state"] = "needs-human"
         result_json["decision"] = created.as_dict()
+        result_json["would_post_checkpoint"] = False
+        result_json["would_post_parent_summary"] = False
         result_json["adopted_children"] = []
         result_json["created_children"] = []
         result_json["phases"] = []
         result_json["phase_count"] = 0
         return result_json, (), issue_context, config, runner, plan_hash, approved_plan, str(workdir)
     if not dry_run:
-        try:
-            post_decomposition_parent_summary(
-                runner,
-                config=config,
-                parent_issue=issue,
-                mode=mode,
-                plan_hash=plan_hash,
-                created=created,
-                topology_source=topology_source,
-                retained_parent_scope=retained_parent_scope,
-            )
-        except TypeError as exc:
-            if "unexpected keyword argument" not in str(exc):
-                raise
-            post_decomposition_parent_summary(
-                runner,
-                config=config,
-                parent_issue=issue,
-                mode=mode,
-                plan_hash=plan_hash,
-                created=created,
-            )
+        post_decomposition_parent_summary(
+            runner,
+            config=config,
+            parent_issue=issue,
+            mode=mode,
+            plan_hash=plan_hash,
+            created=created,
+            topology_source=topology_source,
+            retained_parent_scope=retained_parent_scope,
+        )
     result_json["phases"] = [
         _decomposition_phase_json(
             index, created_issue.phase,

--- a/src/coding_review_agent_loop/child_topology.py
+++ b/src/coding_review_agent_loop/child_topology.py
@@ -62,6 +62,11 @@ class ChildTopologyPreflight:
     missing_count: int
 
 
+def parent_child_search_query(parent_issue: int) -> str:
+    """Find both flat-child title conventions in one recovery query."""
+    return f'"(from #{parent_issue})" in:title OR "[#{parent_issue} stage]" in:title'
+
+
 def preflight_flat_child_count(
     *,
     parent_issue: int,
@@ -97,7 +102,3 @@ def preflight_flat_child_count(
             configured_limit=configured_limit,
         )
     return result
-
-
-def is_needs_human(value: object) -> bool:
-    return isinstance(value, NeedsHumanDecision)

--- a/src/coding_review_agent_loop/child_topology.py
+++ b/src/coding_review_agent_loop/child_topology.py
@@ -1,0 +1,103 @@
+"""Shared planning and preflight primitives for flat child topologies.
+
+The decomposition and split workflows have different payload formats, but
+they share one important invariant: a parent may own only one bounded flat
+set of children.  This module deliberately contains no GitHub mutation code;
+callers can use the result to render and validate every draft before posting a
+checkpoint or creating an issue.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class NeedsHumanDecision:
+    """A deterministic, side-effect-free over-limit outcome."""
+
+    parent_issue: int
+    source: str
+    requested_desired_count: int
+    recognized_existing_count: int
+    projected_total: int
+    configured_limit: int
+    guidance: str = (
+        "Consolidate the flat stages or use the hierarchical decomposition design "
+        "tracked in #720."
+    )
+
+    @property
+    def state(self) -> str:
+        return "needs-human"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "state": self.state,
+            "parent": self.parent_issue,
+            "source": self.source,
+            "requested_desired_count": self.requested_desired_count,
+            "recognized_existing_count": self.recognized_existing_count,
+            "projected_total": self.projected_total,
+            "configured_limit": self.configured_limit,
+            "guidance": self.guidance,
+        }
+
+    def __str__(self) -> str:
+        return (
+            f"Flat child topology for issue #{self.parent_issue} needs human decision: "
+            f"{self.projected_total} projected children exceeds the configured limit "
+            f"of {self.configured_limit}. {self.guidance}"
+        )
+
+
+@dataclass(frozen=True)
+class ChildTopologyPreflight:
+    """The count and identity portion of a topology preflight."""
+
+    desired_count: int
+    recognized_existing_count: int
+    projected_total: int
+    missing_count: int
+
+
+def preflight_flat_child_count(
+    *,
+    parent_issue: int,
+    source: str,
+    desired_keys: Iterable[str],
+    recognized_keys: Iterable[str],
+    configured_limit: int,
+) -> ChildTopologyPreflight | NeedsHumanDecision:
+    """Validate the complete desired topology before any mutation.
+
+    Keys are normalized by callers, but de-duplicating here makes this helper
+    safe for both typed and model-generated topology adapters.  Existing
+    recognized children count once, while a desired child already present in
+    that set does not consume another slot.
+    """
+
+    desired = set(desired_keys)
+    recognized = set(recognized_keys)
+    projected = len(recognized | desired)
+    result = ChildTopologyPreflight(
+        desired_count=len(desired),
+        recognized_existing_count=len(recognized),
+        projected_total=projected,
+        missing_count=len(desired - recognized),
+    )
+    if projected > configured_limit:
+        return NeedsHumanDecision(
+            parent_issue=parent_issue,
+            source=source,
+            requested_desired_count=len(desired),
+            recognized_existing_count=len(recognized),
+            projected_total=projected,
+            configured_limit=configured_limit,
+        )
+    return result
+
+
+def is_needs_human(value: object) -> bool:
+    return isinstance(value, NeedsHumanDecision)

--- a/src/coding_review_agent_loop/child_topology.py
+++ b/src/coding_review_agent_loop/child_topology.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
+from .github import FoundIssue
+
 
 @dataclass(frozen=True)
 class NeedsHumanDecision:
@@ -62,9 +64,42 @@ class ChildTopologyPreflight:
     missing_count: int
 
 
-def parent_child_search_query(parent_issue: int) -> str:
-    """Find both flat-child title conventions in one recovery query."""
-    return f'"(from #{parent_issue})" in:title OR "[#{parent_issue} stage]" in:title'
+def parent_child_search_queries(parent_issue: int) -> tuple[str, str]:
+    """Return the supported flat-child title searches separately.
+
+    GitHub issue search does not implement the boolean ``OR`` operator used by
+    code search. Keeping these as separate queries avoids silently missing one
+    of the two historical child-title conventions during recovery.
+    """
+    return (
+        f'"(from #{parent_issue})" in:title',
+        f'"[#{parent_issue} stage]" in:title',
+    )
+
+
+def merge_found_issues(result_sets: Iterable[Iterable[FoundIssue]]) -> tuple[FoundIssue, ...]:
+    """Merge parent-child search results, de-duplicating by issue number."""
+    merged: dict[int, FoundIssue] = {}
+    without_number: list[FoundIssue] = []
+    for results in result_sets:
+        for found in results:
+            if found.number is None:
+                if found not in without_number:
+                    without_number.append(found)
+                continue
+            previous = merged.get(found.number)
+            if previous is None:
+                merged[found.number] = found
+                continue
+            # A repeated result can differ in completeness between queries;
+            # preserve whichever non-empty representation is available.
+            merged[found.number] = FoundIssue(
+                number=found.number,
+                title=previous.title or found.title,
+                body=previous.body or found.body,
+                url=previous.url or found.url,
+            )
+    return tuple(merged.values()) + tuple(without_number)
 
 
 def preflight_flat_child_count(

--- a/src/coding_review_agent_loop/cli.py
+++ b/src/coding_review_agent_loop/cli.py
@@ -17,6 +17,7 @@ from .config import (
     DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT_SECONDS,
     DEFAULT_MAX_ROUNDS,
     DEFAULT_REPAIR_MODELS,
+    DEFAULT_FLAT_CHILD_LIMIT,
     DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES,
     AgentLoopConfig,
     config_from_args,
@@ -143,6 +144,16 @@ def build_parser() -> argparse.ArgumentParser:
             type=int,
             default=DEFAULT_MAX_ROUNDS,
             help=f"Maximum review/revision rounds (default: {DEFAULT_MAX_ROUNDS}).",
+        )
+        subparser.add_argument(
+            "--flat-child-limit",
+            type=int,
+            default=DEFAULT_FLAT_CHILD_LIMIT,
+            metavar="COUNT",
+            help=(
+                "Maximum flat child issues owned by one parent across decomposition "
+                f"and split materialization (default: {DEFAULT_FLAT_CHILD_LIMIT})."
+            ),
         )
         subparser.add_argument("--auto-merge", action="store_true")
         subparser.add_argument(
@@ -951,6 +962,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 raise AgentLoopError(
                     "--implement-after-approval is only compatible with "
                     "--plan-execution-mode implement-one-shot."
+                )
+            if (
+                plan_execution_mode in {"decompose-only", "implement-by-phase"}
+                and getattr(args, "materialize_split_issues", False)
+            ):
+                raise AgentLoopError(
+                    "--materialize-split-issues cannot be combined with "
+                    "--plan-execution-mode decompose-only or implement-by-phase; "
+                    "those modes select one child topology source."
                 )
             config = AgentLoopConfig(
                 **{

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -51,6 +51,10 @@ DEFAULT_MAX_ROUNDS = 10
 # complex reviews and causes it to exit with "timeout waiting for response".
 DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT_SECONDS = 10 * 60
 DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3.5 Flash (Medium)",)
+# One parent-wide flat topology budget shared by decomposition and split
+# materialization.  Keeping this policy in config prevents each workflow from
+# obtaining a second allowance of children.
+DEFAULT_FLAT_CHILD_LIMIT: int = 15
 
 # Discuss-mode research policy values (#477). The CLI flag choices, the config
 # validation, and the prompt builders all derive from this set.
@@ -152,6 +156,9 @@ class AgentLoopConfig:
     # existing runs keep today's behavior; the orchestrator always warns when
     # split follow-ups would otherwise remain unfiled.
     materialize_split_issues: bool = False
+    # Maximum number of flat child issues owned by one parent.  This is shared
+    # by typed stages, model decomposition, and discuss split proposals.
+    flat_child_limit: int = DEFAULT_FLAT_CHILD_LIMIT
     # Explicit selected-stage resolution for `issue --plan-execution-mode
     # implement-one-shot` when a parent's split proposals were already fully
     # materialized into child issues (#476). None means resolve by unique
@@ -293,6 +300,8 @@ class AgentLoopConfig:
             raise AgentLoopError("--discuss-debater-timeout must be greater than zero seconds.")
         if self.salvage_comment_patch_max_bytes <= 0:
             raise AgentLoopError("--salvage-comment-patch-max-bytes must be greater than zero.")
+        if self.flat_child_limit <= 0:
+            raise AgentLoopError("--flat-child-limit must be greater than zero.")
         normalized_expected = normalize_issue_ids(
             self.expected_closing_issue_ids,
             field_name="expected_closing_issue_ids",
@@ -1071,6 +1080,7 @@ def config_from_args(
         discuss_debater_timeout=getattr(args, "discuss_debater_timeout", None),
         discuss_on_debater_failure=getattr(args, "discuss_on_debater_failure", "fail") or "fail",
         materialize_split_issues=getattr(args, "materialize_split_issues", False),
+        flat_child_limit=getattr(args, "flat_child_limit", DEFAULT_FLAT_CHILD_LIMIT),
         split_stage=getattr(args, "split_stage", None),
         salvage_comments=getattr(args, "salvage_comments", True),
         salvage_comment_patch_max_bytes=getattr(args, "salvage_comment_patch_max_bytes", 20000),

--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -10,12 +10,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .config import AgentLoopConfig
+from .child_topology import NeedsHumanDecision, preflight_flat_child_count
 from .errors import AgentLoopError
-from .github import create_issue, post_issue_comment
+from .github import FoundIssue, create_issue, post_issue_comment, search_issues
 from .runner import Runner
-from .protocol_markers import TrustedBody
+from .protocol_markers import TrustedBody, sanitize_historical_text
 
-MAX_DECOMPOSITION_PHASES = 8
 AUTOMATION_CLASSES = {"agent-pr", "human-action", "manual-close"}
 DECOMPOSITION_MARKER_RE = re.compile(
     r"<!--\s*AGENT_PLAN_DECOMPOSITION:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
@@ -23,6 +23,18 @@ DECOMPOSITION_MARKER_RE = re.compile(
 )
 PHASE_IMPLEMENTATION_MARKER_RE = re.compile(
     r"<!--\s*AGENT_PLAN_PHASE_IMPLEMENTATION:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+TOPOLOGY_CHECKPOINT_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_TOPOLOGY_CHECKPOINT:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+PHASE_IDENTITY_MARKER_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_PHASE_IDENTITY:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+    re.I,
+)
+LEGACY_SPLIT_IDENTITY_RE = re.compile(
+    r"<!--\s*AGENT_SPLIT_CHILD:\s*parent=(?P<parent>\d+)\s+key=(?P<key>[0-9a-f]{64})\s*-->",
     re.I,
 )
 ONE_SHOT_IMPL_HANDOFF_MARKER_RE = re.compile(
@@ -63,6 +75,14 @@ class CreatedPhaseIssue:
     phase: PlanPhase | RecordedPhase
     issue_url: str | None
     issue_number: int | None
+    origin: str = "created"
+
+
+@dataclass(frozen=True)
+class RetainedParentScope:
+    plan_subject: str
+    plan_hash: str
+    excerpt: str
 
 
 @dataclass(frozen=True)
@@ -74,6 +94,18 @@ class DecompositionMetadata:
     phase_titles: tuple[str, ...]
     automation: tuple[str, ...]
     children: tuple[tuple[str, str | None, int | None], ...]
+    topology_source: str = "model"
+    retained_parent_scope: RetainedParentScope | None = None
+
+
+@dataclass(frozen=True)
+class TopologyCheckpoint:
+    parent_issue: int
+    plan_hash: str
+    mode: str
+    topology_source: str
+    phases: tuple[PlanPhase, ...]
+    retained_parent_scope: RetainedParentScope | None = None
 
 
 @dataclass(frozen=True)
@@ -134,12 +166,6 @@ def parse_plan_decomposition(text: str) -> PlanDecomposition:
     phases_payload = payload.get("phases")
     if not isinstance(phases_payload, list) or not phases_payload:
         raise AgentLoopError("Invalid plan decomposition: `phases` must be a non-empty list.")
-    if len(phases_payload) > MAX_DECOMPOSITION_PHASES:
-        raise AgentLoopError(
-            f"Invalid plan decomposition: {len(phases_payload)} phases exceeds "
-            f"MAX_DECOMPOSITION_PHASES={MAX_DECOMPOSITION_PHASES}; consolidate phases."
-        )
-
     title_keys = [
         " ".join(phase_payload["title"].lower().split())
         for phase_payload in phases_payload
@@ -217,22 +243,244 @@ def _phase_issue_title(parent_issue: int, index: int, phase: PlanPhase) -> str:
     return f"{prefix}Phase {index}: {phase.title} (from #{parent_issue})"[:120]
 
 
-def _dependency_lines(phase: PlanPhase, created: Sequence[CreatedPhaseIssue]) -> list[str]:
+def _phase_payload(phase: PlanPhase) -> dict[str, object]:
+    return {
+        "title": phase.title,
+        "scope": phase.scope,
+        "non_goals": phase.non_goals,
+        "dependency_notes": phase.dependency_notes,
+        "rollout_risk": phase.rollout_risk,
+        "validation": phase.validation,
+        "parent_context": phase.parent_context,
+        "automation": phase.automation,
+        "depends_on": list(phase.depends_on),
+    }
+
+
+def phase_identity(
+    *,
+    parent_issue: int,
+    plan_hash: str,
+    topology_source: str,
+    phase_index: int,
+    phase: PlanPhase,
+) -> str:
+    """Return a stable identity independent of the display title truncation."""
+    material = {
+        "parent_issue": parent_issue,
+        "plan_hash": plan_hash,
+        "source": topology_source,
+        "stage_id": phase_index,
+        "phase": _phase_payload(phase),
+    }
+    encoded = json.dumps(material, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _phase_identity_marker(identity: str, *, parent_issue: int, plan_hash: str, source: str, index: int) -> str:
+    return f"<!-- AGENT_PLAN_PHASE_IDENTITY: {_encode_json_payload({'identity': identity, 'parent_issue': parent_issue, 'plan_hash': plan_hash, 'source': source, 'stage_id': index})} -->"
+
+
+def adapt_typed_child_stages(
+    stages: Sequence[object],
+    *,
+    approved_plan: str,
+    plan_subject: str,
+) -> tuple[PlanDecomposition, RetainedParentScope]:
+    """Adapt the two-field typed remainder into the decomposition contract."""
+    excerpt = sanitize_historical_text(approved_plan.strip())
+    retained = RetainedParentScope(
+        plan_subject=sanitize_historical_text(plan_subject),
+        plan_hash=approved_plan_hash(approved_plan),
+        excerpt=excerpt,
+    )
+    phases = tuple(
+        PlanPhase(
+            title=str(stage.title),
+            scope=str(stage.summary),
+            non_goals=(
+                "No stage-specific non-goals were declared; refer to the neutralized "
+                "parent constraints above."
+            ),
+            dependency_notes=(
+                "No stage-specific dependency notes were declared; this typed stage "
+                "has no explicit inter-stage dependency."
+            ),
+            rollout_risk=(
+                "No stage-specific rollout risk was declared; follow the neutralized "
+                "parent constraints above."
+            ),
+            validation=(
+                "No stage-specific validation state was declared; follow the parent "
+                "plan's validation requirements."
+            ),
+            parent_context=excerpt,
+            automation="agent-pr",
+            depends_on=(),
+        )
+        for stage in stages
+    )
+    return PlanDecomposition(phases=phases), retained
+
+
+def _checkpoint_payload(checkpoint: TopologyCheckpoint) -> dict[str, object]:
+    return {
+        "parent_issue": checkpoint.parent_issue,
+        "plan_hash": checkpoint.plan_hash,
+        "mode": checkpoint.mode,
+        "topology_source": checkpoint.topology_source,
+        "phases": [_phase_payload(phase) for phase in checkpoint.phases],
+        "retained_parent_scope": (
+            {
+                "plan_subject": checkpoint.retained_parent_scope.plan_subject,
+                "plan_hash": checkpoint.retained_parent_scope.plan_hash,
+                "excerpt": checkpoint.retained_parent_scope.excerpt,
+            }
+            if checkpoint.retained_parent_scope is not None
+            else None
+        ),
+    }
+
+
+def _phase_from_payload(payload: object) -> PlanPhase:
+    if not isinstance(payload, dict):
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
+    depends = payload.get("depends_on", [])
+    if not isinstance(depends, list):
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
+    values = {}
+    for key in ("title", "scope", "non_goals", "dependency_notes", "rollout_risk", "validation", "parent_context", "automation"):
+        value = payload.get(key)
+        if not isinstance(value, str):
+            raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
+        values[key] = value
+    return PlanPhase(**values, depends_on=tuple(str(item) for item in depends))
+
+
+def _decode_checkpoint(encoded: str) -> TopologyCheckpoint:
+    payload = _decode_json_payload(encoded, marker_name="AGENT_PLAN_TOPOLOGY_CHECKPOINT")
+    phases_payload = payload.get("phases")
+    if not isinstance(phases_payload, list) or not phases_payload:
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
+    retained_payload = payload.get("retained_parent_scope")
+    retained = None
+    if retained_payload is not None:
+        if not isinstance(retained_payload, dict):
+            raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
+        retained = RetainedParentScope(
+            plan_subject=str(retained_payload.get("plan_subject") or ""),
+            plan_hash=str(retained_payload.get("plan_hash") or ""),
+            excerpt=str(retained_payload.get("excerpt") or ""),
+        )
+    try:
+        return TopologyCheckpoint(
+            parent_issue=int(payload["parent_issue"]),
+            plan_hash=str(payload["plan_hash"]),
+            mode=str(payload["mode"]),
+            topology_source=str(payload["topology_source"]),
+            phases=tuple(_phase_from_payload(item) for item in phases_payload),
+            retained_parent_scope=retained,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.") from exc
+
+
+def find_existing_topology_checkpoint(
+    comments: Sequence[object], *, parent_issue: int, plan_hash: str, mode: str
+) -> TopologyCheckpoint | None:
+    found: TopologyCheckpoint | None = None
+    for comment in comments:
+        body = getattr(comment, "body", None)
+        if not isinstance(body, str):
+            continue
+        for match in TOPOLOGY_CHECKPOINT_MARKER_RE.finditer(body):
+            checkpoint = _decode_checkpoint(match.group("payload"))
+            if (
+                checkpoint.parent_issue == parent_issue
+                and checkpoint.plan_hash == plan_hash
+                and checkpoint.mode == mode
+            ):
+                found = checkpoint
+    return found
+
+
+def format_topology_checkpoint(checkpoint: TopologyCheckpoint) -> str:
+    return "\n".join(
+        [
+            f"Topology checkpoint recorded for issue #{checkpoint.parent_issue}.",
+            "",
+            f"Source: {checkpoint.topology_source}",
+            f"Mode: {checkpoint.mode}",
+            f"Stages: {len(checkpoint.phases)}",
+            "",
+            f"<!-- AGENT_PLAN_TOPOLOGY_CHECKPOINT: {_encode_json_payload(_checkpoint_payload(checkpoint))} -->",
+            "-- coding-review-agent-loop",
+        ]
+    )
+
+
+def post_topology_checkpoint(
+    runner: Runner,
+    *,
+    config: AgentLoopConfig,
+    checkpoint: TopologyCheckpoint,
+) -> None:
+    post_issue_comment(
+        runner,
+        config=config,
+        issue_number=checkpoint.parent_issue,
+        body=TrustedBody.canonical(
+            format_topology_checkpoint(checkpoint),
+            expected_tokens=("AGENT_PLAN_TOPOLOGY_CHECKPOINT",),
+        ),
+    )
+
+
+def _dependency_lines(
+    phase: PlanPhase,
+    created: Sequence[CreatedPhaseIssue],
+    *,
+    placeholders: bool = False,
+) -> list[str]:
     if not phase.depends_on:
         return ["- None."]
-    by_title = {item.phase.title: item for item in created}
+    by_title = {
+        " ".join(item.phase.title.lower().split()): item
+        for item in created
+    }
     lines: list[str] = []
     for dependency in phase.depends_on:
-        created_issue = by_title.get(dependency)
+        created_issue = by_title.get(" ".join(dependency.lower().split()))
         if created_issue and created_issue.issue_number is not None:
             lines.append(f"- depends on #{created_issue.issue_number}: {dependency}")
         elif created_issue and created_issue.issue_url:
             lines.append(f"- depends on {created_issue.issue_url}: {dependency}")
         elif created_issue:
-            lines.append(f"- depends on previously created phase with unavailable issue URL: {dependency}")
+            if placeholders:
+                lines.append(f"- depends on __ORCHESTRATOR_ISSUE_NUMBER__: {dependency}")
+            else:
+                lines.append(f"- depends on previously created phase with unavailable issue URL: {dependency}")
         else:
             lines.append(f"- depends on prior phase: {dependency}")
     return lines
+
+
+def _unresolved_dependencies(
+    phase: PlanPhase,
+    created: Sequence[CreatedPhaseIssue],
+) -> tuple[str, ...]:
+    by_title = {
+        " ".join(item.phase.title.lower().split()): item
+        for item in created
+    }
+    return tuple(
+        dependency
+        for dependency in phase.depends_on
+        if (
+            (item := by_title.get(" ".join(dependency.lower().split()))) is None
+            or (item.issue_number is None and not item.issue_url)
+        )
+    )
 
 
 def format_phase_issue_body(
@@ -242,6 +490,11 @@ def format_phase_issue_body(
     approved_plan: str,
     phase: PlanPhase,
     created_so_far: Sequence[CreatedPhaseIssue],
+    phase_identity_value: str | None = None,
+    dependency_placeholders: bool = False,
+    topology_source: str = "model",
+    phase_index: int = 0,
+    phase_plan_hash: str | None = None,
 ) -> str:
     parent_url = f"https://github.com/{repo}/issues/{parent_issue}"
     if phase.automation == "agent-pr":
@@ -259,12 +512,12 @@ def format_phase_issue_body(
             "This phase is a manual closure/checkpoint. A human should add the required remark/update and "
             "close this issue when the checkpoint is satisfied."
         )
-    return "\n".join(
+    body = "\n".join(
         [
             f"Child phase issue for parent #{parent_issue}: {parent_url}",
             "",
             "## Approved parent-plan excerpt for this phase",
-            phase.parent_context,
+            sanitize_historical_text(phase.parent_context),
             "",
             "## Scope",
             phase.scope,
@@ -273,13 +526,13 @@ def format_phase_issue_body(
             phase.non_goals,
             "",
             "## Constraints and invariants from the parent plan",
-            approved_plan.strip(),
+            sanitize_historical_text(approved_plan.strip()),
             "",
             "## Dependency notes",
             phase.dependency_notes,
             "",
             "## Dependency links",
-            *_dependency_lines(phase, created_so_far),
+            *_dependency_lines(phase, created_so_far, placeholders=dependency_placeholders),
             "",
             "## Rollout risk",
             phase.rollout_risk,
@@ -294,6 +547,15 @@ def format_phase_issue_body(
             execution,
         ]
     )
+    if phase_identity_value is not None:
+        body += "\n\n" + _phase_identity_marker(
+            phase_identity_value,
+            parent_issue=parent_issue,
+            plan_hash=phase_plan_hash or approved_plan_hash(approved_plan),
+            source=topology_source,
+            index=phase_index,
+        )
+    return body
 
 
 def create_decomposition_child_issues(
@@ -303,19 +565,193 @@ def create_decomposition_child_issues(
     parent_issue: int,
     approved_plan: str,
     decomposition: PlanDecomposition,
-) -> tuple[CreatedPhaseIssue, ...]:
+    topology_source: str = "model",
+    issue_comments: Sequence[object] = (),
+    mode: str = "decompose-only",
+    retained_parent_scope: RetainedParentScope | None = None,
+) -> tuple[CreatedPhaseIssue, ...] | NeedsHumanDecision:
+    """Preflight, recover, and create one immutable decomposition topology."""
+    plan_hash = approved_plan_hash(approved_plan)
+    phases = tuple(decomposition.phases)
+    if not phases:
+        raise AgentLoopError("Plan decomposition produced no phases.")
+
+    # Search is read-only and intentionally includes every issue state.  It
+    # closes the create-before-summary crash window without trusting authorship.
+    found = search_issues(
+        runner,
+        config=config,
+        search=f'"(from #{parent_issue})" in:title',
+        state="all",
+    )
+    expected_ids = {
+        index: phase_identity(
+            parent_issue=parent_issue,
+            plan_hash=plan_hash,
+            topology_source=topology_source,
+            phase_index=index,
+            phase=phase,
+        )
+        for index, phase in enumerate(phases, start=1)
+    }
+    exact: dict[str, FoundIssue] = {}
+    recognized: set[str] = set()
+    for candidate in found:
+        marker = PHASE_IDENTITY_MARKER_RE.search(candidate.body or "")
+        candidate_identity: str | None = None
+        candidate_parent: int | None = None
+        candidate_plan_hash: str | None = None
+        candidate_source: str | None = None
+        candidate_stage_id: int | None = None
+        if marker:
+            payload = _decode_json_payload(marker.group("payload"), marker_name="AGENT_PLAN_PHASE_IDENTITY")
+            if isinstance(payload.get("identity"), str):
+                candidate_identity = payload["identity"]
+            if isinstance(payload.get("parent_issue"), int) and not isinstance(payload.get("parent_issue"), bool):
+                candidate_parent = payload["parent_issue"]
+            if isinstance(payload.get("plan_hash"), str):
+                candidate_plan_hash = payload["plan_hash"]
+            if isinstance(payload.get("source"), str):
+                candidate_source = payload["source"]
+            if isinstance(payload.get("stage_id"), int) and not isinstance(payload.get("stage_id"), bool):
+                candidate_stage_id = payload["stage_id"]
+        if candidate_identity is not None and candidate_parent == parent_issue:
+            recognized.add(candidate_identity)
+            for index, expected in expected_ids.items():
+                if candidate_identity == expected:
+                    if (
+                        candidate_plan_hash != plan_hash
+                        or candidate_source != topology_source
+                        or candidate_stage_id != index
+                    ):
+                        raise AgentLoopError(
+                            f"Invalid decomposition recovery identity metadata for phase {index}."
+                        )
+                    if expected in exact:
+                        raise AgentLoopError(
+                            f"Ambiguous decomposition recovery: multiple child issues carry identity {expected}."
+                        )
+                    exact[expected] = candidate
+        else:
+            legacy = LEGACY_SPLIT_IDENTITY_RE.search(candidate.body or "")
+            if legacy and int(legacy.group("parent")) == parent_issue:
+                recognized.add("legacy:" + legacy.group("key").lower())
+            elif candidate.body and f"#{parent_issue}" in candidate.body and candidate.title:
+                # Count a parent-linked canonical child from another workflow
+                # toward the parent budget, without adopting it as a desired
+                # decomposition phase.
+                recognized.add("linked:" + " ".join(candidate.title.casefold().split()))
+        if not candidate.body and candidate.title:
+            # Some GitHub search responses omit bodies.  The generated parent
+            # prefixed title is a canonical recovery key in that narrow case.
+            for index, phase in enumerate(phases, start=1):
+                if candidate.title == _phase_issue_title(parent_issue, index, phase):
+                    identity = expected_ids[index]
+                    if identity in exact:
+                        raise AgentLoopError(
+                            f"Ambiguous decomposition recovery: multiple title matches for phase {index}."
+                        )
+                    exact[identity] = candidate
+                    recognized.add(identity)
+
+    count = preflight_flat_child_count(
+        parent_issue=parent_issue,
+        source=topology_source,
+        desired_keys=expected_ids.values(),
+        recognized_keys=recognized,
+        configured_limit=config.flat_child_limit,
+    )
+    if isinstance(count, NeedsHumanDecision):
+        return count
+
+    # Validate every title and body before any checkpoint or create.  Dependency
+    # slots are orchestrator-owned placeholders and can only be replaced later
+    # by adopted/created issue references.
+    empty_prior = [
+        CreatedPhaseIssue(phase=phase, issue_url=None, issue_number=None)
+        for phase in phases
+    ]
+    for index, phase in enumerate(phases, start=1):
+        title = _phase_issue_title(parent_issue, index, phase)
+        TrustedBody.current_untrusted_visible(title)
+        draft = format_phase_issue_body(
+            repo=config.repo,
+            parent_issue=parent_issue,
+            approved_plan=approved_plan,
+            phase=phase,
+            created_so_far=empty_prior[: index - 1],
+            phase_identity_value=expected_ids[index],
+            dependency_placeholders=True,
+            topology_source=topology_source,
+            phase_index=index,
+            phase_plan_hash=plan_hash,
+        )
+        TrustedBody.canonical(draft, expected_tokens=("AGENT_PLAN_PHASE_IDENTITY",))
+
+    # The checkpoint is the durable handoff between complete preflight and
+    # child creation.  It is deliberately not posted for dry-run previews.
+    if not config.dry_run and find_existing_topology_checkpoint(
+        issue_comments,
+        parent_issue=parent_issue,
+        plan_hash=plan_hash,
+        mode=mode,
+    ) is None:
+        post_topology_checkpoint(
+            runner,
+            config=config,
+            checkpoint=TopologyCheckpoint(
+                parent_issue=parent_issue,
+                plan_hash=plan_hash,
+                mode=mode,
+                topology_source=topology_source,
+                phases=phases,
+                retained_parent_scope=retained_parent_scope,
+            ),
+        )
+
     created: list[CreatedPhaseIssue] = []
-    for index, phase in enumerate(decomposition.phases, start=1):
+    for index, phase in enumerate(phases, start=1):
+        identity = expected_ids[index]
+        found = exact.get(identity)
+        if found is not None:
+            created.append(
+                CreatedPhaseIssue(
+                    phase=phase,
+                    issue_url=found.url,
+                    issue_number=found.number or _issue_number_from_url(found.url),
+                    origin="adopted",
+                )
+            )
+            continue
+        unresolved = _unresolved_dependencies(phase, created)
+        if unresolved:
+            raise AgentLoopError(
+                "Cannot create decomposition phase because dependency issue references are unavailable: "
+                + ", ".join(unresolved)
+            )
+        title = _phase_issue_title(parent_issue, index, phase)
+        body = format_phase_issue_body(
+            repo=config.repo,
+            parent_issue=parent_issue,
+            approved_plan=approved_plan,
+            phase=phase,
+            created_so_far=created,
+            phase_identity_value=identity,
+            topology_source=topology_source,
+            phase_index=index,
+            phase_plan_hash=plan_hash,
+        )
+        if "__ORCHESTRATOR_ISSUE_NUMBER__" in body:
+            raise AgentLoopError(
+                "Cannot create decomposition phase because a dependency reference was not resolved."
+            )
         issue_url = create_issue(
             runner,
             config=config,
-            title=_phase_issue_title(parent_issue, index, phase),
-            body=format_phase_issue_body(
-                repo=config.repo,
-                parent_issue=parent_issue,
-                approved_plan=approved_plan,
-                phase=phase,
-                created_so_far=created,
+            title=title,
+            body=TrustedBody.canonical(
+                body,
+                expected_tokens=("AGENT_PLAN_PHASE_IDENTITY",),
             ),
         )
         created.append(
@@ -323,6 +759,7 @@ def create_decomposition_child_issues(
                 phase=phase,
                 issue_url=issue_url,
                 issue_number=_issue_number_from_url(issue_url),
+                origin="created",
             )
         )
     return tuple(created)
@@ -356,6 +793,16 @@ def _encode_metadata(metadata: DecompositionMetadata) -> str:
                 {"title": title, "url": url, "number": number}
                 for title, url, number in metadata.children
             ],
+            "topology_source": metadata.topology_source,
+            "retained_parent_scope": (
+                {
+                    "plan_subject": metadata.retained_parent_scope.plan_subject,
+                    "plan_hash": metadata.retained_parent_scope.plan_hash,
+                    "excerpt": metadata.retained_parent_scope.excerpt,
+                }
+                if metadata.retained_parent_scope is not None
+                else None
+            ),
         }
     )
 
@@ -379,6 +826,14 @@ def _decode_metadata(encoded: str) -> DecompositionMetadata:
             )
         )
     try:
+        retained_payload = payload.get("retained_parent_scope")
+        retained = None
+        if isinstance(retained_payload, dict):
+            retained = RetainedParentScope(
+                plan_subject=str(retained_payload.get("plan_subject") or ""),
+                plan_hash=str(retained_payload.get("plan_hash") or ""),
+                excerpt=str(retained_payload.get("excerpt") or ""),
+            )
         return DecompositionMetadata(
             parent_issue=int(payload["parent_issue"]),
             plan_hash=str(payload["plan_hash"]),
@@ -387,6 +842,8 @@ def _decode_metadata(encoded: str) -> DecompositionMetadata:
             phase_titles=tuple(str(value) for value in payload["phase_titles"]),
             automation=tuple(str(value) for value in payload["automation"]),
             children=tuple(children),
+            topology_source=str(payload.get("topology_source") or "model"),
+            retained_parent_scope=retained,
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise AgentLoopError("Invalid AGENT_PLAN_DECOMPOSITION payload.") from exc
@@ -491,6 +948,8 @@ def format_decomposition_parent_summary(
     mode: str,
     plan_hash: str,
     created: Sequence[CreatedPhaseIssue],
+    topology_source: str = "model",
+    retained_parent_scope: RetainedParentScope | None = None,
 ) -> str:
     metadata = DecompositionMetadata(
         parent_issue=parent_issue,
@@ -503,15 +962,31 @@ def format_decomposition_parent_summary(
             (item.phase.title, item.issue_url, item.issue_number)
             for item in created
         ),
+        topology_source=topology_source,
+        retained_parent_scope=retained_parent_scope,
     )
     lines = [
         f"Approved plan decomposed for issue #{parent_issue}.",
         "",
         f"Mode: {mode}",
+        f"Topology source: {topology_source}",
         "",
         "| Phase | Automation | Child issue | Risk |",
         "| --- | --- | --- | --- |",
     ]
+    if retained_parent_scope is not None:
+        lines.extend(
+            [
+                "## Retained parent scope",
+                f"Plan subject: {sanitize_historical_text(retained_parent_scope.plan_subject)}",
+                f"Plan hash: {retained_parent_scope.plan_hash}",
+                "The approved plan's primary scope remains owned by the parent; "
+                "the typed stages below are its declared remainder.",
+                "",
+                retained_parent_scope.excerpt,
+                "",
+            ]
+        )
     for index, item in enumerate(created, start=1):
         if item.issue_url:
             child = item.issue_url
@@ -609,6 +1084,8 @@ def post_decomposition_parent_summary(
     mode: str,
     plan_hash: str,
     created: Sequence[CreatedPhaseIssue],
+    topology_source: str = "model",
+    retained_parent_scope: RetainedParentScope | None = None,
 ) -> None:
     post_issue_comment(
         runner,
@@ -620,6 +1097,8 @@ def post_decomposition_parent_summary(
                 mode=mode,
                 plan_hash=plan_hash,
                 created=created,
+                topology_source=topology_source,
+                retained_parent_scope=retained_parent_scope,
             ),
             expected_tokens=("AGENT_PLAN_DECOMPOSITION",),
         ),

--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -6,15 +6,21 @@ import base64
 import hashlib
 import json
 import re
+import zlib
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .config import AgentLoopConfig
-from .child_topology import NeedsHumanDecision, preflight_flat_child_count
+from .child_topology import (
+    NeedsHumanDecision,
+    parent_child_search_query,
+    preflight_flat_child_count,
+)
 from .errors import AgentLoopError
 from .github import FoundIssue, create_issue, post_issue_comment, search_issues
 from .runner import Runner
 from .protocol_markers import TrustedBody, sanitize_historical_text
+from .round_transport import MAX_GITHUB_BODY_CHARS
 
 AUTOMATION_CLASSES = {"agent-pr", "human-action", "manual-close"}
 DECOMPOSITION_MARKER_RE = re.compile(
@@ -324,45 +330,94 @@ def adapt_typed_child_stages(
 
 
 def _checkpoint_payload(checkpoint: TopologyCheckpoint) -> dict[str, object]:
+    contexts = tuple(phase.parent_context for phase in checkpoint.phases)
+    shared_context = (
+        contexts[0]
+        if contexts and all(context == contexts[0] for context in contexts)
+        else None
+    )
+    phase_payloads: list[dict[str, object]] = []
+    for phase in checkpoint.phases:
+        payload = _phase_payload(phase)
+        if shared_context is not None:
+            payload.pop("parent_context", None)
+        phase_payloads.append(payload)
+    retained_payload = None
+    if checkpoint.retained_parent_scope is not None:
+        retained_payload = {
+            "plan_subject": checkpoint.retained_parent_scope.plan_subject,
+            "plan_hash": checkpoint.retained_parent_scope.plan_hash,
+            "excerpt": checkpoint.retained_parent_scope.excerpt,
+        }
+        # Typed phases and the retained parent scope deliberately share this
+        # excerpt. Keep it in one place in the checkpoint marker.
+        if (
+            shared_context is not None
+            and checkpoint.retained_parent_scope.excerpt == shared_context
+        ):
+            retained_payload.pop("excerpt")
     return {
         "parent_issue": checkpoint.parent_issue,
         "plan_hash": checkpoint.plan_hash,
         "mode": checkpoint.mode,
         "topology_source": checkpoint.topology_source,
-        "phases": [_phase_payload(phase) for phase in checkpoint.phases],
-        "retained_parent_scope": (
-            {
-                "plan_subject": checkpoint.retained_parent_scope.plan_subject,
-                "plan_hash": checkpoint.retained_parent_scope.plan_hash,
-                "excerpt": checkpoint.retained_parent_scope.excerpt,
-            }
-            if checkpoint.retained_parent_scope is not None
-            else None
-        ),
+        "shared_parent_context": shared_context,
+        "phases": phase_payloads,
+        "retained_parent_scope": retained_payload,
     }
 
 
-def _phase_from_payload(payload: object) -> PlanPhase:
+def _phase_from_payload(payload: object, *, shared_parent_context: str | None = None) -> PlanPhase:
     if not isinstance(payload, dict):
         raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
     depends = payload.get("depends_on", [])
     if not isinstance(depends, list):
         raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
     values = {}
-    for key in ("title", "scope", "non_goals", "dependency_notes", "rollout_risk", "validation", "parent_context", "automation"):
+    for key in (
+        "title",
+        "scope",
+        "non_goals",
+        "dependency_notes",
+        "rollout_risk",
+        "validation",
+        "automation",
+    ):
         value = payload.get(key)
         if not isinstance(value, str):
             raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
         values[key] = value
+    parent_context = payload.get("parent_context", shared_parent_context)
+    if not isinstance(parent_context, str):
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
+    values["parent_context"] = parent_context
     return PlanPhase(**values, depends_on=tuple(str(item) for item in depends))
 
 
 def _decode_checkpoint(encoded: str) -> TopologyCheckpoint:
-    payload = _decode_json_payload(encoded, marker_name="AGENT_PLAN_TOPOLOGY_CHECKPOINT")
+    try:
+        if encoded.startswith("v1_"):
+            raw = zlib.decompress(
+                base64.urlsafe_b64decode(encoded[3:].encode("ascii"))
+            )
+            payload = json.loads(raw.decode("utf-8"))
+        else:
+            # Read the original uncompressed representation for checkpoints
+            # already posted before the compact payload format was introduced.
+            payload = _decode_json_payload(
+                encoded, marker_name="AGENT_PLAN_TOPOLOGY_CHECKPOINT"
+            )
+    except (ValueError, json.JSONDecodeError, zlib.error) as exc:
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.") from exc
+    if not isinstance(payload, dict):
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
     phases_payload = payload.get("phases")
     if not isinstance(phases_payload, list) or not phases_payload:
         raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
     retained_payload = payload.get("retained_parent_scope")
+    shared_parent_context = payload.get("shared_parent_context")
+    if shared_parent_context is not None and not isinstance(shared_parent_context, str):
+        raise AgentLoopError("Invalid AGENT_PLAN_TOPOLOGY_CHECKPOINT payload.")
     retained = None
     if retained_payload is not None:
         if not isinstance(retained_payload, dict):
@@ -370,7 +425,7 @@ def _decode_checkpoint(encoded: str) -> TopologyCheckpoint:
         retained = RetainedParentScope(
             plan_subject=str(retained_payload.get("plan_subject") or ""),
             plan_hash=str(retained_payload.get("plan_hash") or ""),
-            excerpt=str(retained_payload.get("excerpt") or ""),
+            excerpt=str(retained_payload.get("excerpt") or shared_parent_context or ""),
         )
     try:
         return TopologyCheckpoint(
@@ -378,7 +433,10 @@ def _decode_checkpoint(encoded: str) -> TopologyCheckpoint:
             plan_hash=str(payload["plan_hash"]),
             mode=str(payload["mode"]),
             topology_source=str(payload["topology_source"]),
-            phases=tuple(_phase_from_payload(item) for item in phases_payload),
+            phases=tuple(
+                _phase_from_payload(item, shared_parent_context=shared_parent_context)
+                for item in phases_payload
+            ),
             retained_parent_scope=retained,
         )
     except (KeyError, TypeError, ValueError) as exc:
@@ -405,7 +463,14 @@ def find_existing_topology_checkpoint(
 
 
 def format_topology_checkpoint(checkpoint: TopologyCheckpoint) -> str:
-    return "\n".join(
+    raw = json.dumps(
+        _checkpoint_payload(checkpoint),
+        separators=(",", ":"),
+        ensure_ascii=False,
+        sort_keys=True,
+    ).encode("utf-8")
+    encoded = "v1_" + base64.urlsafe_b64encode(zlib.compress(raw, 9)).decode("ascii")
+    body = "\n".join(
         [
             f"Topology checkpoint recorded for issue #{checkpoint.parent_issue}.",
             "",
@@ -413,10 +478,16 @@ def format_topology_checkpoint(checkpoint: TopologyCheckpoint) -> str:
             f"Mode: {checkpoint.mode}",
             f"Stages: {len(checkpoint.phases)}",
             "",
-            f"<!-- AGENT_PLAN_TOPOLOGY_CHECKPOINT: {_encode_json_payload(_checkpoint_payload(checkpoint))} -->",
+            f"<!-- AGENT_PLAN_TOPOLOGY_CHECKPOINT: {encoded} -->",
             "-- coding-review-agent-loop",
         ]
     )
+    if len(body) > MAX_GITHUB_BODY_CHARS:
+        raise AgentLoopError(
+            "Topology checkpoint exceeds the GitHub comment size limit after compact encoding; "
+            "shorten the approved plan or use a smaller flat topology."
+        )
+    return body
 
 
 def post_topology_checkpoint(
@@ -526,7 +597,7 @@ def format_phase_issue_body(
             phase.non_goals,
             "",
             "## Constraints and invariants from the parent plan",
-            sanitize_historical_text(approved_plan.strip()),
+            "The approved parent-plan excerpt above is the complete historical constraint context for this phase.",
             "",
             "## Dependency notes",
             phase.dependency_notes,
@@ -581,7 +652,7 @@ def create_decomposition_child_issues(
     found = search_issues(
         runner,
         config=config,
-        search=f'"(from #{parent_issue})" in:title',
+        search=parent_child_search_query(parent_issue),
         state="all",
     )
     expected_ids = {
@@ -723,7 +794,7 @@ def create_decomposition_child_issues(
                 )
             )
             continue
-        unresolved = _unresolved_dependencies(phase, created)
+        unresolved = () if config.dry_run else _unresolved_dependencies(phase, created)
         if unresolved:
             raise AgentLoopError(
                 "Cannot create decomposition phase because dependency issue references are unavailable: "
@@ -754,6 +825,10 @@ def create_decomposition_child_issues(
                 expected_tokens=("AGENT_PLAN_PHASE_IDENTITY",),
             ),
         )
+        if config.dry_run:
+            # A test double may return a URL even though the real dry-run
+            # Runner intentionally returns no remote issue reference.
+            issue_url = None
         created.append(
             CreatedPhaseIssue(
                 phase=phase,
@@ -971,8 +1046,6 @@ def format_decomposition_parent_summary(
         f"Mode: {mode}",
         f"Topology source: {topology_source}",
         "",
-        "| Phase | Automation | Child issue | Risk |",
-        "| --- | --- | --- | --- |",
     ]
     if retained_parent_scope is not None:
         lines.extend(
@@ -987,6 +1060,12 @@ def format_decomposition_parent_summary(
                 "",
             ]
         )
+    lines.extend(
+        [
+            "| Phase | Automation | Child issue | Risk |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
     for index, item in enumerate(created, start=1):
         if item.issue_url:
             child = item.issue_url

--- a/src/coding_review_agent_loop/decomposition.py
+++ b/src/coding_review_agent_loop/decomposition.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass
 from .config import AgentLoopConfig
 from .child_topology import (
     NeedsHumanDecision,
-    parent_child_search_query,
+    merge_found_issues,
+    parent_child_search_queries,
     preflight_flat_child_count,
 )
 from .errors import AgentLoopError
@@ -597,7 +598,7 @@ def format_phase_issue_body(
             phase.non_goals,
             "",
             "## Constraints and invariants from the parent plan",
-            "The approved parent-plan excerpt above is the complete historical constraint context for this phase.",
+            "The linked parent issue is the source of truth for the complete approved-plan constraints and invariants; the excerpt above is the phase-specific context supplied to this issue.",
             "",
             "## Dependency notes",
             phase.dependency_notes,
@@ -649,11 +650,14 @@ def create_decomposition_child_issues(
 
     # Search is read-only and intentionally includes every issue state.  It
     # closes the create-before-summary crash window without trusting authorship.
-    found = search_issues(
-        runner,
-        config=config,
-        search=parent_child_search_query(parent_issue),
-        state="all",
+    found = merge_found_issues(
+        search_issues(
+            runner,
+            config=config,
+            search=query,
+            state="all",
+        )
+        for query in parent_child_search_queries(parent_issue)
     )
     expected_ids = {
         index: phase_identity(

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -91,7 +91,6 @@ class FoundIssue:
     title: str | None
     url: str | None
     body: str | None
-    state: str | None = None
 
 
 @dataclass(frozen=True)
@@ -121,6 +120,9 @@ class PullRequestMergeability:
 
 PR_METADATA_FIELDS = "number,title,headRefName,baseRefName,headRefOid,url,body"
 PR_REVIEW_CONTEXT_FIELDS = f"{PR_METADATA_FIELDS},comments,reviews"
+# Recovery searches must not inherit gh's small default page size: a parent
+# may have hundreds of unrelated issues before its child topology is found.
+ISSUE_RECOVERY_SEARCH_LIMIT = 100_000
 
 # This intentionally remains looser than the recovery parser below.  It is
 # used by PR review context inference, where a same-repository issue URL is
@@ -1846,9 +1848,9 @@ def search_issues(
                 "--state",
                 state,
                 "--limit",
-                "100000",
+                str(ISSUE_RECOVERY_SEARCH_LIMIT),
                 "--json",
-                "number,title,url,body,state",
+                "number,title,url,body",
             ],
             cwd=active_workdir(config),
         )
@@ -1865,9 +1867,9 @@ def search_issues(
             "--state",
             state,
             "--limit",
-            "100000",
+            str(ISSUE_RECOVERY_SEARCH_LIMIT),
             "--json",
-            "number,title,url,body,state",
+            "number,title,url,body",
         ],
         cwd=active_workdir(config),
     )
@@ -1891,7 +1893,6 @@ def search_issues(
                 title=_optional_str(item.get("title")),
                 url=_optional_str(item.get("url")),
                 body=_optional_str(item.get("body")),
-                state=_optional_str(item.get("state")),
             )
         )
     return tuple(found)

--- a/src/coding_review_agent_loop/github.py
+++ b/src/coding_review_agent_loop/github.py
@@ -91,6 +91,7 @@ class FoundIssue:
     title: str | None
     url: str | None
     body: str | None
+    state: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1844,8 +1845,10 @@ def search_issues(
                 search,
                 "--state",
                 state,
+                "--limit",
+                "100000",
                 "--json",
-                "number,title,url,body",
+                "number,title,url,body,state",
             ],
             cwd=active_workdir(config),
         )
@@ -1861,8 +1864,10 @@ def search_issues(
             search,
             "--state",
             state,
+            "--limit",
+            "100000",
             "--json",
-            "number,title,url,body",
+            "number,title,url,body,state",
         ],
         cwd=active_workdir(config),
     )
@@ -1886,6 +1891,7 @@ def search_issues(
                 title=_optional_str(item.get("title")),
                 url=_optional_str(item.get("url")),
                 body=_optional_str(item.get("body")),
+                state=_optional_str(item.get("state")),
             )
         )
     return tuple(found)

--- a/src/coding_review_agent_loop/managed_ci.py
+++ b/src/coding_review_agent_loop/managed_ci.py
@@ -1250,7 +1250,7 @@ _RECOVERY_VALUE_OPTIONS = frozenset({
     "--progress-interval-seconds", "--agent-max-retries", "--agent-retry-backoff-seconds",
     "--agent-memory-dir", "--salvage-comment-patch-max-bytes", "--planning-context-mode",
     "--pr-review-context-mode", "--expected-closing-issue",
-    "--plan-execution-mode", "--split-stage", "--head", "--title", "--body-file",
+    "--plan-execution-mode", "--flat-child-limit", "--split-stage", "--head", "--title", "--body-file",
     "--approved-followups",
 })
 _RECOVERY_NARGS_VALUE_OPTIONS = frozenset({

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -32,6 +32,7 @@ from .config import (
 from .decomposition import (
     _decode_json_payload,
     CreatedPhaseIssue,
+    PlanDecomposition,
     RecordedPhase,
     approved_plan_hash,
     create_decomposition_child_issues,
@@ -43,7 +44,12 @@ from .decomposition import (
     post_decomposition_parent_summary,
     post_one_shot_impl_handoff_comment,
     post_phase_implementation_handoff_comment,
+    adapt_typed_child_stages,
+    find_existing_topology_checkpoint,
+    post_topology_checkpoint,
+    TopologyCheckpoint,
 )
+from .child_topology import NeedsHumanDecision
 from .errors import (
     AgentInvocationError,
     AgentLoopError,
@@ -3979,7 +3985,7 @@ def _handle_plan_first_split_scope(
     current_plan: str,
     plan_subject: str,
     issue_context: IssueContext,
-) -> bool:
+) -> bool | NeedsHumanDecision:
     """Materialize (or warn about) split/deferred stages before implementation
     handoff (#476), so a plan-first run that narrows scope to one stage cannot
     silently leave the rest unfiled (the #467/#474 gap).
@@ -3991,6 +3997,12 @@ def _handle_plan_first_split_scope(
     `issue_context.comments` snapshot predates this call and would otherwise
     look stale and hide children materialized moments earlier in this same run.
     """
+    # Decomposition modes have exactly one topology source and are dispatched
+    # below.  Keeping split materialization out of this seam prevents typed
+    # stages from being filed once here and again by the decomposition path.
+    if config.plan_execution_mode in {"decompose-only", "implement-by-phase"}:
+        return False
+
     current_deferred_stages = _extract_current_deferred_stages(current_plan)
     current_child_stages = _extract_current_child_stages(current_plan)
     _log_typed_plan_stage_dispositions(current_plan, config=config)
@@ -4014,7 +4026,7 @@ def _handle_plan_first_split_scope(
     )
     if remaining_proposals:
         if config.materialize_split_issues:
-            materialize_split_proposals(
+            materialized = materialize_split_proposals(
                 runner,
                 config=config,
                 parent_issue=issue_number,
@@ -4022,6 +4034,8 @@ def _handle_plan_first_split_scope(
                 proposals=remaining_proposals,
                 issue_comments=issue_context.comments,
             )
+            if isinstance(materialized, NeedsHumanDecision):
+                return materialized
             return True
         log(
             config,
@@ -4663,7 +4677,7 @@ def _decompose_approved_plan(
     mode: str,
     coder_session_id: str | None,
     usage_context: RunUsageContext,
-) -> tuple[CreatedPhaseIssue, ...]:
+) -> tuple[CreatedPhaseIssue, ...] | NeedsHumanDecision:
     plan_hash = approved_plan_hash(approved_plan)
     existing = find_existing_decomposition(
         issue_context.comments,
@@ -4682,33 +4696,64 @@ def _decompose_approved_plan(
             for (title, url, number), automation in zip(existing.children, existing.automation, strict=False)
         )
 
-    coder_name = agent_display_name(config.coder)
-    log(config, f"Planning approved; invoking {coder_name} to decompose issue #{issue_number}")
-    decomposition_response = _run_validated_agent(
-        runner,
-        agent=config.coder,
-        config=config,
-        prompt=build_plan_decomposition_prompt(
-            issue_number,
-            approved_plan,
-            config,
-            memory,
-            issue_context=issue_context,
-        ),
-        session_id=coder_session_id,
-        marker_description="plan decomposition JSON",
-        validate=parse_plan_decomposition,
-        usage_context=usage_context,
-        operation_description="plan decomposition",
+    checkpoint = find_existing_topology_checkpoint(
+        issue_context.comments,
+        parent_issue=issue_number,
+        plan_hash=plan_hash,
+        mode=mode,
     )
-    decomposition = decomposition_response.marker_value
+    retained_parent_scope = None
+    topology_source = "model"
+    if checkpoint is not None:
+        # A checkpoint is the normalized model/typed output.  Reuse it before
+        # invoking a coder so a create-before-summary failure is resumable.
+        decomposition = PlanDecomposition(phases=checkpoint.phases)
+        topology_source = checkpoint.topology_source
+        retained_parent_scope = checkpoint.retained_parent_scope
+    elif mode == "decompose-only":
+        typed_stages = _extract_current_child_stages(approved_plan)
+        if typed_stages:
+            decomposition, retained_parent_scope = adapt_typed_child_stages(
+                typed_stages,
+                approved_plan=approved_plan,
+                plan_subject=_plan_subject(approved_plan),
+            )
+            topology_source = "typed"
+
+    if checkpoint is None and topology_source == "model":
+        coder_name = agent_display_name(config.coder)
+        log(config, f"Planning approved; invoking {coder_name} to decompose issue #{issue_number}")
+        decomposition_response = _run_validated_agent(
+            runner,
+            agent=config.coder,
+            config=config,
+            prompt=build_plan_decomposition_prompt(
+                issue_number,
+                approved_plan,
+                config,
+                memory,
+                issue_context=issue_context,
+            ),
+            session_id=coder_session_id,
+            marker_description="plan decomposition JSON",
+            validate=parse_plan_decomposition,
+            usage_context=usage_context,
+            operation_description="plan decomposition",
+        )
+        decomposition = decomposition_response.marker_value
     created = create_decomposition_child_issues(
         runner,
         config=config,
         parent_issue=issue_number,
         approved_plan=approved_plan,
         decomposition=decomposition,
+        topology_source=topology_source,
+        issue_comments=issue_context.comments,
+        mode=mode,
+        retained_parent_scope=retained_parent_scope,
     )
+    if isinstance(created, NeedsHumanDecision):
+        return created
     post_decomposition_parent_summary(
         runner,
         config=config,
@@ -4716,6 +4761,8 @@ def _decompose_approved_plan(
         mode=mode,
         plan_hash=plan_hash,
         created=created,
+        topology_source=topology_source,
+        retained_parent_scope=retained_parent_scope,
     )
     return created
 
@@ -5535,6 +5582,9 @@ def _run_plan_first_loop(
                 plan_subject=plan_subject,
                 issue_context=issue_context,
             )
+            if isinstance(split_scope_materialized, NeedsHumanDecision):
+                print(json.dumps(split_scope_materialized.as_dict(), sort_keys=True))
+                return 2
             if split_scope_materialized:
                 # Refetch so downstream logic (selected-stage resolution below,
                 # decomposition, etc.) sees the `AGENT_DISCUSS_SPLIT` comment
@@ -5559,6 +5609,9 @@ def _run_plan_first_loop(
                     coder_session_id=coder_session_id,
                     usage_context=usage_context,
                 )
+                if isinstance(created, NeedsHumanDecision):
+                    print(json.dumps(created.as_dict(), sort_keys=True))
+                    return 2
                 if mode == "decompose-only":
                     print(f"Issue #{issue_number} approved plan decomposed into child issues.")
                     return 0
@@ -9203,7 +9256,7 @@ def _handle_discuss_split_outcome(
     final_votes: Sequence[ParsedDiscussReview],
     issue_comments: Sequence[object],
     post_warning_comment: bool,
-) -> None:
+) -> NeedsHumanDecision | None:
     """Materialize (or warn about) a discuss `split` consensus's proposed sub-issues (#476).
 
     Called both when the final summary is freshly posted and on a resumed/
@@ -9221,7 +9274,7 @@ def _handle_discuss_split_outcome(
         rationale = tuple(
             (vote.reviewer, vote.rationale) for vote in final_votes if vote.outcome == "split"
         )
-        materialize_split_proposals(
+        result = materialize_split_proposals(
             runner,
             config=config,
             parent_issue=issue_number,
@@ -9230,6 +9283,8 @@ def _handle_discuss_split_outcome(
             rationale=rationale,
             issue_comments=issue_comments,
         )
+        if isinstance(result, NeedsHumanDecision):
+            return result
         return
     log(
         config,
@@ -10033,7 +10088,7 @@ def _run_discuss_loop(
         recovered = _resolve_final_split_proposals()
         if recovered is not None:
             split_proposals, final_votes = recovered
-            _handle_discuss_split_outcome(
+            split_result = _handle_discuss_split_outcome(
                 runner,
                 issue_number=issue_number,
                 config=config,
@@ -10043,6 +10098,9 @@ def _run_discuss_loop(
                 issue_comments=issue_context.comments,
                 post_warning_comment=False,
             )
+            if isinstance(split_result, NeedsHumanDecision):
+                print(json.dumps(split_result.as_dict(), sort_keys=True))
+                return 2
         elif config.materialize_split_issues:
             log(
                 config,
@@ -10531,7 +10589,7 @@ def _run_discuss_loop(
                 f"(outcome: {outcome}; kind: {consensus_kind})",
             )
             if outcome == "split":
-                _handle_discuss_split_outcome(
+                split_result = _handle_discuss_split_outcome(
                     runner,
                     issue_number=issue_number,
                     config=config,
@@ -10541,6 +10599,9 @@ def _run_discuss_loop(
                     issue_comments=issue_context.comments,
                     post_warning_comment=True,
                 )
+                if isinstance(split_result, NeedsHumanDecision):
+                    print(json.dumps(split_result.as_dict(), sort_keys=True))
+                    return 2
             return 0
         log(
             config,

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -5628,6 +5628,12 @@ def _run_plan_first_loop(
                         f"({first_phase.phase.automation}), so implementation is stopping."
                     )
                     return 0
+                if config.dry_run:
+                    print(
+                        f"Issue #{issue_number} dry-run decomposed the approved plan; "
+                        "phase implementation is not started."
+                    )
+                    return 0
                 if first_agent_phase is None or first_agent_phase.issue_number is None:
                     raise AgentLoopError(
                         "Cannot implement first decomposed phase because its child issue number "

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -12,7 +12,7 @@ from typing import Sequence
 from .agents.base import AgentName
 from .agents.registry import agent_display_name, agent_signature
 from .config import AgentLoopConfig, reviewers
-from .decomposition import MAX_DECOMPOSITION_PHASES, approved_plan_hash
+from .decomposition import approved_plan_hash
 from .github import HumanReviewRequirement, IssueContext, PullRequestChecks, PullRequestMetadata
 from .issue_pr_provenance import IssuePrProvenanceScope, format_issue_pr_provenance
 from .memory import AgentMemoryContext, format_agent_memory_context
@@ -1677,7 +1677,7 @@ Schema:
 }}
 
 Rules:
-- Use between 1 and {MAX_DECOMPOSITION_PHASES} phases. If the plan seems larger,
+- Use between 1 and {config.flat_child_limit} phases. If the plan seems larger,
   consolidate related steps; do not exceed the cap.
 - Preserve dependency ordering. `depends_on` must reference earlier phase titles.
 - Every child issue must be self-contained enough for `agent-loop issue <N>` to

--- a/src/coding_review_agent_loop/protocol_markers.py
+++ b/src/coding_review_agent_loop/protocol_markers.py
@@ -215,6 +215,8 @@ def _make_registry() -> tuple[MarkerDefinition, ...]:
         _b64_definition("AGENT_TYPED_PLAN_STAGES", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_DEFERRED_STAGES", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_PLAN_DECOMPOSITION", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_PLAN_TOPOLOGY_CHECKPOINT", surfaces=_ISSUE_ONLY),
+        _b64_definition("AGENT_PLAN_PHASE_IDENTITY", surfaces=_ISSUE),
         _b64_definition("AGENT_PLAN_PHASE_IMPLEMENTATION", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_PLAN_ONE_SHOT_IMPL", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_DISCUSS_SPLIT", surfaces=_ISSUE_ONLY),

--- a/src/coding_review_agent_loop/protocol_markers.py
+++ b/src/coding_review_agent_loop/protocol_markers.py
@@ -61,6 +61,17 @@ def _canonical_compressed_mapping(match: re.Match[str], *, token: str) -> str:
     return f"<!-- {token}: {canonical} -->"
 
 
+def _canonical_checkpoint(match: re.Match[str]) -> str:
+    """Accept legacy raw checkpoints while emitting the compact form."""
+    encoded = match.group("payload")
+    if not encoded.startswith("v1_"):
+        value = _decode_b64_json(encoded)
+        return f"<!-- AGENT_PLAN_TOPOLOGY_CHECKPOINT: {_b64_json(value)} -->"
+    return _canonical_compressed_mapping(
+        match, token="AGENT_PLAN_TOPOLOGY_CHECKPOINT"
+    )
+
+
 def _canonical_raw_json(match: re.Match[str], *, token: str) -> str:
     value = json.loads(match.group("payload"))
     return f"<!-- {token} {json.dumps(value, separators=(',', ':'), sort_keys=True)} -->"
@@ -215,7 +226,19 @@ def _make_registry() -> tuple[MarkerDefinition, ...]:
         _b64_definition("AGENT_TYPED_PLAN_STAGES", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_DEFERRED_STAGES", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_PLAN_DECOMPOSITION", surfaces=_ISSUE_ONLY),
-        _b64_definition("AGENT_PLAN_TOPOLOGY_CHECKPOINT", surfaces=_ISSUE_ONLY),
+        MarkerDefinition(
+            token="AGENT_PLAN_TOPOLOGY_CHECKPOINT",
+            pattern=re.compile(
+                r"<!--\s*AGENT_PLAN_TOPOLOGY_CHECKPOINT:\s*"
+                r"(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
+                re.I,
+            ),
+            strictness="well-formed-only",
+            codec="compressed-mapping",
+            surfaces=_ISSUE_ONLY,
+            safe_label="[protocol topology checkpoint record]",
+            canonicalizer=_canonical_checkpoint,
+        ),
         _b64_definition("AGENT_PLAN_PHASE_IDENTITY", surfaces=_ISSUE),
         _b64_definition("AGENT_PLAN_PHASE_IMPLEMENTATION", surfaces=_ISSUE_ONLY),
         _b64_definition("AGENT_PLAN_ONE_SHOT_IMPL", surfaces=_ISSUE_ONLY),

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -16,7 +16,8 @@ from dataclasses import dataclass
 from .config import AgentLoopConfig
 from .child_topology import (
     NeedsHumanDecision,
-    parent_child_search_query,
+    merge_found_issues,
+    parent_child_search_queries,
     preflight_flat_child_count,
 )
 from .decomposition import _decode_json_payload, _encode_json_payload, _issue_number_from_url
@@ -427,11 +428,14 @@ def materialize_split_proposals(
     # Search and adoption are read-only.  Count every recognized canonical
     # child owned by this parent before deciding whether the complete desired
     # topology fits; never slice and silently skip approved stages.
-    search_results = search_issues(
-        runner,
-        config=config,
-        search=parent_child_search_query(parent_issue),
-        state="all",
+    search_results = merge_found_issues(
+        search_issues(
+            runner,
+            config=config,
+            search=query,
+            state="all",
+        )
+        for query in parent_child_search_queries(parent_issue)
     )
     adopted_by_key, recognized_from_search = _adopt_from_found(
         search_results,

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -14,21 +14,25 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .config import AgentLoopConfig
+from .child_topology import NeedsHumanDecision, preflight_flat_child_count
 from .decomposition import _decode_json_payload, _encode_json_payload, _issue_number_from_url
 from .errors import AgentLoopError
 from .github import FoundIssue, create_issue, post_issue_comment, search_issues
 from .logging import log
 from .protocol import ChildStage, DeferredStage, ISSUE_REFERENCE_RE, TRACKER_ACTION_TITLE_RE
 from .runner import Runner
-from .protocol_markers import TrustedBody
+from .protocol_markers import TrustedBody, sanitize_historical_text
 
-MAX_SPLIT_CHILDREN = 8
 DISCUSS_SPLIT_MARKER_RE = re.compile(
     r"<!--\s*AGENT_DISCUSS_SPLIT:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
     re.I,
 )
 SPLIT_CHILD_MARKER_RE = re.compile(
     r"<!--\s*AGENT_SPLIT_CHILD:\s*parent=(?P<parent>\d+)\s+key=(?P<key>[0-9a-f]{64})\s*-->",
+    re.I,
+)
+DECOMPOSITION_CHILD_IDENTITY_RE = re.compile(
+    r"<!--\s*AGENT_PLAN_PHASE_IDENTITY:\s*(?P<payload>[A-Za-z0-9+/=_-]+)\s*-->",
     re.I,
 )
 SPLIT_STAGE_HANDOFF_MARKER_RE = re.compile(
@@ -144,7 +148,7 @@ def _sibling_lines(children: Sequence[MaterializedSplitChild]) -> list[str]:
     lines = []
     for child in children:
         ref = child.url or (f"#{child.number}" if child.number is not None else "unavailable")
-        lines.append(f"- {child.title}: {ref}")
+        lines.append(f"- {sanitize_historical_text(child.title)}: {ref}")
     return lines
 
 
@@ -161,13 +165,13 @@ def _format_child_issue_body(
         f"Child stage issue split out of parent #{parent_issue}.",
         "",
         "## Proposed scope",
-        proposal.body,
+        sanitize_historical_text(proposal.body),
         "",
         "## Split rationale from parent discussion",
     ]
     if rationale:
         for reviewer, text in rationale:
-            lines.append(f"- {reviewer}: {text}")
+            lines.append(f"- {sanitize_historical_text(reviewer)}: {sanitize_historical_text(text)}")
     else:
         lines.append("- No structured rationale was recorded; see the parent issue discussion.")
     lines.extend(
@@ -310,21 +314,60 @@ def _adopt_from_search(
         search=f'"[#{parent_issue} stage]" in:title',
         state="all",
     )
+    return _adopt_from_found(
+        results,
+        parent_issue=parent_issue,
+        remaining=remaining,
+        runner=runner,
+        config=config,
+    )[0]
+
+
+def _adopt_from_found(
+    results: Sequence[FoundIssue],
+    *,
+    parent_issue: int,
+    remaining: Sequence[SplitStageProposal],
+    runner: Runner,
+    config: AgentLoopConfig,
+) -> tuple[dict[str, FoundIssue], set[str]]:
+    """Resolve exact split identities and return all recognized parent keys."""
     by_key: dict[str, FoundIssue] = {}
+    recognized: set[str] = set()
     remaining_keys = {proposal.key for proposal in remaining}
     for found in results:
         if not found.title:
             continue
         marker_match = SPLIT_CHILD_MARKER_RE.search(found.body or "")
-        if marker_match and int(marker_match.group("parent")) == parent_issue:
+        decomposition_match = DECOMPOSITION_CHILD_IDENTITY_RE.search(found.body or "")
+        if decomposition_match:
+            payload = _decode_json_payload(
+                decomposition_match.group("payload"),
+                marker_name="AGENT_PLAN_PHASE_IDENTITY",
+            )
+            if payload.get("parent_issue") == parent_issue and isinstance(payload.get("identity"), str):
+                # A detailed decomposition child is already owned by this
+                # parent, even when it is not one of the split proposals.
+                recognized.add("decomposition:" + payload["identity"])
+            key = ""
+        elif marker_match and int(marker_match.group("parent")) == parent_issue:
             key = marker_match.group("key")
+            recognized.add(key)
         else:
             # Fallback for results missing the AGENT_SPLIT_CHILD body marker
             # (e.g. `gh issue list --search` didn't return a body): titles are
             # created as `[#<parent> stage] <proposal title>`, so strip that
             # prefix before hashing to match a bare proposal key.
-            key = _stage_key(_strip_child_title_prefix(found.title, parent_issue))
-        if key in remaining_keys and key not in by_key:
+            if not found.body and found.title.startswith(f"[#{parent_issue} stage] "):
+                key = _stage_key(_strip_child_title_prefix(found.title, parent_issue))
+                recognized.add(key)
+            else:
+                key = ""
+        if key in remaining_keys:
+            if key in by_key:
+                raise AgentLoopError(
+                    f"Ambiguous split-child recovery: multiple child issues match stage key {key}."
+                )
             by_key[key] = found
     # A typed child can be canonicalized by another workflow and lack our
     # marker/prefix. Only adopt an *open*, parent-linked candidate: generic
@@ -334,6 +377,7 @@ def _adopt_from_search(
     for proposal in remaining:
         if proposal.key in by_key or not proposal.typed_child:
             continue
+        weak_matches = []
         for found in search_issues(
             runner,
             config=config,
@@ -345,9 +389,15 @@ def _adopt_from_search(
                 and _stage_key(found.title) == proposal.key
                 and _references_parent_issue(found.body, parent_issue)
             ):
-                by_key[proposal.key] = found
-                break
-    return by_key
+                weak_matches.append(found)
+        if len(weak_matches) > 1:
+            raise AgentLoopError(
+                f"Ambiguous cross-workflow split-child recovery for stage {proposal.title!r}."
+            )
+        if weak_matches:
+            by_key[proposal.key] = weak_matches[0]
+            recognized.add(proposal.key)
+    return by_key, recognized
 
 
 def materialize_split_proposals(
@@ -359,7 +409,7 @@ def materialize_split_proposals(
     proposals: Sequence[SplitStageProposal],
     rationale: Sequence[tuple[str, str]] = (),
     issue_comments: Sequence[object] = (),
-) -> SplitMaterializationMetadata | None:
+) -> SplitMaterializationMetadata | NeedsHumanDecision | None:
     """File one child issue per remaining stage in `proposals`, idempotently.
 
     `proposals` must already exclude the stage the current run is
@@ -396,32 +446,62 @@ def materialize_split_proposals(
     if not to_resolve:
         return existing
 
-    # Remaining capacity is derived from children already recorded in the
-    # parent's cumulative metadata, not just this call's unresolved proposals,
-    # so repeated reruns with the same over-cap proposal set cannot keep
-    # filing new children past MAX_SPLIT_CHILDREN (#492 review).
-    remaining_capacity = max(0, MAX_SPLIT_CHILDREN - len(known_by_key))
-    capped = to_resolve[:remaining_capacity]
-    skipped = to_resolve[remaining_capacity:]
-
-    if not capped:
-        skipped_titles = ", ".join(proposal.title for proposal in skipped)
-        log(
-            config,
-            f"Split materialization for issue #{parent_issue}: skipped {len(skipped)} "
-            f"stage(s) by cap (MAX_SPLIT_CHILDREN={MAX_SPLIT_CHILDREN}, already at cap): "
-            f"{skipped_titles}",
-        )
-        return existing
-
-    adopted_by_key = _adopt_from_search(
-        runner, config=config, parent_issue=parent_issue, remaining=capped
+    # Search and adoption are read-only.  Count every recognized canonical
+    # child owned by this parent before deciding whether the complete desired
+    # topology fits; never slice and silently skip approved stages.
+    search_results = search_issues(
+        runner,
+        config=config,
+        search=f'"[#{parent_issue} stage]" in:title',
+        state="all",
     )
+    adopted_by_key, recognized_from_search = _adopt_from_found(
+        search_results,
+        parent_issue=parent_issue,
+        remaining=to_resolve,
+        runner=runner,
+        config=config,
+    )
+    recognized_keys = set(known_by_key) | recognized_from_search
+    count = preflight_flat_child_count(
+        parent_issue=parent_issue,
+        source="split",
+        desired_keys=(proposal.key for proposal in deduped),
+        recognized_keys=recognized_keys,
+        configured_limit=config.flat_child_limit,
+    )
+    if isinstance(count, NeedsHumanDecision):
+        return count
+
+    # Every draft is immutable and validated before the first create.  Values
+    # copied from historical discussion are neutralized, while the generated
+    # title remains current untrusted input and is rejected if it carries a
+    # reserved record.
+    draft_siblings = tuple(
+        MaterializedSplitChild(
+            title=proposal.title,
+            key=proposal.key,
+            url=None,
+            number=None,
+            origin="created",
+        )
+        for proposal in deduped
+    )
+    for proposal in deduped:
+        title = _child_issue_title(parent_issue, proposal)
+        TrustedBody.current_untrusted_visible(title)
+        draft = _format_child_issue_body(
+            parent_issue=parent_issue,
+            proposal=proposal,
+            rationale=rationale,
+            siblings_so_far=draft_siblings,
+        )
+        TrustedBody.canonical(draft, expected_tokens=("AGENT_SPLIT_CHILD",))
 
     new_children: list[MaterializedSplitChild] = []
     resolved_so_far: list[MaterializedSplitChild] = list(known_by_key.values())
 
-    for proposal in capped:
+    for proposal in to_resolve:
         found = adopted_by_key.get(proposal.key)
         if found is not None:
             child = MaterializedSplitChild(
@@ -464,15 +544,6 @@ def materialize_split_proposals(
             config,
             f"Split materialization for issue #{parent_issue}: {child.origin} child "
             f"{child.title!r} ({location}).",
-        )
-
-    if skipped:
-        skipped_titles = ", ".join(proposal.title for proposal in skipped)
-        # Not filed; surfaced via log only, matching decomposition's cap note style.
-        log(
-            config,
-            f"Split materialization for issue #{parent_issue}: skipped {len(skipped)} "
-            f"stage(s) by cap (MAX_SPLIT_CHILDREN={MAX_SPLIT_CHILDREN}): {skipped_titles}",
         )
 
     all_children = tuple(known_by_key.values()) + tuple(new_children)

--- a/src/coding_review_agent_loop/split_materialization.py
+++ b/src/coding_review_agent_loop/split_materialization.py
@@ -14,7 +14,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from .config import AgentLoopConfig
-from .child_topology import NeedsHumanDecision, preflight_flat_child_count
+from .child_topology import (
+    NeedsHumanDecision,
+    parent_child_search_query,
+    preflight_flat_child_count,
+)
 from .decomposition import _decode_json_payload, _encode_json_payload, _issue_number_from_url
 from .errors import AgentLoopError
 from .github import FoundIssue, create_issue, post_issue_comment, search_issues
@@ -297,32 +301,6 @@ def format_split_materialization_summary(
     return "\n".join(lines)
 
 
-def _adopt_from_search(
-    runner: Runner,
-    *,
-    config: AgentLoopConfig,
-    parent_issue: int,
-    remaining: Sequence[SplitStageProposal],
-) -> dict[str, FoundIssue]:
-    """Crash-window recovery: look for children created before a prior run
-    crashed between `create_issue` and posting the parent marker (#476)."""
-    if not remaining:
-        return {}
-    results = search_issues(
-        runner,
-        config=config,
-        search=f'"[#{parent_issue} stage]" in:title',
-        state="all",
-    )
-    return _adopt_from_found(
-        results,
-        parent_issue=parent_issue,
-        remaining=remaining,
-        runner=runner,
-        config=config,
-    )[0]
-
-
 def _adopt_from_found(
     results: Sequence[FoundIssue],
     *,
@@ -452,7 +430,7 @@ def materialize_split_proposals(
     search_results = search_issues(
         runner,
         config=config,
-        search=f'"[#{parent_issue} stage]" in:title',
+        search=parent_child_search_query(parent_issue),
         state="all",
     )
     adopted_by_key, recognized_from_search = _adopt_from_found(

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -78,7 +78,6 @@ from coding_review_agent_loop.comment_rendering import (
 )
 from coding_review_agent_loop.decomposition import (
     CreatedPhaseIssue,
-    MAX_DECOMPOSITION_PHASES,
     RecordedPhase,
     approved_plan_hash,
     find_existing_phase_implementation_handoff,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2137,6 +2137,34 @@ def test_plan_first_post_approval_options_require_plan_first(capsys):
     assert "--plan-execution-mode requires --plan-first" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize("mode", ["decompose-only", "implement-by-phase"])
+def test_cli_rejects_split_materialization_with_decomposition_modes(tmp_path, capsys, mode):
+    result = main([
+        "issue", "56", "--repo", "OWNER/REPO", "--plan-first",
+        "--plan-execution-mode", mode, "--materialize-split-issues",
+        "--claude-dir", str(tmp_path / "claude"),
+        "--codex-dir", str(tmp_path / "codex"),
+        "--gemini-dir", str(tmp_path / "gemini"),
+        "--dry-run",
+    ])
+
+    assert result == 1
+    assert "cannot be combined" in capsys.readouterr().err
+
+
+def test_flat_child_limit_cli_is_configurable(tmp_path):
+    args = build_parser().parse_args([
+        "issue", "56", "--repo", "OWNER/REPO", "--flat-child-limit", "23",
+        "--claude-dir", str(tmp_path / "claude"),
+        "--codex-dir", str(tmp_path / "codex"),
+        "--gemini-dir", str(tmp_path / "gemini"),
+    ])
+
+    config = config_from_args(args, FakeRunner())
+
+    assert config.flat_child_limit == 23
+
+
 def test_implementation_codex_reasoning_effort_requires_codex_and_model(tmp_path):
     parser = build_parser()
     args = parser.parse_args([

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -4,15 +4,24 @@ from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
 from coding_review_agent_loop.config import DEFAULT_FLAT_CHILD_LIMIT
 from coding_review_agent_loop.decomposition import (
     CreatedPhaseIssue,
+    PlanDecomposition,
+    PlanPhase,
     RecordedPhase,
+    RetainedParentScope,
+    TopologyCheckpoint,
     approved_plan_hash,
+    format_phase_issue_body,
     find_existing_phase_implementation_handoff,
+    find_existing_topology_checkpoint,
     format_decomposition_parent_summary,
     format_phase_implementation_handoff_comment,
+    format_topology_checkpoint,
+    phase_identity,
     parse_plan_decomposition,
     create_decomposition_child_issues,
 )
 from coding_review_agent_loop.github import IssueComment
+from coding_review_agent_loop.child_topology import NeedsHumanDecision
 from coding_review_agent_loop.orchestrator import PostedRoundMetadata, _attach_round_metadata, _plan_subject
 from agent_loop_helpers import (
     FakeRunner,
@@ -176,6 +185,320 @@ def test_parse_plan_decomposition_rejects_duplicates_but_leaves_cap_to_preflight
     phases = [dict(phase, title=f"Phase {index}") for index in range(DEFAULT_FLAT_CHILD_LIMIT + 1)]
     parsed = parse_plan_decomposition(plan_decomposition_json(*phases))
     assert len(parsed.phases) == DEFAULT_FLAT_CHILD_LIMIT + 1
+
+
+def _phase(title: str, *, depends_on: tuple[str, ...] = ()) -> PlanPhase:
+    return PlanPhase(
+        title=title,
+        scope=f"Implement {title}.",
+        non_goals="No unrelated changes.",
+        dependency_notes="Follow the parent plan.",
+        rollout_risk="low.",
+        validation="Run focused tests.",
+        parent_context="Approved parent constraints.",
+        automation="agent-pr",
+        depends_on=depends_on,
+    )
+
+
+def test_topology_checkpoint_stores_shared_context_once_and_round_trips(tmp_path):
+    excerpt = "Approved parent constraints.\n" + ("constraint detail\n" * 500)
+    phases = tuple(
+        PlanPhase(
+            title=f"Stage {index}",
+            scope=f"Implement stage {index}.",
+            non_goals="No unrelated changes.",
+            dependency_notes="Follow the parent plan.",
+            rollout_risk="low.",
+            validation="Run focused tests.",
+            parent_context=excerpt,
+            automation="agent-pr",
+            depends_on=(),
+        )
+        for index in range(13)
+    )
+    checkpoint = TopologyCheckpoint(
+        parent_issue=56,
+        plan_hash="plan-hash",
+        mode="decompose-only",
+        topology_source="typed",
+        phases=phases,
+        retained_parent_scope=RetainedParentScope(
+            plan_subject="Primary scope",
+            plan_hash="plan-hash",
+            excerpt=excerpt,
+        ),
+    )
+
+    body = format_topology_checkpoint(checkpoint)
+    restored = find_existing_topology_checkpoint(
+        (IssueComment(author="bot", created_at=None, body=body),),
+        parent_issue=56,
+        plan_hash="plan-hash",
+        mode="decompose-only",
+    )
+
+    assert len(body) < 60000
+    assert "constraint detail" not in body
+    assert restored == checkpoint
+
+
+def test_dry_run_decomposition_previews_dependency_phases_without_issue_numbers(tmp_path):
+    phases = parse_plan_decomposition(
+        plan_decomposition_json(
+            {
+                "title": "First phase",
+                "scope": "First.",
+                "non_goals": "None.",
+                "dependency_notes": "First.",
+                "rollout_risk": "low.",
+                "validation": "Tests.",
+                "parent_context": "Context.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+            {
+                "title": "Second phase",
+                "scope": "Second.",
+                "non_goals": "None.",
+                "dependency_notes": "After first.",
+                "rollout_risk": "low.",
+                "validation": "Tests.",
+                "parent_context": "Context.",
+                "automation": "agent-pr",
+                "depends_on": ["First phase"],
+            },
+        )
+    )
+    runner = FakeRunner()
+
+    created = create_decomposition_child_issues(
+        runner,
+        config=make_config(tmp_path, dry_run=True),
+        parent_issue=56,
+        approved_plan="approved plan",
+        decomposition=phases,
+    )
+
+    assert len(created) == 2
+    assert all(item.issue_url is None and item.issue_number is None for item in created)
+    assert len(runner.issues) == 2
+    assert runner.comments == []
+
+
+def test_decomposition_preflight_counts_split_children_toward_shared_limit(tmp_path):
+    existing_children = [
+        {
+            "number": 100 + index,
+            "title": f"[#56 stage] Existing {index}",
+            "url": f"https://github.com/OWNER/REPO/issues/{100 + index}",
+            "body": f"Part of #56\n<!-- AGENT_SPLIT_CHILD: parent=56 key={index + 1:064x} -->",
+        }
+        for index in range(DEFAULT_FLAT_CHILD_LIMIT)
+    ]
+    runner = FakeRunner(search_issues_payload=existing_children)
+
+    decision = create_decomposition_child_issues(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=56,
+        approved_plan="approved plan",
+        decomposition=PlanDecomposition(phases=(_phase("New phase"),)),
+    )
+
+    assert isinstance(decision, NeedsHumanDecision)
+    assert decision.recognized_existing_count == DEFAULT_FLAT_CHILD_LIMIT
+    assert decision.projected_total == DEFAULT_FLAT_CHILD_LIMIT + 1
+    assert runner.issues == []
+    assert runner.comments == []
+
+
+def test_decomposition_adopts_closed_exact_identity(tmp_path):
+    phase = _phase("Schema helpers")
+    plan = "approved plan"
+    identity = phase_identity(
+        parent_issue=56,
+        plan_hash=approved_plan_hash(plan),
+        topology_source="model",
+        phase_index=1,
+        phase=phase,
+    )
+    body = format_phase_issue_body(
+        repo="OWNER/REPO",
+        parent_issue=56,
+        approved_plan=plan,
+        phase=phase,
+        created_so_far=(),
+        phase_identity_value=identity,
+        topology_source="model",
+        phase_index=1,
+        phase_plan_hash=approved_plan_hash(plan),
+    )
+    runner = FakeRunner(
+        search_issues_payload=[
+            {
+                "number": 101,
+                "title": "Phase 1: Schema helpers (from #56)",
+                "url": "https://github.com/OWNER/REPO/issues/101",
+                "body": body,
+                "state": "closed",
+            }
+        ]
+    )
+
+    created = create_decomposition_child_issues(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=56,
+        approved_plan=plan,
+        decomposition=PlanDecomposition(phases=(phase,)),
+    )
+
+    assert created[0].origin == "adopted"
+    assert created[0].issue_number == 101
+    assert runner.issues == []
+
+
+def test_decomposition_rejects_ambiguous_exact_identity_before_checkpoint(tmp_path):
+    phase = _phase("Schema helpers")
+    plan = "approved plan"
+    identity = phase_identity(
+        parent_issue=56,
+        plan_hash=approved_plan_hash(plan),
+        topology_source="model",
+        phase_index=1,
+        phase=phase,
+    )
+    body = format_phase_issue_body(
+        repo="OWNER/REPO",
+        parent_issue=56,
+        approved_plan=plan,
+        phase=phase,
+        created_so_far=(),
+        phase_identity_value=identity,
+        topology_source="model",
+        phase_index=1,
+        phase_plan_hash=approved_plan_hash(plan),
+    )
+    runner = FakeRunner(search_issues_payload=[
+        {"number": 101, "title": "Phase 1: Schema helpers (from #56)", "url": "u101", "body": body},
+        {"number": 102, "title": "Phase 1: Schema helpers (from #56)", "url": "u102", "body": body},
+    ])
+
+    with pytest.raises(AgentLoopError, match="Ambiguous decomposition recovery"):
+        create_decomposition_child_issues(
+            runner,
+            config=make_config(tmp_path),
+            parent_issue=56,
+            approved_plan=plan,
+            decomposition=PlanDecomposition(phases=(phase,)),
+        )
+    assert runner.issues == []
+    assert runner.comments == []
+
+
+def test_decomposition_partial_create_recovers_from_checkpoint_and_identity(tmp_path, monkeypatch):
+    phases = parse_plan_decomposition(
+        plan_decomposition_json(
+            {
+                "title": "First phase",
+                "scope": "First.",
+                "non_goals": "None.",
+                "dependency_notes": "First.",
+                "rollout_risk": "low.",
+                "validation": "Tests.",
+                "parent_context": "Context.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+            {
+                "title": "Second phase",
+                "scope": "Second.",
+                "non_goals": "None.",
+                "dependency_notes": "Second.",
+                "rollout_risk": "low.",
+                "validation": "Tests.",
+                "parent_context": "Context.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+        )
+    )
+    plan = "approved plan"
+    runner = FakeRunner(
+        issue_urls=[
+            "https://github.com/OWNER/REPO/issues/101",
+            "https://github.com/OWNER/REPO/issues/102",
+        ],
+        search_issues_payload=[[]],
+    )
+    config = make_config(tmp_path)
+    original_create = __import__(
+        "coding_review_agent_loop.decomposition", fromlist=["create_issue"]
+    ).create_issue
+    calls = {"count": 0}
+
+    def fail_after_first(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise AgentLoopError("simulated create failure")
+        return original_create(*args, **kwargs)
+
+    import coding_review_agent_loop.decomposition as decomp
+
+    monkeypatch.setattr(decomp, "create_issue", fail_after_first)
+    with pytest.raises(AgentLoopError, match="simulated create failure"):
+        create_decomposition_child_issues(
+            runner,
+            config=config,
+            parent_issue=56,
+            approved_plan=plan,
+            decomposition=phases,
+        )
+    assert len(runner.issues) == 1
+    checkpoint_comments = tuple(
+        IssueComment(author="bot", created_at=None, body=comment["body"])
+        for comment in runner.issue_comments
+    )
+    first_identity = phase_identity(
+        parent_issue=56,
+        plan_hash=approved_plan_hash(plan),
+        topology_source="model",
+        phase_index=1,
+        phase=phases.phases[0],
+    )
+    first_body = format_phase_issue_body(
+        repo="OWNER/REPO",
+        parent_issue=56,
+        approved_plan=plan,
+        phase=phases.phases[0],
+        created_so_far=(),
+        phase_identity_value=first_identity,
+        topology_source="model",
+        phase_index=1,
+        phase_plan_hash=approved_plan_hash(plan),
+    )
+    runner.search_issues_payload = [{
+        "number": 101,
+        "title": "Phase 1: First phase (from #56)",
+        "url": "https://github.com/OWNER/REPO/issues/101",
+        "body": first_body,
+    }]
+    monkeypatch.setattr(decomp, "create_issue", original_create)
+
+    resumed = create_decomposition_child_issues(
+        runner,
+        config=config,
+        parent_issue=56,
+        approved_plan=plan,
+        decomposition=phases,
+        issue_comments=checkpoint_comments,
+    )
+
+    assert [item.origin for item in resumed] == ["adopted", "created"]
+    assert [item.issue_number for item in resumed] == [101, 102]
+    assert len(runner.issues) == 2
+    assert sum("Topology checkpoint recorded" in comment for comment in runner.comments) == 1
 
 
 def test_typed_decompose_only_materializes_one_thirteen_stage_topology(tmp_path):
@@ -603,6 +926,55 @@ def test_issue_loop_plan_first_implement_by_phase_stops_on_human_first_phase(tmp
     assert runner.issues[0]["title"].startswith("[Human] Phase 1")
     assert not any("<!-- AGENT_PLAN_PHASE_IMPLEMENTATION:" in comment for comment in runner.comments)
     assert not any(cmd[:3] == ["gh", "pr", "view"] for cmd, _cwd in runner.commands)
+
+
+def test_issue_loop_dry_run_implement_by_phase_allows_dependency_preview(tmp_path):
+    runner = FakeRunner(
+        claude_outputs=[
+            structured_plan_state(summary="Add schema helpers."),
+            plan_decomposition_json(
+                {
+                    "title": "First phase",
+                    "scope": "First.",
+                    "non_goals": "None.",
+                    "dependency_notes": "First.",
+                    "rollout_risk": "low.",
+                    "validation": "Tests.",
+                    "parent_context": "Context.",
+                    "automation": "agent-pr",
+                    "depends_on": [],
+                },
+                {
+                    "title": "Second phase",
+                    "scope": "Second.",
+                    "non_goals": "None.",
+                    "dependency_notes": "After first.",
+                    "rollout_risk": "low.",
+                    "validation": "Tests.",
+                    "parent_context": "Context.",
+                    "automation": "agent-pr",
+                    "depends_on": ["First phase"],
+                },
+            ),
+        ],
+        codex_outputs=[structured_plan_review(state="approved")],
+    )
+
+    result = run_issue_loop(
+        runner,
+        issue_number=56,
+        config=make_config(
+            tmp_path,
+            dry_run=True,
+            plan_execution_mode="implement-by-phase",
+        ),
+        plan_first=True,
+    )
+
+    assert result == 0
+    assert len(runner.issues) == 2
+    claude_calls = [cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]
+    assert len(claude_calls) == 2
 
 def test_issue_loop_plan_first_implement_by_phase_implements_first_agent_phase(tmp_path):
     runner = FakeRunner(

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -201,6 +201,19 @@ def _phase(title: str, *, depends_on: tuple[str, ...] = ()) -> PlanPhase:
     )
 
 
+def test_format_phase_body_points_to_parent_for_complete_constraints():
+    body = format_phase_issue_body(
+        repo="OWNER/REPO",
+        parent_issue=56,
+        approved_plan="The complete approved plan.",
+        phase=_phase("Model-selected phase"),
+        created_so_far=(),
+    )
+
+    assert "The linked parent issue is the source of truth" in body
+    assert "complete historical constraint context" not in body
+
+
 def test_topology_checkpoint_stores_shared_context_once_and_round_trips(tmp_path):
     excerpt = "Approved parent constraints.\n" + ("constraint detail\n" * 500)
     phases = tuple(

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -1,15 +1,16 @@
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError, run_issue_loop
+from coding_review_agent_loop.config import DEFAULT_FLAT_CHILD_LIMIT
 from coding_review_agent_loop.decomposition import (
     CreatedPhaseIssue,
-    MAX_DECOMPOSITION_PHASES,
     RecordedPhase,
     approved_plan_hash,
     find_existing_phase_implementation_handoff,
     format_decomposition_parent_summary,
     format_phase_implementation_handoff_comment,
     parse_plan_decomposition,
+    create_decomposition_child_issues,
 )
 from coding_review_agent_loop.github import IssueComment
 from coding_review_agent_loop.orchestrator import PostedRoundMetadata, _attach_round_metadata, _plan_subject
@@ -157,7 +158,7 @@ def test_parse_plan_decomposition_rejects_invalid_phase_fields(mutate, message):
     with pytest.raises(AgentLoopError, match=message):
         parse_plan_decomposition(plan_decomposition_json(phase))
 
-def test_parse_plan_decomposition_rejects_duplicates_and_over_cap():
+def test_parse_plan_decomposition_rejects_duplicates_but_leaves_cap_to_preflight():
     phase = {
         "title": "Repeated phase",
         "scope": "Add helpers.",
@@ -172,9 +173,71 @@ def test_parse_plan_decomposition_rejects_duplicates_and_over_cap():
     with pytest.raises(AgentLoopError, match="duplicate phase title"):
         parse_plan_decomposition(plan_decomposition_json(phase, dict(phase)))
 
-    phases = [dict(phase, title=f"Phase {index}") for index in range(MAX_DECOMPOSITION_PHASES + 1)]
-    with pytest.raises(AgentLoopError, match="MAX_DECOMPOSITION_PHASES"):
-        parse_plan_decomposition(plan_decomposition_json(*phases))
+    phases = [dict(phase, title=f"Phase {index}") for index in range(DEFAULT_FLAT_CHILD_LIMIT + 1)]
+    parsed = parse_plan_decomposition(plan_decomposition_json(*phases))
+    assert len(parsed.phases) == DEFAULT_FLAT_CHILD_LIMIT + 1
+
+
+def test_typed_decompose_only_materializes_one_thirteen_stage_topology(tmp_path):
+    stages = [
+        {"title": f"Backend stage {index}", "summary": f"Backend work {index}."}
+        for index in range(8)
+    ] + [
+        {"title": f"Frontend stage {index}", "summary": f"Frontend work {index}."}
+        for index in range(5)
+    ]
+    runner = FakeRunner(
+        claude_outputs=[structured_plan_state(summary="Primary approved scope", child_stages=stages)],
+        codex_outputs=[structured_plan_review(state="approved")],
+        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + index}" for index in range(13)],
+    )
+    config = make_config(tmp_path, plan_execution_mode="decompose-only")
+
+    assert run_issue_loop(runner, issue_number=56, config=config, plan_first=True) == 0
+    assert len(runner.issues) == 13
+    assert len([cmd for cmd, _cwd in runner.commands if cmd[:1] == ["claude"]]) == 1
+    assert not any("AGENT_TYPED_PLAN_STAGES" in issue["body"] for issue in runner.issues)
+    assert "Retained parent scope" in runner.comments[-1]
+
+
+def test_decomposition_preflights_last_unsafe_phase_before_any_write(tmp_path):
+    phases = parse_plan_decomposition(
+        plan_decomposition_json(
+            {
+                "title": "Safe phase",
+                "scope": "Safe.",
+                "non_goals": "None.",
+                "dependency_notes": "None.",
+                "rollout_risk": "low.",
+                "validation": "Tests.",
+                "parent_context": "Context.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+            {
+                "title": "Unsafe phase",
+                "scope": "Contains <!-- AGENT_TYPED_PLAN_STAGES: historical -->",
+                "non_goals": "None.",
+                "dependency_notes": "None.",
+                "rollout_risk": "low.",
+                "validation": "Tests.",
+                "parent_context": "Context.",
+                "automation": "agent-pr",
+                "depends_on": [],
+            },
+        )
+    )
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/101"])
+    with pytest.raises(AgentLoopError, match="marker set mismatch"):
+        create_decomposition_child_issues(
+            runner,
+            config=make_config(tmp_path),
+            parent_issue=56,
+            approved_plan="approved plan",
+            decomposition=phases,
+        )
+    assert runner.issues == []
+    assert runner.comments == []
 
 def test_issue_loop_plan_first_decompose_only_summarizes_instead_of_filing_plan_followups(tmp_path):
     runner = FakeRunner(

--- a/tests/test_protocol_markers.py
+++ b/tests/test_protocol_markers.py
@@ -138,7 +138,7 @@ def test_ordinary_issue_comment_writer_enforces_issue_comment_surface():
 
 def test_source_inventory_has_no_unregistered_protocol_literals():
     assert_source_inventory(Path(__file__).parents[1])
-    assert len(RESERVED_MARKER_REGISTRY) == 22
+    assert len(RESERVED_MARKER_REGISTRY) == 24
 
 
 def test_issue_provenance_trailer_is_not_a_reserved_marker_or_forged_body_record():

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -3450,6 +3450,44 @@ class TestRunDecompose:
             assert output["phases"][0]["automation"] == "agent-pr"
             assert output["would_post_parent_summary"] is True
 
+    def test_dry_run_over_limit_returns_structured_needs_human_without_posts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            _write_fake_gh(tmppath)
+            env = _make_fake_gh_env(tmppath)
+            plan = tmppath / "plan.md"
+            payload = {
+                "schema_version": 1,
+                "kind": "plan_state",
+                "state": "blocking",
+                "summary": "Large typed topology",
+                "plan_steps": ["Materialize all typed stages."],
+                "human_requirement_dispositions": [],
+                "child_stages": [
+                    {"title": f"Stage {index}", "summary": f"Work {index}."}
+                    for index in range(16)
+                ],
+            }
+            plan.write_text(
+                json.dumps(payload)
+                + "\n<!-- AGENT_PLAN_STATE: blocking -->\n-- Anthropic Claude\n",
+                encoding="utf-8",
+            )
+            result = _run(
+                "helpers.skill_runner", "run-decompose",
+                "--issue", "9992", "--repo", "test/skill-repo",
+                "--coder", "codex", "--plan-file", str(plan),
+                "--workdir", str(tmppath), "--flat-child-limit", "15",
+                "--dry-run", env=env, check=False,
+            )
+
+            assert result.returncode == 2, result.stderr
+            output = self._last_json(result.stdout)
+            assert output["state"] == "needs-human"
+            assert output["decision"]["projected_total"] == 16
+            assert output["would_post_checkpoint"] is False
+            assert output["would_post_parent_summary"] is False
+
     def test_live_path_creates_children_and_posts_parent_summary(self, monkeypatch, tmp_path) -> None:
         import helpers.skill_runner as sr
         import coding_review_agent_loop.decomposition as decomp
@@ -3472,7 +3510,18 @@ class TestRunDecompose:
                 comments=(), human_requirements=(),
             )
 
-        def fake_create(runner, *, config, parent_issue, approved_plan, decomposition):
+        def fake_create(
+            runner,
+            *,
+            config,
+            parent_issue,
+            approved_plan,
+            decomposition,
+            topology_source,
+            issue_comments,
+            mode,
+            retained_parent_scope,
+        ):
             created_calls.append({
                 "parent_issue": parent_issue,
                 "approved_plan": approved_plan,
@@ -3487,7 +3536,17 @@ class TestRunDecompose:
                 ),
             )
 
-        def fake_post(runner, *, config, parent_issue, mode, plan_hash, created):
+        def fake_post(
+            runner,
+            *,
+            config,
+            parent_issue,
+            mode,
+            plan_hash,
+            created,
+            topology_source,
+            retained_parent_scope,
+        ):
             posted_calls.append({
                 "parent_issue": parent_issue,
                 "mode": mode,
@@ -3522,6 +3581,61 @@ class TestRunDecompose:
         assert posted_calls[0]["parent_issue"] == 77
         assert posted_calls[0]["mode"] == "decompose-only"
         assert posted_calls[0]["created"][0].issue_number == 123
+
+    def test_live_over_limit_returns_needs_human_without_summary(self, monkeypatch, tmp_path, capsys) -> None:
+        import helpers.skill_runner as sr
+        import coding_review_agent_loop.decomposition as decomp
+        import coding_review_agent_loop.github as gh
+        from coding_review_agent_loop.child_topology import NeedsHumanDecision
+        from coding_review_agent_loop.github import IssueContext
+
+        def fake_run_helper(*args, **_kwargs):
+            output = Path(args[args.index("--output") + 1])
+            output.write_text(_DECOMP_JSON, encoding="utf-8")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        def fake_get_issue_context(_runner, *, config, issue_number):
+            return IssueContext(
+                number=issue_number, repo=config.repo, title="T", body="B", url="u",
+                comments=(), human_requirements=(),
+            )
+
+        def fake_create(*_args, **_kwargs):
+            return NeedsHumanDecision(
+                parent_issue=77,
+                source="model",
+                requested_desired_count=16,
+                recognized_existing_count=0,
+                projected_total=16,
+                configured_limit=15,
+            )
+
+        monkeypatch.setattr(sr, "_run_helper", fake_run_helper)
+        monkeypatch.setattr(gh, "get_issue_context", fake_get_issue_context)
+        monkeypatch.setattr(decomp, "create_decomposition_child_issues", fake_create)
+        plan = tmp_path / "plan.md"
+        plan.write_text("Approved plan body", encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exit_info:
+            sr.cmd_run_decompose(types.SimpleNamespace(
+                issue=77,
+                repo="test/skill-repo",
+                coder="codex",
+                plan_file=str(plan),
+                workdir=str(tmp_path),
+                workdir_codex=None,
+                workdir_gemini=None,
+                workdir_antigravity=None,
+                dry_run=False,
+                flat_child_limit=15,
+            ))
+
+        assert exit_info.value.code == 2
+        output = self._last_json(capsys.readouterr().out)
+        assert output["state"] == "needs-human"
+        assert output["decision"]["guidance"].endswith("#720.")
+        assert output["would_post_checkpoint"] is False
+        assert output["would_post_parent_summary"] is False
 
     def test_existing_marker_reuses_without_running_coder(self, monkeypatch, tmp_path, capsys) -> None:
         import helpers.skill_runner as sr

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -1,6 +1,7 @@
 import pytest
 
 from coding_review_agent_loop.cli import AgentLoopError
+from coding_review_agent_loop.config import DEFAULT_FLAT_CHILD_LIMIT
 from coding_review_agent_loop.github import (
     IssueComment,
     find_open_pr_closing_issue,
@@ -10,7 +11,6 @@ from coding_review_agent_loop.github import (
     validate_pr_body_does_not_close_issue,
 )
 from coding_review_agent_loop.split_materialization import (
-    MAX_SPLIT_CHILDREN,
     dedupe_split_stage_proposals,
     find_existing_split_materialization,
     find_existing_split_stage_handoff,
@@ -23,6 +23,7 @@ from coding_review_agent_loop.split_materialization import (
     split_stage_proposal_from_deferred_stage,
     split_stage_proposal_from_text,
 )
+from coding_review_agent_loop.child_topology import NeedsHumanDecision
 from coding_review_agent_loop.protocol import ChildStage, DeferredStage
 from agent_loop_helpers import FakeRunner, make_config
 
@@ -116,6 +117,40 @@ def test_materialize_split_proposals_creates_children_with_markers(tmp_path):
     assert "https://github.com/OWNER/REPO/issues/102" in parent_summary
 
 
+def test_materialize_split_proposals_allows_shared_default_limit(tmp_path):
+    proposals = [split_stage_proposal_from_text(f"Stage {index}") for index in range(15)]
+    runner = FakeRunner(
+        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + index}" for index in range(15)]
+    )
+    metadata = materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=56,
+        subject="subject-a",
+        proposals=proposals,
+    )
+    assert metadata is not None
+    assert not isinstance(metadata, NeedsHumanDecision)
+    assert len(metadata.children) == 15
+
+
+def test_materialize_split_proposals_neutralizes_marker_bearing_historical_text(tmp_path):
+    proposal = split_stage_proposal_from_text(
+        "Marker-bearing stage\n\n<!-- AGENT_TYPED_PLAN_STAGES: historical -->"
+    )
+    runner = FakeRunner(issue_urls=["https://github.com/OWNER/REPO/issues/101"])
+    metadata = materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path),
+        parent_issue=56,
+        subject="subject-a",
+        proposals=[proposal],
+        rationale=(("reviewer <!-- AGENT_TYPED_PLAN_STAGES: historical -->", "old record"),),
+    )
+    assert metadata is not None
+    assert "AGENT_TYPED_PLAN_STAGES" not in runner.issues[0]["body"]
+
+
 def test_materialize_split_proposals_rerun_with_existing_marker_creates_nothing(tmp_path):
     runner = FakeRunner(
         issue_urls=[
@@ -189,14 +224,14 @@ def test_materialize_split_proposals_partial_failure_adopts_existing_child(tmp_p
     assert "adopted" in parent_summary
 
 
-def test_materialize_split_proposals_caps_at_max_children(tmp_path):
-    proposals = [split_stage_proposal_from_text(f"Stage {i}") for i in range(MAX_SPLIT_CHILDREN + 3)]
+def test_materialize_split_proposals_returns_needs_human_before_over_limit_writes(tmp_path):
+    proposals = [split_stage_proposal_from_text(f"Stage {i}") for i in range(DEFAULT_FLAT_CHILD_LIMIT + 3)]
     runner = FakeRunner(
-        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + i}" for i in range(MAX_SPLIT_CHILDREN)]
+        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + i}" for i in range(DEFAULT_FLAT_CHILD_LIMIT)]
     )
     config = make_config(tmp_path)
 
-    metadata = materialize_split_proposals(
+    decision = materialize_split_proposals(
         runner,
         config=config,
         parent_issue=56,
@@ -205,47 +240,29 @@ def test_materialize_split_proposals_caps_at_max_children(tmp_path):
         issue_comments=(),
     )
 
-    assert len(runner.issues) == MAX_SPLIT_CHILDREN
-    assert len(metadata.children) == MAX_SPLIT_CHILDREN
+    assert isinstance(decision, NeedsHumanDecision)
+    assert decision.projected_total == DEFAULT_FLAT_CHILD_LIMIT + 3
+    assert runner.issues == []
+    assert runner.comments == []
 
 
-def test_materialize_split_proposals_rerun_does_not_exceed_cap(tmp_path):
-    """A rerun with the same over-cap proposal set must not keep filing new
-    children past MAX_SPLIT_CHILDREN: remaining capacity must be computed from
-    children already recorded in the parent's cumulative metadata, not just
-    the proposals this call still considers unresolved (#492 review)."""
-    proposals = [split_stage_proposal_from_text(f"Stage {i}") for i in range(MAX_SPLIT_CHILDREN + 3)]
+def test_materialize_split_proposals_rejects_projected_parent_over_limit(tmp_path):
+    """A parent-wide over-limit request is rejected without partial children."""
+    proposals = [split_stage_proposal_from_text(f"Stage {i}") for i in range(DEFAULT_FLAT_CHILD_LIMIT + 3)]
     config = make_config(tmp_path)
 
-    first_runner = FakeRunner(
-        issue_urls=[f"https://github.com/OWNER/REPO/issues/{100 + i}" for i in range(MAX_SPLIT_CHILDREN)]
-    )
-    first_metadata = materialize_split_proposals(
-        first_runner,
+    runner = FakeRunner()
+    decision = materialize_split_proposals(
+        runner,
         config=config,
         parent_issue=56,
         subject="subject-a",
         proposals=proposals,
         issue_comments=(),
     )
-    assert len(first_metadata.children) == MAX_SPLIT_CHILDREN
-    parent_summary_comment = _comment(first_runner.comments[-1])
-
-    # Rerun with the identical over-cap proposal set, seeded with the parent
-    # comment history left behind by the first run.
-    second_runner = FakeRunner()
-    second_metadata = materialize_split_proposals(
-        second_runner,
-        config=config,
-        parent_issue=56,
-        subject="subject-a",
-        proposals=proposals,
-        issue_comments=[parent_summary_comment],
-    )
-
-    assert second_runner.issues == []
-    assert second_metadata.children == first_metadata.children
-    assert len(second_metadata.children) == MAX_SPLIT_CHILDREN
+    assert isinstance(decision, NeedsHumanDecision)
+    assert runner.issues == []
+    assert runner.comments == []
 
 
 def test_materialize_split_proposals_returns_none_for_no_proposals(tmp_path):

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -23,6 +23,7 @@ from coding_review_agent_loop.split_materialization import (
     split_stage_proposal_from_deferred_stage,
     split_stage_proposal_from_text,
 )
+from coding_review_agent_loop.decomposition import _encode_json_payload
 from coding_review_agent_loop.child_topology import NeedsHumanDecision
 from coding_review_agent_loop.protocol import ChildStage, DeferredStage
 from agent_loop_helpers import FakeRunner, make_config
@@ -212,7 +213,9 @@ def test_materialize_split_proposals_partial_failure_adopts_existing_child(tmp_p
         issue_comments=(),
     )
 
-    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
+    assert runner.search_issues_calls == [
+        '"(from #56)" in:title OR "[#56 stage]" in:title'
+    ]
     # Only the unmatched (billing) proposal was created; auth was adopted.
     assert len(runner.issues) == 1
     assert runner.issues[0]["title"] == "[#56 stage] Billing flow"
@@ -293,8 +296,40 @@ def test_materialize_split_proposals_dry_run_previews_search_and_create(tmp_path
     # Dry-run still previews the `gh issue list --search` and `gh issue create`
     # commands (so the materialization path is visible), it just never
     # persists application-level state outside of GitHub CLI echo commands.
-    assert runner.search_issues_calls == ['"[#56 stage]" in:title']
+    assert runner.search_issues_calls == [
+        '"(from #56)" in:title OR "[#56 stage]" in:title'
+    ]
     assert len(runner.issues) == 1
+
+
+def test_split_preflight_counts_decomposition_children_toward_shared_limit(tmp_path):
+    identity_payload = _encode_json_payload(
+        {"identity": "existing-decomposition", "parent_issue": 56}
+    )
+    runner = FakeRunner(
+        search_issues_payload=[
+            {
+                "number": 101,
+                "title": "Phase 1: Existing (from #56)",
+                "url": "https://github.com/OWNER/REPO/issues/101",
+                "body": f"Part of #56\n<!-- AGENT_PLAN_PHASE_IDENTITY: {identity_payload} -->",
+            }
+        ]
+    )
+
+    decision = materialize_split_proposals(
+        runner,
+        config=make_config(tmp_path, flat_child_limit=1),
+        parent_issue=56,
+        subject="discussion",
+        proposals=[split_stage_proposal_from_text("New stage")],
+    )
+
+    assert isinstance(decision, NeedsHumanDecision)
+    assert decision.recognized_existing_count == 1
+    assert decision.projected_total == 2
+    assert runner.issues == []
+    assert runner.comments == []
 
 
 def test_materialize_typed_child_adopts_existing_canonical_issue_instead_of_duplicate(tmp_path):
@@ -367,7 +402,9 @@ def test_materialize_discuss_proposal_skips_canonical_title_search(tmp_path):
         proposals=[split_stage_proposal_from_text('Stage "4"\n\nNew work.')],
     )
 
-    assert runner.search_issues_calls == ['"[#479 stage]" in:title']
+    assert runner.search_issues_calls == [
+        '"(from #479)" in:title OR "[#479 stage]" in:title'
+    ]
 
 
 def test_discuss_split_proposal_can_reference_parent_issue_without_rejection(tmp_path):

--- a/tests/test_split_materialization.py
+++ b/tests/test_split_materialization.py
@@ -214,7 +214,8 @@ def test_materialize_split_proposals_partial_failure_adopts_existing_child(tmp_p
     )
 
     assert runner.search_issues_calls == [
-        '"(from #56)" in:title OR "[#56 stage]" in:title'
+        '"(from #56)" in:title',
+        '"[#56 stage]" in:title',
     ]
     # Only the unmatched (billing) proposal was created; auth was adopted.
     assert len(runner.issues) == 1
@@ -297,7 +298,8 @@ def test_materialize_split_proposals_dry_run_previews_search_and_create(tmp_path
     # commands (so the materialization path is visible), it just never
     # persists application-level state outside of GitHub CLI echo commands.
     assert runner.search_issues_calls == [
-        '"(from #56)" in:title OR "[#56 stage]" in:title'
+        '"(from #56)" in:title',
+        '"[#56 stage]" in:title',
     ]
     assert len(runner.issues) == 1
 
@@ -336,6 +338,7 @@ def test_materialize_typed_child_adopts_existing_canonical_issue_instead_of_dupl
     runner = FakeRunner(
         search_issues_payload=[
             [],
+            [],
             [
                 {
                     "number": 480,
@@ -365,6 +368,7 @@ def test_materialize_typed_child_does_not_adopt_unrelated_title_match(tmp_path):
     runner = FakeRunner(
         issue_urls=["https://github.com/OWNER/REPO/issues/481"],
         search_issues_payload=[
+            [],
             [],
             [
                 {
@@ -403,7 +407,8 @@ def test_materialize_discuss_proposal_skips_canonical_title_search(tmp_path):
     )
 
     assert runner.search_issues_calls == [
-        '"(from #479)" in:title OR "[#479 stage]" in:title'
+        '"(from #479)" in:title',
+        '"[#479 stage]" in:title',
     ]
 
 


### PR DESCRIPTION
## Summary

- Selects one canonical typed or model decomposition topology without duplicate child creation.
- Adds shared configurable flat-child preflight (default 15), protocol-safe drafts, structured over-limit decisions, and checkpoint/identity recovery.
- Aligns CLI and skill-mode behavior and documents the cap, no-truncation rule, recovery, and hierarchical handoff.

## Verification

- Focused decomposition, split, orchestration, protocol, skill, documentation, and managed-CI tests pass.
- Full test suite passes.

Fixes #719