### PR TITLE
Render concise answer-mode discussion summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ Useful optional controls include:
 See [Discuss mode](docs/local_agent_loop.md#open-ended-answer-results) for result
 semantics, research evidence, deadlocks, and resume behavior.
 
+Answer-mode summaries now put a bounded executive state before the audit
+transcript. With a configured `--discuss-analyzer`, completed non-final rounds
+reuse the analyzer's enriched agenda when available and show cumulative current
+consensus, active disagreements, changes, missing facts, and next-round focus.
+The final comment similarly leads with outcome, agreed conclusions, residual
+decisions, and the next action. Exact, semantic-equivalent, and debater-confirmed
+results reuse their mechanically validated artifacts without a redundant final
+synthesis call; only the configured discuss analyzer may perform the explicitly
+bounded fallback or final synthesis call. Analyzer-less or invalid synthesis
+falls back to the existing fail-closed result. Per-agent comments remain the
+authoritative raw audit, and resume metadata carries only the latest validated
+snapshot with bounded, spillable excerpts.
+
 ## Agent Backends
 
 | Backend | CLI | Notes |

--- a/SKILL.md
+++ b/SKILL.md
@@ -160,6 +160,23 @@ Run this only when the user asked to implement (see **issue mode**):
 3. Open a PR that references the issue, and note the PR number. Hand off to the
    PR-loop.
 
+### Answer-mode discussion summaries
+
+When the CLI is used for `discuss --discuss-result-mode answer`, the public
+issue comments lead with a concise state rather than the raw transcript. Each
+completed interim round may expose cumulative consensus, active disagreements,
+changes, missing facts, and next-round focus; a final comment exposes the fixed
+mechanical outcome, agreed conclusions, remaining decisions, and next action.
+The configured `--discuss-analyzer` is the only eligible synthesis agent.
+Enriched agendas cost no additional round call; a legacy agenda permits one
+bounded analyzer fallback, and exact/semantic/debater-confirmed final artifacts
+are adapted without a redundant synthesis call. Missing analyzers, invalid or
+unsupported claims, and transport failures retain the existing fail-closed
+rendering. Partial rounds are labeled as covering responding debaters only and
+cannot become final consensus. The latest validated snapshot is persisted for
+resume, while full per-agent responses remain the audit record and synthesis
+text/excerpts are bounded and spillable.
+
 ### External by-phase implementation (after an approved plan)
 
 Use this when the user asks for skill-mode parity with

--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -477,6 +477,31 @@ Analyzer observations remain non-authoritative and cited research remains a
 separate sourced-facts section. Repair and resume preserve the selected mode;
 transcripts cannot mix answer and triage responses.
 
+Answer-mode presentation is intentionally executive-first. When a configured
+discuss analyzer returns the optional enriched agenda, each completed interim
+comment leads with `Current consensus`, `Active disagreements`, `Changes this
+round`, `Missing facts`, and `Next-round focus`; the final comment leads with
+`Outcome`, `Agreed conclusions`, `Remaining disagreements`, and `Next action`.
+The state is cumulative: a resolved item appears in the change record and does
+not return to the active list unless a later response explicitly reopens it.
+The raw table, analyzer audit, and bounded excerpts are collapsed below the
+state, while each per-agent comment remains the complete authoritative audit.
+
+Only the configured discuss analyzer can synthesize. A normal enriched agenda
+adds no call, a valid legacy agenda permits one bounded same-analyzer fallback,
+and exact-text, semantic-equivalent, or debater-confirmed final artifacts are
+adapted directly without another synthesis call. Other complete or partial
+final paths use at most one bounded final synthesis call; partial finalization
+is always mechanically `material_deadlock`. The mechanical classification is
+never changed by advisory text. Analyzer absence, malformed or unsupported
+claims, failed fidelity checks, marker-like text, corrupt resume metadata, and
+sidecar hydration problems fail closed to the existing rendering. Canonical
+snapshots and visible synthesis text are bounded to 16,000 UTF-8 bytes; answer
+excerpts are limited per responder and in aggregate, and large audit payloads
+spill to transport sidecars. Resume consumes a stored snapshot only while a
+discuss analyzer is configured, preserving analyzer gating when configuration
+changes.
+
 To enable semantic comparison for differently worded final answers, configure
 an independent `--discuss-analyzer`. There is no reviewer fallback when it is
 unset. The analyzer receives final-round answers only and is prohibited from

--- a/src/coding_review_agent_loop/comment_rendering.py
+++ b/src/coding_review_agent_loop/comment_rendering.py
@@ -24,7 +24,9 @@ from .protocol import (
     HumanRequirementDisposition,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
+    ParsedDiscussFinalSynthesis,
     ParsedFailedDiscussResponse,
+    ParsedDiscussRoundSynthesis,
     ParsedDiscussResponse,
     ParsedDiscussReview,
     ParsedPlanReview,
@@ -39,6 +41,7 @@ from .protocol import (
 )
 from .unresolved_items import HUMAN_REQUIREMENTS_ACK_ITEM_ID, MERGE_CONFLICT_ITEM_ID
 from .protocol_markers import sanitize_historical_text
+from .round_transport import MAX_GITHUB_BODY_CHARS
 
 if TYPE_CHECKING:
     from .agents.base import AgentName
@@ -1214,6 +1217,8 @@ def render_discuss_round_summary_comment(
     result_mode: str = "triage",
     semantic_comparison: dict[str, object] | None = None,
     evidence_reconciliation: dict[str, object] | None = None,
+    round_synthesis: ParsedDiscussRoundSynthesis | None = None,
+    final_synthesis: ParsedDiscussFinalSynthesis | None = None,
 ) -> str:
     """Render the orchestrator/analyzer round-summary comment.
 
@@ -1237,6 +1242,7 @@ def render_discuss_round_summary_comment(
             analyzer_name=analyzer_name, research_mode=research_mode,
             failed_debaters=failed_debaters, outcome=outcome,
             semantic_comparison=semantic_comparison, evidence_reconciliation=evidence_reconciliation,
+            round_synthesis=round_synthesis, final_synthesis=final_synthesis,
         )
     if not is_final:
         lines: list[str] = [
@@ -1356,6 +1362,111 @@ def render_discuss_round_summary_comment(
     return "\n".join(lines)
 
 
+def _safe_synthesis_text(text: str) -> str:
+    return sanitize_historical_text(text)
+
+
+def _render_synthesis_consensus(item: object) -> list[str]:
+    text = _safe_synthesis_text(item.text)
+    references = ", ".join(
+        f"{_safe_synthesis_text(reference.reviewer)} (round {reference.round})"
+        for reference in item.references
+    )
+    return [f"- {text} _(supported by {references})_"]
+
+
+def _render_synthesis_disagreement(item: object) -> list[str]:
+    lines = [f"- **{_safe_synthesis_text(item.topic)}**"]
+    for position in item.positions:
+        names = ", ".join(_safe_synthesis_text(name) for name in position.reviewers)
+        lines.append(f"  - {names}: {_safe_synthesis_text(position.position)}")
+    lines.append(f"  - Decision needed: {_safe_synthesis_text(item.decision_needed)}")
+    return lines
+
+
+def _render_round_synthesis_lead(
+    synthesis: ParsedDiscussRoundSynthesis, *, round_number: int
+) -> list[str]:
+    respondents = ", ".join(_safe_synthesis_text(name) for name in synthesis.responding_reviewers)
+    lines = [f"## Round {round_number} discussion state", "", "### Current consensus"]
+    if respondents:
+        lines.append(f"Among responding debaters: {respondents}.")
+    lines.extend(
+        [_render_synthesis_consensus(item)[0] for item in synthesis.consensus]
+        or ["- None established yet."]
+    )
+    lines.extend(["", "### Active disagreements"])
+    lines.extend(
+        line for item in synthesis.disagreements for line in _render_synthesis_disagreement(item)
+    )
+    if not synthesis.disagreements:
+        lines.append("- None currently identified.")
+    lines.extend(["", "### Changes this round"])
+    if synthesis.changes:
+        for change in synthesis.changes:
+            refs = ", ".join(
+                f"{_safe_synthesis_text(ref.reviewer)} (round {ref.round})"
+                for ref in change.references
+            )
+            lines.append(
+                f"- **{_safe_synthesis_text(change.kind)}** "
+                f"{_safe_synthesis_text(change.topic)}: {_safe_synthesis_text(change.text)} "
+                f"_(reported by {refs})_"
+            )
+    else:
+        lines.append("- No state changes identified.")
+    lines.extend(["", "### Missing facts"])
+    lines.extend(
+        f"- {_safe_synthesis_text(item)}" for item in synthesis.missing_facts
+    )
+    if not synthesis.missing_facts:
+        lines.append("- None identified.")
+    lines.extend(["", "### Next-round focus"])
+    lines.extend(
+        f"- {_safe_synthesis_text(item)}" for item in synthesis.next_round_focus
+    )
+    if not synthesis.next_round_focus:
+        lines.append("- No additional focus identified.")
+    return lines
+
+
+def _render_final_synthesis_lead(
+    synthesis: ParsedDiscussFinalSynthesis, *, round_number: int
+) -> list[str]:
+    lines = [
+        "## Executive conclusion",
+        "",
+        "### Outcome",
+        "",
+        f"`{_safe_synthesis_text(synthesis.classification)}` after round {round_number}.",
+        "",
+        "### Agreed conclusions",
+    ]
+    lines.extend(
+        line for item in synthesis.agreed_conclusions for line in _render_synthesis_consensus(item)
+    )
+    if not synthesis.agreed_conclusions:
+        lines.append("- None established.")
+    lines.extend(["", "### Remaining disagreements"])
+    lines.extend(
+        line
+        for item in synthesis.remaining_disagreements
+        for line in _render_synthesis_disagreement(item)
+    )
+    if not synthesis.remaining_disagreements:
+        lines.append("- None; the configured mechanical outcome is supported by the final responses.")
+    lines.extend(["", "### Next action", "", _safe_synthesis_text(synthesis.next_action)])
+    return lines
+
+
+def _bounded_answer_audit_excerpt(text: str, *, remaining: int) -> str:
+    safe = sanitize_historical_text(text).replace("|", "\\|").replace("\n", " ")
+    limit = min(1_500, max(0, remaining))
+    if len(safe) > limit:
+        return safe[: max(0, limit - 1)] + "…"
+    return safe
+
+
 def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number: int,
     reviewer_votes: Sequence[ParsedDiscussAnswer], consensus_kind: str,
     round_history: Sequence[Sequence[ParsedDiscussAnswer]] | None,
@@ -1363,7 +1474,34 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
     final_analyzer_agenda: ParsedDiscussAgenda | None, analyzer_name: str | None,
     research_mode: str | None, failed_debaters: Sequence[tuple[str, str]], outcome: str | None,
     semantic_comparison: dict[str, object] | None = None,
-    evidence_reconciliation: dict[str, object] | None = None) -> str:
+    evidence_reconciliation: dict[str, object] | None = None,
+    round_synthesis: ParsedDiscussRoundSynthesis | None = None,
+    final_synthesis: ParsedDiscussFinalSynthesis | None = None,
+    _bounded_audit: bool = False) -> str:
+    if round_synthesis is not None or final_synthesis is not None:
+        # Keep the pre-synthesis renderer as a bounded audit section. The
+        # executive state remains the only primary reading path.
+        lead = (
+            _render_final_synthesis_lead(final_synthesis, round_number=round_number)
+            if final_synthesis is not None
+            else _render_round_synthesis_lead(round_synthesis, round_number=round_number)
+        )
+        audit = _render_discuss_answer_summary(
+            is_final=is_final, subject=subject, round_number=round_number,
+            reviewer_votes=reviewer_votes, consensus_kind=consensus_kind,
+            round_history=round_history, analyzer_agenda=analyzer_agenda,
+            prior_analyzer_agenda=prior_analyzer_agenda,
+            final_analyzer_agenda=final_analyzer_agenda, analyzer_name=analyzer_name,
+            research_mode=research_mode, failed_debaters=failed_debaters, outcome=outcome,
+            semantic_comparison=semantic_comparison,
+            evidence_reconciliation=evidence_reconciliation,
+            _bounded_audit=True,
+        )
+        # Long answer bodies remain available in their per-agent comments. Keep
+        # the summary audit useful but bounded when the lead is present.
+        if len(("\n".join(lead) + audit).encode("utf-8")) > MAX_GITHUB_BODY_CHARS:
+            audit = "The complete debater responses and provenance remain available in the per-agent audit comments."
+        return "\n".join(lead) + "\n\n<details>\n<summary>Audit details</summary>\n\n" + audit + "\n\n</details>"
     if not is_final:
         heading = f"## Round {round_number} summary: Answer Pending"
     elif outcome == "needs-human":
@@ -1379,8 +1517,15 @@ def _render_discuss_answer_summary(*, is_final: bool, subject: str, round_number
             answer = semantic_comparison.get("confirmed_answer") or semantic_comparison.get("shared_recommendation") if semantic_comparison else answers[0]
             lines.extend(["### Answer", "", str(answer), ""])
     lines.extend(["| Reviewer | Position | Confidence | Answer |", "| --- | --- | --- | --- |"])
+    remaining_excerpt_bytes = 6_000
     for vote in reviewer_votes:
-        answer = (vote.answer or "(no asserted answer)").replace("|", "\\|").replace("\n", " ")
+        if _bounded_audit:
+            answer = _bounded_answer_audit_excerpt(
+                vote.answer or "(no asserted answer)", remaining=remaining_excerpt_bytes
+            )
+            remaining_excerpt_bytes = max(0, remaining_excerpt_bytes - len(answer.encode("utf-8")))
+        else:
+            answer = (vote.answer or "(no asserted answer)").replace("|", "\\|").replace("\n", " ")
         lines.append(f"| {vote.reviewer} | {vote.position} | {vote.confidence} | {answer} |")
     if failed_debaters:
         lines.extend(_render_discuss_failed_debater_lines(failed_debaters, is_final=is_final))

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -193,6 +193,8 @@ from .protocol import (
     ApprovedFollowups,
     DISCUSS_FAILED_OUTCOME,
     DISCUSS_RESEARCH_TARGET_VALUES,
+    DISCUSS_SYNTHESIS_MAX_ENTRIES,
+    DISCUSS_SYNTHESIS_MAX_TEXT_BYTES,
     ChildStage,
     DeferredStage,
     HUMAN_REQUIREMENTS_ADDRESSED_MARKER,
@@ -9652,14 +9654,18 @@ def _disc_synthesis_text_supported_by_vote(text: str, vote: ParsedDiscussRespons
     source = _normalize_discuss_agenda_phrase(_disc_synthesis_vote_text(vote))
     if not normalized or not source:
         return False
-    if normalized in source:
-        return True
-    words = [word for word in re.findall(r"[a-z0-9]+", normalized) if len(word) > 2]
-    source_words = set(re.findall(r"[a-z0-9]+", source))
-    if not words:
+    # Keep synthesis fidelity at least as strict as agenda fidelity. In
+    # particular, boilerplate such as "that", "must", and "should" is not
+    # evidence for an otherwise unsupported claim.
+    if not _tokenize_discuss_agenda_support(normalized):
         return False
-    required = 1 if len(words) <= 4 else max(2, len(words) // 3)
-    return sum(word in source_words for word in set(words)) >= required
+    corpus = _DiscussAgendaSupportCorpus(
+        phrase_segments=(source,),
+        tokens=frozenset(_tokenize_discuss_agenda_support(source)),
+    )
+    return _discuss_agenda_text_has_support(
+        normalized, corpus=corpus, ignored_names=()
+    )
 
 
 def _validate_discuss_round_synthesis_fidelity(
@@ -9719,6 +9725,14 @@ def _validate_discuss_round_synthesis_fidelity(
     prior_change_topics = {
         item.topic.casefold() for item in (prior_synthesis.changes if prior_synthesis else ())
     }
+    prior_settled_topics = {
+        item.text.casefold() for item in (prior_synthesis.consensus if prior_synthesis else ())
+    }
+    prior_settled_topics.update(
+        change.topic.casefold()
+        for change in (prior_synthesis.changes if prior_synthesis else ())
+        if change.kind in {"resolved", "retracted"}
+    )
 
     consensus_texts: set[str] = set()
     for item in synthesis.consensus:
@@ -9746,6 +9760,14 @@ def _validate_discuss_round_synthesis_fidelity(
         topic_key = item.topic.casefold()
         if topic_key in active_topics:
             raise AgentLoopError("round synthesis disagreements must not repeat topics.")
+        reopened = any(
+            change.kind == "reopened" and change.topic.casefold() == topic_key
+            for change in synthesis.changes
+        )
+        if topic_key in prior_settled_topics and not reopened:
+            raise AgentLoopError(
+                "round synthesis cannot reactivate a settled topic without a reopened change."
+            )
         active_topics.add(topic_key)
         if not any(_disc_synthesis_text_supported_by_vote(item.topic, vote) for vote in successful):
             raise AgentLoopError(f"round synthesis disagreement topic lacks current support: {item.topic}")
@@ -9912,10 +9934,11 @@ def _run_discuss_analyzer(
 ) -> tuple[ParsedDiscussAgenda | None, str | None, ParsedDiscussRoundSynthesis | None, str | None]:
     """Run the optional discuss analyzer after a non-final round.
 
-    Returns (parsed_agenda, raw_response, synthesis, raw_synthesis_response). Any analyzer failure that survives
-    the repair pass falls back to (None, None) so the round closes with the
-    mechanical agenda and the next debate round sees the full prior positions;
-    only a quota-reset stop propagates because the whole run must pause.
+    Returns (parsed_agenda, raw_response, synthesis, raw_synthesis_response).
+    Analyzer/agenda failures fall back to the mechanical agenda; a nested
+    synthesis fidelity failure drops only that advisory extension and keeps
+    the validated agenda. Only a quota-reset stop propagates because the
+    whole run must pause.
     """
     analyzer_name = agent_display_name(analyzer)
     log(
@@ -9996,7 +10019,10 @@ def _run_discuss_analyzer(
                 f"discuss: analyzer {analyzer_name} synthesis rejected ({exc}); "
                 "falling back to the mechanical agenda",
             )
-            return None, None, None, None
+            # The synthesis is advisory. Preserve the independently validated
+            # agenda and its raw audit response when only the nested extension
+            # fails fidelity validation.
+            return parsed, response.text, None, None
         return parsed, response.text, synthesis, None
 
     if config.discuss_result_mode != "answer" or not round_history:
@@ -10394,18 +10420,30 @@ def _adapt_discuss_final_synthesis(
 ) -> ParsedDiscussFinalSynthesis | None:
     """Reuse mechanically verified artifacts without another analyzer call."""
     def cap(text: str) -> str:
-        raw = str(text).strip().encode("utf-8")[:512]
+        raw = str(text).strip().encode("utf-8")[:DISCUSS_SYNTHESIS_MAX_TEXT_BYTES]
         return raw.decode("utf-8", "ignore").strip() or "(not stated)"
 
-    answers = [vote for vote in final_votes if isinstance(vote, ParsedDiscussAnswer)]
-    references = tuple(
-        DiscussSynthesisResponseReference(vote.reviewer, round_number)
-        for vote in final_votes
+    def key(text: str) -> str:
+        return cap(text).casefold()
+
+    successful_votes = tuple(
+        vote for vote in final_votes if not is_failed_discuss_response(vote)
     )
+    answers = [vote for vote in successful_votes if isinstance(vote, ParsedDiscussAnswer)]
+    if len(successful_votes) > DISCUSS_SYNTHESIS_MAX_ENTRIES:
+        # The protocol cannot represent a complete reference set above this
+        # bound. Let the normal fail-closed rendering handle that case.
+        references = ()
+    else:
+        references = tuple(
+            DiscussSynthesisResponseReference(vote.reviewer, round_number)
+            for vote in successful_votes
+        )
     if (
         outcome == "answer"
         and consensus_kind in {"unanimous", "converged"}
-        and len(answers) == len(final_votes)
+        and len(answers) == len(successful_votes)
+        and references
         and answers
         and all(vote.answer for vote in answers)
     ):
@@ -10421,7 +10459,11 @@ def _adapt_discuss_final_synthesis(
         )
     if semantic_comparison is not None:
         classification = semantic_comparison.get("classification")
-        if classification == "equivalent" and semantic_comparison.get("shared_recommendation"):
+        if (
+            classification == "equivalent"
+            and semantic_comparison.get("shared_recommendation")
+            and references
+        ):
             return ParsedDiscussFinalSynthesis(
                 classification="consensus",
                 agreed_conclusions=(
@@ -10434,6 +10476,8 @@ def _adapt_discuss_final_synthesis(
                 next_action="Proceed with the shared recommendation.",
             )
         if consensus_kind == "debater-confirmed" and semantic_comparison.get("confirmed_answer"):
+            if not references:
+                return None
             return ParsedDiscussFinalSynthesis(
                 classification="consensus",
                 agreed_conclusions=(
@@ -10448,34 +10492,82 @@ def _adapt_discuss_final_synthesis(
     if outcome == "needs-human" and consensus_kind in {"unanimous", "converged"}:
         human_items = [
             (vote, item)
-            for vote in final_votes
+            for vote in successful_votes
             for item in getattr(vote, "unresolved_items", ())
             if item.status == "human-decision"
         ]
         if human_items:
             groups: dict[str, list[tuple[ParsedDiscussResponse, DiscussUnresolvedItem]]] = {}
             for vote, item in human_items:
-                groups.setdefault(item.text.casefold(), []).append((vote, item))
+                bucket = groups.setdefault(key(item.text), [])
+                if any(existing_vote.reviewer.casefold() == vote.reviewer.casefold() for existing_vote, _ in bucket):
+                    # Multiple equivalent items from one reviewer must not
+                    # create a duplicate reviewer position in one topic.
+                    continue
+                bucket.append((vote, item))
+            groups = dict(list(groups.items())[:DISCUSS_SYNTHESIS_MAX_ENTRIES])
             disagreements = tuple(
                 DiscussSynthesisDisagreement(
                     topic=cap(items[0][1].text),
                     positions=tuple(
                         DiscussSynthesisPosition(
-                            reviewers=(vote.reviewer,), position=cap(vote.rationale)
+                            reviewers=(vote.reviewer,), position=cap(item.text)
                         )
-                        for vote, _item in items
+                        for vote, item in items[:DISCUSS_SYNTHESIS_MAX_ENTRIES]
                     ),
                     decision_needed=cap(items[0][1].text),
                 )
                 for items in groups.values()
             )
+            shared_rationales = [cap(vote.rationale) for vote in successful_votes]
+            agreed_conclusions = ()
+            if (
+                references
+                and shared_rationales
+                and len({_normalize_discuss_answer(item) for item in shared_rationales}) == 1
+            ):
+                agreed_conclusions = (
+                    DiscussSynthesisConsensus(
+                        text=shared_rationales[0], references=references
+                    ),
+                )
             return ParsedDiscussFinalSynthesis(
                 classification="near_consensus",
-                agreed_conclusions=(),
+                agreed_conclusions=agreed_conclusions,
                 remaining_disagreements=disagreements,
-                next_action=cap("A human must decide: " + "; ".join(item[1].text for item in human_items[:8])),
+                next_action=cap(
+                    "A human must decide: "
+                    + "; ".join(item.topic for item in disagreements)
+                ),
             )
     return None
+
+
+def _safe_discuss_synthesis_serialization(
+    synthesis: ParsedDiscussRoundSynthesis | ParsedDiscussFinalSynthesis | None,
+    *,
+    final: bool,
+    config: AgentLoopConfig,
+    location: str,
+) -> tuple[ParsedDiscussRoundSynthesis | ParsedDiscussFinalSynthesis | None, str | None]:
+    """Drop advisory synthesis that cannot be durably encoded.
+
+    Rendering must remain fail-closed even when a mechanically assembled
+    candidate or a legacy structured response is individually valid but cannot
+    fit the canonical sidecar budget.
+    """
+    if synthesis is None:
+        return None, None
+    try:
+        serialized = (
+            serialize_discuss_final_synthesis(synthesis)  # type: ignore[arg-type]
+            if final
+            else serialize_discuss_round_synthesis(synthesis)  # type: ignore[arg-type]
+        )
+    except Exception as exc:
+        log(config, f"discuss: dropping {location} synthesis that could not be serialized ({exc})")
+        return None, None
+    return synthesis, serialized
 
 
 def _post_discuss_debater_comment(
@@ -10705,6 +10797,12 @@ def _run_discuss_loop(
         )
         if final_synthesis is not None:
             final_synthesis_source = "final-analyzer"
+        final_synthesis, final_synthesis_serialized = _safe_discuss_synthesis_serialization(
+            final_synthesis,
+            final=True,
+            config=config,
+            location="resumed final",
+        )
         evidence_groups, evidence_reconciler_raw = _run_discuss_evidence_reconciler(
             runner, issue_number=issue_number, config=config, analyzer=analyzer, subject=f"issue-{issue_number}",
             round_history=round_history, usage_context=usage_context,
@@ -10745,10 +10843,7 @@ def _run_discuss_loop(
                     consensus_kind="deadlock",
                     agenda=(),
                     final_analyzer_response=final_analyzer_response_raw,
-                    final_synthesis=(
-                        serialize_discuss_final_synthesis(final_synthesis)
-                        if final_synthesis is not None else None
-                    ),
+                    final_synthesis=final_synthesis_serialized,
                     synthesis_provenance=(
                         {
                             "source": final_synthesis_source or "final-analyzer",
@@ -11070,7 +11165,11 @@ def _run_discuss_loop(
                     if semantic_comparison is not None
                     else "mechanical-result"
                 )
-            if final_synthesis is None:
+            # Near-consensus candidates are only a bounded mechanical
+            # fallback. Give the configured analyzer the opportunity to
+            # recover agreed recommendations and accurately summarize the
+            # residual human decisions.
+            if final_synthesis is None or final_mechanical_classification == "near_consensus":
                 final_analyzer_agenda, final_analyzer_response_raw, final_synthesis = _run_discuss_final_analyzer(
                     runner,
                     issue_number=issue_number,
@@ -11108,6 +11207,23 @@ def _run_discuss_loop(
             )
             evidence_reconciliation = reconcile_evidence(f"issue-{issue_number}", round_history, evidence_groups)
             evidence_reconciliation["raw_evidence_reconciler_response"] = evidence_reconciler_raw
+        next_round_synthesis, round_synthesis_serialized = _safe_discuss_synthesis_serialization(
+            next_round_synthesis,
+            final=False,
+            config=config,
+            location="round",
+        )
+        raw_synthesis_response = (
+            raw_synthesis_response if next_round_synthesis is not None else None
+        )
+        final_synthesis, final_synthesis_serialized = _safe_discuss_synthesis_serialization(
+            final_synthesis,
+            final=True,
+            config=config,
+            location="final",
+        )
+        if final_synthesis is None:
+            final_synthesis_source = None
         summary_body = render_discuss_round_summary_comment(
             round_number=round_number,
             # The vote table and agenda draw from real positions only; failed
@@ -11149,14 +11265,8 @@ def _run_discuss_loop(
                     agenda=agenda,
                     analyzer_response=analyzer_response_raw,
                     final_analyzer_response=final_analyzer_response_raw,
-                    round_synthesis=(
-                        serialize_discuss_round_synthesis(next_round_synthesis)
-                        if next_round_synthesis is not None else None
-                    ),
-                    final_synthesis=(
-                        serialize_discuss_final_synthesis(final_synthesis)
-                        if final_synthesis is not None else None
-                    ),
+                    round_synthesis=round_synthesis_serialized,
+                    final_synthesis=final_synthesis_serialized,
                     raw_synthesis_response=raw_synthesis_response,
                     synthesis_provenance=(
                         {

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -164,6 +164,8 @@ from .prompts import (
     CompactPriorContext,
     CompactPrReviewTailContext,
     build_discuss_agenda_prompt,
+    build_discuss_round_synthesis_prompt,
+    build_discuss_final_synthesis_prompt,
     build_discuss_final_analysis_prompt,
     build_discuss_evidence_reconciliation_prompt,
     build_discuss_answer_confirmation_prompt,
@@ -197,6 +199,12 @@ from .protocol import (
     ParsedDiscussAgenda,
     ParsedDiscussEvidenceReconciliation,
     ParsedDiscussAnswer,
+    ParsedDiscussFinalSynthesis,
+    ParsedDiscussRoundSynthesis,
+    DiscussSynthesisConsensus,
+    DiscussSynthesisDisagreement,
+    DiscussSynthesisPosition,
+    DiscussSynthesisResponseReference,
     DiscussUnresolvedItem,
     ParsedDiscussSemanticComparison,
     ParsedDiscussResponse,
@@ -235,11 +243,16 @@ from .protocol import (
     validate_structured_plan_state,
     validate_structured_plan_revision,
     validate_structured_discuss_agenda,
+    parse_structured_discuss_final_synthesis,
+    validate_structured_discuss_final_synthesis,
+    validate_structured_discuss_round_synthesis,
     validate_structured_discuss_review,
     validate_structured_discuss_answer,
     validate_structured_discuss_answer_confirmation,
     validate_structured_discuss_evidence_reconciliation,
     validate_structured_discuss_semantic_comparison,
+    serialize_discuss_round_synthesis,
+    serialize_discuss_final_synthesis,
 )
 from .protocol import parse_review
 from .repair import (
@@ -1738,6 +1751,10 @@ def _operation_description_from_context(
         return "discuss review"
     if repair_expected_kind == "discuss_agenda":
         return "discuss analyzer"
+    if repair_expected_kind == "discuss_round_synthesis":
+        return "discuss round synthesis"
+    if repair_expected_kind == "discuss_final_synthesis":
+        return "discuss final synthesis"
     if label and label.startswith("discuss-analyzer"):
         return "discuss analyzer"
     if label and label.startswith("discuss-r"):
@@ -9615,6 +9632,269 @@ def _validate_discuss_analyzer_agenda_fidelity(
             raise AgentLoopError(f"analyzer agenda {field} lacks transcript support: {text}")
 
 
+def _disc_synthesis_vote_text(vote: ParsedDiscussResponse) -> str:
+    parts = [
+        str(getattr(vote, "answer", "") or ""),
+        str(getattr(vote, "rationale", "") or ""),
+        str(getattr(vote, "rebuttal", "") or ""),
+    ]
+    parts.extend(
+        str(item.text)
+        for item in getattr(vote, "unresolved_items", ())
+    )
+    parts.extend(str(item) for item in getattr(vote, "split_proposals", ()))
+    return " ".join(parts)
+
+
+def _disc_synthesis_text_supported_by_vote(text: str, vote: ParsedDiscussResponse) -> bool:
+    """Conservative lexical support check over one current response only."""
+    normalized = _normalize_discuss_agenda_phrase(text)
+    source = _normalize_discuss_agenda_phrase(_disc_synthesis_vote_text(vote))
+    if not normalized or not source:
+        return False
+    if normalized in source:
+        return True
+    words = [word for word in re.findall(r"[a-z0-9]+", normalized) if len(word) > 2]
+    source_words = set(re.findall(r"[a-z0-9]+", source))
+    if not words:
+        return False
+    required = 1 if len(words) <= 4 else max(2, len(words) // 3)
+    return sum(word in source_words for word in set(words)) >= required
+
+
+def _validate_discuss_round_synthesis_fidelity(
+    synthesis: ParsedDiscussRoundSynthesis,
+    *,
+    round_number: int,
+    current_votes: Sequence[ParsedDiscussResponse],
+    prior_synthesis: ParsedDiscussRoundSynthesis | None,
+    configured_reviewers: Sequence[AgentName],
+) -> None:
+    """Validate cumulative synthesis against current responses and legal state transitions."""
+    successful = tuple(vote for vote in current_votes if not is_failed_discuss_response(vote))
+    if len(successful) < 2:
+        raise AgentLoopError("round synthesis requires at least two successful responders.")
+    configured_names = {agent_display_name(agent) for agent in configured_reviewers}
+    current_names = {vote.reviewer for vote in successful}
+    if synthesis.responding_reviewers and set(synthesis.responding_reviewers) != current_names:
+        raise AgentLoopError("round synthesis responding_reviewers must equal current responders.")
+    if not synthesis.responding_reviewers:
+        raise AgentLoopError("round synthesis responding_reviewers must not be empty.")
+    if not current_names <= configured_names:
+        raise AgentLoopError("round synthesis contains an unknown current responder.")
+
+    # The current response set is the only source available to the validator;
+    # prior references are legal only when they identify an existing carried
+    # state, never when they are used as support for a new claim.
+    current_by_name = {vote.reviewer: vote for vote in successful}
+
+    def validate_refs(
+        references: Sequence[DiscussSynthesisResponseReference], *,
+        require_current: bool = False,
+    ) -> None:
+        if not references:
+            raise AgentLoopError("round synthesis statements require response references.")
+        for reference in references:
+            if reference.reviewer not in configured_names:
+                raise AgentLoopError(
+                    f"round synthesis references unknown reviewer {reference.reviewer!r}."
+                )
+            if reference.round > round_number:
+                raise AgentLoopError("round synthesis references a future round.")
+            if require_current and (
+                reference.round != round_number or reference.reviewer not in current_names
+            ):
+                raise AgentLoopError("new round synthesis claims must reference current responders.")
+
+    prior_consensus = {item.text.casefold(): item for item in (prior_synthesis.consensus if prior_synthesis else ())}
+    prior_disagreements = {
+        item.topic.casefold(): item for item in (prior_synthesis.disagreements if prior_synthesis else ())
+    }
+    prior_missing_facts = {
+        item.casefold() for item in (prior_synthesis.missing_facts if prior_synthesis else ())
+    }
+    prior_next_focus = {
+        item.casefold() for item in (prior_synthesis.next_round_focus if prior_synthesis else ())
+    }
+    prior_change_topics = {
+        item.topic.casefold() for item in (prior_synthesis.changes if prior_synthesis else ())
+    }
+
+    consensus_texts: set[str] = set()
+    for item in synthesis.consensus:
+        key = item.text.casefold()
+        if key in consensus_texts:
+            raise AgentLoopError("round synthesis consensus must not contain duplicates.")
+        consensus_texts.add(key)
+        carried = prior_consensus.get(key)
+        if carried is not None:
+            if item.text != carried.text or item.references != carried.references:
+                raise AgentLoopError(
+                    "carried round synthesis consensus must preserve its validated text "
+                    "and response references"
+                )
+            validate_refs(item.references)
+        else:
+            validate_refs(item.references, require_current=True)
+            if any(not _disc_synthesis_text_supported_by_vote(item.text, vote) for vote in successful):
+                raise AgentLoopError(
+                    f"round synthesis consensus lacks independent current support: {item.text}"
+                )
+
+    active_topics: set[str] = set()
+    for item in synthesis.disagreements:
+        topic_key = item.topic.casefold()
+        if topic_key in active_topics:
+            raise AgentLoopError("round synthesis disagreements must not repeat topics.")
+        active_topics.add(topic_key)
+        if not any(_disc_synthesis_text_supported_by_vote(item.topic, vote) for vote in successful):
+            raise AgentLoopError(f"round synthesis disagreement topic lacks current support: {item.topic}")
+        named: set[str] = set()
+        for position in item.positions:
+            for reviewer in position.reviewers:
+                if reviewer in named or reviewer not in current_names:
+                    raise AgentLoopError("round synthesis disagreement has unknown or duplicate reviewer.")
+                named.add(reviewer)
+                if not _disc_synthesis_text_supported_by_vote(position.position, current_by_name[reviewer]):
+                    raise AgentLoopError(
+                        f"round synthesis position lacks support from {reviewer}: {position.position}"
+                    )
+        if not _disc_synthesis_text_supported_by_vote(item.decision_needed, successful[0]):
+            # A decision question can be phrased across responses; require at
+            # least one current response to carry its material vocabulary.
+            if not any(_disc_synthesis_text_supported_by_vote(item.decision_needed, vote) for vote in successful):
+                raise AgentLoopError(
+                    f"round synthesis decision_needed lacks current support: {item.decision_needed}"
+                )
+
+    for change in synthesis.changes:
+        topic_key = change.topic.casefold()
+        validate_refs(change.references, require_current=True)
+        if not any(
+            _disc_synthesis_text_supported_by_vote(change.text, vote)
+            for vote in successful
+        ):
+            raise AgentLoopError(f"round synthesis change lacks current support: {change.text}")
+        if change.kind == "resolved":
+            if prior_synthesis is None or topic_key not in prior_disagreements:
+                raise AgentLoopError("resolved synthesis changes must match a prior active disagreement.")
+            if {ref.reviewer for ref in change.references} != current_names:
+                raise AgentLoopError("resolved synthesis changes require every current responder.")
+            if topic_key in active_topics:
+                raise AgentLoopError("a resolved disagreement cannot remain active in the same snapshot.")
+        elif change.kind == "reopened":
+            if prior_synthesis is None or (
+                topic_key not in prior_consensus
+                and topic_key not in prior_disagreements
+                and topic_key not in prior_change_topics
+            ):
+                raise AgentLoopError("reopened synthesis changes must match prior consensus or resolved state.")
+            if topic_key not in active_topics:
+                raise AgentLoopError("reopened synthesis changes must have an active disagreement.")
+        elif change.kind in {"retracted", "refined"}:
+            if prior_synthesis is None or (
+                topic_key not in prior_consensus
+                and topic_key not in prior_disagreements
+                and topic_key not in prior_change_topics
+            ):
+                raise AgentLoopError("synthesis change does not match prior state.")
+        elif change.kind == "introduced" and prior_synthesis is not None and (
+            topic_key in prior_change_topics
+            or topic_key in prior_disagreements
+        ):
+            raise AgentLoopError("introduced synthesis change repeats prior state.")
+
+    for field_name, values in (
+        ("missing_facts", synthesis.missing_facts),
+        ("next_round_focus", synthesis.next_round_focus),
+    ):
+        for value in values:
+            if value.casefold() in (
+                prior_missing_facts if field_name == "missing_facts" else prior_next_focus
+            ):
+                continue
+            if not any(_disc_synthesis_text_supported_by_vote(value, vote) for vote in successful):
+                raise AgentLoopError(f"round synthesis {field_name} lacks current support: {value}")
+
+
+def _mechanical_discuss_final_classification(
+    *, outcome: str, consensus_kind: str | None, votes: Sequence[ParsedDiscussResponse]
+) -> str:
+    if outcome == "answer" and consensus_kind in {
+        "unanimous", "converged", "semantic-equivalent", "debater-confirmed",
+    }:
+        return "consensus"
+    if (
+        outcome == "needs-human"
+        and consensus_kind in {"unanimous", "converged"}
+        and any(
+            item.status == "human-decision"
+            for vote in votes
+            for item in getattr(vote, "unresolved_items", ())
+        )
+    ):
+        return "near_consensus"
+    if outcome == "deadlock" or consensus_kind in {
+        "deadlock", "material-conflict", "semantic-comparison-failed",
+        "confirmation-failed", "confirmation-disagreement",
+    }:
+        return "material_deadlock"
+    raise AgentLoopError(
+        f"unsupported mechanical answer classification: outcome={outcome!r}, kind={consensus_kind!r}"
+    )
+
+
+def _validate_discuss_final_synthesis_fidelity(
+    synthesis: ParsedDiscussFinalSynthesis,
+    *,
+    expected_classification: str,
+    final_votes: Sequence[ParsedDiscussResponse],
+    round_number: int,
+    configured_reviewers: Sequence[AgentName],
+) -> None:
+    if synthesis.classification != expected_classification:
+        raise AgentLoopError("final synthesis classification does not match the mechanical result.")
+    successful = tuple(vote for vote in final_votes if not is_failed_discuss_response(vote))
+    if len(successful) < 2:
+        raise AgentLoopError("final synthesis requires at least two successful responders.")
+    configured_names = {agent_display_name(agent) for agent in configured_reviewers}
+    names = {vote.reviewer for vote in successful}
+    if not names <= configured_names:
+        raise AgentLoopError("final synthesis contains an unknown responder.")
+
+    def refs_for_current(references: Sequence[DiscussSynthesisResponseReference]) -> None:
+        if {ref.reviewer for ref in references} != names or any(
+            ref.round != round_number for ref in references
+        ):
+            raise AgentLoopError("final synthesis references must cover each final responder exactly once.")
+
+    for item in synthesis.agreed_conclusions:
+        refs_for_current(item.references)
+        if any(not _disc_synthesis_text_supported_by_vote(item.text, vote) for vote in successful):
+            raise AgentLoopError(f"final synthesis agreement lacks independent support: {item.text}")
+    for disagreement in synthesis.remaining_disagreements:
+        if not any(_disc_synthesis_text_supported_by_vote(disagreement.topic, vote) for vote in successful):
+            raise AgentLoopError(f"final synthesis topic lacks final-round support: {disagreement.topic}")
+        named: set[str] = set()
+        for position in disagreement.positions:
+            for reviewer in position.reviewers:
+                if reviewer in named or reviewer not in names:
+                    raise AgentLoopError("final synthesis has an unknown or duplicate reviewer position.")
+                named.add(reviewer)
+                vote = next(vote for vote in successful if vote.reviewer == reviewer)
+                if not _disc_synthesis_text_supported_by_vote(position.position, vote):
+                    raise AgentLoopError(
+                        f"final synthesis position lacks support from {reviewer}: {position.position}"
+                    )
+        if not any(
+            _disc_synthesis_text_supported_by_vote(disagreement.decision_needed, vote)
+            for vote in successful
+        ):
+            raise AgentLoopError(
+                f"final synthesis decision_needed lacks final-round support: {disagreement.decision_needed}"
+            )
+
+
 def _run_discuss_analyzer(
     runner: Runner,
     *,
@@ -9626,12 +9906,13 @@ def _run_discuss_analyzer(
     round_number: int,
     round_history: Sequence[Sequence[ParsedDiscussResponse]],
     prior_agenda: ParsedDiscussAgenda | None,
+    prior_round_synthesis: ParsedDiscussRoundSynthesis | None,
     configured_reviewers: Sequence[AgentName],
     usage_context: RunUsageContext,
-) -> tuple[ParsedDiscussAgenda | None, str | None]:
+) -> tuple[ParsedDiscussAgenda | None, str | None, ParsedDiscussRoundSynthesis | None, str | None]:
     """Run the optional discuss analyzer after a non-final round.
 
-    Returns (parsed_agenda, raw_response). Any analyzer failure that survives
+    Returns (parsed_agenda, raw_response, synthesis, raw_synthesis_response). Any analyzer failure that survives
     the repair pass falls back to (None, None) so the round closes with the
     mechanical agenda and the next debate round sees the full prior positions;
     only a quota-reset stop propagates because the whole run must pause.
@@ -9656,6 +9937,7 @@ def _run_discuss_analyzer(
                 round_number=round_number,
                 round_history=round_history,
                 prior_agenda=prior_agenda,
+                prior_round_synthesis=prior_round_synthesis,
                 research_mode=config.discuss_research,
             ),
             marker_description="<!-- AGENT_PLAN_STATE: approved -->",
@@ -9675,7 +9957,7 @@ def _run_discuss_analyzer(
             f"discuss: analyzer {analyzer_name} failed ({exc}); falling back to the "
             f"mechanical agenda for round {round_number + 1}",
         )
-        return None, None
+        return None, None, None, None
     parsed = response.marker_value
     assert isinstance(parsed, ParsedDiscussAgenda)
     try:
@@ -9693,8 +9975,76 @@ def _run_discuss_analyzer(
             f"discuss: analyzer {analyzer_name} agenda rejected ({exc}); falling back to the "
             f"mechanical agenda for round {round_number + 1}",
         )
-        return None, None
-    return parsed, response.text
+        return None, None, None, None
+    synthesis = (
+        parsed.round_synthesis
+        if config.discuss_result_mode == "answer"
+        else None
+    )
+    if synthesis is not None:
+        try:
+            _validate_discuss_round_synthesis_fidelity(
+                synthesis,
+                round_number=round_number,
+                current_votes=round_history[-1] if round_history else (),
+                prior_synthesis=prior_round_synthesis,
+                configured_reviewers=configured_reviewers,
+            )
+        except AgentLoopError as exc:
+            log(
+                config,
+                f"discuss: analyzer {analyzer_name} synthesis rejected ({exc}); "
+                "falling back to the mechanical agenda",
+            )
+            return None, None, None, None
+        return parsed, response.text, synthesis, None
+
+    if config.discuss_result_mode != "answer" or not round_history:
+        return parsed, response.text, None, None
+    # Legacy agendas are accepted, but answer mode gets one bounded extension
+    # call from the same configured analyzer. The ordinary debaters and coder
+    # never become synthesis agents implicitly.
+    try:
+        fallback = _run_validated_agent(
+            runner,
+            agent=analyzer,
+            config=config,
+            prompt=build_discuss_round_synthesis_prompt(
+                issue_number,
+                config,
+                analyzer=analyzer,
+                round_number=round_number,
+                current_responses=round_history[-1],
+                prior_synthesis=prior_round_synthesis,
+            ),
+            marker_description="<!-- AGENT_PLAN_STATE: approved -->",
+            validate=validate_structured_discuss_round_synthesis,
+            usage_context=usage_context,
+            use_repair=True,
+            repair_expected_kind="discuss_round_synthesis",
+            role="analyzer",
+            label=f"discuss-round-synthesis-r{round_number}",
+            operation_description="discuss round synthesis",
+        )
+        fallback_synthesis = fallback.marker_value
+        assert isinstance(fallback_synthesis, ParsedDiscussRoundSynthesis)
+        _validate_discuss_round_synthesis_fidelity(
+            fallback_synthesis,
+            round_number=round_number,
+            current_votes=round_history[-1],
+            prior_synthesis=prior_round_synthesis,
+            configured_reviewers=configured_reviewers,
+        )
+        return parsed, response.text, fallback_synthesis, fallback.text
+    except QuotaResetExceededError:
+        raise
+    except (AgentLoopError, AgentInvocationError) as exc:
+        log(
+            config,
+            f"discuss: round synthesis fallback unavailable ({exc}); retaining the "
+            "legacy agenda/mechanical rendering",
+        )
+        return parsed, response.text, None, None
 
 
 def _validate_discuss_final_analyzer_fidelity(
@@ -9747,37 +10097,78 @@ def _run_discuss_final_analyzer(
     final_votes: Sequence[ParsedDiscussResponse],
     configured_reviewers: Sequence[AgentName],
     usage_context: RunUsageContext,
-) -> tuple[ParsedDiscussAgenda | None, str | None]:
+    mechanical_classification: str | None = None,
+) -> tuple[ParsedDiscussAgenda | None, str | None, ParsedDiscussFinalSynthesis | None]:
     """Best-effort final-only analyzer pass; failures never affect finalization."""
     if analyzer is None or not final_votes or any(is_failed_discuss_response(vote) for vote in final_votes):
-        return None, None
+        return None, None, None
 
 
     analyzer_name = agent_display_name(analyzer)
     try:
+        def validate_final_output(text: str) -> object:
+            if config.discuss_result_mode == "answer":
+                return validate_structured_discuss_final_synthesis(text)
+            parsed_synthesis = parse_structured_discuss_final_synthesis(text)
+            if parsed_synthesis is not None:
+                return parsed_synthesis
+            return validate_structured_discuss_agenda(text)
+
         response = _run_validated_agent(
             runner, agent=analyzer, config=config,
-            prompt=build_discuss_final_analysis_prompt(
-                issue_number, config, analyzer=analyzer, round_number=round_number,
-                final_votes=final_votes,
+            prompt=(
+                build_discuss_final_synthesis_prompt(
+                    issue_number,
+                    config,
+                    analyzer=analyzer,
+                    round_number=round_number,
+                    final_responses=final_votes,
+                    mechanical_classification=mechanical_classification or "material_deadlock",
+                )
+                if config.discuss_result_mode == "answer"
+                else build_discuss_final_analysis_prompt(
+                    issue_number, config, analyzer=analyzer, round_number=round_number,
+                    final_votes=final_votes,
+                )
             ),
             marker_description="<!-- AGENT_PLAN_STATE: approved -->",
-            validate=validate_structured_discuss_agenda, usage_context=usage_context,
-            use_repair=True, repair_expected_kind="discuss_agenda", role="reviewer",
-            label=f"discuss-final-analyzer-r{round_number}",
-            operation_description="final discuss analyzer",
+            validate=validate_final_output, usage_context=usage_context,
+            use_repair=True,
+            repair_expected_kind=(
+                "discuss_final_synthesis"
+                if config.discuss_result_mode == "answer"
+                else "discuss_agenda"
+            ),
+            role="analyzer",
+            label=(
+                f"discuss-final-synthesis-r{round_number}"
+                if config.discuss_result_mode == "answer"
+                else f"discuss-final-analyzer-r{round_number}"
+            ),
+            operation_description="final discuss synthesis",
         )
         parsed = response.marker_value
+        if isinstance(parsed, ParsedDiscussFinalSynthesis):
+            if mechanical_classification is None:
+                raise AgentLoopError("final synthesis requires a mechanical classification.")
+            _validate_discuss_final_synthesis_fidelity(
+                parsed,
+                expected_classification=mechanical_classification,
+                final_votes=final_votes,
+                round_number=round_number,
+                configured_reviewers=configured_reviewers,
+            )
+            return None, response.text, parsed
         assert isinstance(parsed, ParsedDiscussAgenda)
         _validate_discuss_final_analyzer_fidelity(
             parsed, final_votes=final_votes, configured_reviewers=configured_reviewers, analyzer=analyzer,
         )
-        return parsed, response.text
+        return parsed, response.text, None
     except QuotaResetExceededError:
         raise
-    except Exception as exc:
+    except (AgentLoopError, AgentInvocationError) as exc:
         log(config, f"discuss: final analyzer {analyzer_name} unavailable ({exc}); omitting advisory observations")
-        return None, None
+        return None, None, None
 
 
 def _run_discuss_evidence_reconciler(
@@ -9993,6 +10384,100 @@ def _run_discuss_semantic_finalization(
     return "deadlock", "confirmation-disagreement", audit
 
 
+def _adapt_discuss_final_synthesis(
+    *,
+    outcome: str,
+    consensus_kind: str | None,
+    final_votes: Sequence[ParsedDiscussResponse],
+    round_number: int,
+    semantic_comparison: Mapping[str, object] | None = None,
+) -> ParsedDiscussFinalSynthesis | None:
+    """Reuse mechanically verified artifacts without another analyzer call."""
+    def cap(text: str) -> str:
+        raw = str(text).strip().encode("utf-8")[:512]
+        return raw.decode("utf-8", "ignore").strip() or "(not stated)"
+
+    answers = [vote for vote in final_votes if isinstance(vote, ParsedDiscussAnswer)]
+    references = tuple(
+        DiscussSynthesisResponseReference(vote.reviewer, round_number)
+        for vote in final_votes
+    )
+    if (
+        outcome == "answer"
+        and consensus_kind in {"unanimous", "converged"}
+        and len(answers) == len(final_votes)
+        and answers
+        and all(vote.answer for vote in answers)
+    ):
+        # This is the exact-text path. `_detect_discuss_answer_consensus` has
+        # already established normalized equality, so no model call is needed.
+        return ParsedDiscussFinalSynthesis(
+            classification="consensus",
+            agreed_conclusions=(
+                DiscussSynthesisConsensus(text=cap(answers[0].answer or ""), references=references),
+            ),
+            remaining_disagreements=(),
+            next_action="Proceed with the shared recommendation.",
+        )
+    if semantic_comparison is not None:
+        classification = semantic_comparison.get("classification")
+        if classification == "equivalent" and semantic_comparison.get("shared_recommendation"):
+            return ParsedDiscussFinalSynthesis(
+                classification="consensus",
+                agreed_conclusions=(
+                    DiscussSynthesisConsensus(
+                        text=cap(str(semantic_comparison["shared_recommendation"])),
+                        references=references,
+                    ),
+                ),
+                remaining_disagreements=(),
+                next_action="Proceed with the shared recommendation.",
+            )
+        if consensus_kind == "debater-confirmed" and semantic_comparison.get("confirmed_answer"):
+            return ParsedDiscussFinalSynthesis(
+                classification="consensus",
+                agreed_conclusions=(
+                    DiscussSynthesisConsensus(
+                        text=cap(str(semantic_comparison["confirmed_answer"])),
+                        references=references,
+                    ),
+                ),
+                remaining_disagreements=(),
+                next_action="Proceed with the debater-confirmed recommendation.",
+            )
+    if outcome == "needs-human" and consensus_kind in {"unanimous", "converged"}:
+        human_items = [
+            (vote, item)
+            for vote in final_votes
+            for item in getattr(vote, "unresolved_items", ())
+            if item.status == "human-decision"
+        ]
+        if human_items:
+            groups: dict[str, list[tuple[ParsedDiscussResponse, DiscussUnresolvedItem]]] = {}
+            for vote, item in human_items:
+                groups.setdefault(item.text.casefold(), []).append((vote, item))
+            disagreements = tuple(
+                DiscussSynthesisDisagreement(
+                    topic=cap(items[0][1].text),
+                    positions=tuple(
+                        DiscussSynthesisPosition(
+                            reviewers=(vote.reviewer,), position=cap(vote.rationale)
+                        )
+                        for vote, _item in items
+                    ),
+                    decision_needed=cap(items[0][1].text),
+                )
+                for items in groups.values()
+            )
+            return ParsedDiscussFinalSynthesis(
+                classification="near_consensus",
+                agreed_conclusions=(),
+                remaining_disagreements=disagreements,
+                next_action=cap("A human must decide: " + "; ".join(item[1].text for item in human_items[:8])),
+            )
+    return None
+
+
 def _post_discuss_debater_comment(
     runner: Runner,
     *,
@@ -10148,7 +10633,10 @@ def _run_discuss_loop(
         prior_analyzer_agenda: ParsedDiscussAgenda | None = (
             resume_state.prior_analyzer_agenda if analyzer is not None else None
         )
-        in_progress_votes: dict[str, ParsedDiscussReview] = dict(resume_state.in_progress_votes)
+        prior_round_synthesis: ParsedDiscussRoundSynthesis | None = (
+            resume_state.prior_round_synthesis if analyzer is not None else None
+        )
+        in_progress_votes: dict[str, ParsedDiscussResponse] = dict(resume_state.in_progress_votes)
         if round_history or in_progress_votes:
             log(config, f"discuss: resuming issue #{issue_number} at round {start_round_number}")
     else:
@@ -10156,6 +10644,7 @@ def _run_discuss_loop(
         start_round_number = 1
         prior_round_agenda = []
         prior_analyzer_agenda = None
+        prior_round_synthesis = None
         in_progress_votes = {}
     max_round_number = discuss_max_rounds + 1
     if start_round_number > max_round_number:
@@ -10178,14 +10667,32 @@ def _run_discuss_loop(
         # A resumed partial round (#475) may carry placeholder votes; keep the
         # vote table to real positions and surface the rest as failures.
         final_successful_votes = [
-            vote for vote in final_votes if vote.outcome != DISCUSS_FAILED_OUTCOME
+            vote for vote in final_votes if not is_failed_discuss_response(vote)
         ]
         final_failed_debaters = tuple(
-            (vote.reviewer, failed_discuss_review_category(vote))
+            (
+                vote.reviewer,
+                (
+                    failed_discuss_review_category(vote)
+                    if isinstance(vote, ParsedDiscussReview)
+                    else vote.category
+                ),
+            )
             for vote in final_votes
-            if vote.outcome == DISCUSS_FAILED_OUTCOME
+            if is_failed_discuss_response(vote)
         )
-        final_analyzer_agenda, final_analyzer_response_raw = _run_discuss_final_analyzer(
+        final_synthesis: ParsedDiscussFinalSynthesis | None = None
+        final_analyzer_agenda: ParsedDiscussAgenda | None = None
+        final_analyzer_response_raw: str | None = None
+        final_synthesis_source: str | None = None
+        final_mechanical_classification = (
+            _mechanical_discuss_final_classification(
+                outcome="needs-human", consensus_kind="deadlock", votes=final_votes
+            )
+            if config.discuss_result_mode == "answer"
+            else None
+        )
+        final_analyzer_agenda, final_analyzer_response_raw, final_synthesis = _run_discuss_final_analyzer(
             runner,
             issue_number=issue_number,
             config=config,
@@ -10194,7 +10701,10 @@ def _run_discuss_loop(
             final_votes=final_successful_votes,
             configured_reviewers=configured_reviewers,
             usage_context=usage_context,
+            mechanical_classification=final_mechanical_classification,
         )
+        if final_synthesis is not None:
+            final_synthesis_source = "final-analyzer"
         evidence_groups, evidence_reconciler_raw = _run_discuss_evidence_reconciler(
             runner, issue_number=issue_number, config=config, analyzer=analyzer, subject=f"issue-{issue_number}",
             round_history=round_history, usage_context=usage_context,
@@ -10216,6 +10726,7 @@ def _run_discuss_loop(
             research_mode=config.discuss_research,
             failed_debaters=final_failed_debaters,
             result_mode=config.discuss_result_mode,
+            final_synthesis=final_synthesis,
             evidence_reconciliation=evidence_reconciliation,
         )
         post_issue_comment(
@@ -10234,9 +10745,21 @@ def _run_discuss_loop(
                     consensus_kind="deadlock",
                     agenda=(),
                     final_analyzer_response=final_analyzer_response_raw,
+                    final_synthesis=(
+                        serialize_discuss_final_synthesis(final_synthesis)
+                        if final_synthesis is not None else None
+                    ),
+                    synthesis_provenance=(
+                        {
+                            "source": final_synthesis_source or "final-analyzer",
+                            "round": final_round_number,
+                        }
+                        if final_synthesis is not None else None
+                    ),
                     research_mode=config.discuss_research,
                     failed_debaters=final_failed_debaters,
                     evidence_reconciliation=evidence_reconciliation,
+                    result_mode=config.discuss_result_mode,
                 ),
             ),
         )
@@ -10248,7 +10771,7 @@ def _run_discuss_loop(
         return 0
     for round_number in range(start_round_number, max_round_number + 1):
         prior_round_votes = round_history[-1] if round_history else []
-        votes_by_name: dict[str, ParsedDiscussReview] = {}
+        votes_by_name: dict[str, ParsedDiscussResponse] = {}
         failures_by_name: dict[str, _DiscussDebaterTurnResult] = {}
         pending: list[AgentName] = []
         for reviewer in configured_reviewers:
@@ -10504,10 +11027,19 @@ def _run_discuss_loop(
                 consensus_kind = ("unanimous" if len(round_history) == 1 else "converged") if is_final else None
         next_analyzer_agenda: ParsedDiscussAgenda | None = None
         analyzer_response_raw: str | None = None
+        next_round_synthesis: ParsedDiscussRoundSynthesis | None = None
+        raw_synthesis_response: str | None = None
         final_analyzer_agenda: ParsedDiscussAgenda | None = None
         final_analyzer_response_raw: str | None = None
+        final_synthesis: ParsedDiscussFinalSynthesis | None = None
+        final_synthesis_source: str | None = None
         if not is_final and analyzer is not None:
-            next_analyzer_agenda, analyzer_response_raw = _run_discuss_analyzer(
+            (
+                next_analyzer_agenda,
+                analyzer_response_raw,
+                next_round_synthesis,
+                raw_synthesis_response,
+            ) = _run_discuss_analyzer(
                 runner,
                 issue_number=issue_number,
                 config=config,
@@ -10517,16 +11049,48 @@ def _run_discuss_loop(
                 round_number=round_number,
                 round_history=round_history,
                 prior_agenda=prior_analyzer_agenda,
+                prior_round_synthesis=prior_round_synthesis,
                 configured_reviewers=configured_reviewers,
                 usage_context=usage_context,
             )
-        elif is_final and consensus_kind != "debater-confirmed":
+        elif is_final and config.discuss_result_mode == "answer":
+            final_mechanical_classification = _mechanical_discuss_final_classification(
+                outcome=outcome, consensus_kind=consensus_kind, votes=reviewer_votes
+            )
+            final_synthesis = _adapt_discuss_final_synthesis(
+                outcome=outcome,
+                consensus_kind=consensus_kind,
+                final_votes=successful_votes,
+                round_number=round_number,
+                semantic_comparison=semantic_comparison,
+            )
+            if final_synthesis is not None:
+                final_synthesis_source = (
+                    "semantic-comparison"
+                    if semantic_comparison is not None
+                    else "mechanical-result"
+                )
+            if final_synthesis is None:
+                final_analyzer_agenda, final_analyzer_response_raw, final_synthesis = _run_discuss_final_analyzer(
+                    runner,
+                    issue_number=issue_number,
+                    config=config,
+                    analyzer=analyzer,
+                    round_number=round_number,
+                    final_votes=successful_votes,
+                    configured_reviewers=configured_reviewers,
+                    usage_context=usage_context,
+                    mechanical_classification=final_mechanical_classification,
+                )
+                if final_synthesis is not None:
+                    final_synthesis_source = "final-analyzer"
+        elif is_final:
             # Semantic finalization already used the configured analyzer to
             # compare the completed final-round answers. When every debater
             # confirms that recommendation, keep that audit as the final
             # analyzer record rather than invoking the same analyzer again
             # for advisory observations over identical input.
-            final_analyzer_agenda, final_analyzer_response_raw = _run_discuss_final_analyzer(
+            final_analyzer_agenda, final_analyzer_response_raw, _unused_final_synthesis = _run_discuss_final_analyzer(
                 runner,
                 issue_number=issue_number,
                 config=config,
@@ -10564,6 +11128,8 @@ def _run_discuss_loop(
             result_mode=config.discuss_result_mode,
             semantic_comparison=semantic_comparison,
             evidence_reconciliation=evidence_reconciliation,
+            round_synthesis=next_round_synthesis,
+            final_synthesis=final_synthesis,
         )
         agenda = () if is_final else tuple(_render_discuss_agenda_lines(successful_votes))
         post_issue_comment(
@@ -10583,6 +11149,31 @@ def _run_discuss_loop(
                     agenda=agenda,
                     analyzer_response=analyzer_response_raw,
                     final_analyzer_response=final_analyzer_response_raw,
+                    round_synthesis=(
+                        serialize_discuss_round_synthesis(next_round_synthesis)
+                        if next_round_synthesis is not None else None
+                    ),
+                    final_synthesis=(
+                        serialize_discuss_final_synthesis(final_synthesis)
+                        if final_synthesis is not None else None
+                    ),
+                    raw_synthesis_response=raw_synthesis_response,
+                    synthesis_provenance=(
+                        {
+                            "source": (
+                                "round-analyzer" if raw_synthesis_response is None
+                                else "round-fallback"
+                            ),
+                            "round": round_number,
+                        }
+                        if next_round_synthesis is not None else (
+                            {
+                                "source": final_synthesis_source or "final-analyzer",
+                                "round": round_number,
+                            }
+                            if final_synthesis is not None else None
+                        )
+                    ),
                     research_mode=config.discuss_research,
                     failed_debaters=tuple(failed_debaters),
                     split_proposals=tuple(round_split_proposals) if is_final else (),
@@ -10619,6 +11210,7 @@ def _run_discuss_loop(
         )
         prior_round_agenda = list(agenda)
         prior_analyzer_agenda = next_analyzer_agenda
+        prior_round_synthesis = next_round_synthesis
     return 0
 
 

--- a/src/coding_review_agent_loop/orchestrator.py
+++ b/src/coding_review_agent_loop/orchestrator.py
@@ -11170,7 +11170,11 @@ def _run_discuss_loop(
             # recover agreed recommendations and accurately summarize the
             # residual human decisions.
             if final_synthesis is None or final_mechanical_classification == "near_consensus":
-                final_analyzer_agenda, final_analyzer_response_raw, final_synthesis = _run_discuss_final_analyzer(
+                (
+                    final_analyzer_agenda,
+                    final_analyzer_response_raw,
+                    analyzer_synthesis,
+                ) = _run_discuss_final_analyzer(
                     runner,
                     issue_number=issue_number,
                     config=config,
@@ -11181,7 +11185,11 @@ def _run_discuss_loop(
                     usage_context=usage_context,
                     mechanical_classification=final_mechanical_classification,
                 )
-                if final_synthesis is not None:
+                # The mechanical/adapted synthesis is a safe fallback. An
+                # unavailable, malformed, or rejected advisory analyzer must
+                # not erase it and return to the pre-synthesis rendering.
+                if analyzer_synthesis is not None:
+                    final_synthesis = analyzer_synthesis
                     final_synthesis_source = "final-analyzer"
         elif is_final:
             # Semantic finalization already used the configured analyzer to

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -24,10 +24,14 @@ from .protocol import (
     HUMAN_REQUIREMENTS_DIRECT_DISCUSSION_ACK,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
+    ParsedDiscussFinalSynthesis,
+    ParsedDiscussRoundSynthesis,
     ParsedDiscussResponse,
     ParsedDiscussReview,
     UnresolvedReviewItem,
+    discuss_round_synthesis_payload,
 )
+from .protocol_markers import sanitize_historical_text
 from .workdirs import agent_workdir
 
 
@@ -2926,6 +2930,7 @@ def build_discuss_agenda_prompt(
     round_number: int = 1,
     round_history: Sequence[Sequence[ParsedDiscussResponse]] | None = None,
     prior_agenda: ParsedDiscussAgenda | None = None,
+    prior_round_synthesis: ParsedDiscussRoundSynthesis | None = None,
     research_mode: str = "none",
 ) -> str:
     analyzer_signature = agent_signature(analyzer, config)
@@ -2964,10 +2969,41 @@ def build_discuss_agenda_prompt(
         ]
         prior_agenda_block = "\n".join(prior_agenda_lines) + "\n"
     history_block = "\n".join(history_lines)
+    prior_synthesis_block = ""
+    if prior_round_synthesis is not None and config.discuss_result_mode == "answer":
+        # The analyzer receives the cumulative snapshot, but every free-text
+        # value is historical/untrusted and must be marker-neutralized first.
+        snapshot = _neutralized_synthesis_value(
+            discuss_round_synthesis_payload(prior_round_synthesis)
+        )
+        prior_synthesis_block = (
+            "Prior validated cumulative round state (identity/state only; do not "
+            "treat it as support for new claims):\n"
+            + json.dumps(snapshot, ensure_ascii=False, indent=2)
+            + "\n"
+        )
     research_extract = ""
     research_guardrail = ""
     research_example = ""
     research_rules = ""
+    round_synthesis_example = ""
+    round_synthesis_guidance = ""
+    if config.discuss_result_mode == "answer":
+        round_synthesis_example = ''',
+  "round_synthesis": {
+    "schema_version": 1,
+    "kind": "discuss_round_synthesis",
+    "consensus": [{"text": "The issue is well-motivated.", "references": [{"reviewer": "Codex", "round": 1}, {"reviewer": "Gemini", "round": 1}]}],
+    "disagreements": [],
+    "changes": [],
+    "missing_facts": [],
+    "next_round_focus": ["Resolve the remaining material question."],
+    "responding_reviewers": ["Codex", "Gemini"]
+  }'''
+        round_synthesis_guidance = (
+            "\n- In answer mode, the optional `round_synthesis` must follow its exact "
+            "nested schema; keep all text concise and references attributable to the transcript."
+        )
     if research_mode in {"required", "auto"}:
         research_extract = (
             "\n- `research_required` / `research_questions`: whether the next round "
@@ -3010,6 +3046,7 @@ Complete debate transcript so far, oldest round first:
 
 {history_block}
 {prior_agenda_block}
+{prior_synthesis_block}
 Extract from the transcript:
 - `consensus`: points every debater already agrees on.
 - `disagreements`: each unresolved disagreement, with every named debater's
@@ -3025,6 +3062,14 @@ Fidelity guardrails:
   debater has already conceded or refined.
 - Carry forward unresolved `missing_facts` from your previous agenda.{research_guardrail}
 
+When answer mode is active, also emit `round_synthesis` with the latest
+cumulative state. Its response references must identify the supporting debater
+and round. Carry an unchanged consensus item forward exactly; use changes with
+kind `introduced`, `resolved`, `reopened`, `retracted`, or `refined` for state
+transitions. `responding_reviewers` must contain exactly the successful current
+responders. This nested presentation state is not part of the next debater's
+agenda and must not be used as evidence for itself.
+
 Respond using this mandatory structured JSON format:
 
 {{
@@ -3038,7 +3083,7 @@ Respond using this mandatory structured JSON format:
       "question_for_next_round": "Would splitting the API boundary into its own issue resolve the scope objection?"
     }}
   ],
-  "missing_facts": ["Whether the API boundary is already specified."]{research_example}
+  "missing_facts": ["Whether the API boundary is already specified."]{research_example}{round_synthesis_example}
 }}
 <!-- AGENT_PLAN_STATE: approved -->
 -- {analyzer_signature}
@@ -3047,6 +3092,7 @@ Rules:
 - `consensus`, `disagreements`, and `missing_facts` may be empty arrays.
 - Each disagreement requires non-empty `topic`, `positions`, and `question_for_next_round`.
 - `positions` maps each debater's display name to a short statement of its position.{research_rules}
+{round_synthesis_guidance}
 - The footer must always be `<!-- AGENT_PLAN_STATE: approved -->`.
 - Do not include prose or code fences before the JSON object.
 - Do not place your signature before the `AGENT_PLAN_STATE` footer.
@@ -3054,6 +3100,138 @@ Rules:
 
 <!-- AGENT_PLAN_STATE: approved -->
 -- {analyzer_signature}
+"""
+
+
+def _neutralized_synthesis_value(value: object) -> object:
+    """Recursively neutralize historical text before prompt inclusion."""
+    if isinstance(value, str):
+        return sanitize_historical_text(value)
+    if isinstance(value, list):
+        return [_neutralized_synthesis_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _neutralized_synthesis_value(item) for key, item in value.items()}
+    return value
+
+
+def _render_answer_responses_for_synthesis(
+    responses: Sequence[ParsedDiscussResponse], *, maximum_bytes: int = 12_000
+) -> str:
+    lines: list[str] = []
+    for vote in responses:
+        name = sanitize_historical_text(getattr(vote, "reviewer", "unknown"))
+        position = sanitize_historical_text(
+            str(getattr(vote, "position", getattr(vote, "outcome", "failed")))
+        )
+        lines.append(f"- {name}: position={position}")
+        for field in ("answer", "rationale", "rebuttal"):
+            value = getattr(vote, field, None)
+            if value:
+                rendered = sanitize_historical_text(str(value))
+                lines.append(f"  {field}: {rendered[:1_500]}")
+        for item in getattr(vote, "unresolved_items", ()):
+            lines.append(
+                f"  unresolved ({sanitize_historical_text(item.status)}): "
+                f"{sanitize_historical_text(item.text)[:512]}"
+            )
+    rendered = "\n".join(lines) or "(no successful responses)"
+    return rendered[:maximum_bytes]
+
+
+def build_discuss_round_synthesis_prompt(
+    issue_number: int,
+    config: AgentLoopConfig,
+    *,
+    analyzer: AgentName,
+    round_number: int,
+    current_responses: Sequence[ParsedDiscussResponse],
+    prior_synthesis: ParsedDiscussRoundSynthesis | None = None,
+) -> str:
+    """Build the single bounded fallback used for a legacy agenda."""
+    prior = "(none)"
+    if prior_synthesis is not None:
+        prior_payload = _neutralized_synthesis_value(
+            discuss_round_synthesis_payload(prior_synthesis)
+        )
+        prior = json.dumps(prior_payload, ensure_ascii=False, separators=(",", ":"))[:16_000]
+    return f"""Synthesize only the completed answer-mode responses for GitHub issue #{issue_number} in {config.repo}.
+
+You are the configured discuss analyzer. This is a bounded fallback because the
+normal agenda did not contain its optional synthesis extension. Do not use issue
+prose, earlier agendas, or your own prior synthesis as support for new claims.
+The prior snapshot is identity/state context only.
+
+Completed round {round_number} responses:
+{_render_answer_responses_for_synthesis(current_responses)}
+
+Prior validated snapshot:
+{prior}
+
+Return exactly this object, with all statements attributable to the listed
+responses. `responding_reviewers` must exactly match the successful responses:
+{{
+  "schema_version": 1,
+  "kind": "discuss_round_synthesis",
+  "consensus": [],
+  "disagreements": [],
+  "changes": [],
+  "missing_facts": [],
+  "next_round_focus": [],
+  "responding_reviewers": []
+}}
+Use at most eight entries per collection and five next-round-focus entries;
+each reference is {{"reviewer": "<listed name>", "round": <round number>}}.
+<!-- AGENT_PLAN_STATE: approved -->
+-- {agent_signature(analyzer, config)}
+"""
+
+
+# Kept as an explicit alias for callers that describe the legacy-agenda path
+# as a fallback rather than a synthesis pass.
+build_discuss_round_fallback_prompt = build_discuss_round_synthesis_prompt
+
+
+def build_discuss_final_synthesis_prompt(
+    issue_number: int,
+    config: AgentLoopConfig,
+    *,
+    analyzer: AgentName,
+    round_number: int,
+    final_responses: Sequence[ParsedDiscussResponse],
+    mechanical_classification: str,
+    bounded_context: str = "",
+) -> str:
+    """Build the one bounded advisory final synthesis call."""
+    context = sanitize_historical_text(bounded_context)[:2_000] or "(none)"
+    return f"""Analyze only these completed final-round debater responses for GitHub issue #{issue_number} in {config.repo}, then synthesize their executive conclusion.
+
+You are an advisory analyzer. The mechanically determined classification is
+`{mechanical_classification}` and cannot be changed. Do not use issue prose,
+earlier rounds, prior syntheses, external information, or tools. Do not invent
+agreement. Every conclusion and every named position must be supported by the
+corresponding final response.
+
+Final round {round_number} responses:
+{_render_answer_responses_for_synthesis(final_responses)}
+
+Bounded context:
+{context}
+
+Return exactly:
+{{
+  "schema_version": 1,
+  "kind": "discuss_final_synthesis",
+  "classification": "{mechanical_classification}",
+  "agreed_conclusions": [],
+  "remaining_disagreements": [],
+  "next_action": "State the precise next human action."
+}}
+The classification must remain exactly `{mechanical_classification}`. Use at
+most eight conclusions and disagreements; each conclusion has `text` and
+response `references`, and each disagreement has `topic`, grouped reviewer
+`positions`, and `decision_needed`. Keep every free-text value concise.
+<!-- AGENT_PLAN_STATE: approved -->
+-- {agent_signature(analyzer, config)}
 """
 
 
@@ -3407,7 +3585,7 @@ def build_discuss_semantic_comparison_prompt(
     """A bounded, advisory final-round comparator prompt (#528)."""
     answer_lines = "\n".join(f"- {item.reviewer}: {item.answer}" for item in answers)
     names = [item.reviewer for item in answers]
-    return f"""Compare only these completed final-round answers for GitHub issue #{issue_number} in {config.repo}.
+    return f"""Analyze only these completed final-round debater responses for GitHub issue #{issue_number} in {config.repo}; compare their answers semantically.
 
 This is advisory only and must not create a debater consensus. Do not use web research, tools, repository inspection, or earlier discussion history. Do not decide unresolved product questions.
 

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -30,6 +30,7 @@ from .protocol import (
     ParsedDiscussReview,
     UnresolvedReviewItem,
     discuss_round_synthesis_payload,
+    is_failed_discuss_response,
 )
 from .protocol_markers import sanitize_historical_text
 from .workdirs import agent_workdir
@@ -3119,6 +3120,8 @@ def _render_answer_responses_for_synthesis(
 ) -> str:
     lines: list[str] = []
     for vote in responses:
+        if is_failed_discuss_response(vote):
+            continue
         name = sanitize_historical_text(getattr(vote, "reviewer", "unknown"))
         position = sanitize_historical_text(
             str(getattr(vote, "position", getattr(vote, "outcome", "failed")))
@@ -3167,8 +3170,10 @@ Completed round {round_number} responses:
 Prior validated snapshot:
 {prior}
 
-Return exactly this object, with all statements attributable to the listed
-responses. `responding_reviewers` must exactly match the successful responses:
+Return exactly an object with all statements attributable to the listed
+responses. `responding_reviewers` must exactly match the successful responses.
+Here is the smallest valid empty-state shape (the reviewer list is already
+filled with the successful responders for this round):
 {{
   "schema_version": 1,
   "kind": "discuss_round_synthesis",
@@ -3177,7 +3182,7 @@ responses. `responding_reviewers` must exactly match the successful responses:
   "changes": [],
   "missing_facts": [],
   "next_round_focus": [],
-  "responding_reviewers": []
+  "responding_reviewers": {json.dumps([sanitize_historical_text(getattr(vote, "reviewer", "unknown")) for vote in current_responses if not is_failed_discuss_response(vote)])}
 }}
 Use at most eight entries per collection and five next-round-focus entries;
 each reference is {{"reviewer": "<listed name>", "round": <round number>}}.
@@ -3203,6 +3208,49 @@ def build_discuss_final_synthesis_prompt(
 ) -> str:
     """Build the one bounded advisory final synthesis call."""
     context = sanitize_historical_text(bounded_context)[:2_000] or "(none)"
+    reviewer_names = [
+        sanitize_historical_text(getattr(vote, "reviewer", "listed reviewer"))
+        for vote in final_responses
+        if not is_failed_discuss_response(vote)
+    ] or ["listed reviewer"]
+    references = [
+        {"reviewer": name, "round": round_number} for name in reviewer_names
+    ]
+    if mechanical_classification == "consensus":
+        example = {
+            "schema_version": 1,
+            "kind": "discuss_final_synthesis",
+            "classification": mechanical_classification,
+            "agreed_conclusions": [
+                {
+                    "text": "Replace with one conclusion supported by every final response.",
+                    "references": references,
+                }
+            ],
+            "remaining_disagreements": [],
+            "next_action": "Proceed with the agreed recommendation.",
+        }
+    else:
+        example = {
+            "schema_version": 1,
+            "kind": "discuss_final_synthesis",
+            "classification": mechanical_classification,
+            "agreed_conclusions": [],
+            "remaining_disagreements": [
+                {
+                    "topic": "Replace with one material residual decision.",
+                    "positions": [
+                        {
+                            "reviewers": [reviewer_names[0]],
+                            "position": "Replace with that reviewer's supported position.",
+                        }
+                    ],
+                    "decision_needed": "Replace with the precise decision needed.",
+                }
+            ],
+            "next_action": "State the precise next human action.",
+        }
+    example_json = json.dumps(example, ensure_ascii=False, indent=2)
     return f"""Analyze only these completed final-round debater responses for GitHub issue #{issue_number} in {config.repo}, then synthesize their executive conclusion.
 
 You are an advisory analyzer. The mechanically determined classification is
@@ -3217,15 +3265,14 @@ Final round {round_number} responses:
 Bounded context:
 {context}
 
-Return exactly:
-{{
-  "schema_version": 1,
-  "kind": "discuss_final_synthesis",
-  "classification": "{mechanical_classification}",
-  "agreed_conclusions": [],
-  "remaining_disagreements": [],
-  "next_action": "State the precise next human action."
-}}
+Return exactly an object matching this classification-valid shape. Replace the
+example text with concise statements supported by the final responses:
+{example_json}
+For `consensus`, include at least one agreed conclusion and no
+remaining disagreements. For `near_consensus`, include at least one remaining
+disagreement. For `material_deadlock`, include at least one agreed conclusion
+or remaining disagreement. The placeholders above are illustrative and must
+be replaced; do not emit angle-bracket placeholders.
 The classification must remain exactly `{mechanical_classification}`. Use at
 most eight conclusions and disagreements; each conclusion has `text` and
 response `references`, and each disagreement has `topic`, grouped reviewer

--- a/src/coding_review_agent_loop/protocol.py
+++ b/src/coding_review_agent_loop/protocol.py
@@ -527,6 +527,82 @@ class DiscussAgendaDisagreement:
     question_for_next_round: str
 
 
+DISCUSS_SYNTHESIS_MAX_ENTRIES = 8
+DISCUSS_SYNTHESIS_MAX_NEXT_ROUND_FOCUS = 5
+DISCUSS_SYNTHESIS_MAX_TEXT_BYTES = 512
+DISCUSS_SYNTHESIS_MAX_CANONICAL_BYTES = 16_000
+DISCUSS_SYNTHESIS_CHANGE_KINDS = frozenset(
+    {"introduced", "resolved", "reopened", "retracted", "refined"}
+)
+DISCUSS_SYNTHESIS_CLASSIFICATIONS = frozenset(
+    {"consensus", "near_consensus", "material_deadlock"}
+)
+
+
+@dataclass(frozen=True)
+class DiscussSynthesisResponseReference:
+    """A response that independently supports a synthesized statement."""
+
+    reviewer: str
+    round: int
+
+
+@dataclass(frozen=True)
+class DiscussSynthesisConsensus:
+    text: str
+    references: tuple[DiscussSynthesisResponseReference, ...]
+
+
+@dataclass(frozen=True)
+class DiscussSynthesisPosition:
+    reviewers: tuple[str, ...]
+    position: str
+
+
+@dataclass(frozen=True)
+class DiscussSynthesisDisagreement:
+    topic: str
+    positions: tuple[DiscussSynthesisPosition, ...]
+    decision_needed: str
+
+
+@dataclass(frozen=True)
+class DiscussSynthesisChange:
+    kind: str
+    topic: str
+    text: str
+    references: tuple[DiscussSynthesisResponseReference, ...]
+
+
+@dataclass(frozen=True)
+class ParsedDiscussRoundSynthesis:
+    """Validated cumulative state for one completed answer-mode round."""
+
+    consensus: tuple[DiscussSynthesisConsensus, ...]
+    disagreements: tuple[DiscussSynthesisDisagreement, ...]
+    changes: tuple[DiscussSynthesisChange, ...]
+    missing_facts: tuple[str, ...]
+    next_round_focus: tuple[str, ...]
+    responding_reviewers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ParsedDiscussFinalSynthesis:
+    """Validated executive conclusion for an answer-mode final result."""
+
+    classification: str
+    agreed_conclusions: tuple[DiscussSynthesisConsensus, ...]
+    remaining_disagreements: tuple[DiscussSynthesisDisagreement, ...]
+    next_action: str
+
+
+# Short aliases keep the public protocol vocabulary easy to discover while
+# retaining the explicit response-reference name in serialized models.
+DiscussSynthesisReference = DiscussSynthesisResponseReference
+DiscussRoundSynthesis = ParsedDiscussRoundSynthesis
+DiscussFinalSynthesis = ParsedDiscussFinalSynthesis
+
+
 @dataclass(frozen=True)
 class ParsedDiscussAgenda:
     consensus: tuple[str, ...]
@@ -538,6 +614,9 @@ class ParsedDiscussAgenda:
     research_required: bool = False
     research_questions: tuple[str, ...] = ()
     research_question_targets: tuple[str, ...] = ()
+    # Optional answer-mode presentation state. Legacy agendas deliberately
+    # remain valid and have no synthesis value.
+    round_synthesis: ParsedDiscussRoundSynthesis | None = None
 
 
 @dataclass(frozen=True)
@@ -3104,6 +3183,417 @@ def _parse_discuss_agenda_disagreement(
     )
 
 
+def _bounded_discuss_synthesis_text(value: object, *, context: str) -> str:
+    text = _expect_non_empty_string(value, context=context)
+    if len(text.encode("utf-8")) > DISCUSS_SYNTHESIS_MAX_TEXT_BYTES:
+        raise AgentLoopError(
+            f"{context} exceeds {DISCUSS_SYNTHESIS_MAX_TEXT_BYTES} UTF-8 bytes."
+        )
+    return text
+
+
+def _bounded_discuss_synthesis_list(
+    value: object,
+    *,
+    context: str,
+    item_context: str,
+    maximum: int = DISCUSS_SYNTHESIS_MAX_ENTRIES,
+) -> tuple[str, ...]:
+    values = _expect_string_list(value, context=context, item_context=item_context)
+    if len(values) > maximum:
+        raise AgentLoopError(f"{context} may contain at most {maximum} item(s).")
+    bounded = tuple(
+        _bounded_discuss_synthesis_text(item, context=f"{item_context} at index {index}")
+        for index, item in enumerate(values)
+    )
+    if len({item.casefold() for item in bounded}) != len(bounded):
+        raise AgentLoopError(f"{context} must not contain duplicate entries.")
+    return bounded
+
+
+def _parse_discuss_synthesis_reference(
+    value: object, *, context: str
+) -> DiscussSynthesisResponseReference:
+    payload = _expect_object(value, context=context)
+    _expect_exact_keys(payload, context=context, required={"reviewer", "round"})
+    reviewer = _bounded_discuss_synthesis_text(
+        payload["reviewer"], context=f"{context}.reviewer"
+    )
+    round_number = _expect_int(payload["round"], context=f"{context}.round")
+    if round_number < 1:
+        raise AgentLoopError(f"{context}.round must be at least 1.")
+    return DiscussSynthesisResponseReference(reviewer=reviewer, round=round_number)
+
+
+def _parse_discuss_synthesis_references(
+    value: object, *, context: str
+) -> tuple[DiscussSynthesisResponseReference, ...]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    if not value:
+        raise AgentLoopError(f"{context} must not be empty.")
+    if len(value) > DISCUSS_SYNTHESIS_MAX_ENTRIES:
+        raise AgentLoopError(
+            f"{context} may contain at most {DISCUSS_SYNTHESIS_MAX_ENTRIES} item(s)."
+        )
+    references = tuple(
+        _parse_discuss_synthesis_reference(item, context=f"{context}[{index}]")
+        for index, item in enumerate(value)
+    )
+    keys = [(item.reviewer.casefold(), item.round) for item in references]
+    if len(set(keys)) != len(keys):
+        raise AgentLoopError(f"{context} must not contain duplicate references.")
+    return references
+
+
+def _parse_discuss_synthesis_consensus(
+    value: object, *, context: str
+) -> DiscussSynthesisConsensus:
+    payload = _expect_object(value, context=context)
+    _expect_exact_keys(payload, context=context, required={"text", "references"})
+    return DiscussSynthesisConsensus(
+        text=_bounded_discuss_synthesis_text(payload["text"], context=f"{context}.text"),
+        references=_parse_discuss_synthesis_references(
+            payload["references"], context=f"{context}.references"
+        ),
+    )
+
+
+def _parse_discuss_synthesis_position(
+    value: object, *, context: str
+) -> DiscussSynthesisPosition:
+    payload = _expect_object(value, context=context)
+    _expect_exact_keys(payload, context=context, required={"reviewers", "position"})
+    reviewers = _bounded_discuss_synthesis_list(
+        payload["reviewers"],
+        context=f"{context}.reviewers",
+        item_context=f"{context}.reviewers",
+        maximum=DISCUSS_SYNTHESIS_MAX_ENTRIES,
+    )
+    return DiscussSynthesisPosition(
+        reviewers=reviewers,
+        position=_bounded_discuss_synthesis_text(
+            payload["position"], context=f"{context}.position"
+        ),
+    )
+
+
+def _parse_discuss_synthesis_disagreement(
+    value: object, *, context: str
+) -> DiscussSynthesisDisagreement:
+    payload = _expect_object(value, context=context)
+    _expect_exact_keys(
+        payload, context=context, required={"topic", "positions", "decision_needed"}
+    )
+    positions_value = payload["positions"]
+    if not isinstance(positions_value, list):
+        raise AgentLoopError(f"{context}.positions must be a JSON array.")
+    if not positions_value:
+        raise AgentLoopError(f"{context}.positions must not be empty.")
+    if len(positions_value) > DISCUSS_SYNTHESIS_MAX_ENTRIES:
+        raise AgentLoopError(
+            f"{context}.positions may contain at most {DISCUSS_SYNTHESIS_MAX_ENTRIES} item(s)."
+        )
+    positions = tuple(
+        _parse_discuss_synthesis_position(item, context=f"{context}.positions[{index}]")
+        for index, item in enumerate(positions_value)
+    )
+    all_reviewers = [reviewer for item in positions for reviewer in item.reviewers]
+    if len({reviewer.casefold() for reviewer in all_reviewers}) != len(all_reviewers):
+        raise AgentLoopError(f"{context}.positions must not repeat a reviewer.")
+    return DiscussSynthesisDisagreement(
+        topic=_bounded_discuss_synthesis_text(payload["topic"], context=f"{context}.topic"),
+        positions=positions,
+        decision_needed=_bounded_discuss_synthesis_text(
+            payload["decision_needed"], context=f"{context}.decision_needed"
+        ),
+    )
+
+
+def _parse_discuss_synthesis_change(
+    value: object, *, context: str
+) -> DiscussSynthesisChange:
+    payload = _expect_object(value, context=context)
+    _expect_exact_keys(
+        payload, context=context, required={"kind", "topic", "text", "references"}
+    )
+    kind = _bounded_discuss_synthesis_text(payload["kind"], context=f"{context}.kind")
+    if kind not in DISCUSS_SYNTHESIS_CHANGE_KINDS:
+        raise AgentLoopError(
+            f"{context}.kind must be one of: "
+            + ", ".join(sorted(DISCUSS_SYNTHESIS_CHANGE_KINDS))
+        )
+    return DiscussSynthesisChange(
+        kind=kind,
+        topic=_bounded_discuss_synthesis_text(payload["topic"], context=f"{context}.topic"),
+        text=_bounded_discuss_synthesis_text(payload["text"], context=f"{context}.text"),
+        references=_parse_discuss_synthesis_references(
+            payload["references"], context=f"{context}.references"
+        ),
+    )
+
+
+def _parse_round_synthesis_payload(
+    payload: dict[str, object], *, context: str = "discuss_round_synthesis"
+) -> ParsedDiscussRoundSynthesis:
+    _require_supported_schema_version(payload)
+    _expect_exact_keys(
+        payload,
+        context=context,
+        required={
+            "schema_version", "kind", "consensus", "disagreements", "changes",
+            "missing_facts", "next_round_focus", "responding_reviewers",
+        },
+    )
+    if payload.get("kind") != "discuss_round_synthesis":
+        raise AgentLoopError(
+            "Structured response kind mismatch: expected `discuss_round_synthesis`."
+        )
+    consensus = tuple(
+        _parse_discuss_synthesis_consensus(item, context=f"{context}.consensus[{index}]")
+        for index, item in enumerate(
+            _bounded_synthesis_object_list(payload["consensus"], context=f"{context}.consensus")
+        )
+    )
+    disagreements = tuple(
+        _parse_discuss_synthesis_disagreement(
+            item, context=f"{context}.disagreements[{index}]"
+        )
+        for index, item in enumerate(
+            _bounded_synthesis_object_list(payload["disagreements"], context=f"{context}.disagreements")
+        )
+    )
+    changes = tuple(
+        _parse_discuss_synthesis_change(item, context=f"{context}.changes[{index}]")
+        for index, item in enumerate(
+            _bounded_synthesis_object_list(payload["changes"], context=f"{context}.changes")
+        )
+    )
+    topics = [item.topic.casefold() for item in disagreements]
+    if len(set(topics)) != len(topics):
+        raise AgentLoopError(f"{context}.disagreements must not contain duplicate topics.")
+    missing_facts = _bounded_discuss_synthesis_list(
+        payload["missing_facts"], context=f"{context}.missing_facts", item_context=f"{context}.missing_facts"
+    )
+    next_focus = _bounded_discuss_synthesis_list(
+        payload["next_round_focus"], context=f"{context}.next_round_focus", item_context=f"{context}.next_round_focus",
+        maximum=DISCUSS_SYNTHESIS_MAX_NEXT_ROUND_FOCUS,
+    )
+    responding_reviewers = _bounded_discuss_synthesis_list(
+        payload["responding_reviewers"], context=f"{context}.responding_reviewers", item_context=f"{context}.responding_reviewers"
+    )
+    return ParsedDiscussRoundSynthesis(
+        consensus=consensus, disagreements=disagreements, changes=changes,
+        missing_facts=missing_facts, next_round_focus=next_focus,
+        responding_reviewers=responding_reviewers,
+    )
+
+
+def _bounded_synthesis_object_list(value: object, *, context: str) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise AgentLoopError(f"{context} must be a JSON array.")
+    if len(value) > DISCUSS_SYNTHESIS_MAX_ENTRIES:
+        raise AgentLoopError(
+            f"{context} may contain at most {DISCUSS_SYNTHESIS_MAX_ENTRIES} item(s)."
+        )
+    return [_expect_object(item, context=f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _parse_final_synthesis_payload(
+    payload: dict[str, object], *, context: str = "discuss_final_synthesis"
+) -> ParsedDiscussFinalSynthesis:
+    _require_supported_schema_version(payload)
+    _expect_exact_keys(
+        payload,
+        context=context,
+        required={
+            "schema_version", "kind", "classification", "agreed_conclusions",
+            "remaining_disagreements", "next_action",
+        },
+    )
+    if payload.get("kind") != "discuss_final_synthesis":
+        raise AgentLoopError(
+            "Structured response kind mismatch: expected `discuss_final_synthesis`."
+        )
+    classification = _bounded_discuss_synthesis_text(
+        payload["classification"], context=f"{context}.classification"
+    )
+    if classification not in DISCUSS_SYNTHESIS_CLASSIFICATIONS:
+        raise AgentLoopError(f"{context}.classification is not supported.")
+    agreed = tuple(
+        _parse_discuss_synthesis_consensus(item, context=f"{context}.agreed_conclusions[{index}]")
+        for index, item in enumerate(
+            _bounded_synthesis_object_list(payload["agreed_conclusions"], context=f"{context}.agreed_conclusions")
+        )
+    )
+    disagreements = tuple(
+        _parse_discuss_synthesis_disagreement(
+            item, context=f"{context}.remaining_disagreements[{index}]"
+        )
+        for index, item in enumerate(
+            _bounded_synthesis_object_list(payload["remaining_disagreements"], context=f"{context}.remaining_disagreements")
+        )
+    )
+    topics = [item.topic.casefold() for item in disagreements]
+    if len(set(topics)) != len(topics):
+        raise AgentLoopError(f"{context}.remaining_disagreements must not contain duplicate topics.")
+    if classification == "consensus" and disagreements:
+        raise AgentLoopError("A consensus final synthesis cannot contain remaining disagreements.")
+    if classification == "consensus" and not agreed:
+        raise AgentLoopError("A consensus final synthesis must include an agreed conclusion.")
+    if classification == "near_consensus" and not disagreements:
+        raise AgentLoopError(
+            "A near-consensus final synthesis must include a remaining disagreement."
+        )
+    if classification == "material_deadlock" and not disagreements and not agreed:
+        raise AgentLoopError("A material-deadlock final synthesis must describe the residual state.")
+    return ParsedDiscussFinalSynthesis(
+        classification=classification,
+        agreed_conclusions=agreed,
+        remaining_disagreements=disagreements,
+        next_action=_bounded_discuss_synthesis_text(
+            payload["next_action"], context=f"{context}.next_action"
+        ),
+    )
+
+
+def _disc_synthesis_reference_payload(
+    reference: DiscussSynthesisResponseReference,
+) -> dict[str, object]:
+    return {"reviewer": reference.reviewer, "round": reference.round}
+
+
+def _disc_synthesis_consensus_payload(item: DiscussSynthesisConsensus) -> dict[str, object]:
+    return {
+        "text": item.text,
+        "references": [_disc_synthesis_reference_payload(ref) for ref in item.references],
+    }
+
+
+def _disc_synthesis_disagreement_payload(item: DiscussSynthesisDisagreement) -> dict[str, object]:
+    return {
+        "topic": item.topic,
+        "positions": [
+            {"reviewers": list(position.reviewers), "position": position.position}
+            for position in item.positions
+        ],
+        "decision_needed": item.decision_needed,
+    }
+
+
+def _disc_synthesis_change_payload(item: DiscussSynthesisChange) -> dict[str, object]:
+    return {
+        "kind": item.kind,
+        "topic": item.topic,
+        "text": item.text,
+        "references": [_disc_synthesis_reference_payload(ref) for ref in item.references],
+    }
+
+
+def discuss_round_synthesis_payload(synthesis: ParsedDiscussRoundSynthesis) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "kind": "discuss_round_synthesis",
+        "consensus": [_disc_synthesis_consensus_payload(item) for item in synthesis.consensus],
+        "disagreements": [_disc_synthesis_disagreement_payload(item) for item in synthesis.disagreements],
+        "changes": [_disc_synthesis_change_payload(item) for item in synthesis.changes],
+        "missing_facts": list(synthesis.missing_facts),
+        "next_round_focus": list(synthesis.next_round_focus),
+        "responding_reviewers": list(synthesis.responding_reviewers),
+    }
+
+
+def discuss_final_synthesis_payload(synthesis: ParsedDiscussFinalSynthesis) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "kind": "discuss_final_synthesis",
+        "classification": synthesis.classification,
+        "agreed_conclusions": [_disc_synthesis_consensus_payload(item) for item in synthesis.agreed_conclusions],
+        "remaining_disagreements": [_disc_synthesis_disagreement_payload(item) for item in synthesis.remaining_disagreements],
+        "next_action": synthesis.next_action,
+    }
+
+
+def serialize_discuss_round_synthesis(synthesis: ParsedDiscussRoundSynthesis) -> str:
+    payload = discuss_round_synthesis_payload(synthesis)
+    _parse_round_synthesis_payload(payload)
+    serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    if len(serialized.encode("utf-8")) > DISCUSS_SYNTHESIS_MAX_CANONICAL_BYTES:
+        raise AgentLoopError("Canonical discuss round synthesis exceeds 16,000 UTF-8 bytes.")
+    return serialized
+
+
+def serialize_discuss_final_synthesis(synthesis: ParsedDiscussFinalSynthesis) -> str:
+    payload = discuss_final_synthesis_payload(synthesis)
+    _parse_final_synthesis_payload(payload)
+    serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    if len(serialized.encode("utf-8")) > DISCUSS_SYNTHESIS_MAX_CANONICAL_BYTES:
+        raise AgentLoopError("Canonical discuss final synthesis exceeds 16,000 UTF-8 bytes.")
+    return serialized
+
+
+def _parse_canonical_discuss_synthesis(text: str, *, kind: str) -> dict[str, object] | None:
+    if not isinstance(text, str) or len(text.encode("utf-8")) > DISCUSS_SYNTHESIS_MAX_CANONICAL_BYTES:
+        return None
+    try:
+        value = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict) or value.get("kind") != kind:
+        return None
+    return value
+
+
+def parse_structured_discuss_round_synthesis(text: str) -> ParsedDiscussRoundSynthesis | None:
+    payload = _extract_structured_discuss_review_payload(
+        text, context_label="Structured discuss round synthesis"
+    )
+    if payload is None:
+        return None
+    if payload.get("kind") != "discuss_round_synthesis":
+        return None
+    return _parse_round_synthesis_payload(payload)
+
+
+def validate_structured_discuss_round_synthesis(text: str) -> ParsedDiscussRoundSynthesis:
+    parsed = parse_structured_discuss_round_synthesis(text)
+    if parsed is None:
+        raise AgentLoopError("Discuss round synthesis did not use the required structured format.")
+    return parsed
+
+
+def parse_structured_discuss_final_synthesis(text: str) -> ParsedDiscussFinalSynthesis | None:
+    payload = _extract_structured_discuss_review_payload(
+        text, context_label="Structured discuss final synthesis"
+    )
+    if payload is None:
+        return None
+    if payload.get("kind") != "discuss_final_synthesis":
+        return None
+    return _parse_final_synthesis_payload(payload)
+
+
+def validate_structured_discuss_final_synthesis(text: str) -> ParsedDiscussFinalSynthesis:
+    parsed = parse_structured_discuss_final_synthesis(text)
+    if parsed is None:
+        raise AgentLoopError("Discuss final synthesis did not use the required structured format.")
+    return parsed
+
+
+def parse_canonical_discuss_round_synthesis(text: str) -> ParsedDiscussRoundSynthesis | None:
+    payload = _parse_canonical_discuss_synthesis(text, kind="discuss_round_synthesis")
+    if payload is None:
+        return None
+    return _parse_round_synthesis_payload(payload)
+
+
+def parse_canonical_discuss_final_synthesis(text: str) -> ParsedDiscussFinalSynthesis | None:
+    payload = _parse_canonical_discuss_synthesis(text, kind="discuss_final_synthesis")
+    if payload is None:
+        return None
+    return _parse_final_synthesis_payload(payload)
+
+
 def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
     payload = _extract_structured_discuss_agenda_payload(text)
     if payload is None:
@@ -3116,7 +3606,10 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         payload,
         context="discuss_agenda",
         required={"schema_version", "kind", "consensus", "disagreements"},
-        optional={"missing_facts", "research_required", "research_questions", "research_question_targets"},
+        optional={
+            "missing_facts", "research_required", "research_questions",
+            "research_question_targets", "round_synthesis",
+        },
     )
     consensus = _expect_string_list(
         payload["consensus"],
@@ -3172,6 +3665,14 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         raise AgentLoopError(
             "discuss_agenda.research_questions requires research_required to be true."
         )
+    round_synthesis = None
+    if "round_synthesis" in payload:
+        round_synthesis_payload = _expect_object(
+            payload["round_synthesis"], context="discuss_agenda.round_synthesis"
+        )
+        round_synthesis = _parse_round_synthesis_payload(
+            round_synthesis_payload, context="discuss_agenda.round_synthesis"
+        )
     return ParsedDiscussAgenda(
         consensus=consensus,
         disagreements=disagreements,
@@ -3179,6 +3680,7 @@ def parse_structured_discuss_agenda(text: str) -> ParsedDiscussAgenda | None:
         research_required=research_required,
         research_questions=research_questions,
         research_question_targets=research_question_targets,
+        round_synthesis=round_synthesis,
     )
 
 

--- a/src/coding_review_agent_loop/repair.py
+++ b/src/coding_review_agent_loop/repair.py
@@ -92,7 +92,7 @@ def strip_unknown_prior_item_dispositions(
 
 def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> str | None:
     """Trim envelope-only trailing material without changing structured JSON."""
-    if expected_kind not in {"plan_state", "pr_review", "plan_review", "plan_revision", "coder_followup", "issue_implementation", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
+    if expected_kind not in {"plan_state", "pr_review", "plan_review", "plan_revision", "coder_followup", "issue_implementation", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_round_synthesis", "discuss_final_synthesis", "discuss_semantic_comparison", "discuss_answer_confirmation", "discuss_evidence_reconciliation"}:
         return None
 
     stripped = raw.lstrip()
@@ -107,7 +107,7 @@ def attempt_envelope_normalization(raw: str, *, expected_kind: str | None) -> st
 
     json_text = stripped[:json_end].rstrip()
     trailing = stripped[json_end:]
-    state_re = PLAN_STATE_RE if expected_kind in {"plan_state", "plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"} else STATE_RE
+    state_re = PLAN_STATE_RE if expected_kind in {"plan_state", "plan_review", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_round_synthesis", "discuss_final_synthesis", "discuss_semantic_comparison", "discuss_answer_confirmation"} else STATE_RE
     state_match = state_re.search(trailing)
     if state_match is None:
         return None
@@ -439,6 +439,40 @@ Notes:
 - If no agenda content is recoverable, return the closest faithful output even if it remains invalid; the orchestrator will fall back mechanically.
 - footer must always be <!-- AGENT_PLAN_STATE: approved --> (never blocking).
 
+## Valid Format M — Discuss Round Synthesis:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_round_synthesis",
+  "consensus": [{"text": "<supported cumulative conclusion>", "references": [{"reviewer": "<name>", "round": 1}]}],
+  "disagreements": [{"topic": "<topic>", "positions": [{"reviewers": ["<name>"], "position": "<supported position>"}], "decision_needed": "<decision>"}],
+  "changes": [{"kind": "introduced", "topic": "<topic>", "text": "<change>", "references": [{"reviewer": "<name>", "round": 1}]}],
+  "missing_facts": [],
+  "next_round_focus": [],
+  "responding_reviewers": ["<successful reviewer>"]
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Analyzer Name>
+
+Notes: preserve only fields present in the source. Do not manufacture a
+consensus, transition, reviewer, or response reference.
+
+## Valid Format N — Discuss Final Synthesis:
+
+{
+  "schema_version": 1,
+  "kind": "discuss_final_synthesis",
+  "classification": "consensus" | "near_consensus" | "material_deadlock",
+  "agreed_conclusions": [{"text": "<supported conclusion>", "references": [{"reviewer": "<name>", "round": 1}]}],
+  "remaining_disagreements": [],
+  "next_action": "<precise next action>"
+}
+<!-- AGENT_PLAN_STATE: approved -->
+-- <Analyzer Name>
+
+Notes: the classification is mechanically supplied by the caller and must not
+be changed. Preserve only supported conclusions and attributed positions.
+
 ## Valid Format J — Initial Plan State:
 
 {
@@ -543,6 +577,8 @@ The active planning human-requirements context above is authoritative. Do not us
 - Use Format K if the original contains "issue_implementation" or "pr_number".
 - Use Format D if the original contains "plan_revision".
 - Use Format J if the original contains "plan_state" or "plan_steps".
+- Use Format M if the original contains "discuss_round_synthesis" or "responding_reviewers".
+- Use Format N if the original contains "discuss_final_synthesis" or "agreed_conclusions".
 - Use Format H if the original contains "discuss_semantic_comparison" or "remaining_decisions".
 - Use Format I if the original contains "discuss_answer_confirmation" or "decision".
 - Use Format F if the original contains "discuss_agenda" or "question_for_next_round".
@@ -1051,7 +1087,7 @@ Output ONLY the repaired response. No explanations.
 {raw_response}"""
 
 _REPAIR_MODEL = "gemini-3.1-flash-lite"
-_SUPPORTED_EXPECTED_KINDS = {"plan_state", "pr_review", "plan_review", "coder_followup", "issue_implementation", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_semantic_comparison", "discuss_answer_confirmation"}
+_SUPPORTED_EXPECTED_KINDS = {"plan_state", "pr_review", "plan_review", "coder_followup", "issue_implementation", "plan_revision", "discuss_review", "discuss_answer", "discuss_agenda", "discuss_round_synthesis", "discuss_final_synthesis", "discuss_semantic_comparison", "discuss_answer_confirmation"}
 RepairOutcome = Literal[
     "succeeded", "nonzero_exit", "empty_output", "timeout", "spawn_error", "invalid_output",
     "unavailable_model", "accepted_nonzero_exit", "accepted_timeout",

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -20,6 +20,7 @@ from .protocol import (
     SIGNATURE_RE,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
+    ParsedDiscussFinalSynthesis,
     ParsedDiscussRoundSynthesis,
     ParsedDiscussResponse,
     ParsedDiscussReview,
@@ -28,6 +29,7 @@ from .protocol import (
     failed_discuss_review_placeholder,
     failed_discuss_answer_placeholder,
     parse_structured_discuss_agenda,
+    parse_canonical_discuss_final_synthesis,
     parse_canonical_discuss_round_synthesis,
     parse_structured_discuss_review,
     parse_structured_discuss_answer,
@@ -754,6 +756,7 @@ class ResumedDiscussState:
     prior_round_agenda: tuple[str, ...] = ()
     prior_analyzer_agenda: ParsedDiscussAgenda | None = None
     prior_round_synthesis: ParsedDiscussRoundSynthesis | None = None
+    final_synthesis: ParsedDiscussFinalSynthesis | None = None
     synthesis_provenance: dict | None = None
     in_progress_votes: dict[str, ParsedDiscussResponse] = None  # type: ignore[assignment]
 
@@ -778,6 +781,16 @@ def _decode_round_synthesis(raw: str | None) -> ParsedDiscussRoundSynthesis | No
         return None
     try:
         return parse_canonical_discuss_round_synthesis(raw)
+    except (AgentLoopError, TypeError, ValueError):
+        return None
+
+
+def _decode_final_synthesis(raw: str | None) -> ParsedDiscussFinalSynthesis | None:
+    """Decode an optional canonical final synthesis without poisoning resume."""
+    if not raw or len(raw.encode("utf-8")) > 16_000:
+        return None
+    try:
+        return parse_canonical_discuss_final_synthesis(raw)
     except (AgentLoopError, TypeError, ValueError):
         return None
 
@@ -887,6 +900,7 @@ def _resume_discuss_round(
             prior_round_agenda = summary_record.metadata.agenda
             prior_analyzer_agenda = _decode_analyzer_agenda(summary_record.metadata.analyzer_response)
             prior_round_synthesis = _decode_round_synthesis(summary_record.metadata.round_synthesis)
+            final_synthesis = _decode_final_synthesis(summary_record.metadata.final_synthesis)
             synthesis_provenance = summary_record.metadata.synthesis_provenance
             if summary_record.metadata.is_final:
                 return ResumedDiscussState(
@@ -896,6 +910,7 @@ def _resume_discuss_round(
                     prior_round_agenda=prior_round_agenda,
                     prior_analyzer_agenda=prior_analyzer_agenda,
                     prior_round_synthesis=prior_round_synthesis,
+                    final_synthesis=final_synthesis,
                     synthesis_provenance=synthesis_provenance,
                 )
             next_round_number = round_number + 1
@@ -913,6 +928,7 @@ def _resume_discuss_round(
         prior_round_agenda=prior_round_agenda,
         prior_analyzer_agenda=prior_analyzer_agenda,
         prior_round_synthesis=prior_round_synthesis,
+        final_synthesis=None,
         synthesis_provenance=synthesis_provenance,
         in_progress_votes=in_progress_votes,
     )

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -20,6 +20,8 @@ from .protocol import (
     SIGNATURE_RE,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
+    ParsedDiscussFinalSynthesis,
+    ParsedDiscussRoundSynthesis,
     ParsedDiscussResponse,
     ParsedDiscussReview,
     ReviewItemDisposition,
@@ -27,6 +29,8 @@ from .protocol import (
     failed_discuss_review_placeholder,
     failed_discuss_answer_placeholder,
     parse_structured_discuss_agenda,
+    parse_canonical_discuss_final_synthesis,
+    parse_canonical_discuss_round_synthesis,
     parse_structured_discuss_review,
     parse_structured_discuss_answer,
     parse_legacy_structured_discuss_answer,
@@ -89,6 +93,12 @@ class PostedRoundMetadata:
     # configured-order settlement barrier.  Legacy records are authoritative.
     phase: str = "authoritative"
     canonical_reviewer_response: str | None = None
+    # Answer-mode synthesis snapshots are canonical bounded JSON. These keys
+    # are omitted from serialized triage/review metadata for byte stability.
+    round_synthesis: str | None = None
+    final_synthesis: str | None = None
+    raw_synthesis_response: str | None = None
+    synthesis_provenance: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -197,6 +207,15 @@ def _encode_round_metadata(metadata: PostedRoundMetadata) -> str:
         "phase": metadata.phase,
         "canonical_reviewer_response": metadata.canonical_reviewer_response,
     }
+    if metadata.result_mode == "answer":
+        payload.update(
+            {
+                "round_synthesis": metadata.round_synthesis,
+                "final_synthesis": metadata.final_synthesis,
+                "raw_synthesis_response": metadata.raw_synthesis_response,
+                "synthesis_provenance": metadata.synthesis_provenance,
+            }
+        )
     return encode_mapping(payload)
 
 
@@ -270,6 +289,22 @@ def _decode_round_metadata_mapping(payload: Mapping[str, object]) -> PostedRound
                 str(payload["canonical_reviewer_response"])
                 if payload.get("canonical_reviewer_response") is not None else None
             ),
+            round_synthesis=(
+                str(payload["round_synthesis"])
+                if payload.get("round_synthesis") is not None else None
+            ),
+            final_synthesis=(
+                str(payload["final_synthesis"])
+                if payload.get("final_synthesis") is not None else None
+            ),
+            raw_synthesis_response=(
+                str(payload["raw_synthesis_response"])
+                if payload.get("raw_synthesis_response") is not None else None
+            ),
+            synthesis_provenance=(
+                payload.get("synthesis_provenance")
+                if isinstance(payload.get("synthesis_provenance"), dict) else None
+            ),
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise AgentLoopError("Invalid AGENT_LOOP_META payload.") from exc
@@ -328,10 +363,22 @@ def _extract_round_metadata_records(comments: Sequence[object], *, flow: str) ->
         if not matches:
             continue
         payload, missing = hydrate_mapping(decode_mapping(matches[-1].group("payload")), bodies)
-        if missing:
+        # Synthesis is advisory. A missing synthesis sidecar must not make a
+        # durable vote or legacy agenda unrecoverable; those fields simply
+        # decode as None. Existing PR/review spill fields remain strict.
+        discuss_optional_missing = (
+            {
+                "round_synthesis", "final_synthesis", "raw_synthesis_response",
+                "analyzer_response", "final_analyzer_response",
+            }
+            if flow == "discuss"
+            else set()
+        )
+        required_missing = missing - discuss_optional_missing
+        if required_missing:
             raise AgentLoopError(
                 "Incomplete round metadata: "
-                f"{', '.join(sorted(missing))} sidecars are unavailable; "
+                f"{', '.join(sorted(required_missing))} sidecars are unavailable; "
                 "restore sidecars or remove the incomplete anchor and rerun."
             )
         metadata = _decode_round_metadata_mapping(payload)
@@ -708,6 +755,8 @@ class ResumedDiscussState:
     next_round_number: int
     prior_round_agenda: tuple[str, ...] = ()
     prior_analyzer_agenda: ParsedDiscussAgenda | None = None
+    prior_round_synthesis: ParsedDiscussRoundSynthesis | None = None
+    synthesis_provenance: dict | None = None
     in_progress_votes: dict[str, ParsedDiscussResponse] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
@@ -722,6 +771,25 @@ def _decode_analyzer_agenda(raw: str | None) -> ParsedDiscussAgenda | None:
     try:
         return parse_structured_discuss_agenda(raw)
     except AgentLoopError:
+        return None
+
+
+def _decode_round_synthesis(raw: str | None) -> ParsedDiscussRoundSynthesis | None:
+    """Decode optional canonical synthesis without poisoning a valid resume."""
+    if not raw or len(raw.encode("utf-8")) > 16_000:
+        return None
+    try:
+        return parse_canonical_discuss_round_synthesis(raw)
+    except (AgentLoopError, TypeError, ValueError):
+        return None
+
+
+def _decode_final_synthesis(raw: str | None) -> ParsedDiscussFinalSynthesis | None:
+    if not raw or len(raw.encode("utf-8")) > 16_000:
+        return None
+    try:
+        return parse_canonical_discuss_final_synthesis(raw)
+    except (AgentLoopError, TypeError, ValueError):
         return None
 
 
@@ -786,6 +854,8 @@ def _resume_discuss_round(
     round_history: list[tuple[ParsedDiscussResponse, ...]] = []
     prior_round_agenda: tuple[str, ...] = ()
     prior_analyzer_agenda: ParsedDiscussAgenda | None = None
+    prior_round_synthesis: ParsedDiscussRoundSynthesis | None = None
+    synthesis_provenance: dict | None = None
     next_round_number = 1
     in_progress_votes: dict[str, ParsedDiscussResponse] = {}
     for round_number in sorted(rounds):
@@ -827,6 +897,8 @@ def _resume_discuss_round(
             round_history.append(votes)
             prior_round_agenda = summary_record.metadata.agenda
             prior_analyzer_agenda = _decode_analyzer_agenda(summary_record.metadata.analyzer_response)
+            prior_round_synthesis = _decode_round_synthesis(summary_record.metadata.round_synthesis)
+            synthesis_provenance = summary_record.metadata.synthesis_provenance
             if summary_record.metadata.is_final:
                 return ResumedDiscussState(
                     done=True,
@@ -834,6 +906,8 @@ def _resume_discuss_round(
                     next_round_number=round_number,
                     prior_round_agenda=prior_round_agenda,
                     prior_analyzer_agenda=prior_analyzer_agenda,
+                    prior_round_synthesis=prior_round_synthesis,
+                    synthesis_provenance=synthesis_provenance,
                 )
             next_round_number = round_number + 1
         else:
@@ -849,5 +923,7 @@ def _resume_discuss_round(
         next_round_number=next_round_number,
         prior_round_agenda=prior_round_agenda,
         prior_analyzer_agenda=prior_analyzer_agenda,
+        prior_round_synthesis=prior_round_synthesis,
+        synthesis_provenance=synthesis_provenance,
         in_progress_votes=in_progress_votes,
     )

--- a/src/coding_review_agent_loop/round_state.py
+++ b/src/coding_review_agent_loop/round_state.py
@@ -20,7 +20,6 @@ from .protocol import (
     SIGNATURE_RE,
     ParsedDiscussAgenda,
     ParsedDiscussAnswer,
-    ParsedDiscussFinalSynthesis,
     ParsedDiscussRoundSynthesis,
     ParsedDiscussResponse,
     ParsedDiscussReview,
@@ -29,7 +28,6 @@ from .protocol import (
     failed_discuss_review_placeholder,
     failed_discuss_answer_placeholder,
     parse_structured_discuss_agenda,
-    parse_canonical_discuss_final_synthesis,
     parse_canonical_discuss_round_synthesis,
     parse_structured_discuss_review,
     parse_structured_discuss_answer,
@@ -780,15 +778,6 @@ def _decode_round_synthesis(raw: str | None) -> ParsedDiscussRoundSynthesis | No
         return None
     try:
         return parse_canonical_discuss_round_synthesis(raw)
-    except (AgentLoopError, TypeError, ValueError):
-        return None
-
-
-def _decode_final_synthesis(raw: str | None) -> ParsedDiscussFinalSynthesis | None:
-    if not raw or len(raw.encode("utf-8")) > 16_000:
-        return None
-    try:
-        return parse_canonical_discuss_final_synthesis(raw)
     except (AgentLoopError, TypeError, ValueError):
         return None
 

--- a/src/coding_review_agent_loop/round_transport.py
+++ b/src/coding_review_agent_loop/round_transport.py
@@ -25,6 +25,11 @@ _SPILL_FIELDS = (
     "canonical_reviewer_response",
     "raw_structured_coder_response",
     "canonical_plan",
+    "round_synthesis",
+    "final_synthesis",
+    "analyzer_response",
+    "final_analyzer_response",
+    "raw_synthesis_response",
 )
 _MAX_COMPRESSED = 8_000_000
 _MAX_DECOMPRESSED = 16_000_000

--- a/tests/agent_loop_helpers.py
+++ b/tests/agent_loop_helpers.py
@@ -49,7 +49,11 @@ from coding_review_agent_loop.cli import (
     run_pr_loop,
     run_task_loop,
 )
-from coding_review_agent_loop.errors import QuotaResetExceededError, UnknownPriorItemDispositionError
+from coding_review_agent_loop.errors import (
+    AgentInvocationError,
+    QuotaResetExceededError,
+    UnknownPriorItemDispositionError,
+)
 from coding_review_agent_loop.orchestrator import (
     _decode_public_response_json_prefix,
     _format_reset_duration,
@@ -531,6 +535,11 @@ class FakeRunner(Runner):
         return output
 
     def _next_agent_output(self, outputs):
+        if not outputs:
+            raise AgentInvocationError(
+                "scripted agent output exhausted",
+                failure_category="deterministic",
+            )
         output = outputs.pop(0)
         if isinstance(output, dict):
             return output

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -1332,6 +1332,67 @@ def test_render_answer_final_synthesis_is_primary_and_raw_answers_are_secondary(
     assert "| Codex |" in rendered
 
 
+def test_render_answer_synthesis_bounds_long_audit_and_drops_overflowing_audit():
+    votes = [
+        ParsedDiscussAnswer(
+            position="answer", rationale="Use an API boundary.", confidence="high",
+            unresolved_items=(), reviewer="Codex", answer="A" * 3_000,
+        ),
+        ParsedDiscussAnswer(
+            position="answer", rationale="Use an API boundary.", confidence="high",
+            unresolved_items=(), reviewer="Gemini", answer="B" * 3_000,
+        ),
+    ]
+    synthesis = ParsedDiscussFinalSynthesis(
+        classification="consensus",
+        agreed_conclusions=(DiscussSynthesisConsensus(
+            text="Use an API boundary.",
+            references=(
+                DiscussSynthesisResponseReference("Codex", 1),
+                DiscussSynthesisResponseReference("Gemini", 1),
+            ),
+        ),),
+        remaining_disagreements=(),
+        next_action="Proceed with the shared recommendation.",
+    )
+
+    bounded = render_discuss_round_summary_comment(
+        is_final=True,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=votes,
+        outcome="answer",
+        consensus_kind="unanimous",
+        result_mode="answer",
+        final_synthesis=synthesis,
+    )
+    assert "A" * 1_499 + "…" in bounded
+    assert "A" * 1_500 + "…" not in bounded
+    assert "B" * 1_499 + "…" in bounded
+
+    oversized = ParsedDiscussFinalSynthesis(
+        classification="consensus",
+        agreed_conclusions=tuple(
+            DiscussSynthesisConsensus(text="S" * 10_000, references=())
+            for _ in range(8)
+        ),
+        remaining_disagreements=(),
+        next_action="Proceed.",
+    )
+    overflow = render_discuss_round_summary_comment(
+        is_final=True,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=votes,
+        outcome="answer",
+        consensus_kind="unanimous",
+        result_mode="answer",
+        final_synthesis=oversized,
+    )
+    assert "The complete debater responses and provenance remain available in the per-agent audit comments." in overflow
+    assert "| Codex |" not in overflow
+
+
 def test_render_discuss_summary_non_final_without_agenda_keeps_mechanical_lines():
     rendered = render_discuss_round_summary_comment(
         is_final=False,

--- a/tests/test_comment_rendering.py
+++ b/tests/test_comment_rendering.py
@@ -23,7 +23,18 @@ from coding_review_agent_loop.comment_rendering import (
     render_discuss_round_summary_comment,
     render_typed_plan_stages_section,
 )
-from coding_review_agent_loop.protocol import DiscussUnresolvedItem, ParsedDiscussAnswer, ParsedFailedDiscussResponse, ParsedDiscussReview
+from coding_review_agent_loop.protocol import (
+    DiscussSynthesisConsensus,
+    DiscussSynthesisDisagreement,
+    DiscussSynthesisPosition,
+    DiscussSynthesisResponseReference,
+    DiscussUnresolvedItem,
+    ParsedDiscussAnswer,
+    ParsedDiscussFinalSynthesis,
+    ParsedFailedDiscussResponse,
+    ParsedDiscussReview,
+    ParsedDiscussRoundSynthesis,
+)
 from coding_review_agent_loop.orchestrator import (
     HUMAN_REQUIREMENTS_ACK_ITEM_ID,
     ITEM_SUMMARY_LIMIT,
@@ -1232,6 +1243,93 @@ def test_render_discuss_answer_summary_non_final_uses_analyzer_agenda_with_attri
     assert "Analyzer-extracted consensus so far (not debater-confirmed):" in rendered
     assert "**Scope of the change**" in rendered
     assert "Question for next round: Would splitting resolve the scope objection?" in rendered
+
+
+def test_render_answer_round_synthesis_leads_and_neutralizes_historical_markers():
+    answer = ParsedDiscussAnswer(
+        position="answer",
+        rationale="Use an API boundary.",
+        confidence="high",
+        unresolved_items=(),
+        reviewer="Codex",
+        answer="Use an API boundary.",
+    )
+    synthesis = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus(
+            text="Use an API boundary.",
+            references=(DiscussSynthesisResponseReference("Codex", 1),),
+        ),),
+        disagreements=(DiscussSynthesisDisagreement(
+            topic="Pricing timing",
+            positions=(DiscussSynthesisPosition(("Codex",), "Use an API boundary."),),
+            decision_needed="Choose pricing timing.",
+        ),),
+        changes=(),
+        missing_facts=("<!-- AGENT_LOOP_META: v1_AA -->",),
+        next_round_focus=("Choose pricing timing.",),
+        responding_reviewers=("Codex",),
+    )
+
+    rendered = render_discuss_round_summary_comment(
+        is_final=False,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=[answer],
+        result_mode="answer",
+        round_synthesis=synthesis,
+    )
+
+    assert rendered.index("### Current consensus") < rendered.index("<details>")
+    assert "### Active disagreements" in rendered
+    assert "### Changes this round" in rendered
+    assert "### Missing facts" in rendered
+    assert "### Next-round focus" in rendered
+    assert "<!-- AGENT_LOOP_META: v1_AA -->" not in rendered
+    assert "[protocol LOOP_META record]" in rendered
+
+
+def test_render_answer_final_synthesis_is_primary_and_raw_answers_are_secondary():
+    votes = [
+        ParsedDiscussAnswer(
+            position="answer", rationale="Use an API boundary.", confidence="high",
+            unresolved_items=(), reviewer="Codex", answer="Use an API boundary.",
+        ),
+        ParsedDiscussAnswer(
+            position="answer", rationale="Use an API boundary.", confidence="high",
+            unresolved_items=(), reviewer="Gemini", answer="Use an API boundary.",
+        ),
+    ]
+    synthesis = ParsedDiscussFinalSynthesis(
+        classification="consensus",
+        agreed_conclusions=(DiscussSynthesisConsensus(
+            text="Use an API boundary.",
+            references=(
+                DiscussSynthesisResponseReference("Codex", 1),
+                DiscussSynthesisResponseReference("Gemini", 1),
+            ),
+        ),),
+        remaining_disagreements=(),
+        next_action="Proceed with the shared recommendation.",
+    )
+
+    rendered = render_discuss_round_summary_comment(
+        is_final=True,
+        subject="abc123",
+        round_number=1,
+        reviewer_votes=votes,
+        outcome="answer",
+        consensus_kind="unanimous",
+        result_mode="answer",
+        final_synthesis=synthesis,
+    )
+
+    assert rendered.startswith("## Executive conclusion")
+    assert "### Outcome" in rendered
+    assert "### Agreed conclusions" in rendered
+    assert "### Remaining disagreements" in rendered
+    assert "### Next action" in rendered
+    assert rendered.index("<details>") > rendered.index("### Next action")
+    assert "| Codex |" in rendered
 
 
 def test_render_discuss_summary_non_final_without_agenda_keeps_mechanical_lines():

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -14,6 +14,7 @@ from coding_review_agent_loop.orchestrator import (
     _discuss_subject,
     _validate_discuss_analyzer_agenda_fidelity,
     _validate_discuss_final_analyzer_fidelity,
+    _validate_discuss_final_synthesis_fidelity,
     _validate_discuss_round_synthesis_fidelity,
     _adapt_discuss_final_synthesis,
     _mechanical_discuss_final_classification,
@@ -40,6 +41,7 @@ from coding_review_agent_loop.protocol import (
     DiscussSynthesisPosition,
     DiscussSynthesisResponseReference,
     ParsedDiscussRoundSynthesis,
+    ParsedDiscussFinalSynthesis,
     ParsedFailedDiscussResponse,
     serialize_discuss_round_synthesis,
 )
@@ -337,6 +339,7 @@ def _seed_summary_comment(
     failed_debaters: tuple[tuple[str, str], ...] = (),
     result_mode: str = "triage",
     round_synthesis: str | None = None,
+    synthesis_provenance: dict | None = None,
 ) -> dict:
     """Build an issue-comment payload matching what `_run_discuss_loop` posts for a round summary."""
     body = render_discuss_round_summary_comment(
@@ -366,6 +369,7 @@ def _seed_summary_comment(
             failed_debaters=failed_debaters,
             result_mode=result_mode,
             round_synthesis=round_synthesis,
+            synthesis_provenance=synthesis_provenance,
         ),
     )
     return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
@@ -476,6 +480,44 @@ def test_adapt_near_consensus_handles_truncation_collisions_and_duplicate_review
     )[1] is not None
 
 
+def test_adapt_reuses_exact_semantic_and_debater_confirmed_recommendations():
+    exact_votes = (
+        ParsedDiscussAnswer("answer", "API boundary.", "high", (), "Codex", answer="API boundary."),
+        ParsedDiscussAnswer("answer", "API boundary.", "high", (), "Gemini", answer="API boundary."),
+    )
+    exact = _adapt_discuss_final_synthesis(
+        outcome="answer", consensus_kind="unanimous", final_votes=exact_votes, round_number=1
+    )
+    assert exact is not None and exact.classification == "consensus"
+    assert exact.agreed_conclusions[0].text == "API boundary."
+
+    semantic_votes = (
+        ParsedDiscussAnswer("answer", "API boundary.", "high", (), "Codex", answer="Use an API."),
+        ParsedDiscussAnswer("answer", "API boundary.", "high", (), "Gemini", answer="Use a boundary."),
+    )
+    semantic = _adapt_discuss_final_synthesis(
+        outcome="answer", consensus_kind="semantic-equivalent", final_votes=semantic_votes,
+        round_number=1,
+        semantic_comparison={
+            "classification": "equivalent",
+            "shared_recommendation": "Use an API boundary.",
+        },
+    )
+    assert semantic is not None
+    assert semantic.agreed_conclusions[0].text == "Use an API boundary."
+
+    confirmed = _adapt_discuss_final_synthesis(
+        outcome="answer", consensus_kind="debater-confirmed", final_votes=semantic_votes,
+        round_number=1,
+        semantic_comparison={
+            "classification": "compatible_with_residual_decisions",
+            "confirmed_answer": "Use an API boundary.",
+        },
+    )
+    assert confirmed is not None
+    assert confirmed.agreed_conclusions[0].text == "Use an API boundary."
+
+
 def test_advisory_synthesis_serialization_failure_falls_back(tmp_path):
     synthesis = ParsedDiscussRoundSynthesis(
         consensus=(),
@@ -537,6 +579,7 @@ def test_resume_restores_persisted_round_synthesis_state(tmp_path):
         _seed_summary_comment(
             round_number=1, reviewer_votes=[vote1, vote2], is_final=False, subject=subject,
             result_mode="answer", round_synthesis=serialize_discuss_round_synthesis(synthesis),
+            synthesis_provenance={"source": "round-analyzer", "round": 1},
         ),
     ]
 
@@ -550,7 +593,165 @@ def test_resume_restores_persisted_round_synthesis_state(tmp_path):
 
     assert state is not None
     assert state.prior_round_synthesis == synthesis
+    assert state.synthesis_provenance == {"source": "round-analyzer", "round": 1}
     assert state.next_round_number == 2
+
+
+def test_round_synthesis_fidelity_covers_carry_and_all_state_transitions():
+    current_votes = (
+        _needs_human_vote("Codex", ("Choose pricing. API boundary pricing security",)),
+        _needs_human_vote("Gemini", ("Choose pricing. API boundary pricing security",)),
+    )
+    current_refs = (
+        DiscussSynthesisResponseReference("Codex", 2),
+        DiscussSynthesisResponseReference("Gemini", 2),
+    )
+    prior_refs = (
+        DiscussSynthesisResponseReference("Codex", 1),
+        DiscussSynthesisResponseReference("Gemini", 1),
+    )
+    prior_disagreement = DiscussSynthesisDisagreement(
+        topic="pricing",
+        positions=(
+            DiscussSynthesisPosition(("Codex",), "API boundary pricing"),
+            DiscussSynthesisPosition(("Gemini",), "API boundary pricing"),
+        ),
+        decision_needed="Choose pricing.",
+    )
+    prior = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus("API boundary", prior_refs),),
+        disagreements=(prior_disagreement,),
+        changes=(), missing_facts=(), next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+
+    carried = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus("API boundary", prior_refs),),
+        disagreements=(), changes=(), missing_facts=(), next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    _validate_discuss_round_synthesis_fidelity(
+        carried, round_number=2, current_votes=current_votes,
+        prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+    )
+    changed_refs = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus("API boundary", current_refs),),
+        disagreements=(), changes=(), missing_facts=(), next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    with pytest.raises(AgentLoopError, match="preserve"):
+        _validate_discuss_round_synthesis_fidelity(
+            changed_refs, round_number=2, current_votes=current_votes,
+            prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+        )
+
+    new_claim = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus("API boundary pricing", current_refs),),
+        disagreements=(), changes=(), missing_facts=(), next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    _validate_discuss_round_synthesis_fidelity(
+        new_claim, round_number=2, current_votes=current_votes,
+        prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+    )
+    old_refs_claim = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus("API boundary pricing", prior_refs),),
+        disagreements=(), changes=(), missing_facts=(), next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    with pytest.raises(AgentLoopError, match="current responders"):
+        _validate_discuss_round_synthesis_fidelity(
+            old_refs_claim, round_number=2, current_votes=current_votes,
+            prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+        )
+
+    def transitioned(kind: str, *, topic: str = "pricing") -> ParsedDiscussRoundSynthesis:
+        return ParsedDiscussRoundSynthesis(
+            consensus=(),
+            disagreements=() if kind != "reopened" else (prior_disagreement,),
+            changes=(DiscussSynthesisChange(kind, topic, "API boundary pricing", current_refs),),
+            missing_facts=(), next_round_focus=(),
+            responding_reviewers=("Codex", "Gemini"),
+        )
+
+    for kind in ("resolved", "retracted", "refined"):
+        _validate_discuss_round_synthesis_fidelity(
+            transitioned(kind), round_number=2, current_votes=current_votes,
+            prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+        )
+    introduced = transitioned("introduced", topic="security")
+    _validate_discuss_round_synthesis_fidelity(
+        introduced, round_number=2, current_votes=current_votes,
+        prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+    )
+    _validate_discuss_round_synthesis_fidelity(
+        transitioned("reopened"), round_number=2, current_votes=current_votes,
+        prior_synthesis=prior, configured_reviewers=("codex", "gemini"),
+    )
+
+
+def test_final_synthesis_fidelity_validates_classification_references_and_positions():
+    votes = (
+        _needs_human_vote("Codex", ("Choose pricing.",), rationale="API boundary pricing."),
+        _needs_human_vote("Gemini", ("Choose pricing.",), rationale="API boundary pricing."),
+    )
+    refs = (
+        DiscussSynthesisResponseReference("Codex", 1),
+        DiscussSynthesisResponseReference("Gemini", 1),
+    )
+    valid = ParsedDiscussFinalSynthesis(
+        classification="near_consensus",
+        agreed_conclusions=(),
+        remaining_disagreements=(DiscussSynthesisDisagreement(
+            topic="Choose pricing.",
+            positions=(
+                DiscussSynthesisPosition(("Codex",), "Choose pricing."),
+                DiscussSynthesisPosition(("Gemini",), "Choose pricing."),
+            ),
+            decision_needed="Choose pricing.",
+        ),),
+        next_action="A human chooses pricing.",
+    )
+    _validate_discuss_final_synthesis_fidelity(
+        valid, expected_classification="near_consensus", final_votes=votes,
+        round_number=1, configured_reviewers=("codex", "gemini"),
+    )
+    mismatch = ParsedDiscussFinalSynthesis(
+        classification="consensus", agreed_conclusions=(),
+        remaining_disagreements=valid.remaining_disagreements, next_action="Choose.",
+    )
+    with pytest.raises(AgentLoopError, match="classification"):
+        _validate_discuss_final_synthesis_fidelity(
+            mismatch, expected_classification="near_consensus", final_votes=votes,
+            round_number=1, configured_reviewers=("codex", "gemini"),
+        )
+    unsupported = ParsedDiscussFinalSynthesis(
+        classification="near_consensus", agreed_conclusions=(),
+        remaining_disagreements=(DiscussSynthesisDisagreement(
+            topic="Invented topic.",
+            positions=(DiscussSynthesisPosition(("Codex",), "Invented position."),),
+            decision_needed="Invented decision.",
+        ),), next_action="Choose.",
+    )
+    with pytest.raises(AgentLoopError, match="topic"):
+        _validate_discuss_final_synthesis_fidelity(
+            unsupported, expected_classification="near_consensus", final_votes=votes,
+            round_number=1, configured_reviewers=("codex", "gemini"),
+        )
+    unknown_reference = ParsedDiscussFinalSynthesis(
+        classification="near_consensus",
+        agreed_conclusions=(DiscussSynthesisConsensus(
+            "API boundary pricing.",
+            (DiscussSynthesisResponseReference("Claude", 1),),
+        ),),
+        remaining_disagreements=valid.remaining_disagreements,
+        next_action="Choose.",
+    )
+    with pytest.raises(AgentLoopError, match="references"):
+        _validate_discuss_final_synthesis_fidelity(
+            unknown_reference, expected_classification="near_consensus", final_votes=votes,
+            round_number=1, configured_reviewers=("codex", "gemini"),
+        )
 
 
 def test_synthesis_fidelity_rejects_filler_only_support_and_reactivation_without_reopen():

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -43,6 +43,7 @@ from coding_review_agent_loop.protocol import (
     ParsedDiscussRoundSynthesis,
     ParsedDiscussFinalSynthesis,
     ParsedFailedDiscussResponse,
+    serialize_discuss_final_synthesis,
     serialize_discuss_round_synthesis,
 )
 
@@ -597,6 +598,78 @@ def test_resume_restores_persisted_round_synthesis_state(tmp_path):
     assert state.next_round_number == 2
 
 
+def test_resume_decodes_persisted_final_synthesis_state(tmp_path):
+    subject = _issue_subject()
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    vote1 = ParsedDiscussAnswer(
+        position="answer", rationale="Use an API boundary.", confidence="high",
+        unresolved_items=(), reviewer="Codex", answer="Use an API boundary.",
+    )
+    vote2 = ParsedDiscussAnswer(
+        position="answer", rationale="Use an API boundary.", confidence="high",
+        unresolved_items=(), reviewer="Gemini", answer="Use an API boundary.",
+    )
+    synthesis = ParsedDiscussFinalSynthesis(
+        classification="consensus",
+        agreed_conclusions=(DiscussSynthesisConsensus(
+            "Use an API boundary.",
+            (
+                DiscussSynthesisResponseReference("Codex", 1),
+                DiscussSynthesisResponseReference("Gemini", 1),
+            ),
+        ),),
+        remaining_disagreements=(),
+        next_action="Proceed with the shared recommendation.",
+    )
+    comments = [
+        _seed_answer_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            answer="Use an API boundary.", config=config,
+        ),
+        _seed_answer_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            answer="Use an API boundary.", config=config,
+        ),
+    ]
+    summary_body = render_discuss_round_summary_comment(
+        round_number=1,
+        reviewer_votes=[vote1, vote2],
+        is_final=True,
+        subject=subject,
+        outcome="answer",
+        consensus_kind="unanimous",
+        result_mode="answer",
+        final_synthesis=synthesis,
+    )
+    comments.append({
+        "author": {"login": "bot"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "body": _attach_round_metadata(
+            summary_body,
+            PostedRoundMetadata(
+                flow="discuss", role="summary", agent="Orchestrator", round_number=1,
+                subject=subject, is_final=True, consensus_kind="unanimous",
+                result_mode="answer",
+                final_synthesis=serialize_discuss_final_synthesis(synthesis),
+                synthesis_provenance={"source": "mechanical-result", "round": 1},
+            ),
+        ),
+    })
+
+    state = _resume_discuss_round(
+        [IssueComment(author="bot", created_at="2026-01-01T00:00:00Z", body=comment["body"])
+         for comment in comments],
+        subject=subject,
+        configured_reviewers=("codex", "gemini"),
+        reviewer_workdirs={"Codex": config.codex_dir, "Gemini": config.gemini_dir},
+        result_mode="answer",
+    )
+
+    assert state is not None
+    assert state.done
+    assert state.final_synthesis == synthesis
+
+
 def test_round_synthesis_fidelity_covers_carry_and_all_state_transitions():
     current_votes = (
         _needs_human_vote("Codex", ("Choose pricing. API boundary pricing security",)),
@@ -867,6 +940,37 @@ def test_near_consensus_invokes_final_analyzer_and_keeps_mechanical_classificati
     )
     assert "near_consensus" in runner.comments[-1]
     assert decision in runner.comments[-1]
+
+
+def test_near_consensus_without_analyzer_keeps_mechanical_synthesis(tmp_path):
+    decision = "Choose the pricing timing."
+    codex = _discuss_answer_text(
+        answer=None,
+        position="needs-human",
+        rationale="The implementation direction is shared; choose the pricing timing.",
+        unresolved_items=[{"status": "human-decision", "text": decision}],
+        reviewer="OpenAI Codex",
+    )
+    gemini = _discuss_answer_text(
+        answer=None,
+        position="needs-human",
+        rationale="The implementation direction is shared; choose the pricing timing.",
+        unresolved_items=[{"status": "human-decision", "text": decision}],
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(codex_outputs=[codex], gemini_outputs=[gemini])
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer"
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+
+    final = runner.comments[-1]
+    assert final.startswith("## Executive conclusion")
+    assert "`near_consensus`" in final
+    assert decision in final
+    assert "The debaters did not converge on one normalized answer" not in final
+    assert not any(command[:1] == ["claude"] for command, _cwd in runner.commands)
 
 
 def test_mechanical_final_classification_fails_closed_for_unknown_pair():

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -613,8 +613,12 @@ def test_discuss_loop_answer_research_required_and_analyzer_prompt_are_mode_awar
     assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
     assert "Use an API boundary." in runner.comments[-1]
     assert all('"kind": "discuss_answer"' in " ".join(cmd) for cmd, _ in runner.commands if cmd[:1] in (["codex"], ["gemini"]))
-    assert any(
-        "Analyze only these completed final-round debater responses" in " ".join(command)
+    # Exact normalized answer consensus is synthesized directly from the
+    # final responses; the analyzer is not charged a redundant final call.
+    # The pre-existing evidence reconciliation pass may still run for sourced
+    # research, but it is a distinct operation.
+    assert not any(
+        '"kind": "discuss_final_synthesis"' in " ".join(command)
         for command in _claude_commands(runner)
     )
 
@@ -645,6 +649,48 @@ def test_discuss_loop_answer_partial_live_round_records_failure_and_deadlocks(tm
         for command, _ in runner.commands
         if command[:1] == ["agy"]
     )
+
+
+def test_discuss_loop_answer_legacy_agenda_uses_one_bounded_round_fallback(tmp_path):
+    round_synthesis = {
+        "schema_version": 1,
+        "kind": "discuss_round_synthesis",
+        "consensus": [{
+            "text": "Use an API boundary.",
+            "references": [
+                {"reviewer": "Codex", "round": 1},
+                {"reviewer": "Gemini", "round": 1},
+            ],
+        }],
+        "disagreements": [],
+        "changes": [],
+        "missing_facts": [],
+        "next_round_focus": [],
+        "responding_reviewers": ["Codex", "Gemini"],
+    }
+    fallback = json.dumps(round_synthesis) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+    first = _discuss_answer_text(answer="Use an API boundary.", rationale="First position.")
+    second = _discuss_answer_text(answer="Use a library boundary.", rationale="Different position.")
+    final = _discuss_answer_text(
+        answer="Use an API boundary.", rationale="Converged position.", rebuttal="The boundary concern is resolved."
+    )
+    runner = FakeRunner(
+        codex_outputs=[first, final],
+        gemini_outputs=[second, final],
+        claude_outputs=[_discuss_agenda_text(), fallback],
+        issue_payload=_grounded_agenda_issue_payload(),
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"),
+        discuss_result_mode="answer", discuss_analyzer="claude",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1) == 0
+    first_summary = runner.comments[2]
+    assert "### Current consensus" in first_summary
+    assert "Use an API boundary." in first_summary
+    assert "<details>" in first_summary
+    assert len(_claude_commands(runner)) == 2
 
 
 def test_discuss_loop_answer_mode_never_materializes_split_issues(tmp_path):

--- a/tests/test_discuss_loop.py
+++ b/tests/test_discuss_loop.py
@@ -14,6 +14,12 @@ from coding_review_agent_loop.orchestrator import (
     _discuss_subject,
     _validate_discuss_analyzer_agenda_fidelity,
     _validate_discuss_final_analyzer_fidelity,
+    _validate_discuss_round_synthesis_fidelity,
+    _adapt_discuss_final_synthesis,
+    _mechanical_discuss_final_classification,
+    _safe_discuss_synthesis_serialization,
+    _disc_synthesis_text_supported_by_vote,
+    _resume_discuss_round,
     render_public_agent_comment,
     run_discuss_loop,
     _detect_discuss_answer_consensus,
@@ -28,6 +34,14 @@ from coding_review_agent_loop.protocol import (
     ParsedDiscussReview,
     ParsedDiscussAnswer,
     DiscussUnresolvedItem,
+    DiscussSynthesisChange,
+    DiscussSynthesisConsensus,
+    DiscussSynthesisDisagreement,
+    DiscussSynthesisPosition,
+    DiscussSynthesisResponseReference,
+    ParsedDiscussRoundSynthesis,
+    ParsedFailedDiscussResponse,
+    serialize_discuss_round_synthesis,
 )
 
 from agent_loop_helpers import FakeRunner, make_config
@@ -321,6 +335,8 @@ def _seed_summary_comment(
     agenda: tuple[str, ...] = (),
     analyzer_response: str | None = None,
     failed_debaters: tuple[tuple[str, str], ...] = (),
+    result_mode: str = "triage",
+    round_synthesis: str | None = None,
 ) -> dict:
     """Build an issue-comment payload matching what `_run_discuss_loop` posts for a round summary."""
     body = render_discuss_round_summary_comment(
@@ -333,6 +349,7 @@ def _seed_summary_comment(
         round_history=round_history,
         split_proposals=split_proposals,
         failed_debaters=failed_debaters,
+        result_mode=result_mode,
     )
     body = _attach_round_metadata(
         body,
@@ -347,6 +364,8 @@ def _seed_summary_comment(
             agenda=agenda,
             analyzer_response=analyzer_response,
             failed_debaters=failed_debaters,
+            result_mode=result_mode,
+            round_synthesis=round_synthesis,
         ),
     )
     return {"author": {"login": "bot"}, "createdAt": "2026-01-01T00:00:00Z", "body": body}
@@ -378,6 +397,282 @@ def test_discuss_loop_unanimous_answer_is_not_triage(tmp_path):
     assert "Consensus Answer" in runner.comments[-1]
     assert "Use an API boundary." in runner.comments[-1]
     assert "Consensus: Implement" not in runner.comments[-1]
+
+
+def _needs_human_vote(reviewer: str, items: tuple[str, ...], rationale: str = "Shared implementation direction.") -> ParsedDiscussAnswer:
+    return ParsedDiscussAnswer(
+        position="needs-human",
+        rationale=rationale,
+        confidence="medium",
+        unresolved_items=tuple(DiscussUnresolvedItem("human-decision", item) for item in items),
+        reviewer=reviewer,
+    )
+
+
+def test_adapt_near_consensus_bounds_and_deduplicates_human_decisions(tmp_path):
+    votes = tuple(
+        _needs_human_vote(
+            reviewer,
+            tuple(f"Decision {index} for {reviewer}" for index in range(3)),
+            rationale=f"{reviewer} shares the implementation direction.",
+        )
+        for reviewer in ("Codex", "Gemini", "Claude")
+    )
+
+    synthesis = _adapt_discuss_final_synthesis(
+        outcome="needs-human",
+        consensus_kind="converged",
+        final_votes=votes,
+        round_number=2,
+    )
+
+    assert synthesis is not None
+    assert synthesis.classification == "near_consensus"
+    assert len(synthesis.remaining_disagreements) <= 8
+    assert all(
+        position.position != vote.rationale
+        for disagreement in synthesis.remaining_disagreements
+        for position in disagreement.positions
+        for vote in votes
+    )
+    restored, canonical = _safe_discuss_synthesis_serialization(
+        synthesis,
+        final=True,
+        config=make_config(tmp_path, reviewer=("codex", "gemini", "claude"), discuss_result_mode="answer"),
+        location="test",
+    )
+    assert restored == synthesis
+    assert canonical is not None
+
+
+def test_adapt_near_consensus_handles_truncation_collisions_and_duplicate_reviewer(tmp_path):
+    prefix = "x" * 512
+    votes = (
+        _needs_human_vote("Codex", (prefix + " one", prefix + " two", "Choose the API.")),
+        _needs_human_vote("Gemini", (prefix + " other", "Choose the API.")),
+    )
+
+    synthesis = _adapt_discuss_final_synthesis(
+        outcome="needs-human",
+        consensus_kind="unanimous",
+        final_votes=votes,
+        round_number=1,
+    )
+
+    assert synthesis is not None
+    collision = next(
+        disagreement
+        for disagreement in synthesis.remaining_disagreements
+        if disagreement.topic == prefix
+    )
+    assert [reviewer for position in collision.positions for reviewer in position.reviewers] == [
+        "Codex", "Gemini"
+    ]
+    assert _safe_discuss_synthesis_serialization(
+        synthesis,
+        final=True,
+        config=make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer"),
+        location="test",
+    )[1] is not None
+
+
+def test_advisory_synthesis_serialization_failure_falls_back(tmp_path):
+    synthesis = ParsedDiscussRoundSynthesis(
+        consensus=(),
+        disagreements=tuple(
+            DiscussSynthesisDisagreement(
+                topic=f"topic {index} " + "t" * 490,
+                positions=(
+                    DiscussSynthesisPosition(("Codex",), "Codex position " + "p" * 490),
+                    DiscussSynthesisPosition(("Gemini",), "Gemini position " + "p" * 490),
+                ),
+                decision_needed="decision " + "d" * 490,
+            )
+            for index in range(8)
+        ),
+        changes=(),
+        missing_facts=(),
+        next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+
+    restored, canonical = _safe_discuss_synthesis_serialization(
+        synthesis,
+        final=False,
+        config=make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer"),
+        location="test",
+    )
+    assert restored is None
+    assert canonical is None
+
+
+def test_resume_restores_persisted_round_synthesis_state(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    subject = _issue_subject()
+    vote1 = ParsedDiscussAnswer(
+        position="answer", rationale="Use an API boundary.", confidence="high",
+        unresolved_items=(), reviewer="Codex", answer="Use an API boundary.",
+    )
+    vote2 = ParsedDiscussAnswer(
+        position="answer", rationale="Use an API boundary.", confidence="high",
+        unresolved_items=(), reviewer="Gemini", answer="Use an API boundary.",
+    )
+    synthesis = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus(
+            "Use an API boundary.",
+            (DiscussSynthesisResponseReference("Codex", 1), DiscussSynthesisResponseReference("Gemini", 1)),
+        ),),
+        disagreements=(), changes=(), missing_facts=(), next_round_focus=("Confirm the boundary.",),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    comments = [
+        _seed_answer_debater_comment(
+            reviewer="Codex", round_number=1, subject=subject,
+            answer="Use an API boundary.", config=config,
+        ),
+        _seed_answer_debater_comment(
+            reviewer="Gemini", round_number=1, subject=subject,
+            answer="Use an API boundary.", config=config,
+        ),
+        _seed_summary_comment(
+            round_number=1, reviewer_votes=[vote1, vote2], is_final=False, subject=subject,
+            result_mode="answer", round_synthesis=serialize_discuss_round_synthesis(synthesis),
+        ),
+    ]
+
+    state = _resume_discuss_round(
+        [IssueComment(author="bot", created_at="2026-01-01T00:00:00Z", body=comment["body"]) for comment in comments],
+        subject=subject,
+        configured_reviewers=("codex", "gemini"),
+        reviewer_workdirs={"Codex": config.codex_dir, "Gemini": config.gemini_dir},
+        result_mode="answer",
+    )
+
+    assert state is not None
+    assert state.prior_round_synthesis == synthesis
+    assert state.next_round_number == 2
+
+
+def test_synthesis_fidelity_rejects_filler_only_support_and_reactivation_without_reopen():
+    vote = _needs_human_vote("Codex", ("Use API boundary.",), rationale="Use API boundary is supported.")
+    second = _needs_human_vote("Gemini", ("Use API boundary.",), rationale="Use API boundary is supported.")
+    assert not _disc_synthesis_text_supported_by_vote("that with must should", vote)
+    assert _disc_synthesis_text_supported_by_vote("API boundary", vote)
+
+    references = (
+        DiscussSynthesisResponseReference("Codex", 1),
+        DiscussSynthesisResponseReference("Gemini", 1),
+    )
+    prior = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus("Use API boundary.", references),),
+        disagreements=(),
+        changes=(),
+        missing_facts=(),
+        next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    disagreement = DiscussSynthesisDisagreement(
+        topic="Use API boundary.",
+        positions=(
+            DiscussSynthesisPosition(("Codex",), "Use API boundary."),
+            DiscussSynthesisPosition(("Gemini",), "Use API boundary."),
+        ),
+        decision_needed="Use API boundary.",
+    )
+    current = ParsedDiscussRoundSynthesis(
+        consensus=(), disagreements=(disagreement,), changes=(), missing_facts=(),
+        next_round_focus=(), responding_reviewers=("Codex", "Gemini"),
+    )
+    with pytest.raises(AgentLoopError, match="settled topic"):
+        _validate_discuss_round_synthesis_fidelity(
+            current,
+            round_number=2,
+            current_votes=(vote, second),
+            prior_synthesis=prior,
+            configured_reviewers=("codex", "gemini"),
+        )
+
+    reopened = ParsedDiscussRoundSynthesis(
+        consensus=(),
+        disagreements=(disagreement,),
+        changes=(
+            DiscussSynthesisChange(
+                kind="reopened",
+                topic="Use API boundary.",
+                text="Use API boundary.",
+                references=(
+                    DiscussSynthesisResponseReference("Codex", 2),
+                    DiscussSynthesisResponseReference("Gemini", 2),
+                ),
+            ),
+        ),
+        missing_facts=(),
+        next_round_focus=(),
+        responding_reviewers=("Codex", "Gemini"),
+    )
+    _validate_discuss_round_synthesis_fidelity(
+        reopened,
+        round_number=2,
+        current_votes=(vote, second),
+        prior_synthesis=prior,
+        configured_reviewers=("codex", "gemini"),
+    )
+
+
+def test_near_consensus_invokes_final_analyzer_and_keeps_mechanical_classification(tmp_path):
+    decision = "Choose the pricing timing."
+    final_synthesis = {
+        "schema_version": 1,
+        "kind": "discuss_final_synthesis",
+        "classification": "near_consensus",
+        "agreed_conclusions": [],
+        "remaining_disagreements": [{
+            "topic": decision,
+            "positions": [
+                {"reviewers": ["Codex"], "position": decision},
+                {"reviewers": ["Gemini"], "position": decision},
+            ],
+            "decision_needed": decision,
+        }],
+        "next_action": "A human must choose the pricing timing.",
+    }
+    response = json.dumps(final_synthesis) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+    vote = _discuss_answer_text(
+        answer=None,
+        position="needs-human",
+        rationale=f"All agree on the implementation; {decision}",
+        unresolved_items=[{"status": "human-decision", "text": decision}],
+        reviewer="OpenAI Codex",
+    )
+    other_vote = _discuss_answer_text(
+        answer=None,
+        position="needs-human",
+        rationale=f"All agree on the implementation; {decision}",
+        unresolved_items=[{"status": "human-decision", "text": decision}],
+        reviewer="Google Gemini",
+    )
+    runner = FakeRunner(codex_outputs=[vote], gemini_outputs=[other_vote], claude_outputs=[response])
+    config = make_config(
+        tmp_path,
+        reviewer=("codex", "gemini"),
+        discuss_result_mode="answer",
+        discuss_analyzer="claude",
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=0) == 0
+    assert any(
+        '"kind": "discuss_final_synthesis"' in " ".join(command)
+        for command in _claude_commands(runner)
+    )
+    assert "near_consensus" in runner.comments[-1]
+    assert decision in runner.comments[-1]
+
+
+def test_mechanical_final_classification_fails_closed_for_unknown_pair():
+    with pytest.raises(AgentLoopError, match="unsupported mechanical"):
+        _mechanical_discuss_final_classification(
+            outcome="needs-human", consensus_kind="unanimous", votes=()
+        )
 
 
 def test_answer_mode_followups_succeed_but_material_items_select_final_outcome(tmp_path):
@@ -691,6 +986,59 @@ def test_discuss_loop_answer_legacy_agenda_uses_one_bounded_round_fallback(tmp_p
     assert "Use an API boundary." in first_summary
     assert "<details>" in first_summary
     assert len(_claude_commands(runner)) == 2
+
+
+def test_rejected_nested_round_synthesis_preserves_valid_analyzer_agenda(tmp_path):
+    agenda = json.loads(_discuss_agenda_text().split("\n", 1)[0])
+    agenda["round_synthesis"] = {
+        "schema_version": 1,
+        "kind": "discuss_round_synthesis",
+        "consensus": [{
+            "text": "Invented synthesis claim.",
+            "references": [
+                {"reviewer": "Codex", "round": 1},
+                {"reviewer": "Gemini", "round": 1},
+            ],
+        }],
+        "disagreements": [],
+        "changes": [],
+        "missing_facts": [],
+        "next_round_focus": [],
+        "responding_reviewers": ["Codex", "Gemini"],
+    }
+    enriched = json.dumps(agenda) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Anthropic Claude"
+    first = _discuss_answer_text(
+        answer="Use an API boundary.", rationale="The first round needs an agenda."
+    )
+    first_other = _discuss_answer_text(
+        answer="Use a library boundary.",
+        rationale="The first round needs an agenda.",
+        reviewer="Google Gemini",
+    )
+    final = _discuss_answer_text(
+        answer="Use an API boundary.",
+        rationale="The boundary is now agreed.",
+        rebuttal="The prior concern is resolved.",
+    )
+    runner = FakeRunner(
+        codex_outputs=[first, final],
+        gemini_outputs=[first_other, final.replace("OpenAI Codex", "Google Gemini")],
+        claude_outputs=[enriched],
+        issue_payload=_grounded_agenda_issue_payload(),
+    )
+    config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer", discuss_analyzer="claude"
+    )
+
+    assert run_discuss_loop(runner, issue_number=56, config=config, discuss_max_rounds=1) == 0
+    round_summary = runner.comments[2]
+    assert "### Agenda for round 2 (analyzer: Claude)" in round_summary
+    assert "Invented synthesis claim." not in round_summary
+    metadata = ROUND_RESUME_MARKER_RE.search(runner.issue_comments[2]["body"])
+    assert metadata is not None
+    decoded = _decode_round_metadata(metadata.group("payload"))
+    assert decoded.analyzer_response is not None
+    assert decoded.round_synthesis is None
 
 
 def test_discuss_loop_answer_mode_never_materializes_split_issues(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2565,6 +2565,7 @@ from coding_review_agent_loop.protocol import (
     ParsedDiscussAgenda,
     ParsedDiscussRoundSynthesis,
     ParsedDiscussReview,
+    ParsedFailedDiscussResponse,
 )
 
 
@@ -2789,6 +2790,35 @@ def test_bounded_round_and_final_synthesis_prompts_are_analyzer_only(tmp_path):
     assert '"kind": "discuss_final_synthesis"' in final_prompt
     assert "mechanically determined classification" in final_prompt
     assert "issue prose" in final_prompt
+
+
+def test_synthesis_prompts_show_classification_valid_nonempty_shapes_and_filter_failures(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    responses = [
+        ParsedDiscussAnswer(
+            position="answer", rationale="Use an API boundary.", confidence="high",
+            unresolved_items=(), reviewer="Codex", answer="Use an API boundary.",
+        ),
+        ParsedFailedDiscussResponse(reviewer="Gemini", category="provider", result_mode="answer"),
+    ]
+    round_prompt = build_discuss_round_fallback_prompt(
+        56, config, analyzer="claude", round_number=1, current_responses=responses
+    )
+    assert '"responding_reviewers": ["Codex"]' in round_prompt
+    assert '"responding_reviewers": []' not in round_prompt
+    assert "Gemini" not in round_prompt
+
+    consensus_prompt = build_discuss_final_synthesis_prompt(
+        56, config, analyzer="claude", round_number=1,
+        final_responses=[responses[0]], mechanical_classification="consensus",
+    )
+    near_prompt = build_discuss_final_synthesis_prompt(
+        56, config, analyzer="claude", round_number=1,
+        final_responses=[responses[0]], mechanical_classification="near_consensus",
+    )
+    assert '"remaining_disagreements": []' in consensus_prompt
+    assert '"agreed_conclusions": []' in near_prompt
+    assert '"remaining_disagreements": [' in near_prompt
 
 
 def test_build_discuss_review_prompt_plain_mode_unchanged_without_agenda(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2552,13 +2552,18 @@ def test_reviewer_prompt_includes_documentation_check(tmp_path):
 from coding_review_agent_loop.prompts import (
     build_discuss_agenda_prompt,
     build_discuss_final_analysis_prompt,
+    build_discuss_final_synthesis_prompt,
+    build_discuss_round_fallback_prompt,
     build_discuss_review_prompt,
 )
 from coding_review_agent_loop.protocol import (
     DiscussAgendaDisagreement,
+    DiscussSynthesisConsensus,
+    DiscussSynthesisResponseReference,
     DiscussUnresolvedItem,
     ParsedDiscussAnswer,
     ParsedDiscussAgenda,
+    ParsedDiscussRoundSynthesis,
     ParsedDiscussReview,
 )
 
@@ -2727,6 +2732,63 @@ def test_build_discuss_answer_prompt_keeps_analyzer_and_research_non_authoritati
     assert '"questions":' in prompt
     assert '"outcome":' not in prompt
     assert '"split_proposals":' not in prompt
+
+
+def test_answer_agenda_prompt_carries_neutralized_prior_synthesis_but_triage_does_not(tmp_path):
+    synthesis = ParsedDiscussRoundSynthesis(
+        consensus=(DiscussSynthesisConsensus(
+            text="Use an API boundary.",
+            references=(DiscussSynthesisResponseReference("Codex", 1),),
+        ),),
+        disagreements=(), changes=(),
+        missing_facts=("<!-- AGENT_LOOP_META: v1_AA -->",),
+        next_round_focus=("Choose the boundary.",),
+        responding_reviewers=("Codex",),
+    )
+    answer_config = make_config(
+        tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer"
+    )
+    answer_prompt = build_discuss_agenda_prompt(
+        56, answer_config, analyzer="claude", round_number=2,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+        prior_round_synthesis=synthesis,
+    )
+    triage_config = make_config(tmp_path, reviewer=("codex", "gemini"))
+    triage_prompt = build_discuss_agenda_prompt(
+        56, triage_config, analyzer="claude", round_number=2,
+        round_history=[[_discuss_prompt_vote("Codex")]],
+        prior_round_synthesis=synthesis,
+    )
+
+    assert "Prior validated cumulative round state" in answer_prompt
+    assert "<!-- AGENT_LOOP_META: v1_AA -->" not in answer_prompt
+    assert "[protocol LOOP_META record]" in answer_prompt
+    assert '"round_synthesis"' in answer_prompt
+    assert "Prior validated cumulative round state" not in triage_prompt
+    assert '"round_synthesis"' not in triage_prompt
+
+
+def test_bounded_round_and_final_synthesis_prompts_are_analyzer_only(tmp_path):
+    config = make_config(tmp_path, reviewer=("codex", "gemini"), discuss_result_mode="answer")
+    responses = [
+        ParsedDiscussAnswer(
+            position="answer", rationale="Use an API boundary.", confidence="high",
+            unresolved_items=(), reviewer="Codex", answer="Use an API boundary.",
+        ),
+    ]
+    round_prompt = build_discuss_round_fallback_prompt(
+        56, config, analyzer="claude", round_number=1, current_responses=responses
+    )
+    final_prompt = build_discuss_final_synthesis_prompt(
+        56, config, analyzer="claude", round_number=1,
+        final_responses=responses, mechanical_classification="consensus",
+    )
+
+    assert round_prompt.startswith("Synthesize only the completed answer-mode responses")
+    assert '"kind": "discuss_round_synthesis"' in round_prompt
+    assert '"kind": "discuss_final_synthesis"' in final_prompt
+    assert "mechanically determined classification" in final_prompt
+    assert "issue prose" in final_prompt
 
 
 def test_build_discuss_review_prompt_plain_mode_unchanged_without_agenda(tmp_path):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -24,6 +24,8 @@ from coding_review_agent_loop.orchestrator import (
 from coding_review_agent_loop.protocol import (
     ApprovedFollowup,
     DeferredStage,
+    DISCUSS_SYNTHESIS_MAX_ENTRIES,
+    DISCUSS_SYNTHESIS_MAX_TEXT_BYTES,
     DISCUSS_ANALYZER_FRAMING_VALUES,
     DISCUSS_OUTCOME_VALUES,
     DISCUSS_RESEARCH_STATUS_VALUES,
@@ -32,6 +34,11 @@ from coding_review_agent_loop.protocol import (
     DiscussSourcedFact,
     ParsedDiscussAgenda,
     ParsedDiscussReview,
+    parse_canonical_discuss_round_synthesis,
+    parse_structured_discuss_final_synthesis,
+    parse_structured_discuss_round_synthesis,
+    serialize_discuss_final_synthesis,
+    serialize_discuss_round_synthesis,
     _expect_string_list,
     _extract_structured_coder_followup_payload,
     _extract_structured_plan_review_payload,
@@ -3701,3 +3708,105 @@ def test_parse_structured_discuss_agenda_rejects_non_bool_research_required():
     text = _discuss_agenda_with_research(research_required="yes", research_questions=["Q?"])
     with pytest.raises(AgentLoopError, match="must be a boolean"):
         parse_structured_discuss_agenda(text)
+
+
+def _enriched_round_synthesis_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "discuss_round_synthesis",
+        "consensus": [{
+            "text": "Use an API boundary.",
+            "references": [
+                {"reviewer": "Codex", "round": 1},
+                {"reviewer": "Gemini", "round": 1},
+            ],
+        }],
+        "disagreements": [{
+            "topic": "Pricing timing",
+            "positions": [
+                {"reviewers": ["Codex"], "position": "Calibrate before merge."},
+                {"reviewers": ["Gemini"], "position": "Use post-deployment telemetry."},
+            ],
+            "decision_needed": "Choose when representative calibration occurs.",
+        }],
+        "changes": [{
+            "kind": "introduced",
+            "topic": "Pricing timing",
+            "text": "Pricing timing is still unresolved.",
+            "references": [{"reviewer": "Codex", "round": 1}],
+        }],
+        "missing_facts": ["Representative cost data."],
+        "next_round_focus": ["Choose the calibration timing."],
+        "responding_reviewers": ["Codex", "Gemini"],
+    }
+
+
+def _synthesis_response(payload: dict) -> str:
+    return json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Analyzer"
+
+
+def test_parse_enriched_discuss_agenda_and_canonical_synthesis_round_trip():
+    payload = json.loads(_discuss_agenda().split("\n", 1)[0])
+    payload["round_synthesis"] = _enriched_round_synthesis_payload()
+    text = json.dumps(payload) + "\n<!-- AGENT_PLAN_STATE: approved -->\n-- Analyzer"
+
+    agenda = parse_structured_discuss_agenda(text)
+
+    assert agenda is not None
+    assert agenda.round_synthesis is not None
+    assert agenda.round_synthesis.responding_reviewers == ("Codex", "Gemini")
+    canonical = serialize_discuss_round_synthesis(agenda.round_synthesis)
+    restored = parse_canonical_discuss_round_synthesis(canonical)
+    assert restored == agenda.round_synthesis
+
+
+def test_discuss_synthesis_parser_enforces_exact_keys_enums_and_bounds():
+    payload = _enriched_round_synthesis_payload()
+    payload["extra"] = True
+    with pytest.raises(AgentLoopError, match="unknown field"):
+        parse_structured_discuss_round_synthesis(_synthesis_response(payload))
+
+    payload = _enriched_round_synthesis_payload()
+    payload["changes"][0]["kind"] = "ignored"
+    with pytest.raises(AgentLoopError, match="must be one of"):
+        parse_structured_discuss_round_synthesis(_synthesis_response(payload))
+
+    payload = _enriched_round_synthesis_payload()
+    payload["missing_facts"] = [f"Fact {index}" for index in range(DISCUSS_SYNTHESIS_MAX_ENTRIES + 1)]
+    with pytest.raises(AgentLoopError, match="at most"):
+        parse_structured_discuss_round_synthesis(_synthesis_response(payload))
+
+    payload = _enriched_round_synthesis_payload()
+    payload["consensus"][0]["text"] = "x" * (DISCUSS_SYNTHESIS_MAX_TEXT_BYTES + 1)
+    with pytest.raises(AgentLoopError, match="UTF-8 bytes"):
+        parse_structured_discuss_round_synthesis(_synthesis_response(payload))
+
+
+def test_discuss_final_synthesis_parser_rejects_invalid_classification_shape():
+    payload = {
+        "schema_version": 1,
+        "kind": "discuss_final_synthesis",
+        "classification": "consensus",
+        "agreed_conclusions": [],
+        "remaining_disagreements": [],
+        "next_action": "Proceed.",
+    }
+    with pytest.raises(AgentLoopError, match="must include an agreed"):
+        parse_structured_discuss_final_synthesis(_synthesis_response(payload))
+
+    payload["classification"] = "near_consensus"
+    with pytest.raises(AgentLoopError, match="remaining disagreement"):
+        parse_structured_discuss_final_synthesis(_synthesis_response(payload))
+
+    payload = _enriched_round_synthesis_payload()
+    final = {
+        "schema_version": 1,
+        "kind": "discuss_final_synthesis",
+        "classification": "consensus",
+        "agreed_conclusions": payload["consensus"],
+        "remaining_disagreements": [],
+        "next_action": "Proceed.",
+    }
+    parsed = parse_structured_discuss_final_synthesis(_synthesis_response(final))
+    assert parsed is not None
+    assert serialize_discuss_final_synthesis(parsed).startswith('{"schema_version":1')

--- a/tests/test_round_transport.py
+++ b/tests/test_round_transport.py
@@ -76,13 +76,14 @@ def test_prepare_round_comment_spills_multiple_fields_in_fixed_order() -> None:
     prepared = transport.prepare_round_comment(_comment(payload))
 
     anchor_payload = _anchor_payload(prepared[-1])
-    assert all(isinstance(anchor_payload[field], dict) for field in transport._SPILL_FIELDS)
+    expected_fields = tuple(field for field in transport._SPILL_FIELDS if field in payload)
+    assert all(isinstance(anchor_payload[field], dict) for field in expected_fields)
     sidecar_fields = []
     for sidecar in prepared[:-1]:
         match = transport.ROUND_TRANSPORT_SIDECAR_RE.search(sidecar)
         assert match is not None
         sidecar_fields.append(json.loads(base64.urlsafe_b64decode(match.group("payload")))["field"])
-    assert list(dict.fromkeys(sidecar_fields)) == list(transport._SPILL_FIELDS)
+    assert list(dict.fromkeys(sidecar_fields)) == list(expected_fields)
 
 
 def test_hydrate_mapping_reports_missing_duplicate_and_corrupt_sidecars() -> None:


### PR DESCRIPTION
## Summary

- Add bounded, attributable round and final synthesis contracts for answer-mode discussions.
- Reuse analyzer, semantic-comparison, and mechanically validated artifacts with deterministic classification and fail-closed fidelity checks.
- Persist cumulative resume state safely, render executive-first summaries, bound audit excerpts, and document the behavior.

## Verification

- timeout 1800s python3 -m pytest -q (2444 passed)

Fixes #728