### PR TITLE
Require body files for coder GitHub writes

### DIFF
--- a/docs/local_agent_loop.md
+++ b/docs/local_agent_loop.md
@@ -1290,6 +1290,8 @@ unless the user explicitly authorizes another path. Coder prompts also ask the
 agent to run `pwd` and `git status --branch --short` before tests or commits,
 and to avoid sibling, home, deployment, or duplicate clones such as `~/REPO` or
 `~/claude-code/REPO`.
+Every coder `gh` body must be written to a temporary file outside the checkout
+and passed with `--body-file`.
 
 The orchestrator validates coder-reported test commands before posting normal
 coder progress. For `Tests:` reports and structured `tests_run` entries, it is
@@ -1647,11 +1649,12 @@ through that account).
 For auto-merge issue work, a v2 preflight gives the coder an atomic creation
 intent: create or verify `agent-loop-managed`, use the reserved
 `agent-loop/managed-<issue>` branch, then run `gh pr create --draft --label
-agent-loop-managed`. The workflow can suppress later reopened/synchronize
-matrices only for the complete tuple: same-repository head, trusted REST
-author, reserved branch, draft, and label. The opening event is necessarily
-evaluated before GitHub's separate label write and therefore uses the same
-tuple without the label; agent-loop must apply the label before continuing.
+agent-loop-managed --body-file <path>`. The workflow can suppress later
+reopened/synchronize matrices only for the complete tuple: same-repository
+head, trusted REST author, reserved branch, draft, and label. The opening event
+is necessarily evaluated before GitHub's separate label write and therefore
+uses the same tuple without the label; agent-loop must apply the label before
+continuing.
 A contributor-editable label, branch, or body alone is never trusted. Forks
 and ordinary PRs retain regular CI unless they are explicitly adopted as
 described below.

--- a/src/coding_review_agent_loop/prompts.py
+++ b/src/coding_review_agent_loop/prompts.py
@@ -295,6 +295,18 @@ def _coder_documentation_guidance() -> str:
     )
 
 
+def _coder_github_body_file_guidance() -> str:
+    return (
+        "For every GitHub issue, pull-request, or comment body you create or edit with `gh`, "
+        "first write the exact Markdown to a temporary file outside the repository checkout, "
+        "then pass that file with `--body-file`. Never use `--body` for GitHub body content, "
+        "never use `gh pr create --fill`, and never place Markdown backticks inside a "
+        "double-quoted shell argument: the shell can execute them as command substitutions. "
+        "After the write, fetch the resulting body and verify that headings, lists, code, and "
+        "newlines rendered as intended.\n"
+    )
+
+
 def _issue_pr_provenance_guidance(scope: IssuePrProvenanceScope) -> str:
     trailer = format_issue_pr_provenance(scope)
     return (
@@ -302,9 +314,10 @@ def _issue_pr_provenance_guidance(scope: IssuePrProvenanceScope) -> str:
         "adoption of an unrelated open PR; it is not an authentication boundary. Before creating "
         "the PR, ensure at least one implementation commit carries this complete Git trailer line "
         f"exactly: `{trailer}`. Keep this trailer out of the PR body and all comments. Use an "
-        "explicit PR body when creating the PR; if `gh pr create --fill` copied the trailer into "
-        "the body, remove that copy before opening or update the body explicitly while preserving "
-        "all required closing references. Do not rewrite or force-push solely to add the trailer "
+        "explicit PR body file when creating the PR; never use `gh pr create --fill`, because it "
+        "can copy the trailer into the body. Keep using the explicit body file while preserving "
+        "all required closing references. Do not "
+        "rewrite or force-push solely to add the trailer "
         "after a canonical handoff exists."
         "\n"
     )
@@ -1392,7 +1405,8 @@ def _managed_ci_creation_guidance(
     return (
         "\nThis invocation has authenticated managed-CI v2 enabled. Create the PR atomically: "
         f"use exactly the reserved branch `{intent.branch}`, create or verify the `agent-loop-managed` "
-        "label, then run `gh pr create --draft --label agent-loop-managed` so it is born open, draft, "
+        "label, then run `gh pr create --draft --label agent-loop-managed --body-file <path>` so it "
+        "is born open, draft, "
         "and labeled. Do not create a second PR or apply a readiness transition. Do not mark it ready; "
         f"agent-loop will dispatch exact-head qualification after review.{override}\n"
     )
@@ -1436,7 +1450,7 @@ Use this local checkout as your workspace. Create a branch, implement the fix,
 run relevant tests, commit, push, and open a pull request against {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 {pr_reference_guidance}
 {provenance_guidance}
 {managed_creation_guidance}
@@ -2036,7 +2050,7 @@ approved plan, run relevant tests, commit, push, and open a pull request against
 {config.base}.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 {pr_reference_guidance}
 {provenance_guidance}
 {managed_creation_guidance}
@@ -2096,7 +2110,7 @@ task-output file. If you know its process ID, terminate it once (a single
 foreground under the bounded timeout below, waiting for it to finish; launch
 nothing new in the background. Then commit, push, and open the pull request if
 that is not already done, or continue exactly where you left off.
-{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 {human_requirements_context.block}
 {implementation_contract}
 {_issue_implementation_terminal_marker_guidance(reviewer_name=reviewer_name, coder_signature=coder_signature)}"""
@@ -2123,7 +2137,7 @@ Use this local checkout as your workspace. Decide between two paths:
     {config.base}. Do not wait for {reviewer_name}; this local orchestrator
     will run {reviewer_name} after you create the PR.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(config, structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(config, structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 
 (b) If the task is genuinely ambiguous or missing information that would change
     the implementation, do NOT write code. Instead, ask focused clarifying
@@ -2178,7 +2192,7 @@ Clarification so far:
 Now proceed. Strongly prefer to implement the task and open a PR. Only ask
 again if a critical detail is still missing.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(config, structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=False)}{_coder_local_test_scope_guidance(config, structured=False)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 
 {_agent_unavailable_guidance(coder_signature)}
 If you cannot safely proceed and cannot create a PR — for example after a
@@ -2796,7 +2810,7 @@ needed, implement fixes, run relevant tests, commit, and push to the same PR.
 Do not create a new PR.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory, config, include_runtime=True)}
@@ -2845,7 +2859,7 @@ current PR. Keep the change narrowly scoped to the listed items. Do not take on
 larger redesigns or unrelated future work; call that out instead. The PR
 remains blocked pending another review round after this cleanup.
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_ci_wait_guidance()}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory, config, include_runtime=True)}
@@ -2899,7 +2913,7 @@ or wait for CI runs in this round -- CI and reviews are re-evaluated automatical
 against the new head after your push.
 {_coder_workdir_guidance(config)}
 {_scratch_file_guidance()}
-{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_documentation_guidance()}
+{_coder_test_reporting_guidance(structured=True)}{_coder_local_test_scope_guidance(config, structured=True)}{_coder_documentation_guidance()}{_coder_github_body_file_guidance()}
 {_issue_context_block(issue_context)}
 {human_requirements_context.block}{_coder_human_requirements_guidance(human_requirements_context)}
 {_memory_block(memory, config, include_runtime=True)}

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -226,6 +226,21 @@ def test_managed_ci_docs_describe_precreation_managed_pr_mode():
     assert "--allow-unprotected-managed-ci" in text
 
 
+def test_coder_docs_require_github_body_files():
+    text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
+    normalized_text = " ".join(text.split())
+
+    assert (
+        "Every coder `gh` body must be written to a temporary file outside the checkout"
+        in text
+    )
+    assert "passed with `--body-file`" in text
+    assert (
+        "`gh pr create --draft --label agent-loop-managed --body-file <path>`"
+        in normalized_text
+    )
+
+
 def test_local_agent_loop_doc_has_focused_bounded_local_test_section():
     text = LOCAL_AGENT_LOOP_DOC.read_text(encoding="utf-8")
     assert f"### {LOCAL_TEST_SCOPE_HEADING_TEXT}" in text

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -302,7 +302,7 @@ def test_issue_implementation_prompts_inject_exact_scoped_trailer_guidance(tmp_p
     for prompt in (direct_prompt, approved_prompt):
         assert "at least one implementation commit carries" in prompt
         assert "Keep this trailer out of the PR body and all comments" in prompt
-        assert "gh pr create --fill" in prompt
+        assert "never use `gh pr create --fill`" in prompt
         assert "preserving all required closing references" in prompt
 
 
@@ -1880,6 +1880,38 @@ def test_coder_prompts_forbid_unbounded_ci_waits_with_exact_bound(tmp_path, buil
         ),
     ],
 )
+def test_coder_prompts_require_github_body_files(tmp_path, builder):
+    prompt = builder(make_config(tmp_path))
+
+    assert "write the exact Markdown to a temporary file" in prompt
+    assert "pass that file with `--body-file`" in prompt
+    assert "Never use `--body` for GitHub body content" in prompt
+    assert "never use `gh pr create --fill`" in prompt
+    assert "shell can execute them as command substitutions" in prompt
+    assert "fetch the resulting body and verify" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda config: build_issue_prompt(56, config),
+        lambda config: build_issue_implementation_prompt(56, "1. Fix it.", config),
+        lambda config: build_completion_recovery_prompt(config),
+        lambda config: build_task_prompt("Fix the bug.", config),
+        lambda config: build_task_clarification_prompt("Fix the bug.", [], config),
+        lambda config: build_followup_prompt(77, 1, "Needs tests.", config),
+        lambda config: build_same_pr_followup_prompt(77, 1, "Tighten docs.", config),
+        lambda config: build_merge_conflict_prompt(
+            77,
+            1,
+            "Resolve the conflict.",
+            config,
+            base_branch="main",
+            head_sha="deadbeef",
+            merge_state_detail="mergeable=CONFLICTING",
+        ),
+    ],
+)
 def test_coder_prompts_require_focused_bounded_local_tests(tmp_path, builder):
     config = make_config(tmp_path)
     prompt = " ".join(builder(config).split())
@@ -3137,7 +3169,7 @@ def test_build_issue_prompt_carries_explicit_managed_creation_contract(tmp_path)
     )
 
     assert "agent-loop/managed-56" in prompt
-    assert "gh pr create --draft --label agent-loop-managed" in prompt
+    assert "gh pr create --draft --label agent-loop-managed --body-file <path>" in prompt
     assert "Do not mark it ready" in prompt
     guidance = prompt[prompt.index("This invocation has authenticated managed-CI v2 enabled."):]
     assert guidance.split("\n", 1)[0] in plan_prompt


### PR DESCRIPTION
## Summary

- require every implementation-agent GitHub body write to use a temporary Markdown file and `--body-file`
- forbid multiline `--body`, `gh pr create --fill`, and shell-quoted Markdown backticks that can trigger command substitution
- require agents to fetch and verify the resulting body after creating or editing it
- update the managed-CI PR creation example and cover every coder prompt shape with regression tests

## Why

An implementation turn for #731 embedded backticked test commands inside a double-quoted `gh pr create --body` argument. Bash executed those tests again as command substitutions, delaying handoff and risking a malformed PR body. The implementation had already passed 2,492 tests, committed, and pushed before this avoidable rerun began.

## Validation

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_prompts.py -q` (`163 passed`)
