### PR TITLE
Parse agy 1.1.22 model catalogs

### DIFF
--- a/src/coding_review_agent_loop/agents/antigravity.py
+++ b/src/coding_review_agent_loop/agents/antigravity.py
@@ -231,9 +231,29 @@ def _parse_model_catalog(raw: str) -> set[str]:
         if not value or set(value) <= {"-", "=", "_"}:
             continue
         lowered = value.lower().rstrip(":")
+        status = "fetching available models..."
+        if status in lowered:
+            # PTY capture normalizes carriage-return spinner updates away, so
+            # the final status frame can be joined directly to the first row.
+            value = value[lowered.rfind(status) + len(status) :].strip()
+            if not value:
+                continue
+            lowered = value.lower().rstrip(":")
         if lowered in {"models", "available models", "available model", "name", "model"}:
             continue
         if lowered.startswith(("error:", "warning:", "usage:", "command:")):
+            continue
+        # agy 1.1.22 renders a two-column catalog (machine slug followed by
+        # display label), while older releases emitted one label per line.
+        # Accept either spelling because --model supports both forms.
+        row = re.fullmatch(
+            r"(?P<slug>[a-z0-9][a-z0-9._-]*)[ \t]{2,}(?P<label>\S.*)",
+            value,
+            re.IGNORECASE,
+        )
+        if row is not None:
+            models.add(row.group("slug"))
+            models.add(row.group("label").strip())
             continue
         models.add(value)
     return models

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -983,6 +983,48 @@ def test_antigravity_repair_validates_once_and_falls_back_to_catalog_chain(tmp_p
     assert all(use_pty for _, use_pty in calls)
 
 
+def test_antigravity_repair_accepts_agy_1_1_22_two_column_catalog(tmp_path, monkeypatch):
+    from coding_review_agent_loop.agents import antigravity as agy_mod
+
+    monkeypatch.setattr(agy_mod, "_antigravity_settings_path", lambda: tmp_path / "settings.json")
+    valid = structured_pr_review(state="approved", reviewer="Google Antigravity")
+    catalog = (
+        "\r\u280b Fetching available models..."
+        "\r\x1b[Kgemini-3.7-flash-high     Gemini 3.7 Flash (High)\r\n"
+        "gemini-3.7-flash-medium   Gemini 3.7 Flash (Medium)\r\n"
+    )
+    runner = FakeRunner(
+        antigravity_catalog_outputs=[(catalog, 0)],
+        antigravity_outputs=[(valid, 0)],
+    )
+    config = make_config(
+        tmp_path,
+        repair_models=("Gemini 3.5 Flash (Medium)",),
+        antigravity_models=("Gemini 3.7 Flash (High)",),
+    )
+
+    repaired, _, attempts = execute_repair(
+        "malformed",
+        runner=runner,
+        config=config,
+        run_id="catalog-1-1-22",
+        usage_context=None,
+        validate=lambda text: parse_structured_pr_review(
+            text, reviewer="Google Antigravity"
+        ),
+        expected_kind="pr_review",
+    )
+
+    assert repaired == valid
+    assert [attempt.model for attempt in attempts] == [
+        "Gemini 3.5 Flash (Medium)",
+        "Gemini 3.7 Flash (High)",
+    ]
+    assert attempts[0].outcome == "unavailable_model"
+    assert attempts[1].outcome == "succeeded"
+    assert "Fetching available models" not in attempts[0].diagnostic
+
+
 def test_antigravity_repair_attempts_directly_when_catalog_fails(tmp_path, monkeypatch):
     from coding_review_agent_loop.agents import antigravity as agy_mod
 


### PR DESCRIPTION
## Summary

- Parse the two-column model catalog emitted by `agy` 1.1.22 into both machine slugs and display labels.
- Preserve compatibility with older one-label-per-line catalogs.
- Remove PTY spinner text, including the final frame that can be joined to the first model row.

## Context

During the 1.1.22/Gemini 3.7 trial on issue #719, the Antigravity reviewer completed successfully. A later malformed-response repair falsely classified `Gemini 3.7 Flash (High)` as unavailable even though that exact model appeared in the catalog diagnostic. The parser was comparing the configured display label against the complete two-column row.

## Verification

`PYTHONPATH=src pytest tests/test_antigravity.py tests/test_repair.py -q` (205 passed)
