### PR TITLE
Clarify agent-loop review semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ requirements and remain approval-critical. See
 [Human requirements](docs/local_agent_loop.md#human-requirements) for the exact
 contract.
 
+### What "review" and "approval" mean
+
+Agent-loop publishes model reviews as structured comments in the pull
+request's conversation. An `Approved` verdict means that the named model
+approved the recorded PR head under agent-loop's protocol. It is not a native
+GitHub pull-request review, does not populate GitHub's **Reviewers** or
+**Reviews** panels, and does not satisfy a branch-protection rule that requires
+approving GitHub reviews.
+
+The agent CLIs normally share the GitHub identity authenticated through `gh`,
+so their model signatures identify protocol participants rather than distinct
+GitHub accounts. If a repository requires native GitHub approvals, obtain them
+separately from an eligible human, bot, or GitHub App identity. GitHub's own
+merge protections remain in force in addition to agent-loop's reviewer and CI
+gates.
+
 ## Current Limitations
 
 - Run only one active `agent-loop` invocation per repository per machine. The

--- a/tests/test_docs_guidance.py
+++ b/tests/test_docs_guidance.py
@@ -71,6 +71,25 @@ def test_readme_documents_same_repo_concurrency_limit():
     assert "system temporary directory (`/tmp` on Linux)" in section
 
 
+def test_readme_documents_review_and_approval_semantics():
+    readme_text = README.read_text(encoding="utf-8")
+    section_start = readme_text.index('### What "review" and "approval" mean')
+    section_end = readme_text.index("## Current Limitations", section_start)
+    section = " ".join(readme_text[section_start:section_end].split())
+
+    assert "not a native GitHub pull-request review" in section
+    assert (
+        "does not satisfy a branch-protection rule that requires approving GitHub reviews"
+        in section
+    )
+    assert (
+        "The agent CLIs normally share the GitHub identity authenticated through `gh`, "
+        "so their model signatures identify protocol participants rather than distinct "
+        "GitHub accounts."
+        in section
+    )
+
+
 def test_readme_documents_ci_watcher_controls():
     readme_text = README.read_text(encoding="utf-8")
     section_start = readme_text.index("## CI and Merge")


### PR DESCRIPTION
## Summary

- explain that agent-loop publishes structured model verdicts as PR conversation comments
- distinguish those verdicts from GitHub-native reviews and requested reviewers
- clarify that model signatures are protocol identities when agents share one authenticated GitHub account
- state that repositories requiring native approvals must obtain them separately and that GitHub merge protections remain in force

## Validation

- `/home/wwind123/tools/coding-review-agent-loop/.venv/bin/pytest tests/test_docs_guidance.py -q` (`21 passed`)
