### PR TITLE
Default Antigravity to Gemini 3.7 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ agent-loop task "Fix the flaky test" --repo OWNER/REPO --coder antigravity --rev
 
 Pick the model with `--antigravity-model "<name>"` (as listed by `agy models`),
 or supply an ordered fallback chain with `--antigravity-models "<name>" ["<name>" ...]`
-(tried in order after provider-framed capacity exhaustion; default `Gemini 3.6 Flash (High)` →
-`Gemini 3.5 Flash (High)` → `Gemini 3.1 Pro (High)`). When a `gemini` invocation fails with an
+(tried in order after provider-framed capacity exhaustion; default `Gemini 3.7 Flash (High)` →
+`Gemini 3.6 Flash (High)` → `Gemini 3.1 Pro (High)`). When a `gemini` invocation fails with an
 auth/quota error near or after the cutoff, the tool surfaces this migration
 guidance. Notes: Antigravity turns are single-shot (no cross-round session
 resume) and report estimated token usage (`agy` emits no token counts).
@@ -994,7 +994,7 @@ payloads into normal public GitHub comments, so raw JSON is not posted.
 
 When a structured plan review, plan revision, PR review, or coder follow-up is
 present but malformed, the loop may run a model-backed repair pass. The default
-backend is Antigravity (`agy`) with the default model `Gemini 3.5 Flash (Medium)`. The
+backend is Antigravity (`agy`) with the default model `Gemini 3.7 Flash (Medium)`. The
 repair pass is format-only: it asks the model to re-emit the agent's intent as the
 required JSON object, footer marker, and signature. The repaired response is
 accepted only if it passes the same strict validation as the original response;
@@ -1009,7 +1009,7 @@ duplicates removed. The loop validates candidates once with `agy models`, report
 available choices for stale names, and attempts candidates directly when discovery
 is unavailable. For example:
 
-`--repair-model "Gemini 3.5 Flash (Medium)" --repair-model "Gemini 3.1 Pro (High)"`
+`--repair-model "Gemini 3.7 Flash (Medium)" --repair-model "Gemini 3.1 Pro (High)"`
 
 The legacy `gemini --prompt` path is used only with
 `--repair-backend gemini` and requires non-interactive enterprise/API-key/Vertex

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,8 +83,8 @@ mode, you need `OWNER/REPO` and the reviewer set (`codex`, `gemini`, and/or
 that Google retires on 2026-06-18). `antigravity` works wherever an external
 coder/reviewer does (`--coder antigravity` / `--reviewers antigravity ...`); `agy` is
 accepted as an alias (e.g. `--coder agy` / `--reviewers agy`), normalized to `antigravity`.
-With no override, it uses the ordered fallback chain `Gemini 3.6 Flash (High)` →
-`Gemini 3.5 Flash (High)` → `Gemini 3.1 Pro (High)`. Use `--model MODEL` for the legacy single-model
+With no override, it uses the ordered fallback chain `Gemini 3.7 Flash (High)` →
+`Gemini 3.6 Flash (High)` → `Gemini 3.1 Pro (High)`. Use `--model MODEL` for the legacy single-model
 override or `--antigravity-models MODEL [MODEL ...]` for a custom ordered chain;
 the two model options are mutually exclusive. Customize fallback detection with
 `--antigravity-quota-signatures SIGNATURE [SIGNATURE ...]`. Each `agy --print`

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -13,7 +13,7 @@ The default flow is:
 
 The default coder is Claude and the default reviewer is Codex. Reverse the direction with `--coder codex --reviewer claude`, or use Gemini with `--coder gemini` / `--reviewer gemini`. Repeat `--reviewer` to require multiple reviewer approvals.
 
-Gemini CLI consumer access (free / Google AI Pro / Ultra) is retiring on June 18, 2026; personal-account `gemini` users should migrate to the Antigravity CLI (`agy`) with `--coder antigravity` / `--reviewer antigravity` (pick a single model via `--antigravity-model`, or an ordered fallback chain via `--antigravity-models`; default chain `Gemini 3.6 Flash (High)` → `Gemini 3.5 Flash (High)` → `Gemini 3.1 Pro (High)`). Enterprise / API-key Gemini CLI paths may remain available for organizations that still have access, so the `gemini` backend is retained for those users. Direct Gemini CLI support is best-effort: maintainers without enterprise Gemini CLI access need reporter-provided `.agent-loop-logs/*gemini.log` output, response-file contents, CLI version, and any sharable account/access context to debug live `gemini` failures. Antigravity turns are single-shot (no cross-round session resume) and report estimated usage.
+Gemini CLI consumer access (free / Google AI Pro / Ultra) is retiring on June 18, 2026; personal-account `gemini` users should migrate to the Antigravity CLI (`agy`) with `--coder antigravity` / `--reviewer antigravity` (pick a single model via `--antigravity-model`, or an ordered fallback chain via `--antigravity-models`; default chain `Gemini 3.7 Flash (High)` → `Gemini 3.6 Flash (High)` → `Gemini 3.1 Pro (High)`). Enterprise / API-key Gemini CLI paths may remain available for organizations that still have access, so the `gemini` backend is retained for those users. Direct Gemini CLI support is best-effort: maintainers without enterprise Gemini CLI access need reporter-provided `.agent-loop-logs/*gemini.log` output, response-file contents, CLI version, and any sharable account/access context to debug live `gemini` failures. Antigravity turns are single-shot (no cross-round session resume) and report estimated usage.
 
 Every `agy --print` call passes `--print-timeout` from
 `--antigravity-print-timeout-seconds` (default `600`, i.e. ten minutes), which
@@ -2202,7 +2202,7 @@ issue, matching how a successful PR-creating implementation is already posted.
 For structured plan reviews, plan revisions, PR reviews, and coder follow-ups,
 a present but malformed structured response may get a repair pass before the
 local failure is raised. By default the repair pass calls Antigravity through
-the existing PTY backend with the default model `Gemini 3.5 Flash (Medium)`;
+the existing PTY backend with the default model `Gemini 3.7 Flash (Medium)`;
 explicit repair models are followed by the configured coder/reviewer chain. It uses a fresh temporary
 workdir, empty tool permissions, and repair-only instructions forbidding file
 inspection, tests, mutation, background work, and subagents. The format-repair

--- a/docs/skill_mode.md
+++ b/docs/skill_mode.md
@@ -93,7 +93,7 @@ Merge stays a human decision.
 The external agent can be `codex`, `gemini`, or `antigravity` (the `agy` CLI —
 the migration path for Gemini CLI consumer access, which Google retires on
 2026-06-18). With no override, Antigravity uses the ordered fallback chain
-`Gemini 3.6 Flash (High)` → `Gemini 3.5 Flash (High)` → `Gemini 3.1 Pro (High)`. Use `--model MODEL` for the
+`Gemini 3.7 Flash (High)` → `Gemini 3.6 Flash (High)` → `Gemini 3.1 Pro (High)`. Use `--model MODEL` for the
 legacy single-model override or `--antigravity-models MODEL [MODEL ...]` for a
 custom ordered chain; these options are mutually exclusive. Use
 `--antigravity-quota-signatures SIGNATURE [SIGNATURE ...]` to customize the
@@ -188,7 +188,7 @@ never falsely reported `approved`. A malformed-but-content-bearing structured
 review is recovered automatically when possible: safe skill normalization,
 envelope normalization, deterministic unknown-prior-item stripping against the
 complete carried ledger, and then model format repair. Local-loop repair now
-defaults to isolated Antigravity with `Gemini 3.5 Flash (Medium)`; explicit repeatable
+defaults to isolated Antigravity with `Gemini 3.7 Flash (Medium)`; explicit repeatable
 repair models are tried first, followed by the configured Antigravity chain. Legacy
 Gemini CLI repair requires
 `--repair-backend gemini` and suitable non-interactive authentication. The

--- a/src/coding_review_agent_loop/config.py
+++ b/src/coding_review_agent_loop/config.py
@@ -42,15 +42,15 @@ DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES: tuple[str, ...] = (
 # legacy antigravity_model nor an explicit antigravity_models chain is given. Named
 # for discoverability/symmetry with DEFAULT_ANTIGRAVITY_QUOTA_SIGNATURES.
 DEFAULT_ANTIGRAVITY_MODELS: tuple[str, ...] = (
+    "Gemini 3.7 Flash (High)",
     "Gemini 3.6 Flash (High)",
-    "Gemini 3.5 Flash (High)",
     "Gemini 3.1 Pro (High)",
 )
 DEFAULT_MAX_ROUNDS = 10
 # `agy --print` otherwise defaults to five minutes, which is too short for
 # complex reviews and causes it to exit with "timeout waiting for response".
 DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT_SECONDS = 10 * 60
-DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3.5 Flash (Medium)",)
+DEFAULT_REPAIR_MODELS: tuple[str, ...] = ("Gemini 3.7 Flash (Medium)",)
 # One parent-wide flat topology budget shared by decomposition and split
 # materialization.  Keeping this policy in config prevents each workflow from
 # obtaining a second allowance of children.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -5161,7 +5161,7 @@ def test_agent_signature_uses_configured_model(tmp_path):
     config = make_config(tmp_path, codex_model="gpt-5.2-codex", codex_reasoning_effort="high")
     assert agent_signature("codex", config) == "OpenAI Codex: gpt-5.2-codex (high)"
     # antigravity model is always declared (effort already embedded).
-    assert agent_signature("antigravity", config) == "Google Antigravity: Gemini 3.6 Flash (High)"
+    assert agent_signature("antigravity", config) == "Google Antigravity: Gemini 3.7 Flash (High)"
     # gemini with no declared model falls back to the generic signature.
     assert agent_signature("gemini", make_config(tmp_path)) == "Google Gemini"
 

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -429,8 +429,8 @@ def test_config_from_args_antigravity_defaults(tmp_path):
     assert config.antigravity_cmd == "agy"
     assert config.antigravity_model is None
     assert config.antigravity_models == (
+        "Gemini 3.7 Flash (High)",
         "Gemini 3.6 Flash (High)",
-        "Gemini 3.5 Flash (High)",
         "Gemini 3.1 Pro (High)",
     )
     assert config.antigravity_print_timeout_seconds == 600

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -1390,9 +1390,9 @@ class TestRunExternalRetries:
         assert exit_code == 0
         assert calls["n"] == 3
         assert calls["models"] == [
+            ("Gemini 3.7 Flash (High)",),
+            ("Gemini 3.7 Flash (High)",),
             ("Gemini 3.6 Flash (High)",),
-            ("Gemini 3.6 Flash (High)",),
-            ("Gemini 3.5 Flash (High)",),
         ]
         assert sleeps == [1]
         assert Path(output_path).read_text(encoding="utf-8") == "final review body"
@@ -4154,7 +4154,7 @@ class TestAntigravitySkill:
         [
             (
                 (),
-                ("Gemini 3.6 Flash (High)", "Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)"),
+                ("Gemini 3.7 Flash (High)", "Gemini 3.6 Flash (High)", "Gemini 3.1 Pro (High)"),
                 ("quota", "rate limit", "too many requests", "resource exhausted", "RESOURCE_EXHAUSTED", "429", "high traffic", "try again in a minute", "overload", "no capacity", "temporarily at capacity"),
             ),
             (("--model", "Model X"), ("Model X",), ("quota", "rate limit", "too many requests", "resource exhausted", "RESOURCE_EXHAUSTED", "429", "high traffic", "try again in a minute", "overload", "no capacity", "temporarily at capacity")),
@@ -4165,7 +4165,7 @@ class TestAntigravitySkill:
             ),
             (
                 ("--antigravity-quota-signatures", "Quota Hit", "429"),
-                ("Gemini 3.6 Flash (High)", "Gemini 3.5 Flash (High)", "Gemini 3.1 Pro (High)"),
+                ("Gemini 3.7 Flash (High)", "Gemini 3.6 Flash (High)", "Gemini 3.1 Pro (High)"),
                 ("Quota Hit", "429"),
             ),
         ],


### PR DESCRIPTION
## Summary

- Make `Gemini 3.7 Flash (High)` the primary default Antigravity model.
- Retain `Gemini 3.6 Flash (High)` and `Gemini 3.1 Pro (High)` as capacity fallbacks.
- Replace the unavailable Gemini 3.5 repair default with `Gemini 3.7 Flash (Medium)`.
- Update CLI/skill documentation and default-model expectations.

## Context

Live issue and PR review trials succeeded with `agy` 1.1.22 and Gemini 3.7 Flash High. The 1.1.22 model catalog no longer includes the previous Gemini 3.5 defaults, so retaining them would cause avoidable deterministic failures during fallback and malformed-response repair.

The dangerous-permission launcher is intentionally a machine-local operator choice and is not made the project-wide default by this PR.

## Verification

- Focused Antigravity, repair, documentation, and signature tests: 238 passed.
- Focused skill-runner default/fallback tests: 5 passed.
