### PR TITLE
Trust generated scope-narrowing warning

### DIFF
--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -4068,20 +4068,23 @@ def _handle_plan_first_split_scope(
         runner,
         config=config,
         issue_number=issue_number,
-        body="\n".join(
-            [
-                "### Possible unfiled scope narrowing",
-                "",
-                "The approved plan's text appears to narrow scope (mentions a stage, "
-                "follow-up issue, or out-of-scope work), but no `deferred_stages` were "
-                "structurally declared and no discuss split proposals exist for this issue. "
-                "If this plan intentionally defers work, declare it via `deferred_stages` in a "
-                "future revision or file the follow-up issue(s) manually. This is a heuristic "
-                "warning only; the orchestrator never auto-creates issues from prose.",
-                "",
-                f"<!-- AGENT_SPLIT_UNFILED_WARNING: issue={issue_number} subject={plan_subject} -->",
-                "-- coding-review-agent-loop",
-            ]
+        body=TrustedBody.canonical(
+            "\n".join(
+                [
+                    "### Possible unfiled scope narrowing",
+                    "",
+                    "The approved plan's text appears to narrow scope (mentions a stage, "
+                    "follow-up issue, or out-of-scope work), but no `deferred_stages` were "
+                    "structurally declared and no discuss split proposals exist for this issue. "
+                    "If this plan intentionally defers work, declare it via `deferred_stages` in a "
+                    "future revision or file the follow-up issue(s) manually. This is a heuristic "
+                    "warning only; the orchestrator never auto-creates issues from prose.",
+                    "",
+                    f"<!-- AGENT_SPLIT_UNFILED_WARNING: issue={issue_number} subject={plan_subject} -->",
+                    "-- coding-review-agent-loop",
+                ]
+            ),
+            expected_tokens=("AGENT_SPLIT_UNFILED_WARNING",),
         ),
     )
     return False

--- a/tests/test_split_orchestration.py
+++ b/tests/test_split_orchestration.py
@@ -9,11 +9,12 @@ from coding_review_agent_loop.decomposition import (
     approved_plan_hash,
     format_one_shot_impl_handoff_comment,
 )
-from coding_review_agent_loop.github import validate_pr_body_does_not_close_issue
+from coding_review_agent_loop.github import IssueContext, validate_pr_body_does_not_close_issue
 from coding_review_agent_loop.issue_pr_handoff import format_issue_pr_handoff_comment
 from coding_review_agent_loop.orchestrator import (
     PostedRoundMetadata,
     _attach_round_metadata,
+    _handle_plan_first_split_scope,
     _log_typed_plan_stage_dispositions,
     _plan_subject,
 )
@@ -243,6 +244,28 @@ def test_plan_first_no_prior_split_warns_when_materialization_disabled(tmp_path)
 
     assert runner.issues == []
     assert any("NOT filed as issues" in comment and "Auth flow" in comment for comment in runner.comments)
+
+
+def test_plan_first_scope_narrowing_warning_posts_trusted_marker(tmp_path):
+    runner = FakeRunner()
+    config = make_config(tmp_path)
+    plan = "Implement one focused PR. File a follow-up issue only if dev telemetry differs."
+    subject = _plan_subject(plan)
+
+    result = _handle_plan_first_split_scope(
+        runner,
+        issue_number=56,
+        config=config,
+        current_plan=plan,
+        plan_subject=subject,
+        issue_context=IssueContext(56, config.repo, "Title", "Body", None, ()),
+    )
+
+    assert result is False
+    warning = next(
+        comment for comment in runner.comments if "Possible unfiled scope narrowing" in comment
+    )
+    assert f"<!-- AGENT_SPLIT_UNFILED_WARNING: issue=56 subject={subject} -->" in warning
 
 
 def test_plan_first_selected_stage_handoff_by_unique_title_match(tmp_path):


### PR DESCRIPTION
## Summary

- Mark the orchestrator-generated split-warning record in the heuristic scope-narrowing path as canonical trusted protocol output.
- Add a regression test for the exact approved-plan path that failed on `wwind123/llm-dialectic#1021`.

## Context

Protocol-marker hardening correctly rejects reserved markers in untrusted agent and GitHub text. The heuristic "Possible unfiled scope narrowing" writer, however, generated a reserved marker and passed it to `post_issue_comment()` as a raw string. The write boundary therefore rejected the orchestrator's own output after all plan reviewers had approved, before implementation could start.

The ordinary split-warning helper already uses `TrustedBody.canonical(...)`; this change applies the same trust boundary to the remaining direct writer.

## Verification

- `PYTHONPATH=src pytest tests/test_split_orchestration.py -q` (21 passed)
- `PYTHONPATH=src pytest tests/test_protocol_markers.py tests/test_split_materialization.py tests/test_split_orchestration.py -q` (131 passed)
